### PR TITLE
feat: add Linux support (dev + build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "onlyBuiltDependencies": [
       "better-sqlite3",
       "electron",
-      "esbuild"
+      "esbuild",
+      "acp-extension-codex-linux-x64"
     ]
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,7 +6,9 @@
   "main": "./out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",
-    "build": "electron-vite build && electron-builder --mac --arm64",
+    "build": "electron-vite build && electron-builder --publish never",
+    "build:mac": "electron-vite build && electron-builder --mac --arm64",
+    "build:linux": "electron-vite build && electron-builder --linux",
     "build:electron": "electron-vite build",
     "preview": "electron-vite preview",
     "clean": "rm -rf out dist-electron",
@@ -20,7 +22,6 @@
     "@tanstack/react-virtual": "^3.13.6",
     "acp-extension-claude": "^0.21.0",
     "acp-extension-codex": "^0.10.0",
-    "acp-extension-codex-darwin-arm64": "^0.10.0",
     "better-sqlite3": "^11.10.0",
     "bindings": "^1.5.0",
     "electron-updater": "^6.8.3",
@@ -47,6 +48,7 @@
       "node_modules/acp-extension-claude/**",
       "node_modules/acp-extension-codex/**",
       "node_modules/acp-extension-codex-darwin-arm64/**",
+      "node_modules/acp-extension-codex-linux-x64/**",
       "node_modules/acp-extension-core/**",
       "node_modules/@agentclientprotocol/**",
       "node_modules/@anthropic-ai/claude-agent-sdk/**",
@@ -70,6 +72,18 @@
         }
       ]
     },
+    "linux": {
+      "category": "Development",
+      "icon": "resources/icon.png",
+      "target": [
+        {
+          "target": "AppImage"
+        },
+        {
+          "target": "tar.gz"
+        }
+      ]
+    },
     "dmg": {
       "title": "Spool",
       "iconSize": 80,
@@ -86,6 +100,10 @@
         }
       ]
     }
+  },
+  "optionalDependencies": {
+    "acp-extension-codex-darwin-arm64": "^0.10.0",
+    "acp-extension-codex-linux-x64": "^0.10.0"
   },
   "devDependencies": {
     "@electron/rebuild": "^3.7.1",

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -10,7 +10,7 @@ import {
 import { setupTray } from './tray.js'
 import { AcpManager } from './acp.js'
 import { setupAutoUpdater, downloadUpdate, quitAndInstall } from './updater.js'
-import { execSync } from 'node:child_process'
+import { execSync, spawn } from 'node:child_process'
 import type Database from 'better-sqlite3'
 
 // macOS menu bar shows the first menu's label as the app name
@@ -161,12 +161,16 @@ ipcMain.handle('spool:sync-now', () => {
 
 ipcMain.handle('spool:resume-cli', (_e, { sessionUuid, source }: { sessionUuid: string; source: string }) => {
   try {
-    if (source === 'claude') {
-      const script = `tell application "Terminal" to do script "claude --resume ${sessionUuid}"`
-      execSync(`osascript -e '${script}'`)
-    } else {
-      const script = `tell application "Terminal" to activate`
-      execSync(`osascript -e '${script}'`)
+    if (process.platform === 'darwin') {
+      if (source === 'claude') {
+        const script = `tell application "Terminal" to do script "claude --resume ${sessionUuid}"`
+        execSync(`osascript -e '${script}'`)
+      } else {
+        const script = `tell application "Terminal" to activate`
+        execSync(`osascript -e '${script}'`)
+      }
+    } else if (source === 'claude') {
+      spawn('xdg-terminal-exec', ['claude', '--resume', sessionUuid], { stdio: 'ignore', detached: true }).unref()
     }
     return { ok: true }
   } catch (err) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       acp-extension-codex:
         specifier: ^0.10.0
         version: 0.10.0
-      acp-extension-codex-darwin-arm64:
-        specifier: ^0.10.0
-        version: 0.10.0
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -108,6 +105,13 @@ importers:
       vite:
         specifier: ^6.3.3
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)
+    optionalDependencies:
+      acp-extension-codex-darwin-arm64:
+        specifier: ^0.10.0
+        version: 0.10.0
+      acp-extension-codex-linux-x64:
+        specifier: ^0.10.0
+        version: 0.10.0
 
   packages/cli:
     dependencies:
@@ -4178,7 +4182,8 @@ snapshots:
       acp-extension-core: 0.0.5
       zod: 4.3.6
 
-  acp-extension-codex-darwin-arm64@0.10.0: {}
+  acp-extension-codex-darwin-arm64@0.10.0:
+    optional: true
 
   acp-extension-codex-darwin-x64@0.10.0:
     optional: true


### PR DESCRIPTION
## Summary

- Add Linux electron-builder targets (AppImage + tar.gz)
- Move platform-specific codex native binaries (`darwin-arm64`, `linux-x64`) to `optionalDependencies` so install doesn't fail on either platform
- Add platform detection for `resume-cli` handler: uses `xdg-terminal-exec` on Linux (user's default terminal)
- Use `spawn` with args array instead of `execSync` string interpolation to avoid blocking the main process and prevent command injection

## Tested on

- Arch Linux (CachyOS), Wayland, x86_64
- `pnpm dev` works, `pnpm build` produces AppImage + tar.gz, `pnpm test` passes

## Notes

- macOS behavior is unchanged — all existing code paths are preserved
- `xdg-terminal-exec` is the [freedesktop standard](https://www.freedesktop.org/wiki/Software/Xterm/) for launching the user's preferred terminal
- `ELECTRON_OZONE_PLATFORM_HINT=auto` can be set by users for native Wayland support (no code change needed)

## Test plan

- [x] `pnpm install` succeeds on Linux
- [x] `pnpm dev` starts Electron app
- [x] `pnpm build` produces AppImage and tar.gz
- [x] `pnpm test` passes (4/4)
- [ ] Verify macOS build is unaffected (no macOS machine to test)