### PR TITLE
Support profile-based Claude/Codex session discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pnpm build
 
 Spool indexes your AI conversations and bookmarks into a single local search box.
 
-- **AI sessions** — watches `~/.claude/` and `~/.codex/` in real time
+- **AI sessions** — watches Claude/Codex session dirs in real time, including profile-based paths like `~/.claude-profiles/*/projects` and `~/.codex-profiles/*/sessions`
 - **Bookmarks & stars** — pulls from 50+ platforms via [OpenCLI](https://github.com/jackwener/opencli)
 - **URL capture** — save any URL with `Cmd+K`
 - **Agent search** — a `/spool` skill inside Claude Code feeds matching fragments back into your conversation

--- a/packages/app/src/renderer/components/FragmentResults.tsx
+++ b/packages/app/src/renderer/components/FragmentResults.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import type { FragmentResult, CaptureResult, SearchResult } from '@spool/core'
 import ContinueActions from './ContinueActions.js'
 
-interface Props {
+type Props = {
   results: SearchResult[]
   query: string
   onOpenSession: (uuid: string) => void
@@ -78,7 +78,10 @@ function FragmentRow({ result, onOpenSession }: { result: FragmentResult & { kin
     <div data-testid="fragment-row" className="px-4 py-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors">
       <div className="flex items-center gap-2 mb-1.5">
         <SourceBadge source={result.source} />
-        <span className="text-xs text-warm-muted dark:text-dark-muted truncate flex-1">You discussed this · {project}</span>
+        <span className="text-xs text-warm-muted dark:text-dark-muted truncate flex-1">
+          You discussed this · {project}
+          {result.profileLabel && <span> · {result.profileLabel}</span>}
+        </span>
         <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
       </div>
 

--- a/packages/core/src/db/queries.ts
+++ b/packages/core/src/db/queries.ts
@@ -229,6 +229,7 @@ export function searchFragments(
       m.timestamp   AS messageTimestamp,
       sess.id       AS sessionId,
       sess.session_uuid AS sessionUuid,
+      sess.file_path AS filePath,
       sess.title    AS sessionTitle,
       sess.started_at AS startedAt,
       p.display_path AS project,
@@ -245,18 +246,23 @@ export function searchFragments(
   `
 
   return (db.prepare(sql).all(...params) as Array<Record<string, unknown>>).map(
-    (row, i) => ({
-      rank: i + 1,
-      sessionId: row['sessionId'] as number,
-      sessionUuid: row['sessionUuid'] as string,
-      sessionTitle: (row['sessionTitle'] as string | null) ?? '(no title)',
-      source: row['source'] as 'claude' | 'codex',
-      project: row['project'] as string,
-      startedAt: row['startedAt'] as string,
-      snippet: row['snippet'] as string,
-      messageRole: row['messageRole'] as string,
-      messageTimestamp: row['messageTimestamp'] as string,
-    }),
+    (row, i) => {
+      const profileLabel = getProfileLabelFromFilePath(row['filePath'] as string)
+
+      return {
+        rank: i + 1,
+        sessionId: row['sessionId'] as number,
+        sessionUuid: row['sessionUuid'] as string,
+        sessionTitle: (row['sessionTitle'] as string | null) ?? '(no title)',
+        source: row['source'] as 'claude' | 'codex',
+        ...(profileLabel ? { profileLabel } : {}),
+        project: row['project'] as string,
+        startedAt: row['startedAt'] as string,
+        snippet: row['snippet'] as string,
+        messageRole: row['messageRole'] as string,
+        messageTimestamp: row['messageTimestamp'] as string,
+      }
+    },
   )
 }
 
@@ -303,6 +309,11 @@ function rowToSession(r: Record<string, unknown>): Session {
     projectDisplayPath: r['projectDisplayPath'] as string,
     projectDisplayName: r['projectDisplayName'] as string,
   }
+}
+
+function getProfileLabelFromFilePath(filePath: string): string | undefined {
+  const match = filePath.match(/\/\.(?:claude|codex)-profiles\/([^/]+)\//)
+  return match?.[1]
 }
 
 // ── OpenCLI / Captures ──────────────────────────────────────────────────────

--- a/packages/core/src/sync/source-paths.test.ts
+++ b/packages/core/src/sync/source-paths.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { detectSessionSource, getSessionRoots } from './source-paths.js'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('getSessionRoots', () => {
+  test('should normalize configured profile roots to their session directories', () => {
+    const baseDir = mkdtempSync(join(tmpdir(), 'spool-source-paths-'))
+    tempDirs.push(baseDir)
+
+    const workProfile = join(baseDir, 'work')
+    const personalProjects = join(baseDir, 'personal', 'projects')
+    mkdirSync(join(workProfile, 'projects'), { recursive: true })
+    mkdirSync(personalProjects, { recursive: true })
+
+    vi.stubEnv('SPOOL_CLAUDE_DIR', `${workProfile}\n${personalProjects}`)
+
+    expect(getSessionRoots('claude')).toEqual([
+      join(workProfile, 'projects'),
+      personalProjects,
+    ])
+  })
+})
+
+describe('detectSessionSource', () => {
+  test('should classify profile-backed Claude and Codex session files correctly', () => {
+    const baseDir = mkdtempSync(join(tmpdir(), 'spool-source-detect-'))
+    tempDirs.push(baseDir)
+
+    const claudeRoot = join(baseDir, 'claude-work', 'projects')
+    const codexRoot = join(baseDir, 'codex-personal', 'sessions')
+    mkdirSync(join(claudeRoot, 'project-a'), { recursive: true })
+    mkdirSync(join(codexRoot, '2026', '03', '29'), { recursive: true })
+
+    const sourceRoots = {
+      claude: [claudeRoot],
+      codex: [codexRoot],
+    } as const
+
+    expect(detectSessionSource(join(claudeRoot, 'project-a', 'session.jsonl'), sourceRoots)).toBe('claude')
+    expect(detectSessionSource(join(codexRoot, '2026', '03', '29', 'rollout.jsonl'), sourceRoots)).toBe('codex')
+    expect(detectSessionSource(join(baseDir, 'other', 'session.jsonl'), sourceRoots)).toBeUndefined()
+  })
+})

--- a/packages/core/src/sync/source-paths.ts
+++ b/packages/core/src/sync/source-paths.ts
@@ -1,0 +1,100 @@
+import { existsSync, readdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { basename, delimiter, isAbsolute, join, relative, resolve } from 'node:path'
+
+export type SessionSource = 'claude' | 'codex'
+
+const SOURCE_DIR_NAMES: Record<SessionSource, string> = {
+  claude: 'projects',
+  codex: 'sessions',
+}
+
+const SOURCE_ENV_VARS: Record<SessionSource, string> = {
+  claude: 'SPOOL_CLAUDE_DIR',
+  codex: 'SPOOL_CODEX_DIR',
+}
+
+const SOURCE_DEFAULT_BASES: Record<SessionSource, string> = {
+  claude: '.claude',
+  codex: '.codex',
+}
+
+const SOURCE_PROFILE_BASES: Record<SessionSource, string> = {
+  claude: '.claude-profiles',
+  codex: '.codex-profiles',
+}
+
+export function getSessionRoots(source: SessionSource): string[] {
+  const configured = process.env[SOURCE_ENV_VARS[source]]
+  if (configured) {
+    return dedupePaths(splitConfiguredPaths(configured).map(path => normalizeSourceRoot(source, path)))
+  }
+
+  const home = homedir()
+  const childDir = SOURCE_DIR_NAMES[source]
+  const roots = [join(home, SOURCE_DEFAULT_BASES[source], childDir)]
+  const profilesBase = join(home, SOURCE_PROFILE_BASES[source])
+
+  let entries: import('node:fs').Dirent<string>[] = []
+  try {
+    entries = readdirSync(profilesBase, { withFileTypes: true, encoding: 'utf8' })
+  } catch {
+    return roots
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name.startsWith('.')) continue
+    roots.push(join(profilesBase, entry.name, childDir))
+  }
+
+  return dedupePaths(roots)
+}
+
+export function detectSessionSource(
+  filePath: string,
+  sourceRoots: Record<SessionSource, string[]> = {
+    claude: getSessionRoots('claude'),
+    codex: getSessionRoots('codex'),
+  },
+): SessionSource | undefined {
+  for (const source of ['claude', 'codex'] as const) {
+    if (sourceRoots[source].some(root => isWithinRoot(filePath, root))) {
+      return source
+    }
+  }
+  return undefined
+}
+
+function splitConfiguredPaths(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .flatMap(part => part.split(delimiter))
+    .map(part => part.trim())
+    .filter(Boolean)
+}
+
+function normalizeSourceRoot(source: SessionSource, filePath: string): string {
+  const resolvedPath = resolve(expandHome(filePath))
+  const childDir = SOURCE_DIR_NAMES[source]
+  if (basename(resolvedPath) === childDir) return resolvedPath
+
+  const nestedPath = join(resolvedPath, childDir)
+  return existsSync(nestedPath) ? nestedPath : resolvedPath
+}
+
+function expandHome(filePath: string): string {
+  if (filePath === '~') return homedir()
+  if (filePath.startsWith('~/')) return join(homedir(), filePath.slice(2))
+  return filePath
+}
+
+function dedupePaths(paths: string[]): string[] {
+  return Array.from(new Set(paths.map(path => resolve(expandHome(path)))))
+}
+
+function isWithinRoot(filePath: string, root: string): boolean {
+  const resolvedFile = resolve(filePath)
+  const resolvedRoot = resolve(root)
+  const rel = relative(resolvedRoot, resolvedFile)
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+}

--- a/packages/core/src/sync/syncer.ts
+++ b/packages/core/src/sync/syncer.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os'
 import type Database from 'better-sqlite3'
 import { parseClaudeSession, decodeProjectSlug } from '../parsers/claude.js'
 import { parseCodexSession } from '../parsers/codex.js'
+import { getSessionRoots } from './source-paths.js'
 import {
   getSourceId,
   getOrCreateProject,
@@ -32,13 +33,15 @@ export class Syncer {
   }
 
   syncAll(): SyncResult {
-    const claudeDir = process.env['SPOOL_CLAUDE_DIR'] ?? join(homedir(), '.claude', 'projects')
-    const codexDir = process.env['SPOOL_CODEX_DIR'] ?? join(homedir(), '.codex', 'sessions')
-
+    const seenPaths = new Set<string>()
     const files: Array<{ path: string; source: 'claude' | 'codex' }> = []
 
-    try { files.push(...collectJSONL(claudeDir, 'claude')) } catch { /* dir may not exist */ }
-    try { files.push(...collectJSONL(codexDir, 'codex')) } catch { /* dir may not exist */ }
+    for (const dir of getSessionRoots('claude')) {
+      try { addUniqueFiles(files, seenPaths, collectJSONL(dir, 'claude')) } catch { /* dir may not exist */ }
+    }
+    for (const dir of getSessionRoots('codex')) {
+      try { addUniqueFiles(files, seenPaths, collectJSONL(dir, 'codex')) } catch { /* dir may not exist */ }
+    }
 
     this.onProgress?.({ phase: 'scanning', count: 0, total: files.length })
 
@@ -123,6 +126,18 @@ export class Syncer {
       } catch { /* ignore log errors */ }
       return 'error'
     }
+  }
+}
+
+function addUniqueFiles(
+  files: Array<{ path: string; source: 'claude' | 'codex' }>,
+  seenPaths: Set<string>,
+  candidates: Array<{ path: string; source: 'claude' | 'codex' }>,
+): void {
+  for (const candidate of candidates) {
+    if (seenPaths.has(candidate.path)) continue
+    seenPaths.add(candidate.path)
+    files.push(candidate)
   }
 }
 

--- a/packages/core/src/sync/watcher.ts
+++ b/packages/core/src/sync/watcher.ts
@@ -1,7 +1,7 @@
 import chokidar, { type FSWatcher } from 'chokidar'
 import { join } from 'node:path'
-import { homedir } from 'node:os'
 import type { Syncer } from './syncer.js'
+import { detectSessionSource, getSessionRoots } from './source-paths.js'
 // No native module dependencies — uses node:sqlite via @spool/core
 
 export type WatcherEvent = 'new-sessions'
@@ -12,16 +12,19 @@ export class SpoolWatcher {
   private listeners: WatcherEventCallback[] = []
   private pendingNew = 0
   private flushTimer: ReturnType<typeof setTimeout> | null = null
+  private sourceRoots: Record<'claude' | 'codex', string[]> = {
+    claude: [],
+    codex: [],
+  }
 
   constructor(private syncer: Syncer) {}
 
   start(): void {
-    const claudeBase = process.env['SPOOL_CLAUDE_DIR'] ?? join(homedir(), '.claude', 'projects')
-    const codexBase = process.env['SPOOL_CODEX_DIR'] ?? join(homedir(), '.codex', 'sessions')
-    const patterns = [
-      join(claudeBase, '**', '*.jsonl'),
-      join(codexBase, '**', '*.jsonl'),
-    ]
+    this.sourceRoots = {
+      claude: getSessionRoots('claude'),
+      codex: getSessionRoots('codex'),
+    }
+    const patterns = [...this.sourceRoots.claude, ...this.sourceRoots.codex].map(root => join(root, '**', '*.jsonl'))
 
     this.watcher = chokidar.watch(patterns, {
       persistent: true,
@@ -48,7 +51,8 @@ export class SpoolWatcher {
   }
 
   private handleFile(filePath: string): void {
-    const source = filePath.includes('/.claude/') ? 'claude' : 'codex'
+    const source = detectSessionSource(filePath, this.sourceRoots)
+    if (!source) return
     const result = this.syncer.syncFile(filePath, source)
 
     if (result === 'added' || result === 'updated') {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -60,6 +60,7 @@ export interface FragmentResult {
   sessionUuid: string
   sessionTitle: string
   source: Source
+  profileLabel?: string
   project: string
   startedAt: string
   snippet: string

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/landing/public/index.html
+++ b/packages/landing/public/index.html
@@ -943,7 +943,7 @@ Spool<span class="dot">.</span></a>
       <div class="step">
         <div class="step-number">02</div>
         <h3>Index everything</h3>
-        <p>Spool watches <code>~/.claude/</code> and <code>~/.codex/</code> in real time. Every agent conversation, searchable the moment it's written.</p>
+        <p>Spool watches your Claude and Codex session directories in real time, including profile-based paths. Every agent conversation is searchable the moment it's written.</p>
       </div>
       <div class="step">
         <div class="step-number">03</div>
@@ -971,7 +971,7 @@ Spool<span class="dot">.</span></a>
           <p>Spool watches your session directories in real time. Every conversation you have with Claude Code or Codex becomes searchable the moment it's written. No manual export, no copy-paste.</p>
         </div>
         <div class="feature-visual">
-          <div class="line"><span class="dim">~/.claude/sessions/</span></div>
+          <div class="line"><span class="dim">~/.claude/projects/</span></div>
           <div class="line" style="margin-top: 4px">
             <span class="prompt">&#9654;</span>
             <span class="highlight">auth-middleware-rewrite</span>


### PR DESCRIPTION
This PR adds the following user-facing changes:

- Spool can now find sessions from profile directories like `work` and `personal`, not just the default Claude/Codex locations. (expected profile locations are ~/.codex-profiles/* and ~/.claude-profiles/*)
- Search results show the profile label, like `work` or `personal`, when applicable.

<img width="862" height="622" alt="2026-03-29_Spool_23-12-57" src="https://github.com/user-attachments/assets/54cd19ec-b38f-421a-afe2-47eaecd2a00d" />
