### PR TITLE
fix: use POSIX-compatible regex in install.sh

### DIFF
--- a/packages/landing/public/install.sh
+++ b/packages/landing/public/install.sh
@@ -21,9 +21,9 @@ command -v curl >/dev/null || err "curl is required."
 # ── Find latest release DMG ──
 info "Finding latest release..."
 DOWNLOAD_URL=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-  | grep -o '"browser_download_url":\s*"[^"]*arm64\.dmg"' \
+  | grep -oE '"browser_download_url":[[:space:]]*"[^"]*arm64\.dmg"' \
   | head -1 \
-  | sed 's/"browser_download_url":\s*"//;s/"//')
+  | sed -E 's/"browser_download_url":[[:space:]]*"//;s/"//')
 
 [[ -n "$DOWNLOAD_URL" ]] || err "Could not find DMG in latest release."
 


### PR DESCRIPTION
Closes #21

## Problem

`install.sh` uses `\s` in `grep` and `sed` patterns to match whitespace. `\s` is a PCRE shorthand that macOS BSD sed/grep does not support — it's silently treated as a literal `s` character, causing the URL extraction to fail:

```
curl: (3) URL rejected: Malformed input to a URL function
```

**Before (broken on macOS):**
```bash
grep -o '"browser_download_url":\s*"[^"]*arm64\.dmg"'
sed 's/"browser_download_url":\s*"//;s/"//'
```

The `sed` only strips `"browser_download_urls` (matching literal `s`), leaving a malformed URL.

## Fix

Replace `\s` with the POSIX character class `[[:space:]]` and add `-E` flag for extended regex:

```bash
grep -oE '"browser_download_url":[[:space:]]*"[^"]*arm64\.dmg"'
sed -E 's/"browser_download_url":[[:space:]]*"//;s/"//'
```

## Verification

```bash
# Before fix — outputs malformed result:
echo '"browser_download_url": "https://example.com/Spool-0.2.1-arm64.dmg"' \
  | sed 's/"browser_download_url":\s*"//;s/"//'
# => browser_download_url": "https://example.com/Spool-0.2.1-arm64.dmg"

# After fix — correct output:
echo '"browser_download_url": "https://example.com/Spool-0.2.1-arm64.dmg"' \
  | sed -E 's/"browser_download_url":[[:space:]]*"//;s/"//'
# => https://example.com/Spool-0.2.1-arm64.dmg
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)