### PR TITLE
feat: display user-renamed session titles

### DIFF
--- a/packages/core/src/parsers/claude.test.ts
+++ b/packages/core/src/parsers/claude.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { parseClaudeSession } from './claude.js'
+
+function writeTmpSession(lines: Record<string, unknown>[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'spool-test-'))
+  const fp = join(dir, 'session.jsonl')
+  writeFileSync(fp, lines.map(l => JSON.stringify(l)).join('\n'))
+  return fp
+}
+
+const baseRecord = (overrides: Record<string, unknown>) => ({
+  sessionId: 'test-uuid',
+  cwd: '/tmp',
+  timestamp: '2026-01-01T00:00:00Z',
+  ...overrides,
+})
+
+describe('parseClaudeSession', () => {
+  it('uses first user message as title by default', () => {
+    const fp = writeTmpSession([
+      baseRecord({ type: 'user', uuid: 'u1', message: { role: 'user', content: 'Help me fix the login bug' } }),
+      baseRecord({ type: 'assistant', uuid: 'a1', message: { role: 'assistant', content: 'Sure', model: 'claude-opus-4-6' } }),
+    ])
+    const result = parseClaudeSession(fp)
+    expect(result?.title).toBe('Help me fix the login bug')
+  })
+
+  it('uses custom-title when present', () => {
+    const fp = writeTmpSession([
+      baseRecord({ type: 'user', uuid: 'u1', message: { role: 'user', content: 'Help me fix the login bug' } }),
+      baseRecord({ type: 'custom-title', customTitle: 'login-bugfix' }),
+      baseRecord({ type: 'assistant', uuid: 'a1', message: { role: 'assistant', content: 'Sure', model: 'claude-opus-4-6' } }),
+    ])
+    const result = parseClaudeSession(fp)
+    expect(result?.title).toBe('login-bugfix')
+  })
+
+  it('uses last custom-title when renamed multiple times', () => {
+    const fp = writeTmpSession([
+      baseRecord({ type: 'user', uuid: 'u1', message: { role: 'user', content: 'Help me' } }),
+      baseRecord({ type: 'custom-title', customTitle: 'first-name' }),
+      baseRecord({ type: 'custom-title', customTitle: 'final-name' }),
+      baseRecord({ type: 'assistant', uuid: 'a1', message: { role: 'assistant', content: 'Ok', model: 'claude-opus-4-6' } }),
+    ])
+    const result = parseClaudeSession(fp)
+    expect(result?.title).toBe('final-name')
+  })
+})

