### PR TITLE
fix: cli build fails due to missing bin/spool.js

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,21 @@ on:
   pull_request:
 
 jobs:
+  unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @spool/core build
+      - run: pnpm --filter @spool/cli build
+      - run: pnpm --filter @spool/cli test
+
   e2e:
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ out/
 packages/*/dist/
 packages/*/out/
 packages/app/out/
-packages/cli/bin/
 
 # Electron build
 dist-electron/

--- a/packages/cli/bin/spool.js
+++ b/packages/cli/bin/spool.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/index.js'

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,13 +15,15 @@
   "scripts": {
     "build": "tsc && chmod +x bin/spool.js",
     "dev": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "vitest run"
   },
   "dependencies": {
     "@spool/core": "workspace:*",
     "commander": "^13.1.0"
   },
   "devDependencies": {
-    "@types/node": "^22.15.3"
+    "@types/node": "^22.15.3",
+    "vitest": "^3.1.2"
   }
 }

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import { existsSync, statSync } from 'node:fs'
+
+const BIN = resolve(import.meta.dirname, '..', 'bin', 'spool.js')
+
+describe('cli entry point', () => {
+  it('bin/spool.js exists and is executable', () => {
+    expect(existsSync(BIN)).toBe(true)
+    const mode = statSync(BIN).mode
+    expect(mode & 0o111).toBeGreaterThan(0)
+  })
+
+  it('--help prints usage', () => {
+    const out = execFileSync('node', [BIN, '--help'], { encoding: 'utf8' })
+    expect(out).toContain('Usage: spool')
+    expect(out).toContain('search')
+    expect(out).toContain('sync')
+  })
+
+  it('--version prints version', () => {
+    const out = execFileSync('node', [BIN, '--version'], { encoding: 'utf8' })
+    expect(out.trim()).toMatch(/^\d+\.\d+\.\d+$/)
+  })
+
+  it('unknown command exits with error', () => {
+    expect(() =>
+      execFileSync('node', [BIN, 'nonexistent'], { encoding: 'utf8', stdio: 'pipe' })
+    ).toThrow()
+  })
+})

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       '@types/node':
         specifier: ^22.15.3
         version: 22.19.15
+      vitest:
+        specifier: ^3.1.2
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)
 
   packages/core:
     dependencies:
@@ -1277,7 +1280,6 @@ packages:
 
   acp-extension-codex-darwin-arm64@0.10.0:
     resolution: {integrity: sha512-YkRkWG+osG+mf8QgaYqteKHIuzqiU4XD3nzQAT+XjfVvh7xGOnBJGV5e3U3qlf0WJuKiBUDARpugy9CGB4ZjVQ==}
-    cpu: [arm64]
     os: [darwin]
     hasBin: true
 


### PR DESCRIPTION
## Summary
- `package.json` declared `"bin": "./bin/spool.js"` but the file never existed — `chmod +x bin/spool.js` failed
- Added the missing shebang entry point (`bin/spool.js`)
- Removed `packages/cli/bin/` from `.gitignore` (source file, not build artifact)
- Added smoke tests for CLI (--help, --version, unknown command) using vitest

## Test plan
- [x] `pnpm --filter @spool/cli run build` succeeds
- [x] `pnpm --filter @spool/cli run test` — 4 tests pass
- [x] `node packages/cli/bin/spool.js --help` prints usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)