### PR TITLE
fix: stop auto-opening DevTools on window creation

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -39,7 +39,6 @@ function createWindow(): BrowserWindow {
 
   if (process.env['ELECTRON_RENDERER_URL']) {
     win.loadURL(process.env['ELECTRON_RENDERER_URL'])
-    win.webContents.openDevTools()
   } else {
     win.loadFile(join(__dirname, '../renderer/index.html'))
   }


### PR DESCRIPTION
## Summary

- Remove unconditional `win.webContents.openDevTools()` call in `createWindow()`
- In dev mode, DevTools were opened every time a window was created — including when re-activating the app from tray/dock after closing the window, which caused the DevTools panel to appear unexpectedly
- DevTools remain accessible via `Cmd+Option+I` (already in the Electron view menu)

## Test plan

- [x] Run `pnpm dev`, verify the app opens without DevTools
- [x] Close the window, click the tray icon or dock icon to reopen — verify no DevTools
- [x] Press `Cmd+Option+I` — verify DevTools still open manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)