--- a/packages/core/src/parsers/claude.ts
+++ b/packages/core/src/parsers/claude.ts
@@ -21,6 +21,7 @@ export function parseClaudeSession(filePath: string): ParsedSession | null {
   let sessionUuid = ''
   let cwd = ''
   let model = ''
+  let customTitle = ''
 
   const SKIP_TYPES = new Set([
     'file-history-snapshot',
@@ -42,6 +43,12 @@ export function parseClaudeSession(filePath: string): ParsedSession | null {
 
     if (!sessionUuid && record['sessionId']) sessionUuid = record['sessionId'] as string
     if (!cwd && record['cwd']) cwd = record['cwd'] as string
+
+    if (type === 'custom-title') {
+      const ct = record['customTitle'] as string | undefined
+      if (ct) customTitle = ct
+      continue
+    }
 
     if (type === 'assistant') {
       const msg = record['message'] as Record<string, unknown> | undefined
@@ -100,9 +107,10 @@ export function parseClaudeSession(filePath: string): ParsedSession | null {
   }
 
   const firstUserMsg = messages.find(m => m.role === 'user' && m.contentText.length > 0 && !m.isSidechain)
-  const title = firstUserMsg
-    ? firstUserMsg.contentText.replace(/<[^>]+>/g, '').trim().slice(0, 120)
-    : '(no title)'
+  const title = customTitle
+    || (firstUserMsg
+      ? firstUserMsg.contentText.replace(/<[^>]+>/g, '').trim().slice(0, 120)
+      : '(no title)')
 
   const timestamps = messages.map(m => m.timestamp).filter(Boolean).sort()
 

--- a/packages/core/src/sync/syncer.ts
+++ b/packages/core/src/sync/syncer.ts
@@ -1,4 +1,4 @@
-import { statSync, readdirSync } from 'node:fs'
+import { statSync, readdirSync, readFileSync } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
 import { homedir } from 'node:os'
 import type Database from 'better-sqlite3'
@@ -26,6 +26,7 @@ export type SyncEventCallback = (event: SyncProgressEvent) => void
 export class Syncer {
   private db: Database.Database
   private onProgress: SyncEventCallback | undefined
+  private codexTitleIndex: Map<string, string> = new Map()
 
   constructor(db: Database.Database, onProgress?: SyncEventCallback) {
     this.db = db
@@ -46,6 +47,7 @@ export class Syncer {
     this.onProgress?.({ phase: 'scanning', count: 0, total: files.length })
 
     const knownMtimes = getAllSessionMtimes(this.db)
+    this.codexTitleIndex = loadCodexSessionIndex()
 
     let added = 0
     let updated = 0
@@ -63,8 +65,22 @@ export class Syncer {
       this.onProgress?.({ phase: 'syncing', count: Math.min(i + BATCH, files.length), total: files.length })
     }
 
+    this.applyCodexTitles()
+
     this.onProgress?.({ phase: 'done', count: files.length, total: files.length })
     return { added, updated, errors }
+  }
+
+  private applyCodexTitles(): void {
+    if (this.codexTitleIndex.size === 0) return
+    const stmt = this.db.prepare(
+      'UPDATE sessions SET title = ? WHERE session_uuid = ? AND title != ?',
+    )
+    this.db.transaction(() => {
+      for (const [uuid, title] of this.codexTitleIndex) {
+        stmt.run(title, uuid, title)
+      }
+    })()
   }
 
   syncFile(filePath: string, source: 'claude' | 'codex', knownMtimes?: Map<string, string>): 'added' | 'updated' | 'skipped' | 'error' {
@@ -80,6 +96,11 @@ export class Syncer {
         : parseCodexSession(filePath)
 
       if (!parsed) return 'skipped'
+
+      if (source === 'codex') {
+        const codexTitle = this.codexTitleIndex.get(parsed.sessionUuid)
+        if (codexTitle) parsed.title = codexTitle
+      }
 
       const sourceId = getSourceId(this.db, source)
       const { slug, displayPath, displayName } = resolveProject(filePath, source, parsed.cwd)
@@ -173,6 +194,21 @@ function walkDir(
       results.push({ path: fullPath, source })
     }
   }
+}
+
+function loadCodexSessionIndex(): Map<string, string> {
+  const titles = new Map<string, string>()
+  try {
+    const raw = readFileSync(join(homedir(), '.codex', 'session_index.jsonl'), 'utf8')
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue
+      try {
+        const rec = JSON.parse(line) as { id?: string; thread_name?: string }
+        if (rec.id && rec.thread_name) titles.set(rec.id, rec.thread_name)
+      } catch { /* skip malformed lines */ }
+    }
+  } catch { /* file may not exist */ }
+  return titles
 }
 
 function resolveProject(


### PR DESCRIPTION
## Summary

Show custom session titles set by users via `/rename` (Claude Code) or `/title` (Codex) in search results, recent sessions, and session detail views.

### How it works

- **Claude Code**: Sessions contain `{"type":"custom-title","customTitle":"..."}` records inline in the JSONL file. The parser now reads these and uses the last one as the session title.
- **Codex**: Custom titles are stored externally in `~/.codex/session_index.jsonl` as `thread_name` keyed by session UUID. The syncer loads this index once per sync and applies titles both during parsing (for new/updated sessions) and as a post-sync pass (for already-synced sessions whose JSONL mtime hasn't changed).
- **Fallback**: Sessions without a custom title continue to use the first user message (truncated to 120 chars).

### Files changed

- `packages/core/src/parsers/claude.ts` — Parse `custom-title` records
- `packages/core/src/sync/syncer.ts` — Load Codex `session_index.jsonl` and apply `thread_name` as title
- `packages/core/src/parsers/claude.test.ts` — Tests for custom title parsing

## Test plan

- [x] Existing core tests pass
- [x] New tests: default title, custom-title override, multiple renames (last wins)
- [x] Local verification: Claude Code renamed sessions show custom title
- [x] Local verification: Codex renamed sessions show custom title

🤖 Generated with [Claude Code](https://claude.com/claude-code)