### PR TITLE
feat: auto-detect terminal for session resume with settings override

### DIFF
--- a/packages/app/src/main/acp.ts
+++ b/packages/app/src/main/acp.ts
@@ -27,6 +27,8 @@ export interface AgentsConfig {
   defaultAgent?: string
   /** Which sort order to use by default in search results */
   defaultSearchSort?: 'relevance' | 'newest' | 'oldest'
+  /** Preferred terminal app for session resume (e.g. "iTerm2", "Warp"). Auto-detected if unset. */
+  terminal?: string
   /** Custom agent definitions (extend beyond builtins) */
   customAgents?: Record<string, {
     name?: string

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -10,7 +10,7 @@ import {
 import { setupTray } from './tray.js'
 import { AcpManager } from './acp.js'
 import { setupAutoUpdater, downloadUpdate, quitAndInstall } from './updater.js'
-import { execSync } from 'node:child_process'
+import { openTerminal } from './terminal.js'
 import type Database from 'better-sqlite3'
 
 // macOS menu bar shows the first menu's label as the app name
@@ -159,17 +159,14 @@ ipcMain.handle('spool:sync-now', () => {
   return syncer.syncAll()
 })
 
-ipcMain.handle('spool:resume-cli', (_e, { sessionUuid, source }: { sessionUuid: string; source: string }) => {
+ipcMain.handle('spool:resume-cli', (_e, { sessionUuid, source, cwd }: { sessionUuid: string; source: string; cwd?: string }) => {
   try {
-    if (source === 'claude') {
-      const script = `tell application "Terminal" to do script "claude --resume ${sessionUuid}"`
-      execSync(`osascript -e '${script}'`)
-    } else {
-      const script = `tell application "Terminal" to activate`
-      execSync(`osascript -e '${script}'`)
-    }
+    const command = source === 'claude' ? `claude --resume ${sessionUuid}` : null
+    const terminal = acpManager.getAgentsConfig().terminal
+    openTerminal(command, terminal, cwd)
     return { ok: true }
   } catch (err) {
+    console.error('[spool:resume-cli]', err)
     return { ok: false, error: String(err) }
   }
 })

--- a/packages/app/src/main/terminal.ts
+++ b/packages/app/src/main/terminal.ts
@@ -1,0 +1,180 @@
+/**
+ * Terminal detection and command execution for session resume.
+ *
+ * Strategy:
+ *   1. If the user has configured a preferred terminal in settings, use that.
+ *   2. Otherwise, check which third-party terminal is currently running via
+ *      AppleScript. If the user has Warp / iTerm / etc. open, that's what
+ *      they use daily.
+ *   3. If no known third-party terminal is running, fall back to Terminal.app.
+ *      This guarantees the resume command always runs — opening the "wrong"
+ *      terminal is acceptable; silently dropping the command is not.
+ *
+ * Per-terminal execution methods:
+ *   - Terminal.app / iTerm2: AppleScript (official scripting dictionaries)
+ *   - Kitty / Alacritty / WezTerm: CLI arguments (designed for this)
+ *   - Warp: Launch Configurations + warp:// URI scheme (official API,
+ *     see https://docs.warp.dev/terminal/sessions/launch-configurations)
+ *
+ * Detection result is cached for the lifetime of the process since the user's
+ * terminal choice doesn't change mid-session.
+ */
+
+import { execSync } from 'node:child_process'
+import { existsSync, writeFileSync, mkdirSync, unlinkSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { shell } from 'electron'
+
+/**
+ * Terminal identifiers. These double as the display names shown in settings
+ * and the keys used in the runners map.
+ */
+export const SUPPORTED_TERMINALS = ['Terminal', 'iTerm2', 'Warp', 'kitty', 'Alacritty', 'WezTerm'] as const
+export type SupportedTerminal = (typeof SUPPORTED_TERMINALS)[number]
+
+/** Third-party terminals to probe, in order of popularity. */
+const THIRD_PARTY: SupportedTerminal[] = ['iTerm2', 'Warp', 'kitty', 'Alacritty', 'WezTerm']
+
+let autoDetectedTerminal: SupportedTerminal | undefined
+
+/**
+ * Auto-detect by checking which terminal app is currently running.
+ * Third-party terminals are checked first — if the user installed and is
+ * running one, they almost certainly prefer it over the built-in Terminal.app.
+ */
+function autoDetect(): SupportedTerminal {
+  if (autoDetectedTerminal !== undefined) return autoDetectedTerminal
+
+  for (const name of THIRD_PARTY) {
+    try {
+      const running = execSync(
+        `osascript -e 'application "${name}" is running'`,
+        { timeout: 2000 },
+      ).toString().trim()
+      if (running === 'true') {
+        autoDetectedTerminal = name
+        return autoDetectedTerminal
+      }
+    } catch { /* app not installed or osascript failed — skip */ }
+  }
+
+  autoDetectedTerminal = 'Terminal'
+  return autoDetectedTerminal
+}
+
+/** Prepend `cd '<cwd>' &&` to a command if cwd is provided. */
+function withCwd(cmd: string, cwd?: string): string {
+  return cwd ? `cd '${cwd}' && ${cmd}` : cmd
+}
+
+/**
+ * Per-terminal command runners. Each takes a shell command string and an
+ * optional cwd, then opens a new terminal window/tab to execute it.
+ */
+const runners: Record<SupportedTerminal, (cmd: string, cwd?: string) => void> = {
+  // Terminal.app — AppleScript `do script`
+  'Terminal': (cmd, cwd) => {
+    execSync(`osascript -e 'tell application "Terminal" to do script "${withCwd(cmd, cwd)}"'`)
+  },
+
+  // iTerm2 — AppleScript `create window with default profile command`
+  'iTerm2': (cmd, cwd) => {
+    const full = withCwd(cmd, cwd)
+    const script = `tell application "iTerm2"
+      activate
+      set w to (create window with default profile command "${full}")
+    end tell`
+    execSync(`osascript -e '${script}'`)
+  },
+
+  // Warp — uses Launch Configurations (official API). We write a fixed-name YAML
+  // config to ~/.warp/launch_configurations/ and open it via warp:// URI scheme.
+  // Docs: https://docs.warp.dev/terminal/sessions/launch-configurations
+  'Warp': (cmd, cwd) => {
+    const configDir = join(homedir(), '.warp', 'launch_configurations')
+    const configName = `spool-resume-${Date.now()}`
+    const configPath = join(configDir, `${configName}.yaml`)
+
+    mkdirSync(configDir, { recursive: true })
+
+    // Clean up stale spool-resume-* configs from previous runs
+    for (const f of readdirSync(configDir)) {
+      if (f.startsWith('spool-resume-')) {
+        try { unlinkSync(join(configDir, f)) } catch {}
+      }
+    }
+
+    writeFileSync(configPath, `---
+name: ${configName}
+windows:
+  - tabs:
+      - title: Session Resume
+        layout:
+          cwd: "${cwd || homedir()}"
+          commands:
+            - exec: ${cmd}
+`)
+    shell.openExternal(`warp://launch/${configName}`)
+  },
+
+  // Kitty — `open --args`; `exec $SHELL` keeps the window alive
+  'kitty': (cmd, cwd) => {
+    execSync(`open -a kitty --args sh -c '${withCwd(cmd, cwd)}; exec $SHELL'`)
+  },
+
+  // Alacritty — uses `-e` flag for command execution
+  'Alacritty': (cmd, cwd) => {
+    execSync(`open -a Alacritty --args -e sh -c '${withCwd(cmd, cwd)}; exec $SHELL'`)
+  },
+
+  // WezTerm — `start --` separates wezterm args from the spawned command
+  'WezTerm': (cmd, cwd) => {
+    execSync(`open -a WezTerm --args start -- sh -c '${withCwd(cmd, cwd)}; exec $SHELL'`)
+  },
+}
+
+/** App bundle paths for installation checks. Terminal.app is always present. */
+const APP_PATHS: Record<SupportedTerminal, string> = {
+  'Terminal': '/System/Applications/Utilities/Terminal.app',
+  'iTerm2': '/Applications/iTerm.app',
+  'Warp': '/Applications/Warp.app',
+  'kitty': '/Applications/kitty.app',
+  'Alacritty': '/Applications/Alacritty.app',
+  'WezTerm': '/Applications/WezTerm.app',
+}
+
+function isInstalled(terminal: SupportedTerminal): boolean {
+  return existsSync(APP_PATHS[terminal])
+}
+
+/**
+ * Resolve which terminal to use: user preference > auto-detection > Terminal.app.
+ * If the user picked a terminal that isn't installed, fall back gracefully.
+ */
+function resolve(preference?: string): SupportedTerminal {
+  if (preference && preference in runners) {
+    const pref = preference as SupportedTerminal
+    if (isInstalled(pref)) return pref
+  }
+  return autoDetect()
+}
+
+/**
+ * Open a terminal and execute a command for session resume.
+ * @param command  Shell command to run, or null to just activate the terminal.
+ * @param preference  User-configured terminal name from settings (optional).
+ * @param cwd  Working directory to open the terminal in (optional).
+ */
+export function openTerminal(command: string | null, preference?: string, cwd?: string): void {
+  const terminal = resolve(preference)
+  // Expand ~ to absolute path (Warp launch configs require absolute paths)
+  const resolvedCwd = cwd?.replace(/^~/, homedir())
+
+  if (!command) {
+    execSync(`osascript -e 'tell application "${terminal}" to activate'`)
+    return
+  }
+
+  runners[terminal](command, resolvedCwd)
+}

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -19,6 +19,7 @@ export interface BuiltinAgent {
 export interface AgentsConfig {
   defaultAgent?: string
   defaultSearchSort?: SearchSortOrder
+  terminal?: string
   customAgents?: Record<string, {
     name?: string
     bin: string
@@ -47,8 +48,8 @@ const api = {
   syncNow: (): Promise<SyncResult> =>
     ipcRenderer.invoke('spool:sync-now'),
 
-  resumeCLI: (sessionUuid: string, source: string): Promise<{ ok: boolean; error?: string }> =>
-    ipcRenderer.invoke('spool:resume-cli', { sessionUuid, source }),
+  resumeCLI: (sessionUuid: string, source: string, cwd?: string): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('spool:resume-cli', { sessionUuid, source, cwd }),
 
   copyFragment: (text: string): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('spool:copy-fragment', { text }),

--- a/packages/app/src/renderer/components/ContinueActions.tsx
+++ b/packages/app/src/renderer/components/ContinueActions.tsx
@@ -20,7 +20,7 @@ export default function ContinueActions({ result, onOpenSession, onCopySessionId
 
   async function handleResume() {
     setResuming(true)
-    await window.spool.resumeCLI(result.sessionUuid, result.source)
+    await window.spool.resumeCLI(result.sessionUuid, result.source, result.cwd)
     setTimeout(() => setResuming(false), 1000)
   }
 

--- a/packages/app/src/renderer/components/SettingsPanel.tsx
+++ b/packages/app/src/renderer/components/SettingsPanel.tsx
@@ -1,6 +1,17 @@
 import { useState, useEffect } from 'react'
 import { DEFAULT_SEARCH_SORT_ORDER, SEARCH_SORT_OPTIONS, type SearchSortOrder } from '../../shared/searchSort.js'
 
+/** Must match SUPPORTED_TERMINALS in main/terminal.ts */
+const TERMINAL_OPTIONS = [
+  { value: '', label: 'Auto-detect' },
+  { value: 'Terminal', label: 'Terminal' },
+  { value: 'iTerm2', label: 'iTerm2' },
+  { value: 'Warp', label: 'Warp' },
+  { value: 'kitty', label: 'Kitty' },
+  { value: 'Alacritty', label: 'Alacritty' },
+  { value: 'WezTerm', label: 'WezTerm' },
+] as const
+
 interface AgentInfo {
   id: string
   name: string
@@ -46,23 +57,13 @@ export default function SettingsPanel({ onClose }: Props) {
     ? config.defaultAgent
     : readyAgents[0]?.id ?? ''
 
-  const selectAgent = async (id: string) => {
-    const next: AgentsConfig = { ...config, defaultAgent: id }
+  const updateConfig = async (patch: Partial<AgentsConfig>) => {
+    const next: AgentsConfig = { ...config, ...patch }
     setConfig(next)
     try {
       await window.spool.setAgentsConfig(next)
     } catch (err) {
-      console.error('Failed to save agent config:', err)
-    }
-  }
-
-  const selectDefaultSearchSort = async (defaultSearchSort: SearchSortOrder) => {
-    const next: AgentsConfig = { ...config, defaultSearchSort }
-    setConfig(next)
-    try {
-      await window.spool.setAgentsConfig(next)
-    } catch (err) {
-      console.error('Failed to save agent config:', err)
+      console.error('Failed to save config:', err)
     }
   }
 
@@ -92,7 +93,7 @@ export default function SettingsPanel({ onClose }: Props) {
                 return (
                   <button
                     key={agent.id}
-                    onClick={() => isReady && selectAgent(agent.id)}
+                    onClick={() => isReady && updateConfig({ defaultAgent: agent.id })}
                     disabled={!isReady}
                     className={`w-full flex items-center gap-3 px-3 py-2.5 border rounded-[8px] text-left transition-colors ${
                       isSelected
@@ -171,7 +172,7 @@ export default function SettingsPanel({ onClose }: Props) {
                 <div className="relative flex-none">
                   <select
                     value={config.defaultSearchSort ?? DEFAULT_SEARCH_SORT_ORDER}
-                    onChange={(event) => selectDefaultSearchSort(event.target.value as SearchSortOrder)}
+                    onChange={(e) => updateConfig({ defaultSearchSort: e.target.value as SearchSortOrder })}
                     aria-label="Default search sort"
                     className="appearance-none h-8 rounded-full border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg pl-3 pr-9 text-xs font-medium text-warm-text dark:text-dark-text outline-none transition-colors hover:border-accent/50 hover:bg-warm-surface2 dark:hover:bg-dark-surface2 focus:border-accent"
                   >
@@ -194,6 +195,41 @@ export default function SettingsPanel({ onClose }: Props) {
             </div>
             <p className="text-[11px] text-warm-faint dark:text-dark-muted mt-2">
               Choose which sort order new search results should use by default.
+            </p>
+          </div>
+
+          {/* Terminal */}
+          <div className="mb-6">
+            <h3 className="text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.04em] uppercase mb-3">
+              Terminal
+            </h3>
+            <div className="px-3 py-2.5 bg-warm-surface dark:bg-dark-surface border border-warm-border dark:border-dark-border rounded-[8px]">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-xs text-warm-muted dark:text-dark-muted">Session resume</span>
+                <div className="relative flex-none">
+                  <select
+                    value={config.terminal ?? ''}
+                    onChange={(e) => updateConfig({ terminal: e.target.value || undefined })}
+                    aria-label="Terminal for session resume"
+                    className="appearance-none h-8 rounded-full border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg pl-3 pr-9 text-xs font-medium text-warm-text dark:text-dark-text outline-none transition-colors hover:border-accent/50 hover:bg-warm-surface2 dark:hover:bg-dark-surface2 focus:border-accent"
+                  >
+                    {TERMINAL_OPTIONS.map(opt => (
+                      <option key={opt.value} value={opt.value}>{opt.label}</option>
+                    ))}
+                  </select>
+                  <svg
+                    aria-hidden="true"
+                    viewBox="0 0 12 12"
+                    className="pointer-events-none absolute right-3 top-1/2 h-3 w-3 -translate-y-1/2 text-warm-muted dark:text-dark-muted"
+                    fill="none"
+                  >
+                    <path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </div>
+              </div>
+            </div>
+            <p className="text-[11px] text-warm-faint dark:text-dark-muted mt-2">
+              Which terminal to open when resuming a session. Auto-detect checks for running third-party terminals.
             </p>
           </div>
 

--- a/packages/core/src/db/queries.ts
+++ b/packages/core/src/db/queries.ts
@@ -232,6 +232,7 @@ export function searchFragments(
       sess.file_path AS filePath,
       sess.title    AS sessionTitle,
       sess.started_at AS startedAt,
+      sess.cwd      AS cwd,
       p.display_path AS project,
       src2.name     AS source,
       snippet(messages_fts, -1, '<mark>', '</mark>', '…', 20) AS snippet
@@ -256,6 +257,7 @@ export function searchFragments(
         sessionTitle: (row['sessionTitle'] as string | null) ?? '(no title)',
         source: row['source'] as 'claude' | 'codex',
         ...(profileLabel ? { profileLabel } : {}),
+        ...(row['cwd'] ? { cwd: row['cwd'] as string } : {}),
         project: row['project'] as string,
         startedAt: row['startedAt'] as string,
         snippet: row['snippet'] as string,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,6 +61,7 @@ export interface FragmentResult {
   sessionTitle: string
   source: Source
   profileLabel?: string
+  cwd?: string
   project: string
   startedAt: string
   snippet: string


### PR DESCRIPTION
## Summary

Session resume previously always opened macOS Terminal.app. This PR adds:

- **Auto-detection of the user's terminal** — checks which third-party terminal is currently running (iTerm2, Warp, Kitty, Alacritty, WezTerm) and uses it for session resume. Falls back to Terminal.app if none are detected.
- **Manual terminal preference in Settings** — users can override auto-detection by selecting a specific terminal from a dropdown. If the chosen terminal isn't installed, falls back gracefully to auto-detect.
- **Session cwd support** — resume now opens the terminal in the session's original working directory, not the home directory.

## How it works

### Terminal detection (`packages/app/src/main/terminal.ts`)
- New module with per-terminal execution strategies:
  - **Terminal.app / iTerm2**: AppleScript (official scripting dictionaries)
  - **Kitty / Alacritty / WezTerm**: CLI arguments (`open -a <app> --args`)
  - **Warp**: [Launch Configurations](https://docs.warp.dev/terminal/sessions/launch-configurations) — writes a temporary YAML config to `~/.warp/launch_configurations/` and opens it via `warp://launch/` URI scheme (Warp's official API, no Accessibility permissions needed)
- Auto-detection runs `osascript -e 'application "X" is running'` for each known third-party terminal, cached for the process lifetime
- Installation check via `existsSync` on `/Applications/<app>.app` prevents selecting a terminal that isn't installed

### Settings UI (`packages/app/src/renderer/components/SettingsPanel.tsx`)
- New "Terminal" section with a dropdown: Auto-detect / Terminal / iTerm2 / Warp / Kitty / Alacritty / WezTerm
- Persisted in `~/.spool/agents.json` as `terminal` field in `AgentsConfig`
- Refactored three duplicate config-save handlers (`selectAgent`, `selectTerminal`, `selectDefaultSearchSort`) into a single `updateConfig` function

### Session cwd (`packages/core/src/types.ts`, `packages/core/src/db/queries.ts`)
- Added `cwd` field to `FragmentResult` (from `sessions.cwd` column, not `projects.display_path`)
- Resume now uses the session's actual working directory, fixing cases where the project record has a stale path

## Files changed

| File | Change |
|------|--------|
| `packages/app/src/main/terminal.ts` | **New** — terminal detection, per-terminal runners, `openTerminal()` |
| `packages/app/src/main/index.ts` | Resume handler delegates to `openTerminal()` with cwd and preference |
| `packages/app/src/main/acp.ts` | Added `terminal` to `AgentsConfig` |
| `packages/app/src/preload/index.ts` | Added `terminal` to config, `cwd` to `resumeCLI` |
| `packages/app/src/renderer/components/SettingsPanel.tsx` | Terminal dropdown + refactored config save |
| `packages/app/src/renderer/components/ContinueActions.tsx` | Pass `result.cwd` to `resumeCLI` |
| `packages/core/src/types.ts` | Added `cwd?` to `FragmentResult` |
| `packages/core/src/db/queries.ts` | Added `sess.cwd` to search query |

## Test plan

- [x] Terminal.app resume works
- [x] Warp resume works (via Launch Configurations)
- [x] Settings dropdown persists terminal preference
- [x] Session opens in correct working directory
- [x] Selecting an uninstalled terminal falls back to auto-detect
- [ ] iTerm2 / Kitty / Alacritty / WezTerm (not installed locally, uses standard APIs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)