### PR TITLE
fix: improve error handling in CLI status command

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -11,8 +11,13 @@ export const statusCommand = new Command('status')
       console.log(`Size:         ${formatBytes(s.dbSizeBytes)}`)
       console.log(`Sessions:     ${s.totalSessions} total  (claude: ${s.claudeSessions}, codex: ${s.codexSessions})`)
       console.log(`Last synced:  ${s.lastSyncedAt ? formatDate(s.lastSyncedAt) : 'never'}`)
-    } catch {
-      console.log('No index found. Run `spool sync` to create it.')
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('SQLITE_CANTOPEN')) {
+        console.log('No index found. Run `spool sync` to create it.')
+      } else {
+        console.error('Failed to read index:', err instanceof Error ? err.message : err)
+        process.exitCode = 1
+      }
     }
   })
 


### PR DESCRIPTION
## Summary

The `spool status` catch block was swallowing all exceptions and displaying "No index found. Run `spool sync` to create it." regardless of the actual error, masking real issues behind a misleading message.

## Problem

When `better-sqlite3`'s `NODE_MODULE_VERSION` doesn't match the current Node version, `getDB()` throws `ERR_DLOPEN_FAILED`. The catch block treated this as a missing database:

```
$ spool status
No index found. Run `spool sync` to create it.
```

In reality, `~/.spool/spool.db` existed with 47.5MB of data (340+ sessions). The actual problem was a native module version mismatch that the user never got to see.

## Fix

- Only show "No index found" when the error is `SQLITE_CANTOPEN` (database truly doesn't exist)
- Surface all other errors with the actual message and a non-zero exit code

## Test plan

- [x] `spool status` displays index info correctly when DB exists
- [x] Native module errors now show the real error message instead of "No index found"
- [x] Other commands (search, list, show, sync, sources) verified working

Submitted by: @graydawnc

🤖 Generated with [Claude Code](https://claude.com/claude-code)