### PR TITLE
feat: unify codex to use ACP protocol

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -18,6 +18,7 @@
     "@spool/core": "workspace:*",
     "@tanstack/react-virtual": "^3.13.6",
     "acp-extension-claude": "^0.21.0",
+    "acp-extension-codex": "^0.10.0",
     "better-sqlite3": "^11.10.0",
     "bindings": "^1.5.0",
     "file-uri-to-path": "^2.0.0",

--- a/packages/app/src/main/acp.ts
+++ b/packages/app/src/main/acp.ts
@@ -1,4 +1,8 @@
 import { spawn, execSync, type ChildProcess } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
 import type { FragmentResult } from '@spool/core'
 
 export interface AgentInfo {
@@ -16,10 +20,15 @@ export interface ToolCallEvent {
 
 interface AcpSession {
   proc: ChildProcess
-  conn: any // ClientSideConnection
+  conn: unknown
   sessionId: string | null
   initialized: boolean
 }
+
+interface TerminalParams { command?: string; args?: string[]; cwd?: string; sessionId?: string }
+interface TerminalIdParams { terminalId: string; sessionId?: string }
+interface ReadFileParams { path: string; sessionId?: string }
+interface SessionNotification { update?: { sessionUpdate?: string; content?: { type: string; text?: string }; toolCallId?: string; title?: string; status?: string; kind?: string } }
 
 /**
  * ACP Manager — connects to local agents via the Agent Client Protocol.
@@ -47,9 +56,6 @@ function resolveSystemBinary(name: string, extraSearchPaths: string[] = []): str
     if (p) return p
   } catch {}
 
-  // Check well-known paths directly
-  const { existsSync } = require('node:fs')
-  const { homedir } = require('node:os')
   const home = homedir()
   const searchPaths = [
     ...extraSearchPaths,
@@ -72,6 +78,27 @@ function cachedResolve(name: string, extras: string[] = []): string | null {
   return resolvedPaths[name]
 }
 
+interface AgentConfig {
+  name: string
+  bin: string
+  envSetup?: () => Record<string, string>
+}
+
+const AGENT_CONFIGS: Record<string, AgentConfig> = {
+  claude: {
+    name: 'Claude Code',
+    bin: 'claude',
+    envSetup: () => {
+      const claudePath = cachedResolve('claude')
+      return claudePath ? { CLAUDE_CODE_EXECUTABLE: claudePath } : {}
+    },
+  },
+  codex: {
+    name: 'Codex CLI',
+    bin: 'codex',
+  },
+}
+
 export class AcpManager {
   private detectedAgents: AgentInfo[] | null = null
   private activeSession: AcpSession | null = null
@@ -81,14 +108,9 @@ export class AcpManager {
     if (this.detectedAgents) return this.detectedAgents
 
     const agents: AgentInfo[] = []
-    const candidates = [
-      { id: 'claude', name: 'Claude Code', bin: 'claude' },
-      { id: 'codex', name: 'Codex CLI', bin: 'codex' },
-    ]
-
-    for (const c of candidates) {
-      const p = cachedResolve(c.bin)
-      if (p) agents.push({ id: c.id, name: c.name, path: p })
+    for (const [id, config] of Object.entries(AGENT_CONFIGS)) {
+      const p = cachedResolve(config.bin)
+      if (p) agents.push({ id, name: config.name, path: p })
     }
 
     this.detectedAgents = agents
@@ -111,11 +133,7 @@ export class AcpManager {
 
     const prompt = this.buildPrompt(userQuery)
 
-    if (agentId === 'claude') {
-      return this.queryViaAcp(prompt, onChunk, onToolCall)
-    } else {
-      return this.queryCodex(agent.path, prompt, onChunk)
-    }
+    return this.queryViaAcp(agentId, prompt, onChunk, onToolCall)
   }
 
   /**
@@ -124,6 +142,7 @@ export class AcpManager {
    * then does initialize → newSession → prompt with streaming sessionUpdate chunks.
    */
   private async queryViaAcp(
+    agentId: string,
     prompt: string,
     onChunk: (text: string) => void,
     onToolCall?: (event: ToolCallEvent) => void,
@@ -131,8 +150,8 @@ export class AcpManager {
     // Dynamically import the ESM-only ACP SDK
     const acp = await import('@agentclientprotocol/sdk')
 
-    // Resolve the acp-extension-claude binary
-    const agentBin = this.resolveAcpExtensionClaude()
+    // Resolve the acp-extension binary for this agent
+    const agentBin = this.resolveAcpExtension(agentId)
 
     // Spawn the ACP agent subprocess.
     // Must use system Node.js — not Electron's binary — because the extension
@@ -140,17 +159,18 @@ export class AcpManager {
     // Also set CLAUDE_CODE_EXECUTABLE so the SDK finds the real CLI.
     const nodePath = cachedResolve('node')
     if (!nodePath) throw new Error('Could not find Node.js. Ensure node is installed and in PATH.')
-    const claudePath = cachedResolve('claude')
+    const config = AGENT_CONFIGS[agentId]
+    const agentEnv = {
+      ...process.env as Record<string, string>,
+      ...config?.envSetup?.() ?? {},
+    }
     const proc = spawn(nodePath, [agentBin], {
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
-        ...(claudePath ? { CLAUDE_CODE_EXECUTABLE: claudePath } : {}),
-      },
+      env: agentEnv,
     })
 
     proc.stderr?.on('data', (d: Buffer) => {
-      console.error(`[acp-claude] ${d.toString().trim()}`)
+      console.error(`[acp-${agentId}] ${d.toString().trim()}`)
     })
 
     // Convert Node streams to Web streams for the ACP SDK
@@ -180,11 +200,73 @@ export class AcpManager {
 
     let fullText = ''
 
+    const MAX_TERMINAL_OUTPUT = 1024 * 1024 // 1 MB cap
+    const terminals = new Map<string, { proc: ChildProcess; output: string; exitCode: number | null }>()
+    let terminalCounter = 0
+
+    function killTerminalProc(t: { proc: ChildProcess }) {
+      if (t.proc.exitCode === null) try { t.proc.kill() } catch {}
+    }
+
+    function cleanupAllTerminals() {
+      for (const t of terminals.values()) killTerminalProc(t)
+      terminals.clear()
+    }
+
     const conn = new acp.ClientSideConnection(() => ({
       requestPermission: async () => ({
         outcome: { outcome: 'selected' as const, optionId: 'allow' },
       }),
-      sessionUpdate: async (notification: any) => {
+      extMethod: async () => ({}),
+      createTerminal: async (params: TerminalParams) => {
+        const id = `term-${++terminalCounter}`
+        const termProc = spawn(params.command ?? 'bash', params.args ?? [], {
+          cwd: params.cwd || process.cwd(),
+          env: process.env,
+          stdio: ['pipe', 'pipe', 'pipe'],
+          shell: true,
+        })
+        const state = { proc: termProc, output: '', exitCode: null as number | null }
+        const append = (d: Buffer) => {
+          if (state.output.length < MAX_TERMINAL_OUTPUT) state.output += d.toString()
+        }
+        termProc.stdout?.on('data', append)
+        termProc.stderr?.on('data', append)
+        termProc.on('close', (code) => { state.exitCode = code })
+        terminals.set(id, state)
+        return { terminalId: id }
+      },
+      terminalOutput: async (params: TerminalIdParams) => {
+        const t = terminals.get(params.terminalId)
+        return { output: t?.output ?? '', exitCode: t?.exitCode ?? null }
+      },
+      waitForTerminalExit: async (params: TerminalIdParams) => {
+        const t = terminals.get(params.terminalId)
+        if (!t) return { exitCode: -1 }
+        if (t.exitCode !== null) return { exitCode: t.exitCode }
+        return new Promise((resolve) => {
+          t.proc.on('close', (code) => resolve({ exitCode: code ?? -1 }))
+        })
+      },
+      killTerminal: async (params: TerminalIdParams) => {
+        const t = terminals.get(params.terminalId)
+        if (t) killTerminalProc(t)
+        return {}
+      },
+      releaseTerminal: async (params: TerminalIdParams) => {
+        const t = terminals.get(params.terminalId)
+        if (t) killTerminalProc(t)
+        terminals.delete(params.terminalId)
+        return {}
+      },
+      readTextFile: async (params: ReadFileParams) => {
+        try {
+          return { content: await readFile(params.path, 'utf8') }
+        } catch {
+          return { content: '' }
+        }
+      },
+      sessionUpdate: async (notification: SessionNotification) => {
         const update = notification.update
         if (!update || !('sessionUpdate' in update)) return
 
@@ -247,10 +329,10 @@ export class AcpManager {
       return fullText
     } catch (err) {
       if (fullText) return fullText
-      const msg = err instanceof Error ? err.message : (typeof err === 'object' && err !== null && 'message' in err) ? String((err as any).message) : String(err)
+      const msg = err instanceof Error ? err.message : (typeof err === 'object' && err !== null && 'message' in err) ? String((err as Record<string, unknown>).message) : String(err)
       throw new Error(msg)
     } finally {
-      // Clean up the subprocess
+      cleanupAllTerminals()
       this.killSession()
     }
   }
@@ -259,74 +341,21 @@ export class AcpManager {
    * Resolve the path to the acp-extension-claude entry point.
    * The package is ESM-only so require.resolve() won't work directly.
    */
-  private resolveAcpExtensionClaude(): string {
-    const path = require('node:path')
-    const fs = require('node:fs')
-    // __dirname in dev = packages/app/out/main
-    // node_modules is at packages/app/node_modules (../../node_modules from __dirname)
-    const candidates = [
-      path.resolve(__dirname, '..', '..', 'node_modules', 'acp-extension-claude', 'dist', 'index.js'),
-      path.resolve(__dirname, '..', 'node_modules', 'acp-extension-claude', 'dist', 'index.js'),
-      path.resolve(__dirname, '..', '..', '..', 'node_modules', 'acp-extension-claude', 'dist', 'index.js'),
+  private resolveAcpExtension(name: string): string {
+    const pkg = `acp-extension-${name}`
+    const entryPoints = ['dist/index.js', `bin/${pkg}.js`]
+    const roots = [
+      resolve(__dirname, '..', '..', 'node_modules', pkg),
+      resolve(__dirname, '..', 'node_modules', pkg),
+      resolve(__dirname, '..', '..', '..', 'node_modules', pkg),
     ]
-    for (const c of candidates) {
-      if (fs.existsSync(c)) return c
+    for (const root of roots) {
+      for (const entry of entryPoints) {
+        const candidate = join(root, entry)
+        if (existsSync(candidate)) return candidate
+      }
     }
-    throw new Error('Could not find acp-extension-claude. Run: pnpm add acp-extension-claude')
-  }
-
-  /**
-   * Codex CLI: use `codex exec --json <prompt>`
-   */
-  private queryCodex(
-    binPath: string,
-    prompt: string,
-    onChunk: (text: string) => void,
-  ): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const proc = spawn(binPath, ['exec', '--json', prompt], {
-        stdio: ['pipe', 'pipe', 'pipe'],
-        env: { ...process.env },
-      })
-
-      const session: AcpSession = { proc, conn: null, sessionId: null, initialized: false }
-      this.activeSession = session
-
-      let fullText = ''
-      const readline = require('node:readline')
-      const rl = readline.createInterface({ input: proc.stdout! })
-      rl.on('line', (line: string) => {
-        try {
-          const event = JSON.parse(line)
-          if (event.type === 'item.completed' && event.item?.type === 'agent_message' && typeof event.item.text === 'string') {
-            fullText += event.item.text
-            onChunk(event.item.text)
-          }
-        } catch {
-          // skip non-JSON lines
-        }
-      })
-
-      proc.stderr?.on('data', (d: Buffer) => {
-        console.error(`[codex] ${d.toString().trim()}`)
-      })
-
-      proc.stdin!.end()
-
-      proc.on('close', (code) => {
-        this.activeSession = null
-        if (code === 0 || fullText) {
-          resolve(fullText)
-        } else {
-          reject(new Error(`Codex exited with code ${code}`))
-        }
-      })
-
-      proc.on('error', (err) => {
-        this.activeSession = null
-        reject(err)
-      })
-    })
+    throw new Error(`Could not find ${pkg}. Run: pnpm add ${pkg}`)
   }
 
   cancel(): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       acp-extension-claude:
         specifier: ^0.21.0
         version: 0.21.0
+      acp-extension-codex:
+        specifier: ^0.10.0
+        version: 0.10.0
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -80,7 +83,7 @@ importers:
         version: 34.5.8
       electron-builder:
         specifier: ^26.0.12
-        version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
+        version: 26.8.1(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1))
       electron-vite:
         specifier: ^3.1.0
         version: 3.1.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))
@@ -695,105 +698,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -920,79 +907,66 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -1077,28 +1051,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -1292,6 +1262,46 @@ packages:
 
   acp-extension-claude@0.21.0:
     resolution: {integrity: sha512-DwRRgYRXsA8TAMSA205Q9HEIl/soxNdEt5DlUivHqJMxv16I2uwJ8TKjzsDidBIpB/4vnXhBeBuihFycKcCJlA==}
+    hasBin: true
+
+  acp-extension-codex-darwin-arm64@0.10.0:
+    resolution: {integrity: sha512-YkRkWG+osG+mf8QgaYqteKHIuzqiU4XD3nzQAT+XjfVvh7xGOnBJGV5e3U3qlf0WJuKiBUDARpugy9CGB4ZjVQ==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  acp-extension-codex-darwin-x64@0.10.0:
+    resolution: {integrity: sha512-RFHO7xCKePPKHSmcadnTtmIK7Qd0CiXbjFfj2obv4bXC7edNgDAU5RVeLPIvG6nfnJIZ3iDIU/O3eWaUixV5rg==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  acp-extension-codex-linux-arm64@0.10.0:
+    resolution: {integrity: sha512-v4xhT3mTBSloewFoixX1sq/KnrwhaR5yVk65Ms830HY0+sRGpgWQ1N9G83Yo2Aik/VhCVEiR/qjoWcJGGUcmXg==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  acp-extension-codex-linux-x64@0.10.0:
+    resolution: {integrity: sha512-moK4grQe2XaS5P/jL/HCia3z0HgBHXdUZLRP/WWTaouQFY5U4bvQv0dQIpwdPPOWkPguVIV4+3WKP2VdA2X8cg==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  acp-extension-codex-win32-arm64@0.10.0:
+    resolution: {integrity: sha512-plrB26PtpfP1VsU9XKwV0IwzAQrQWFSRvvBfIbe54cWH50jntY7U8qDfjNM92T/Wkivw9U3VY/yTabVjjgwKBQ==}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+
+  acp-extension-codex-win32-x64@0.10.0:
+    resolution: {integrity: sha512-WjLM52b7nSK5N5HlCrGLgs0vuKfgYeOJn3PNmeS/TS8fwgIw7vuXpafoJV8tW/EcZibVAfgZFbrKFp2Rr3XiKQ==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  acp-extension-codex@0.10.0:
+    resolution: {integrity: sha512-vpyXIe1uvf8sFpzOChK/4Msf70+VyYEcs2OC2HbHIhQnYIX86dTslPI/rDLb9BOpG2S4WicFnybheuDGR3AIRw==}
     hasBin: true
 
   acp-extension-core@0.0.5:
@@ -2127,28 +2137,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4061,6 +4067,33 @@ snapshots:
       acp-extension-core: 0.0.5
       zod: 4.3.6
 
+  acp-extension-codex-darwin-arm64@0.10.0:
+    optional: true
+
+  acp-extension-codex-darwin-x64@0.10.0:
+    optional: true
+
+  acp-extension-codex-linux-arm64@0.10.0:
+    optional: true
+
+  acp-extension-codex-linux-x64@0.10.0:
+    optional: true
+
+  acp-extension-codex-win32-arm64@0.10.0:
+    optional: true
+
+  acp-extension-codex-win32-x64@0.10.0:
+    optional: true
+
+  acp-extension-codex@0.10.0:
+    optionalDependencies:
+      acp-extension-codex-darwin-arm64: 0.10.0
+      acp-extension-codex-darwin-x64: 0.10.0
+      acp-extension-codex-linux-arm64: 0.10.0
+      acp-extension-codex-linux-x64: 0.10.0
+      acp-extension-codex-win32-arm64: 0.10.0
+      acp-extension-codex-win32-x64: 0.10.0
+
   acp-extension-core@0.0.5: {}
 
   agent-base@6.0.2:
@@ -4103,7 +4136,7 @@ snapshots:
 
   app-builder-bin@5.0.0-alpha.12: {}
 
-  app-builder-lib@26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1):
+  app-builder-lib@26.8.1(dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1))(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1)):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/asar': 3.4.1
@@ -4456,7 +4489,7 @@ snapshots:
 
   dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1):
     dependencies:
-      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
+      app-builder-lib: 26.8.1(dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1))(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1))
       builder-util: 26.8.1
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
@@ -4499,16 +4532,16 @@ snapshots:
 
   electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1):
     dependencies:
-      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
+      app-builder-lib: 26.8.1(dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1))(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1))
       builder-util: 26.8.1
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
       - dmg-builder
       - supports-color
 
-  electron-builder@26.8.1(electron-builder-squirrel-windows@26.8.1):
+  electron-builder@26.8.1(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1)):
     dependencies:
-      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
+      app-builder-lib: 26.8.1(dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1))(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1))
       builder-util: 26.8.1
       builder-util-runtime: 9.5.1
       chalk: 4.1.2


### PR DESCRIPTION
## Summary
- Route both Claude Code and Codex CLI through a single ACP protocol path, replacing the old `codex exec --json` shim
- Add `AGENT_CONFIGS` map so new agents only need a config entry, no routing logic
- Implement ACP client-side terminal/fs handlers so agents can execute commands and read files
- Fix terminal process leaks, cap output buffer, remove all `any` types

## Changes
- `packages/app/src/main/acp.ts` — refactored ACP manager
- `packages/app/package.json` — added `acp-extension-codex` dependency

## Test plan
- [x] Claude Code AI mode works (no regression from #3)
- [x] Codex CLI AI mode works via ACP (tool calls + streaming response)
- [x] `electron-vite build` passes
- [x] Verify both agents on a fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Submitter: @graydawnc