### PR TITLE
feat: add Linux support (dev + build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "onlyBuiltDependencies": [
       "better-sqlite3",
       "electron",
-      "esbuild"
+      "esbuild",
+      "acp-extension-codex-linux-x64",
+      "acp-extension-codex-linux-arm64"
     ]
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,7 +6,9 @@
   "main": "./out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",
-    "build": "electron-vite build && electron-builder --mac --arm64",
+    "build": "electron-vite build && electron-builder --publish never",
+    "build:mac": "electron-vite build && electron-builder --mac --arm64",
+    "build:linux": "electron-vite build && electron-builder --linux",
     "build:electron": "electron-vite build",
     "preview": "electron-vite preview",
     "clean": "rm -rf out dist-electron",
@@ -20,7 +22,6 @@
     "@tanstack/react-virtual": "^3.13.6",
     "acp-extension-claude": "^0.21.0",
     "acp-extension-codex": "^0.10.0",
-    "acp-extension-codex-darwin-arm64": "^0.10.0",
     "better-sqlite3": "^11.10.0",
     "bindings": "^1.5.0",
     "electron-updater": "^6.8.3",
@@ -47,6 +48,8 @@
       "node_modules/acp-extension-claude/**",
       "node_modules/acp-extension-codex/**",
       "node_modules/acp-extension-codex-darwin-arm64/**",
+      "node_modules/acp-extension-codex-linux-x64/**",
+      "node_modules/acp-extension-codex-linux-arm64/**",
       "node_modules/acp-extension-core/**",
       "node_modules/@agentclientprotocol/**",
       "node_modules/@anthropic-ai/claude-agent-sdk/**",
@@ -70,6 +73,18 @@
         }
       ]
     },
+    "linux": {
+      "category": "Development",
+      "icon": "resources/icon.png",
+      "target": [
+        {
+          "target": "AppImage"
+        },
+        {
+          "target": "tar.gz"
+        }
+      ]
+    },
     "dmg": {
       "title": "Spool",
       "iconSize": 80,
@@ -86,6 +101,11 @@
         }
       ]
     }
+  },
+  "optionalDependencies": {
+    "acp-extension-codex-darwin-arm64": "^0.10.0",
+    "acp-extension-codex-linux-x64": "^0.10.0",
+    "acp-extension-codex-linux-arm64": "^0.10.0"
   },
   "devDependencies": {
     "@electron/rebuild": "^3.7.1",

--- a/packages/app/src/main/terminal.ts
+++ b/packages/app/src/main/terminal.ts
@@ -20,7 +20,7 @@
  * terminal choice doesn't change mid-session.
  */
 
-import { execSync } from 'node:child_process'
+import { execSync, spawn } from 'node:child_process'
 import { existsSync, writeFileSync, mkdirSync, unlinkSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
@@ -167,9 +167,25 @@ function resolve(preference?: string): SupportedTerminal {
  * @param cwd  Working directory to open the terminal in (optional).
  */
 export function openTerminal(command: string | null, preference?: string, cwd?: string): void {
-  const terminal = resolve(preference)
-  // Expand ~ to absolute path (Warp launch configs require absolute paths)
+  // Expand ~ to absolute path
   const resolvedCwd = cwd?.replace(/^~/, homedir())
+
+  // Linux: use xdg-terminal-exec (freedesktop standard for launching the user's preferred terminal)
+  if (process.platform !== 'darwin') {
+    if (command) {
+      spawn('xdg-terminal-exec', ['sh', '-c', command], {
+        stdio: 'ignore', detached: true, ...(resolvedCwd && { cwd: resolvedCwd }),
+      }).unref()
+    } else {
+      spawn('xdg-terminal-exec', [], {
+        stdio: 'ignore', detached: true, ...(resolvedCwd && { cwd: resolvedCwd }),
+      }).unref()
+    }
+    return
+  }
+
+  // macOS: detect and use the user's preferred terminal app
+  const terminal = resolve(preference)
 
   if (!command) {
     execSync(`osascript -e 'tell application "${terminal}" to activate'`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       acp-extension-codex:
         specifier: ^0.10.0
         version: 0.10.0
-      acp-extension-codex-darwin-arm64:
-        specifier: ^0.10.0
-        version: 0.10.0
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -108,6 +105,16 @@ importers:
       vite:
         specifier: ^6.3.3
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)
+    optionalDependencies:
+      acp-extension-codex-darwin-arm64:
+        specifier: ^0.10.0
+        version: 0.10.0
+      acp-extension-codex-linux-arm64:
+        specifier: ^0.10.0
+        version: 0.10.0
+      acp-extension-codex-linux-x64:
+        specifier: ^0.10.0
+        version: 0.10.0
 
   packages/cli:
     dependencies:
@@ -4178,7 +4185,8 @@ snapshots:
       acp-extension-core: 0.0.5
       zod: 4.3.6
 
-  acp-extension-codex-darwin-arm64@0.10.0: {}
+  acp-extension-codex-darwin-arm64@0.10.0:
+    optional: true
 
   acp-extension-codex-darwin-x64@0.10.0:
     optional: true


### PR DESCRIPTION
- Add Linux electron-builder targets (AppImage + tar.gz)
- Move platform-specific codex native binaries to optionalDependencies (darwin-arm64, linux-x64, linux-arm64)
- Add Linux platform gate in terminal.ts: uses xdg-terminal-exec (freedesktop standard) instead of macOS-only osascript/AppleScript
- Add build:mac and build:linux scripts, default build uses --publish never
- Add linux-arm64 support alongside linux-x64

Based on PR #25 by @2725244134, rebased onto current main and extended with linux-arm64 support and terminal.ts integration.

Co-authored-by: baiye <2725244134@qq.com>

https://claude.ai/code/session_01N5XGgU4C5pNqiQMEhRsPRj