### PR TITLE
fix: parse sync timestamp as UTC in SourcesPanel

### DIFF
--- a/packages/app/src/renderer/components/SourcesPanel.tsx
+++ b/packages/app/src/renderer/components/SourcesPanel.tsx
@@ -40,7 +40,8 @@ const PLATFORM_COLORS: Record<string, string> = {
 
 function formatSyncTime(iso: string | null): string {
   if (!iso) return 'never synced'
-  const diff = Date.now() - new Date(iso).getTime()
+  const utcIso = iso.endsWith('Z') ? iso : iso + 'Z'
+  const diff = Date.now() - new Date(utcIso).getTime()
   const mins = Math.floor(diff / 60000)
   if (mins < 1) return 'just now'
   if (mins < 60) return `${mins}m ago`


### PR DESCRIPTION
## Summary
- `formatSyncTime` in SourcesPanel parsed SQLite UTC timestamps (without `Z` suffix) as local time, causing freshly synced sources to show "8h ago" in UTC+8 timezone
- Append `Z` suffix before parsing to ensure UTC interpretation, consistent with `formatTimeAgo` in StatusBar

## Test plan
- [x] Verified locally that sync time displays correctly after syncing

🤖 Generated with [Claude Code](https://claude.com/claude-code)