### PR TITLE
fix: add robots.txt, sitemap.xml and fix canonical URL for Google indexing

### DIFF
--- a/packages/landing/public/index.html
+++ b/packages/landing/public/index.html
@@ -16,7 +16,7 @@
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://spool.pro">
+  <meta property="og:url" content="https://spool.pro/">
   <meta property="og:title" content="Spool — The missing search engine for your own data">
   <meta property="og:description" content="Search your Claude Code sessions, ChatGPT history, GitHub stars, Twitter bookmarks, and YouTube likes — locally.">
   <meta property="og:image" content="https://spool.pro/og-image.png">
@@ -31,7 +31,7 @@
   <meta name="twitter:image" content="https://spool.pro/og-image.png">
 
   <!-- SEO -->
-  <link rel="canonical" href="https://spool.pro">
+  <link rel="canonical" href="https://spool.pro/">
   <meta name="robots" content="index, follow">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/packages/landing/public/robots.txt
+++ b/packages/landing/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://spool.pro/sitemap.xml

--- a/packages/landing/public/sitemap.xml
+++ b/packages/landing/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://spool.pro/</loc>
+    <lastmod>2026-04-02</lastmod>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Google Search Console reported "page auto-redirects" preventing indexing.
Root causes:
- Missing robots.txt caused Googlebot to get redirect responses
- Missing sitemap.xml meant no authoritative URL list for crawlers
- Canonical URL lacked trailing slash, conflicting with Cloudflare Pages'
  automatic trailing-slash redirect

https://claude.ai/code/session_01D6cLHztnVDRFkA4k33yJZT