### PR TITLE
fix: tray click crashes after closing recreated window

### DIFF
--- a/packages/app/e2e/window-lifecycle.spec.ts
+++ b/packages/app/e2e/window-lifecycle.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './helpers/launch'
+
+let ctx: AppContext
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+test('window recovers after close → activate cycle', async () => {
+  const { app } = ctx
+
+  // Close the window
+  const firstWindow = await app.firstWindow()
+  await firstWindow.close()
+
+  // Trigger activate (same code path as tray click)
+  await app.evaluate(({ app: a }) => a.emit('activate'))
+  const restored = await app.firstWindow()
+  await expect(restored.locator('h1')).toContainText('Spool')
+
+  // Second cycle — this is where the bug manifested
+  await restored.close()
+  await app.evaluate(({ app: a }) => a.emit('activate'))
+  const restoredAgain = await app.firstWindow()
+  await expect(restoredAgain.locator('h1')).toContainText('Spool')
+})

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -44,6 +44,11 @@ function createWindow(): BrowserWindow {
     win.loadFile(join(__dirname, '../renderer/index.html'))
   }
 
+  win.on('closed', () => {
+    mainWindow = null
+    app.dock?.hide()
+  })
+
   return win
 }
 
@@ -96,21 +101,17 @@ app.whenReady().then(() => {
   // Auto-updater (only runs in packaged builds)
   setupAutoUpdater(() => mainWindow)
 
-  // Background mode — hide from dock when window is closed
-  mainWindow.on('closed', () => {
-    mainWindow = null
-    app.dock?.hide()
-  })
 
-  setupTray(() => {
-    if (mainWindow) {
+  function showOrCreateWindow() {
+    if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.show()
-      app.dock?.show()
     } else {
       mainWindow = createWindow()
-      app.dock?.show()
     }
-  }, () => {
+    app.dock?.show()
+  }
+
+  setupTray(showOrCreateWindow, () => {
     syncer.syncAll()
   })
 
@@ -124,14 +125,7 @@ app.whenReady().then(() => {
     globalShortcut.unregister('CommandOrControl+K')
   })
 
-  app.on('activate', () => {
-    if (!mainWindow) {
-      mainWindow = createWindow()
-      app.dock?.show()
-    } else {
-      mainWindow.show()
-    }
-  })
+  app.on('activate', showOrCreateWindow)
 })
 
 app.on('window-all-closed', (e) => {


### PR DESCRIPTION
## Problem

Opening Spool → closing the main window → clicking tray to reopen → closing again → clicking tray a second time triggers:

```
Uncaught Exception:
TypeError: Object has been destroyed
  at Tray.<anonymous>
```

## Root Cause

The `closed` event handler (which sets `mainWindow = null`) was only bound to the **initial** BrowserWindow created in `app.whenReady()`. When the tray click or `activate` event created a **new** window, that window never got the `closed` handler. On its next close:

1. `mainWindow` still references the destroyed BrowserWindow (not `null`)
2. Tray click calls `mainWindow.show()` on the destroyed object → crash

## Fix

- **Move `closed` handler into `createWindow()`** — every window now clears the `mainWindow` reference on close
- **Extract `showOrCreateWindow()`** — shared by tray click and `app.on('activate')`, eliminating duplicated logic
- **Add `isDestroyed()` guard** — defensive check so even if `closed` doesn't fire, the app won't crash
- **Add e2e test** — covers two close→reopen cycles via the `activate` event (same code path as tray click)

## Test plan

- [x] `pnpm --filter @spool/app test:e2e` — new `window-lifecycle.spec.ts` passes
- [x] Manual: open Spool → close window → tray click → close → tray click → window opens without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)