### PR TITLE
Improve resume-related actions for session search results

### DIFF
--- a/packages/app/e2e/fast-search.spec.ts
+++ b/packages/app/e2e/fast-search.spec.ts
@@ -64,3 +64,19 @@ test('search for non-existent keyword shows no results', async () => {
   await expect(window.locator('text=No results')).toBeVisible({ timeout: 5000 })
   await expect(window.locator('[data-testid="fragment-row"]')).toHaveCount(0)
 })
+
+test('codex search results expose resume-related actions', async () => {
+  const { window } = ctx
+
+  await search(window, 'BASSOON_CANARY_77')
+
+  const row = window.locator('[data-testid="fragment-row"]').first()
+  await expect(row).toBeVisible({ timeout: 5000 })
+  await expect(row.locator('text=codex')).toBeVisible()
+
+  const copyCommand = row.getByRole('button', { name: 'Copy Command' })
+  await expect(copyCommand).toBeVisible()
+
+  const resumeInCli = row.getByRole('button', { name: 'Resume in CLI' })
+  await expect(resumeInCli).toBeVisible()
+})

--- a/packages/app/e2e/fixtures/codex-sessions/2026/01/17/rollout-2026-01-17T12-34-56-11111111-2222-4333-8444-555555555555.jsonl
+++ b/packages/app/e2e/fixtures/codex-sessions/2026/01/17/rollout-2026-01-17T12-34-56-11111111-2222-4333-8444-555555555555.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-01-17T12:34:56Z","type":"session_meta","payload":{"id":"11111111-2222-4333-8444-555555555555","cwd":"/tmp/test-project"}}
+{"timestamp":"2026-01-17T12:34:57Z","type":"turn_context","payload":{"model":"gpt-5-codex","cwd":"/tmp/test-project"}}
+{"timestamp":"2026-01-17T12:35:00Z","type":"event_msg","payload":{"type":"user_message","message":"Where does BASSOON_CANARY_77 get initialized?"}}
+{"timestamp":"2026-01-17T12:35:04Z","type":"event_msg","payload":{"type":"agent_message","message":"BASSOON_CANARY_77 is initialized in src/main.ts during app startup."}}

--- a/packages/app/e2e/helpers/launch.ts
+++ b/packages/app/e2e/helpers/launch.ts
@@ -18,13 +18,15 @@ export async function launchApp(opts: { mockAgent?: 'success' | 'error' } = {}):
   const tmpDir = mkdtempSync(join(tmpdir(), 'spool-e2e-'))
 
   const claudeDir = join(tmpDir, 'claude', 'projects')
+  const codexDir = join(tmpDir, 'codex', 'sessions')
   cpSync(join(FIXTURES_DIR, 'claude-projects'), claudeDir, { recursive: true })
+  cpSync(join(FIXTURES_DIR, 'codex-sessions'), codexDir, { recursive: true })
 
   const env: Record<string, string> = {
     ...process.env as Record<string, string>,
     SPOOL_DATA_DIR: join(tmpDir, 'data'),
     SPOOL_CLAUDE_DIR: claudeDir,
-    SPOOL_CODEX_DIR: join(tmpDir, 'codex', 'sessions'),
+    SPOOL_CODEX_DIR: codexDir,
     ELECTRON_DISABLE_GPU: '1',
   }
 

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -12,6 +12,8 @@ import { setupTray } from './tray.js'
 import { AcpManager } from './acp.js'
 import { setupAutoUpdater, downloadUpdate, quitAndInstall } from './updater.js'
 import { openTerminal } from './terminal.js'
+import { getSessionResumeCommand } from '../shared/resumeCommand.js'
+import { resolveResumeWorkingDirectory } from './sessionResume.js'
 import type Database from 'better-sqlite3'
 import type { SyncWorkerMessage } from './sync-worker.js'
 
