### PR TITLE
fix: sync time always showing stale 8h ago

### DIFF
--- a/packages/app/src/renderer/components/StatusBar.tsx
+++ b/packages/app/src/renderer/components/StatusBar.tsx
@@ -92,7 +92,8 @@ function getSyncStatusText(
 
 function formatTimeAgo(iso: string): string {
   try {
-    const diff = Date.now() - new Date(iso).getTime()
+    const utcIso = iso.endsWith('Z') ? iso : iso + 'Z'
+    const diff = Date.now() - new Date(utcIso).getTime()
     const minutes = Math.floor(diff / 60000)
     if (minutes < 1) return 'just now'
     if (minutes < 60) return `${minutes}m ago`

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -23,5 +23,5 @@ function formatBytes(bytes: number): string {
 }
 
 function formatDate(iso: string): string {
-  try { return new Date(iso).toLocaleString() } catch { return iso }
+  try { return new Date(iso.endsWith('Z') ? iso : iso + 'Z').toLocaleString() } catch { return iso }
 }


### PR DESCRIPTION
## Summary
- SQLite `datetime('now')` stores UTC without a `Z` suffix — JS `new Date()` parsed it as local time, so the sync timestamp was always off by the user's timezone offset (8h in UTC+8)
- Append `Z` before parsing in both the Electron status bar and CLI status command

## Test plan
- [ ] Run `pnpm dev`, trigger sync, verify status bar shows "just now" instead of "8h ago"
- [ ] Run `spool status` in CLI, verify last synced time is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)