### PR TITLE
Improve session resume UX in search and detail views

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -31,6 +31,7 @@ export default function App() {
   const [syncStatus, setSyncStatus] = useState<{ phase: string; count: number; total: number } | null>(null)
   const [status, setStatus] = useState<StatusInfo | null>(null)
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // AI mode state
   const [searchMode, setSearchMode] = useState<SearchMode>('fast')
@@ -48,6 +49,7 @@ export default function App() {
   const [showCaptureModal, setShowCaptureModal] = useState(false)
   const [showSettings, setShowSettings] = useState(false)
   const [captureSources, setCaptureSources] = useState<Array<{ label: string; count: number }>>([])
+  const [resumeToastSource, setResumeToastSource] = useState<'claude' | 'codex' | null>(null)
 
 
   const isHomeMode = homeMode && view === 'search' && !selectedSession
@@ -70,6 +72,12 @@ export default function App() {
 
   // Detect available ACP agents on mount
   useEffect(() => { refreshAgents() }, [])
+
+  useEffect(() => {
+    return () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current)
+    }
+  }, [])
 
   // Listen for AI streaming chunks and tool calls
   useEffect(() => {
@@ -249,11 +257,17 @@ export default function App() {
     if (query.trim() && searchMode === 'fast') doSearch(query)
   }, [query, searchMode, doSearch, refreshCaptureSources])
 
+  const handleCopySessionId = useCallback((source: FragmentResult['source']) => {
+    setResumeToastSource(source === 'claude' ? 'claude' : 'codex')
+    if (toastTimer.current) clearTimeout(toastTimer.current)
+    toastTimer.current = setTimeout(() => setResumeToastSource(null), 3200)
+  }, [])
+
   const activeAgentName = availableAgents.find(a => a.id === aiAgent)?.name ?? aiAgent
   const hasAgents = availableAgents.length > 0
 
   return (
-    <div className="flex flex-col h-screen bg-warm-bg dark:bg-dark-bg text-warm-text dark:text-dark-text">
+    <div className="relative flex flex-col h-screen bg-warm-bg dark:bg-dark-bg text-warm-text dark:text-dark-text">
       <div className="flex flex-col flex-1 min-h-0">
         {isHomeMode ? (
           <HomeView
@@ -298,7 +312,7 @@ export default function App() {
 
             <div className="flex-1 min-h-0 overflow-hidden">
               {view === 'session' && selectedSession ? (
-                <SessionDetail sessionUuid={selectedSession} />
+                <SessionDetail sessionUuid={selectedSession} onCopySessionId={handleCopySessionId} />
               ) : (
                 <div className="h-full flex flex-col overflow-hidden">
                   {/* AI answer card — shown above results in AI mode */}
@@ -328,7 +342,12 @@ export default function App() {
                     </div>
                   ) : (
                     <div className="flex-1 min-h-0">
-                      <FragmentResults results={results} query={query} onOpenSession={handleOpenSession} />
+                      <FragmentResults
+                        results={results}
+                        query={query}
+                        onOpenSession={handleOpenSession}
+                        onCopySessionId={handleCopySessionId}
+                      />
                     </div>
                   )}
                 </div>
@@ -345,6 +364,10 @@ export default function App() {
         onSourcesClick={() => setShowSourcesPanel(true)}
         onSettingsClick={() => setShowSettings(true)}
       />
+
+      {resumeToastSource && (
+        <ResumeToast source={resumeToastSource} />
+      )}
 
       {/* Modals */}
       {showOnboarding && (
@@ -369,6 +392,23 @@ export default function App() {
       {showSettings && (
         <SettingsPanel onClose={() => { setShowSettings(false); refreshAgents() }} />
       )}
+    </div>
+  )
+}
+
+function ResumeToast({ source }: { source: 'claude' | 'codex' }) {
+  const command = source === 'claude' ? 'claude -r' : 'codex resume'
+  const suffix = source === 'claude'
+    ? 'then then paste the id to resume this session'
+    : 'then paste the id to resume this session'
+
+  return (
+    <div className="pointer-events-none absolute bottom-10 left-1/2 z-40 -translate-x-1/2 animate-in fade-in duration-150 px-4">
+      <div className="rounded-full border border-warm-border dark:border-dark-border bg-warm-surface2/95 dark:bg-dark-surface2/95 px-4 py-2 shadow-lg backdrop-blur-sm">
+        <p className="whitespace-nowrap text-xs text-warm-text dark:text-dark-text">
+          Write <code className="rounded bg-warm-bg dark:bg-dark-bg px-1.5 py-0.5 font-mono text-[11px]">{command}</code> {suffix}
+        </p>
+      </div>
     </div>
   )
 }

--- a/packages/app/src/renderer/components/ContinueActions.tsx
+++ b/packages/app/src/renderer/components/ContinueActions.tsx
@@ -1,19 +1,19 @@
 import { useState } from 'react'
 import type { FragmentResult } from '@spool/core'
 
-interface Props {
+type Props = {
   result: FragmentResult
   onOpenSession: (uuid: string) => void
+  onCopySessionId: (source: FragmentResult['source']) => void
 }
 
-export default function ContinueActions({ result, onOpenSession }: Props) {
+export default function ContinueActions({ result, onOpenSession, onCopySessionId }: Props) {
   const [copied, setCopied] = useState(false)
   const [resuming, setResuming] = useState(false)
 
-  const plainSnippet = result.snippet.replace(/<\/?mark>/g, '')
-
   async function handleCopy() {
-    await window.spool.copyFragment(plainSnippet)
+    await navigator.clipboard.writeText(result.sessionUuid)
+    onCopySessionId(result.source)
     setCopied(true)
     setTimeout(() => setCopied(false), 1500)
   }
@@ -26,23 +26,18 @@ export default function ContinueActions({ result, onOpenSession }: Props) {
 
   return (
     <div className="flex items-center gap-1 mt-2">
-      <ActionButton onClick={handleCopy} title="Copy fragment to clipboard">
-        {copied ? (
-          <>
-            <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
-              <path d="M2 7L5 10L11 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
-            Copied
-          </>
-        ) : (
-          <>
-            <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+      <ActionButton onClick={handleCopy} title="Copy session ID for CLI resume">
+        <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+          {copied ? (
+            <path d="M2 7L5 10L11 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+          ) : (
+            <>
               <rect x="4.5" y="4.5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.2"/>
               <path d="M8.5 4.5V3C8.5 2.17 7.83 1.5 7 1.5H3C2.17 1.5 1.5 2.17 1.5 3V7C1.5 7.83 2.17 8.5 3 8.5H4.5" stroke="currentColor" strokeWidth="1.2"/>
-            </svg>
-            Copy
-          </>
-        )}
+            </>
+          )}
+        </svg>
+        Copy Session ID
       </ActionButton>
 
       {result.source === 'claude' && (

--- a/packages/app/src/renderer/components/FragmentResults.tsx
+++ b/packages/app/src/renderer/components/FragmentResults.tsx
@@ -2,13 +2,14 @@ import { useState } from 'react'
 import type { FragmentResult, CaptureResult, SearchResult } from '@spool/core'
 import ContinueActions from './ContinueActions.js'
 
-interface Props {
+type Props = {
   results: SearchResult[]
   query: string
   onOpenSession: (uuid: string) => void
+  onCopySessionId: (source: FragmentResult['source']) => void
 }
 
-export default function FragmentResults({ results, query, onOpenSession }: Props) {
+export default function FragmentResults({ results, query, onOpenSession, onCopySessionId }: Props) {
   const [activeFilter, setActiveFilter] = useState('all')
 
   if (results.length === 0) {
@@ -61,7 +62,7 @@ export default function FragmentResults({ results, query, onOpenSession }: Props
           {filtered.map((result, i) =>
             result.kind === 'capture'
               ? <CaptureRow key={`cap-${result.captureId}`} result={result} />
-              : <FragmentRow key={`frag-${result.sessionUuid}-${i}`} result={result} onOpenSession={onOpenSession} />
+              : <FragmentRow key={`frag-${result.sessionUuid}-${i}`} result={result} onOpenSession={onOpenSession} onCopySessionId={onCopySessionId} />
           )}
         </div>
       </div>
@@ -69,7 +70,15 @@ export default function FragmentResults({ results, query, onOpenSession }: Props
   )
 }
 
-function FragmentRow({ result, onOpenSession }: { result: FragmentResult & { kind: 'fragment' }; onOpenSession: (uuid: string) => void }) {
+function FragmentRow({
+  result,
+  onOpenSession,
+  onCopySessionId,
+}: {
+  result: FragmentResult & { kind: 'fragment' }
+  onOpenSession: (uuid: string) => void
+  onCopySessionId: (source: FragmentResult['source']) => void
+}) {
   const snippet = result.snippet.replace(/<mark>/g, '<strong>').replace(/<\/mark>/g, '</strong>')
   const date = formatDate(result.startedAt)
   const project = result.project.split('/').pop() ?? result.project
@@ -91,7 +100,7 @@ function FragmentRow({ result, onOpenSession }: { result: FragmentResult & { kin
         {result.sessionTitle}
       </p>
 
-      <ContinueActions result={result} onOpenSession={onOpenSession} />
+      <ContinueActions result={result} onOpenSession={onOpenSession} onCopySessionId={onCopySessionId} />
     </div>
   )
 }

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -2,11 +2,12 @@ import { useEffect, useState } from 'react'
 import type { Session, Message } from '@spool/core'
 import MessageBubble from './MessageBubble.js'
 
-interface Props {
+type Props = {
   sessionUuid: string
+  onCopySessionId: (source: Session['source']) => void
 }
 
-export default function SessionDetail({ sessionUuid }: Props) {
+export default function SessionDetail({ sessionUuid, onCopySessionId }: Props) {
   const [session, setSession] = useState<Session | null>(null)
   const [messages, setMessages] = useState<Message[]>([])
   const [loading, setLoading] = useState(true)
@@ -38,16 +39,35 @@ export default function SessionDetail({ sessionUuid }: Props) {
     )
   }
 
+  async function handleCopySessionId() {
+    await navigator.clipboard.writeText(session.sessionUuid)
+    onCopySessionId(session.source)
+  }
+
   return (
     <div className="flex flex-col h-full">
       {/* Session header */}
-      <div className="flex-none px-4 py-2 border-b border-neutral-100 dark:border-neutral-800">
-        <p className="text-xs font-medium text-neutral-500 truncate">{session.projectDisplayPath}</p>
-        <p className="text-sm text-neutral-800 dark:text-neutral-200 mt-0.5 truncate">{session.title ?? '(no title)'}</p>
-        <p className="text-xs text-neutral-400 mt-0.5">
-          {formatDate(session.startedAt)} · {session.messageCount} messages
-          {session.model && ` · ${session.model}`}
-        </p>
+      <div className="flex items-end justify-between gap-3 flex-none px-4 py-2 border-b border-neutral-100 dark:border-neutral-800">
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-medium text-neutral-500 truncate">{session.projectDisplayPath}</p>
+          <p className="text-sm text-neutral-800 dark:text-neutral-200 mt-0.5 truncate">{session.title ?? '(no title)'}</p>
+          <p className="text-xs text-neutral-400 mt-0.5">
+            {formatDate(session.startedAt)} · {session.messageCount} messages
+            {session.model && ` · ${session.model}`}
+          </p>
+        </div>
+
+        <button
+          onClick={handleCopySessionId}
+          title="Copy session ID for CLI resume"
+          className="flex items-center gap-1.5 self-end text-xs text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 rounded px-2.5 py-1 transition-colors flex-none"
+        >
+          <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+            <rect x="4.5" y="4.5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.2"/>
+            <path d="M8.5 4.5V3C8.5 2.17 7.83 1.5 7 1.5H3C2.17 1.5 1.5 2.17 1.5 3V7C1.5 7.83 2.17 8.5 3 8.5H4.5" stroke="currentColor" strokeWidth="1.2"/>
+          </svg>
+          Copy Session ID
+        </button>
       </div>
 
       {/* Messages */}


### PR DESCRIPTION
@doodlewind 

This is the 2nd PR, this lets you copy the session id so you can do `codex resume <session-id>` or `claude -r <session-id>` to return to that session.

This code was written by GPT 5.4 high with my supervision.

Added:
- Search results now have `Copy Session ID`.
- Copying shows resume instructions for Claude or Codex.
- Session detail also has a `Copy Session ID` action.

### Button to copy in the search results:

<img width="1720" height="1240" alt="Spool 2026-03-29 22 57 13" src="https://github.com/user-attachments/assets/5cc8a230-a948-4c7f-a56f-b89771b49e0e" />

### When clicking on the button it shows a toast on how to resume (different command for codex / claude)

<img width="1720" height="1240" alt="2026-03-29_Spool_22-57-18@2x" src="https://github.com/user-attachments/assets/8a5becc2-2dd8-46a6-bcea-ed3fdffc2426" />

### Shows copy button in the session details also

<img width="1720" height="1240" alt="2026-03-29_Spool_22-57-35@2x" src="https://github.com/user-attachments/assets/3cc2cd51-54bb-4fda-b026-6de3323fb06d" />