### PR TITLE
fix(opencli): always append well-known Node manager paths to avoid error

### DIFF
--- a/packages/core/src/opencli/manager.ts
+++ b/packages/core/src/opencli/manager.ts
@@ -212,10 +212,12 @@ export class OpenCLIManager {
   /** Build a PATH that includes common Node manager dirs — needed for macOS GUI apps. */
   private getFullPath(): string {
     if (this._fullPath) return this._fullPath
-    const base = process.env['PATH'] ?? ''
     const home = homedir()
 
-    // Try user's login shell for full PATH (zsh first — macOS default, then bash)
+    // Try user's login shell for full PATH (zsh first — macOS default, then bash).
+    // Note: `zsh -lc` is non-interactive so it won't source .zshrc where
+    // nvm/fnm are typically initialised — we always append well-known dirs below.
+    let basePath = process.env['PATH'] ?? ''
     const shells = [
       process.env['SHELL'] ?? 'zsh',
       'bash',
@@ -223,23 +225,24 @@ export class OpenCLIManager {
     for (const sh of shells) {
       try {
         const shellPath = execSync(`${sh} -lc "echo \\$PATH"`, { encoding: 'utf8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim()
-        if (shellPath && shellPath !== base) {
-          this._fullPath = shellPath
-          return shellPath
+        if (shellPath && shellPath !== basePath) {
+          basePath = shellPath
+          break
         }
       } catch {}
     }
 
-    // Fallback: well-known paths + nvm version dirs
+    // Always prepend well-known Node manager paths — login shell may miss them
     const nvmBins = this.nvmVersionBins(home)
     const extras = [
       '/opt/homebrew/bin',
       '/usr/local/bin',
       `${home}/.local/bin`,
       `${home}/.nvm/current/bin`,
+      `${home}/.fnm/aliases/default/bin`,
       ...nvmBins,
     ]
-    this._fullPath = [...extras, base].join(':')
+    this._fullPath = [...extras, basePath].join(':')
     return this._fullPath
   }
 


### PR DESCRIPTION
Try to fix: #13 