@@ -189,9 +191,21 @@ ipcMain.handle('spool:sync-now', () => {
 
 ipcMain.handle('spool:resume-cli', (_e, { sessionUuid, source, cwd }: { sessionUuid: string; source: string; cwd?: string }) => {
   try {
-    const command = source === 'claude' ? `claude --resume ${sessionUuid}` : null
+    const command = getSessionResumeCommand(source, sessionUuid)
+    if (!command) {
+      return { ok: false, error: `Session source "${source}" cannot be resumed from the CLI.` }
+    }
+    const session = getSessionWithMessages(db, sessionUuid)?.session
+    const resumeCwd = session
+      ? resolveResumeWorkingDirectory(session)
+      : resolveResumeWorkingDirectory({
+          source: source as 'claude' | 'codex',
+          cwd: cwd ?? null,
+          projectDisplayPath: '',
+          filePath: '',
+        })
     const terminal = acpManager.getAgentsConfig().terminal
-    openTerminal(command, terminal, cwd)
+    openTerminal(command, terminal, resumeCwd)
     return { ok: true }
   } catch (err) {
     console.error('[spool:resume-cli]', err)

--- a/packages/app/src/main/sessionResume.test.ts
+++ b/packages/app/src/main/sessionResume.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { resolveResumeWorkingDirectory } from './sessionResume.js'
+
+function makeTempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix))
+}
+
+describe('resolveResumeWorkingDirectory', () => {
+  it('uses the stored cwd when it points to an existing directory', () => {
+    const cwd = makeTempDir('spool-resume-cwd-')
+
+    expect(resolveResumeWorkingDirectory({
+      source: 'claude',
+      cwd,
+      projectDisplayPath: '/unused/project',
+      filePath: '/Users/test/.claude/projects/-Users-test-project/session.jsonl',
+    })).toBe(cwd)
+
+    rmSync(cwd, { recursive: true, force: true })
+  })
+
+  it('falls back to the decoded Claude project slug when cwd is missing', () => {
+    const root = makeTempDir('spoolresumeclaude')
+    const projectDir = join(root, 'workspace')
+    mkdirSync(projectDir, { recursive: true })
+    const slug = `-${projectDir.slice(1).replace(/\//g, '-')}`
+    const filePath = join(root, '.claude', 'projects', slug, 'session.jsonl')
+    mkdirSync(join(root, '.claude', 'projects', slug), { recursive: true })
+
+    expect(resolveResumeWorkingDirectory({
+      source: 'claude',
+      cwd: '',
+      projectDisplayPath: 'workspace',
+      filePath,
+    })).toBe(projectDir)
+
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('falls back to projectDisplayPath when cwd is unusable', () => {
+    const projectDir = makeTempDir('spool-resume-project-')
+
+    expect(resolveResumeWorkingDirectory({
+      source: 'codex',
+      cwd: '/path/that/does/not/exist',
+      projectDisplayPath: projectDir,
+      filePath: '/Users/test/.codex/sessions/2026/04/05/rollout.jsonl',
+    })).toBe(projectDir)
+
+    rmSync(projectDir, { recursive: true, force: true })
+  })
+
+  it('returns undefined when no usable working directory is available', () => {
+    expect(resolveResumeWorkingDirectory({
+      source: 'codex',
+      cwd: '/path/that/does/not/exist',
+      projectDisplayPath: '/another/missing/path',
+      filePath: '/Users/test/.codex/sessions/2026/04/05/rollout.jsonl',
+    })).toBeUndefined()
+  })
+})

--- a/packages/app/src/main/sessionResume.ts
+++ b/packages/app/src/main/sessionResume.ts
@@ -1,0 +1,44 @@
+import { existsSync, statSync } from 'node:fs'
+import { basename, dirname } from 'node:path'
+import { homedir } from 'node:os'
+import { decodeProjectSlug, type Session } from '@spool/core'
+
+type ResumeSessionContext = Pick<Session, 'source' | 'cwd' | 'projectDisplayPath' | 'filePath'>
+
+export function resolveResumeWorkingDirectory(session: ResumeSessionContext): string | undefined {
+  const cwd = normalizePath(session.cwd)
+  if (isUsableDirectory(cwd)) return cwd
+
+  if (session.source === 'claude') {
+    const decodedSlugPath = decodeClaudeProjectPath(session.filePath)
+    if (isUsableDirectory(decodedSlugPath)) return decodedSlugPath
+  }
+
+  const projectPath = normalizePath(session.projectDisplayPath)
+  if (isUsableDirectory(projectPath)) return projectPath
+
+  return undefined
+}
+
+function decodeClaudeProjectPath(filePath: string): string | undefined {
+  const slug = basename(dirname(filePath))
+  const decoded = normalizePath(decodeProjectSlug(slug))
+  if (!decoded || !decoded.startsWith('/')) return undefined
+  return decoded
+}
+
+function normalizePath(value: string | null | undefined): string | undefined {
+  if (!value) return undefined
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+  return trimmed.replace(/^~(?=\/|$)/, homedir())
+}
+
+function isUsableDirectory(value: string | undefined): value is string {
+  if (!value) return false
+  try {
+    return existsSync(value) && statSync(value).isDirectory()
+  } catch {
+    return false
+  }
+}

--- a/packages/app/src/main/terminal.ts
+++ b/packages/app/src/main/terminal.ts
@@ -65,7 +65,11 @@ function autoDetect(): SupportedTerminal {
 
 /** Prepend `cd '<cwd>' &&` to a command if cwd is provided. */
 function withCwd(cmd: string, cwd?: string): string {
-  return cwd ? `cd '${cwd}' && ${cmd}` : cmd
+  return cwd ? `cd ${shellQuote(cwd)} && ${cmd}` : cmd
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
 /**

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -10,6 +10,7 @@ import OnboardingFlow from './components/OnboardingFlow.js'
 import SourcesPanel from './components/SourcesPanel.js'
 import CaptureUrlModal from './components/CaptureUrlModal.js'
 import SettingsPanel from './components/SettingsPanel.js'
+import { getSessionResumeCommandPrefix } from '../shared/resumeCommand.js'
 import { DEFAULT_SEARCH_SORT_ORDER, type SearchSortOrder } from '../shared/searchSort.js'
 
 type View = 'search' | 'session'
@@ -52,7 +53,7 @@ export default function App() {
   const [showSettings, setShowSettings] = useState(false)
   const [captureSources, setCaptureSources] = useState<Array<{ label: string; count: number }>>([])
   const [defaultSearchSort, setDefaultSearchSort] = useState<SearchSortOrder>(DEFAULT_SEARCH_SORT_ORDER)
-  const [resumeToastSource, setResumeToastSource] = useState<'claude' | 'codex' | null>(null)
+  const [resumeToastCommand, setResumeToastCommand] = useState<string | null>(null)
 
 
   const isHomeMode = homeMode && view === 'search' && !selectedSession
@@ -264,9 +265,11 @@ export default function App() {
   }, [query, searchMode, doSearch, refreshCaptureSources])
 
   const handleCopySessionId = useCallback((source: FragmentResult['source']) => {
-    setResumeToastSource(source === 'claude' ? 'claude' : 'codex')
+    const command = getSessionResumeCommandPrefix(source)
+    if (!command) return
+    setResumeToastCommand(command)
     if (toastTimer.current) clearTimeout(toastTimer.current)
-    toastTimer.current = setTimeout(() => setResumeToastSource(null), 3200)
+    toastTimer.current = setTimeout(() => setResumeToastCommand(null), 3200)
   }, [])
 
   const activeAgentInfo = availableAgents.find(a => a.id === aiAgent)
@@ -376,8 +379,8 @@ export default function App() {
         onSettingsClick={() => setShowSettings(true)}
       />
 
-      {resumeToastSource && (
-        <ResumeToast source={resumeToastSource} />
+      {resumeToastCommand && (
+        <ResumeToast command={resumeToastCommand} />
       )}
 
       {/* Modals */}
@@ -407,8 +410,7 @@ export default function App() {
   )
 }
 
-function ResumeToast({ source }: { source: 'claude' | 'codex' }) {
-  const command = source === 'claude' ? 'claude -r' : 'codex resume'
+function ResumeToast({ command }: { command: string }) {
   const suffix = 'then paste the id to resume this session'
 
   return (

--- a/packages/app/src/renderer/components/ContinueActions.tsx
+++ b/packages/app/src/renderer/components/ContinueActions.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { FragmentResult } from '@spool/core'
+import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
 
 type Props = {
   result: FragmentResult
@@ -9,7 +10,9 @@ type Props = {
 
 export default function ContinueActions({ result, onOpenSession, onCopySessionId }: Props) {
   const [copied, setCopied] = useState(false)
+  const [commandCopied, setCommandCopied] = useState(false)
   const [resuming, setResuming] = useState(false)
+  const resumeCommand = getSessionResumeCommand(result.source, result.sessionUuid)
 
   async function handleCopy() {
     await navigator.clipboard.writeText(result.sessionUuid)
@@ -22,6 +25,13 @@ export default function ContinueActions({ result, onOpenSession, onCopySessionId
     setResuming(true)
     await window.spool.resumeCLI(result.sessionUuid, result.source, result.cwd)
     setTimeout(() => setResuming(false), 1000)
+  }
+
+  async function handleCopyCommand() {
+    if (!resumeCommand) return
+    await navigator.clipboard.writeText(resumeCommand)
+    setCommandCopied(true)
+    setTimeout(() => setCommandCopied(false), 1500)
   }
 
   return (
@@ -40,7 +50,31 @@ export default function ContinueActions({ result, onOpenSession, onCopySessionId
         Copy Session ID
       </ActionButton>
 
-      {result.source === 'claude' && (
+      {resumeCommand && (
+        <ActionButton onClick={handleCopyCommand} title="Copy the full CLI resume command">
+          {commandCopied ? (
+            <>
+              <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+                <path d="M2 7L5 10L11 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+              Copied Command
+            </>
+          ) : (
+            <>
+              <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+                <path d="M2 3.5H11" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
+                <path d="M2 6.5H8.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
+                <path d="M2 9.5H6.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
+                <path d="M9.5 9.5L11.5 11.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
+                <path d="M11.5 9.5L9.5 11.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
+              </svg>
+              Copy Command
+            </>
+          )}
+        </ActionButton>
+      )}
+
+      {resumeCommand && (
         <ActionButton onClick={handleResume} title="Resume this session in Terminal">
           {resuming ? (
             <>

--- a/packages/app/src/shared/resumeCommand.test.ts
+++ b/packages/app/src/shared/resumeCommand.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { getSessionResumeCommand, getSessionResumeCommandPrefix } from './resumeCommand.js'
+
+describe('getSessionResumeCommandPrefix', () => {
+  it('returns the configured CLI prefix for resumable session sources', () => {
+    expect(getSessionResumeCommandPrefix('claude')).toBe('claude --resume')
+    expect(getSessionResumeCommandPrefix('codex')).toBe('codex resume')
+  })
+
+  it('returns null for unsupported sources', () => {
+    expect(getSessionResumeCommandPrefix('opencli')).toBeNull()
+    expect(getSessionResumeCommandPrefix('unknown-cli')).toBeNull()
+  })
+})
+
+describe('getSessionResumeCommand', () => {
+  it('builds the full shell command with a quoted session id', () => {
+    expect(getSessionResumeCommand('claude', 'test-session-uuid')).toBe("claude --resume 'test-session-uuid'")
+    expect(getSessionResumeCommand('codex', '11111111-2222-4333-8444-555555555555')).toBe("codex resume '11111111-2222-4333-8444-555555555555'")
+  })
+
+  it('escapes embedded single quotes safely', () => {
+    expect(getSessionResumeCommand('claude', "session'with'quotes")).toBe("claude --resume 'session'\\''with'\\''quotes'")
+  })
+})

--- a/packages/app/src/shared/resumeCommand.ts
+++ b/packages/app/src/shared/resumeCommand.ts
@@ -1,0 +1,18 @@
+const RESUME_COMMAND_PREFIXES: Record<string, string> = {
+  claude: 'claude --resume',
+  codex: 'codex resume',
+}
+
+export function getSessionResumeCommandPrefix(source: string): string | null {
+  return RESUME_COMMAND_PREFIXES[source] ?? null
+}
+
+export function getSessionResumeCommand(source: string, sessionUuid: string): string | null {
+  const prefix = getSessionResumeCommandPrefix(source)
+  if (!prefix) return null
+  return `${prefix} ${shellQuote(sessionUuid)}`
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}


### PR DESCRIPTION
## Summary

- add a source-aware `Copy Command` action for resumable search-result sessions
- show `Resume in CLI` for Codex and other resumable sources, not just Claude
- resolve a safer working directory for resume commands, with validation and fallback behavior
- add Codex fixtures and regression coverage for the new resume-related actions

## Testing

- `packages/core/node_modules/.bin/vitest run packages/app/src/shared/resumeCommand.test.ts packages/app/src/main/sessionResume.test.ts`
- `npm_config_cache=/tmp/spool-npm-cache PNPM_HOME=/tmp/spool-pnpm-home PNPM_STORE_DIR=/tmp/spool-pnpm-store npx pnpm --filter @spool/app build:electron`
- `node_modules/.bin/playwright test --config e2e/playwright.config.ts e2e/fast-search.spec.ts`

Closes #37
