### PR TITLE
fix: prevent electron-builder auto-publish in CI release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,10 @@ jobs:
         run: pnpm --filter @spool/core build
 
       - name: Build app (arm64 DMG)
-        run: pnpm --filter @spool/app build
+        run: |
+          cd packages/app
+          npx electron-vite build
+          npx electron-builder --mac --arm64 --publish never
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
 


### PR DESCRIPTION
## Summary
- electron-builder was crashing in CI because it tried to auto-publish to GitHub Releases without `GH_TOKEN` being set in the build step
- Added `--publish never` to the electron-builder command so it only generates artifacts (DMG, ZIP, latest-mac.yml) without publishing
- The existing `gh release upload` step handles the actual upload

## Test plan
- [ ] Trigger the Release workflow manually and verify it completes successfully
- [ ] Verify DMG, ZIP, and latest-mac.yml are all uploaded to the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Submitter: @graydawnc