### PR TITLE
feat: native Twitter Bookmark sync via connector framework

### DIFF
--- a/docs/connector-sync-architecture.md
+++ b/docs/connector-sync-architecture.md
@@ -1,0 +1,536 @@
+# Connector & Sync Architecture
+
+## Overview
+
+This document defines the architecture for Spool's data source connectors and the universal sync engine that drives them. The goal is to replace the current OpenCLI-centric approach with a plugin-based connector model, starting with native Twitter Bookmark support.
+
+Reference implementation: [fieldtheory-cli](https://github.com/afar1/fieldtheory-cli)
+
+---
+
+## Data Ownership Model
+
+Not all platform data is equal. Spool distinguishes two kinds:
+
+| Kind | Description | Sync strategy | Examples |
+|------|-------------|---------------|----------|
+| **User-owned** | Data the user created, saved, or explicitly curated | Persistent dual-frontier sync | Bookmarks, stars, saved posts, favorites, published content, reviews, following lists, watch history |
+| **Ephemeral** | Public/trending data not tied to user actions | Full-replace cache | Hot topics, trending, rankings, explore feeds, frontpage |
+
+Only user-owned data warrants the full local-first sync treatment. Ephemeral data can be fetched on demand and discarded/re-fetched freely.
+
+### Classification of current OpenCLI strategies
+
+**User-owned (persistent sync):**
+- Twitter: bookmarks, following, notifications
+- Reddit: saved, upvoted
+- YouTube: subscriptions
+- GitHub: stars, notifications
+- Bilibili: favorite, history, feed, dynamic
+- Instagram: saved
+- Facebook: notifications, groups
+- Notion: favorites, sidebar
+- Douban: marks, reviews
+- Xiaohongshu: notifications, creator-notes
+- Douyin: videos, collections
+- Jike: feed, notifications
+- TikTok: following, notifications
+- V2EX: notifications
+- Weibo: feed
+
+**Ephemeral (cache):**
+- HN: top, best, new, show, ask, jobs
+- Reddit: frontpage, popular
+- Bilibili: hot, ranking
+- Weibo: hot
+- Zhihu: hot
+- Xiaohongshu: feed (algorithm-recommended)
+- Douban: movie-hot, book-hot, top250
+- Substack: feed
+- Medium: feed
+- Instagram: explore
+- TikTok: explore
+- V2EX: hot, latest
+- DEV.to: top
+- Lobsters: hot, newest
+- Stack Overflow: hot
+- Wikipedia: trending
+- Steam: top-sellers
+
+**Gray area (timeline/algorithmic feeds):** Twitter timeline, LinkedIn timeline, Reddit hot, Facebook feed — algorithm-ranked, essentially ephemeral.
+
+---
+
+## Connector Interface
+
+A connector is a self-contained module that knows how to authenticate with and fetch data from one specific source. It does NOT know about scheduling, sync state, or storage — those are handled by the framework.
+
+```typescript
+interface Connector {
+  /** Unique identifier, e.g. 'twitter-bookmarks' */
+  id: string
+
+  /** Platform name for grouping, e.g. 'twitter' */
+  platform: string
+
+  /** Human-readable label, e.g. 'X Bookmarks' */
+  label: string
+
+  /** Short description for the connector picker */
+  description: string
+
+  /** UI color for badges/dots */
+  color: string
+
+  /** Whether this is ephemeral (cache) or user-owned (persistent) */
+  ephemeral: boolean
+
+  /** Check if authentication is available */
+  checkAuth(opts?: Record<string, string>): Promise<AuthStatus>
+
+  /**
+   * Fetch one page of data.
+   *
+   * This is the ONLY method a connector must implement for data fetching.
+   * The sync engine calls this repeatedly with cursors to paginate.
+   *
+   * @param cursor - null for first page, otherwise the cursor from previous page
+   * @returns items on this page + cursor for next page (null = no more pages)
+   */
+  fetchPage(cursor: string | null): Promise<PageResult>
+}
+
+interface AuthStatus {
+  ok: boolean
+  error?: string
+  /** Guidance for the user on how to fix auth, e.g. "Log into X in Chrome" */
+  hint?: string
+}
+
+interface PageResult {
+  items: CapturedItem[]
+  /** Cursor for the next page. null means no more data in this direction. */
+  nextCursor: string | null
+}
+```
+
+### Example: Twitter Bookmarks Connector
+
+```typescript
+class TwitterBookmarksConnector implements Connector {
+  id = 'twitter-bookmarks'
+  platform = 'twitter'
+  label = 'X Bookmarks'
+  description = 'Your saved tweets on X'
+  color = '#1DA1F2'
+  ephemeral = false
+
+  async checkAuth() {
+    try {
+      extractChromeXCookies(defaultChromeDir, 'Default')
+      return { ok: true }
+    } catch (e) {
+      return { ok: false, error: e.message, hint: 'Log into X in Chrome, then retry.' }
+    }
+  }
+
+  async fetchPage(cursor: string | null): Promise<PageResult> {
+    const cookies = extractChromeXCookies(...)
+    const response = await fetchGraphQLBookmarks(cookies, cursor)
+    return {
+      items: response.records.map(toCaputredItem),
+      nextCursor: response.nextCursor ?? null,
+    }
+  }
+}
+```
+
+### File structure
+
+```
+packages/core/src/connectors/
+├── types.ts                     ← Connector, AuthStatus, PageResult interfaces
+├── registry.ts                  ← ConnectorRegistry (register, list, get)
+├── sync-engine.ts               ← SyncEngine (dual-frontier logic)
+├── sync-scheduler.ts            ← SyncScheduler (timing, orchestration)
+├── twitter-bookmarks/
+│   ├── index.ts                 ← TwitterBookmarksConnector
+│   ├── chrome-cookies.ts        ← copied from fieldtheory-cli
+│   └── graphql-fetch.ts         ← copied from fieldtheory-cli
+├── github-stars/                ← future
+│   └── index.ts
+└── opencli-generic/             ← wraps OpenCLI as a fallback connector
+    └── index.ts
+```
+
+---
+
+## Sync Engine: Dual-Frontier Model
+
+The sync engine is platform-agnostic. It takes any `Connector` and manages the sync state.
+
+### Concept
+
+```
+[history end] ◄── tail frontier ──── stored data ──── head frontier ──► [newest]
+                   (backfill ←)                        (→ forward)
+```
+
+Two independent frontiers:
+
+- **Head (forward):** Fetches new items added since last sync. Runs frequently (every 15min). Stops when it encounters already-known items or runs out of pages.
+- **Tail (backfill):** Fills in historical data. Runs less frequently (idle time). Stops when it reaches the end of available history or exhausts its page budget.
+
+### Sync State (per connector, stored in DB)
+
+```typescript
+interface SyncState {
+  connectorId: string
+
+  // Head frontier
+  headCursor: string | null      // cursor to resume forward sync
+  headItemId: string | null      // platform_id of newest known item
+
+  // Tail frontier
+  tailCursor: string | null      // cursor to resume backfill
+  tailComplete: boolean          // true = reached end of history
+
+  // Metadata
+  lastForwardSyncAt: string | null
+  lastBackfillSyncAt: string | null
+  totalSynced: number
+  consecutiveErrors: number      // for backoff calculation
+}
+```
+
+### Sync Engine Implementation
+
+```typescript
+class SyncEngine {
+  constructor(private db: Database.Database) {}
+
+  /**
+   * Run a sync cycle for a connector.
+   * The engine handles state, dedup, and stop conditions.
+   * The connector just fetches pages.
+   */
+  async sync(connector: Connector, opts?: SyncOptions): Promise<SyncResult> {
+    if (connector.ephemeral) {
+      return this.syncEphemeral(connector, opts)
+    }
+    return this.syncPersistent(connector, opts)
+  }
+
+  /** Persistent sync: dual-frontier for user-owned data */
+  private async syncPersistent(connector, opts): Promise<SyncResult> {
+    const state = this.loadState(connector.id)
+    let added = 0
+
+    // Phase 1: Forward sync (high priority)
+    // Fetch from newest, stop when we hit known items
+    if (opts?.direction !== 'backfill') {
+      let cursor = null  // start from newest
+      let stalePages = 0
+      for (let page = 0; page < maxPages; page++) {
+        const result = await connector.fetchPage(cursor)
+        const { newCount } = this.upsertItems(connector, result.items)
+        added += newCount
+
+        if (newCount === 0) stalePages++
+        else stalePages = 0
+
+        // Stop conditions
+        if (stalePages >= 3) break            // caught up
+        if (!result.nextCursor) break          // no more pages
+        if (this.hasKnownItem(result.items, state)) break  // overlap
+
+        cursor = result.nextCursor
+        await this.delay(opts?.delayMs ?? 600)
+      }
+      state.headCursor = cursor
+      state.lastForwardSyncAt = new Date().toISOString()
+    }
+
+    // Phase 2: Backfill (lower priority, budget-limited)
+    if (!state.tailComplete && opts?.direction !== 'forward') {
+      let cursor = state.tailCursor  // resume from last position
+      const backfillBudget = opts?.backfillPages ?? 10
+      for (let page = 0; page < backfillBudget; page++) {
+        const result = await connector.fetchPage(cursor)
+        const { newCount } = this.upsertItems(connector, result.items)
+        added += newCount
+
+        if (!result.nextCursor) {
+          state.tailComplete = true
+          break
+        }
+        cursor = result.nextCursor
+        await this.delay(opts?.delayMs ?? 600)
+      }
+      state.tailCursor = cursor
+      state.lastBackfillSyncAt = new Date().toISOString()
+    }
+
+    state.totalSynced += added
+    state.consecutiveErrors = 0
+    this.saveState(state)
+    return { added, total: state.totalSynced }
+  }
+
+  /** Ephemeral sync: full-replace for trending/cache data */
+  private async syncEphemeral(connector, opts): Promise<SyncResult> {
+    // Delete existing items for this connector, fetch fresh
+    this.deleteItems(connector.id)
+    let cursor = null
+    let added = 0
+    const maxPages = opts?.maxPages ?? 5
+    for (let page = 0; page < maxPages; page++) {
+      const result = await connector.fetchPage(cursor)
+      this.insertItems(connector, result.items)
+      added += result.items.length
+      if (!result.nextCursor) break
+      cursor = result.nextCursor
+    }
+    return { added, total: added }
+  }
+}
+```
+
+### Stop conditions for forward sync
+
+The engine stops forward-syncing when ANY of:
+1. **Stale pages**: 3 consecutive pages with 0 new items (caught up)
+2. **Known overlap**: A fetched item's `platformId` already exists in DB
+3. **No cursor**: API returned no `nextCursor` (end of data)
+4. **Budget**: Hit `maxPages` limit
+5. **Timeout**: Exceeded `maxMinutes`
+
+### CapturedItem dedup
+
+All items go through `insertCapture()` which already deduplicates by `(platform, platform_id)`. The sync engine doesn't need its own dedup logic — it just counts how many were new vs. updated to decide stop conditions.
+
+---
+
+## Sync Scheduler
+
+The scheduler is the orchestration layer that decides WHEN to run syncs. It runs in the Electron background worker thread.
+
+### Design Principles
+
+1. **Connectors don't know about scheduling.** A connector is a pure data fetcher.
+2. **Sync engine doesn't know about timing.** It runs one sync cycle when asked.
+3. **Scheduler owns the clock.** It decides what to sync, when, and in what order.
+
+### Schedule Configuration
+
+```typescript
+interface ScheduleConfig {
+  /** Forward sync interval. Default: 15 min */
+  forwardIntervalMs: number
+
+  /** Backfill sync interval. Default: 60 min */
+  backfillIntervalMs: number
+
+  /** Max connectors syncing concurrently. Default: 1 */
+  concurrency: number
+
+  /** Base delay between pages within a sync. Default: 600ms */
+  pageDelayMs: number
+
+  /** Max pages per forward sync cycle. Default: 50 */
+  forwardMaxPages: number
+
+  /** Max pages per backfill cycle. Default: 10 */
+  backfillMaxPages: number
+
+  /** Retry backoff sequence (ms). Default: [1min, 5min, 30min, 2hr] */
+  retryBackoffMs: number[]
+
+  /** Max time for a single sync run. Default: 5 min */
+  maxMinutesPerRun: number
+}
+
+const DEFAULT_SCHEDULE: ScheduleConfig = {
+  forwardIntervalMs: 15 * 60_000,    // 15 min
+  backfillIntervalMs: 60 * 60_000,   // 1 hr
+  concurrency: 1,
+  pageDelayMs: 600,
+  forwardMaxPages: 50,
+  backfillMaxPages: 10,
+  retryBackoffMs: [60_000, 300_000, 1_800_000, 7_200_000],
+  maxMinutesPerRun: 5,
+}
+```
+
+### Scheduler Implementation
+
+```typescript
+class SyncScheduler {
+  private engine: SyncEngine
+  private registry: ConnectorRegistry
+  private queue: PriorityQueue<SyncJob>
+  private running: Map<string, AbortController>
+  private timer: NodeJS.Timeout | null
+
+  constructor(engine: SyncEngine, registry: ConnectorRegistry) { ... }
+
+  /** Start the scheduler. Called on app launch. */
+  start(): void {
+    // 1. Queue immediate forward sync for all enabled connectors
+    // 2. Start the tick loop
+    this.queueAllForward()
+    this.tick()
+  }
+
+  /** Stop all syncs and the timer. Called on app quit. */
+  stop(): void { ... }
+
+  /** Manually trigger sync for a specific connector. */
+  triggerNow(connectorId: string): void {
+    this.queue.push({ connectorId, direction: 'forward', priority: 100 })
+    this.tick()
+  }
+
+  /** The main loop. Runs every few seconds. */
+  private async tick(): Promise<void> {
+    // 1. Check if any connectors are due for forward sync
+    //    (lastForwardSyncAt + forwardIntervalMs < now)
+    // 2. Check if any non-complete connectors are due for backfill
+    //    (lastBackfillSyncAt + backfillIntervalMs < now)
+    // 3. Queue jobs, respecting concurrency limit
+    // 4. Run next job from priority queue
+    // 5. Schedule next tick
+  }
+
+  /** Get status for UI display. */
+  getStatus(): SchedulerStatus {
+    return {
+      connectors: this.registry.list().map(c => ({
+        id: c.id,
+        label: c.label,
+        state: this.engine.loadState(c.id),
+        syncing: this.running.has(c.id),
+      })),
+    }
+  }
+}
+```
+
+### Priority Queue
+
+Jobs are prioritized:
+
+| Priority | Trigger | Description |
+|----------|---------|-------------|
+| 100 | Manual | User clicked "Sync now" |
+| 80 | Launch | First sync after app launch |
+| 60 | Wake | Sync after system wake from sleep |
+| 40 | Interval | Scheduled forward sync |
+| 20 | Backfill | Background history backfill |
+
+Higher priority jobs run first. Only `concurrency` jobs run at once (default: 1 to avoid rate limit issues across platforms).
+
+### Lifecycle Events
+
+| Event | Action |
+|-------|--------|
+| **App launch** | Queue forward sync for all connectors (priority 80) |
+| **System wake** | Queue forward sync for all connectors (priority 60) |
+| **Interval tick** | Check which connectors are due, queue at priority 40 |
+| **Idle time** | Queue backfill for incomplete connectors (priority 20) |
+| **Manual trigger** | Queue specific connector (priority 100) |
+| **Auth change** | Re-check auth, queue if newly available |
+| **Error** | Exponential backoff: skip connector for `retryBackoffMs[consecutiveErrors]` |
+| **App quit** | Graceful stop: finish current page, save state, abort remaining |
+
+### Error Handling & Backoff
+
+```
+consecutiveErrors = 0  →  next sync at normal interval
+consecutiveErrors = 1  →  wait 1 min before retry
+consecutiveErrors = 2  →  wait 5 min
+consecutiveErrors = 3  →  wait 30 min
+consecutiveErrors ≥ 4  →  wait 2 hr (cap)
+```
+
+Auth errors (401/403) are special: the scheduler marks the connector as `needsReauth` and stops scheduling it until the user re-authenticates.
+
+### Checkpoint & Crash Safety
+
+The sync engine writes state to DB after every page (or every N pages for performance). If the app crashes mid-sync:
+- Forward sync: may re-fetch some pages, but dedup prevents duplicates
+- Backfill: resumes from last saved `tailCursor`
+- No data loss, at most some redundant API calls
+
+---
+
+## DB Schema Changes
+
+New table for sync state (replaces `opencli_sources` over time):
+
+```sql
+CREATE TABLE IF NOT EXISTS connector_sync_state (
+  connector_id   TEXT PRIMARY KEY,
+  head_cursor    TEXT,
+  head_item_id   TEXT,
+  tail_cursor    TEXT,
+  tail_complete  INTEGER DEFAULT 0,
+  last_forward_sync_at  TEXT,
+  last_backfill_sync_at TEXT,
+  total_synced   INTEGER DEFAULT 0,
+  consecutive_errors    INTEGER DEFAULT 0,
+  enabled        INTEGER DEFAULT 1,
+  config_json    TEXT    -- per-connector overrides (e.g. chrome profile)
+);
+```
+
+The existing `captures` table is unchanged. The `opencli_src_id` foreign key becomes optional — native connectors set it to NULL and use `connector_id` in `connector_sync_state` instead.
+
+---
+
+## Integration Points
+
+### Electron Main Process
+
+```typescript
+// On app ready
+const registry = new ConnectorRegistry()
+registry.register(new TwitterBookmarksConnector())
+// registry.register(new GitHubStarsConnector())  // future
+
+const engine = new SyncEngine(db)
+const scheduler = new SyncScheduler(engine, registry)
+
+// IPC handlers
+ipcMain.handle('connector:list', () => registry.list())
+ipcMain.handle('connector:check-auth', (_, id) => registry.get(id).checkAuth())
+ipcMain.handle('connector:sync-now', (_, id) => scheduler.triggerNow(id))
+ipcMain.handle('connector:status', () => scheduler.getStatus())
+
+// Start scheduler in worker thread
+scheduler.start()
+```
+
+### Worker Thread
+
+The scheduler and engine run in the existing sync worker thread (`sync-worker.ts`), alongside the file-based session syncer. They share the same DB connection.
+
+### CLI
+
+```bash
+spool sync                    # forward sync all connectors + session files
+spool sync --connector twitter-bookmarks   # sync specific connector
+spool sync --backfill         # run backfill for all incomplete connectors
+spool status                  # show connector states + sync progress
+```
+
+---
+
+## Migration Path
+
+1. **Phase 1**: Implement Connector interface + SyncEngine + TwitterBookmarksConnector. Wire into Electron and CLI. Existing OpenCLI code untouched.
+2. **Phase 2**: Implement SyncScheduler. Replace manual sync triggers with scheduled sync.
+3. **Phase 3**: Remove Twitter-related OpenCLI strategies. Wrap remaining OpenCLI platforms as `OpenCLIGenericConnector` instances using the same Connector interface.
+4. **Phase 4**: Gradually replace high-value OpenCLI strategies with native connectors (GitHub Stars, etc.).
+
+At each phase, existing data can be wiped and re-synced. No backward compatibility needed.

--- a/docs/twitter-bookmark-native.md
+++ b/docs/twitter-bookmark-native.md
@@ -1,0 +1,124 @@
+# Twitter Bookmark Native Support
+
+## Background
+
+Spool currently fetches Twitter bookmarks via OpenCLI (`opencli twitter bookmarks -f json`). This works but depends on an external CLI tool and its browser bridge, adding friction and a layer of indirection.
+
+[fieldtheory-cli](https://github.com/afar1/fieldtheory-cli) is a standalone CLI that syncs X/Twitter bookmarks locally using X's internal GraphQL API, authenticated via Chrome cookie extraction. It's battle-tested, handles rate limiting, pagination, and Chrome DB encryption edge cases well.
+
+Goal: replace the OpenCLI-based Twitter bookmark sync with a native implementation based on fieldtheory-cli's approach, removing the OpenCLI dependency for Twitter entirely.
+
+---
+
+## Decision: Hybrid Copy + Rewrite
+
+### Copy (nearly verbatim)
+
+| File | Lines | Reason |
+|------|-------|--------|
+| `chrome-cookies.ts` | ~230 | Security-sensitive crypto (AES-128-CBC, PBKDF2, macOS Keychain). Handles locked DB, Chrome version differences, multiple browser variants. No benefit to rewriting. |
+| GraphQL fetch + parse from `graphql-bookmarks.ts` | ~250 | X's internal API: query ID, feature flags, response shape parsing (`convertTweetToRecord`, `parseBookmarksResponse`), retry with exponential backoff, rate limit (429) handling, cursor pagination. Getting this right requires exact knowledge of their response format. |
+
+### Rewrite (adapt to spool architecture)
+
+| Component | Reason |
+|-----------|--------|
+| Storage layer | fieldtheory uses JSONL cache + `sql.js`. Spool has `better-sqlite3` with `captures` table + FTS5. Tweets go into `captures` like any other source. |
+| Sync orchestration | New `TwitterBookmarkManager` class paralleling `OpenCLIManager`, writing directly to spool's DB. |
+| Type mapping | Map fieldtheory's `BookmarkRecord` to spool's `CapturedItem` at the boundary. |
+
+### Skip entirely
+
+- OAuth flow (`bookmarks.ts`, `xauth.ts`) -- GraphQL via Chrome cookies is sufficient for macOS
+- Classification system (`bookmark-classify.ts`, `bookmark-classify-llm.ts`) -- spool has its own FTS search
+- JSONL cache layer -- unnecessary when writing directly to SQLite
+- `sql.js` / `sql.js-fts5` dependency -- spool uses `better-sqlite3`
+- Viz/stats/sample/domains CLI commands -- not in scope
+
+### Remove from spool
+
+- Twitter-related OpenCLI strategies (`twitter bookmarks`, `timeline`, `notifications`, `following`) from `strategies.ts`
+- Any existing Twitter bookmark data in the DB (no backward compatibility needed)
+
+---
+
+## Target Architecture
+
+```
+packages/core/src/twitter/
+├── chrome-cookies.ts    -- copied from fieldtheory (minimal adaptation)
+├── graphql-fetch.ts     -- copied: fetch, parse, retry, pagination logic
+├── manager.ts           -- new: TwitterBookmarkManager
+└── types.ts             -- internal BookmarkRecord subset
+```
+
+### TwitterBookmarkManager
+
+Responsibilities:
+1. Extract Chrome cookies (macOS only for now)
+2. Fetch bookmarks via GraphQL with cursor pagination
+3. Parse tweet responses into `BookmarkRecord`
+4. Convert `BookmarkRecord` -> `CapturedItem`
+5. Insert/upsert into existing `captures` table (dedup by `platform_id`)
+6. Emit progress events (same pattern as `OpenCLIManager`)
+7. Track sync state (incremental sync: stop at newest known bookmark)
+
+Interface sketch:
+
+```typescript
+class TwitterBookmarkManager {
+  constructor(db: Database.Database, onProgress?: ProgressCallback)
+
+  /** Check if Chrome cookies are available for X. */
+  checkAuth(opts?: { chromeProfileDirectory?: string }): AuthStatus
+
+  /** Sync bookmarks from X via GraphQL. */
+  syncBookmarks(opts?: SyncOptions): Promise<SyncResult>
+}
+```
+
+### Integration Points
+
+- **Electron IPC**: `twitter:check-auth`, `twitter:sync-bookmarks` handlers alongside existing `opencli:*` handlers
+- **Sync worker**: Called from the background sync worker, same as OpenCLI sync
+- **CLI**: `spool sync` includes Twitter bookmark sync automatically when auth is available
+- **Core exports**: `TwitterBookmarkManager` exported from `@spool/core`
+
+### CapturedItem Mapping
+
+```
+BookmarkRecord.tweetId       -> CapturedItem.platformId
+BookmarkRecord.url           -> CapturedItem.url
+BookmarkRecord.text          -> CapturedItem.contentText
+BookmarkRecord.authorHandle  -> CapturedItem.author
+"twitter"                    -> CapturedItem.platform
+BookmarkRecord.tweetId       -> CapturedItem.platformId
+"tweet"                      -> CapturedItem.contentType
+BookmarkRecord.authorProfileImageUrl -> CapturedItem.thumbnailUrl
+{ engagement, media, links, author, language, ... } -> CapturedItem.metadata (JSON)
+BookmarkRecord.postedAt      -> CapturedItem.capturedAt
+full BookmarkRecord JSON     -> CapturedItem.rawJson
+```
+
+---
+
+## Open Questions (UX/Product)
+
+> To be discussed before implementation.
+
+- How should the Twitter sync be surfaced in the UI? Separate from OpenCLI sources or unified?
+- What does the first-run auth flow look like? (Chrome must be logged into X)
+- Should sync be automatic on app launch, or manual trigger only?
+- How to handle auth failures gracefully in the desktop app?
+- Should we show Twitter-specific metadata (engagement counts, media previews) in search results?
+- Chrome profile selection UX -- how does the user pick which Chrome profile to use?
+
+---
+
+## Dependencies
+
+No new npm dependencies required. All functionality uses Node.js built-ins:
+- `node:crypto` (PBKDF2, AES decryption)
+- `node:child_process` (sqlite3 CLI for Chrome DB, macOS Keychain)
+- `node:fs`, `node:os`, `node:path`
+- Native `fetch` (Node 18+)

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -7,7 +7,9 @@ import {
   OpenCLIManager,
   getOpenCLISourceId, listOpenCLISources, addOpenCLISource, removeOpenCLISource, getCaptureCount,
   getSetupValue, setSetupValue,
+  ConnectorRegistry, SyncEngine, SyncScheduler, TwitterBookmarksConnector,
 } from '@spool/core'
+import type { ConnectorStatus, AuthStatus } from '@spool/core'
 import { setupTray } from './tray.js'
 import { AcpManager } from './acp.js'
 import { setupAutoUpdater, downloadUpdate, quitAndInstall } from './updater.js'
@@ -26,6 +28,8 @@ let syncer: Syncer
 let watcher: SpoolWatcher
 let acpManager: AcpManager
 let opencliManager: OpenCLIManager
+let connectorRegistry: ConnectorRegistry
+let syncScheduler: SyncScheduler
 
 function createWindow(): BrowserWindow {
   const win = new BrowserWindow({
@@ -118,6 +122,16 @@ app.whenReady().then(() => {
   watcher.on('new-sessions', (_event, data) => {
     mainWindow?.webContents.send('spool:new-sessions', data)
   })
+
+  // ── Connector framework ──────────────────────────────────────────────
+  connectorRegistry = new ConnectorRegistry()
+  connectorRegistry.register(new TwitterBookmarksConnector())
+
+  syncScheduler = new SyncScheduler(db, connectorRegistry)
+  syncScheduler.on((event) => {
+    mainWindow?.webContents.send('connector:event', event)
+  })
+  syncScheduler.start()
 
   // Initial sync in worker thread (non-blocking)
   runSyncWorker().then(() => {
@@ -356,4 +370,32 @@ ipcMain.handle('opencli:get-setup-value', (_e, { key }: { key: string }) => {
 ipcMain.handle('opencli:set-setup-value', (_e, { key, value }: { key: string; value: string }) => {
   setSetupValue(db, key, value)
   return { ok: true }
+})
+
+// ── Connector Handlers ──────────────────────────────────────────────────
+
+ipcMain.handle('connector:list', (): ConnectorStatus[] => {
+  return syncScheduler.getStatus().connectors
+})
+
+ipcMain.handle('connector:check-auth', async (_e, { id }: { id: string }): Promise<AuthStatus> => {
+  const connector = connectorRegistry.get(id)
+  return connector.checkAuth()
+})
+
+ipcMain.handle('connector:sync-now', (_e, { id }: { id: string }) => {
+  syncScheduler.triggerNow(id)
+  return { ok: true }
+})
+
+ipcMain.handle('connector:get-status', () => {
+  return syncScheduler.getStatus()
+})
+
+ipcMain.handle('connector:get-capture-count', (_e, { connectorId }: { connectorId: string }) => {
+  const connector = connectorRegistry.get(connectorId)
+  const row = db.prepare(
+    "SELECT COUNT(*) as cnt FROM captures WHERE platform = ? AND json_extract(metadata, '$.connectorId') = ?",
+  ).get(connector.platform, connectorId) as { cnt: number }
+  return row.cnt
 })

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -8,6 +8,7 @@ import {
   getOpenCLISourceId, listOpenCLISources, addOpenCLISource, removeOpenCLISource, getCaptureCount,
   getSetupValue, setSetupValue,
   ConnectorRegistry, SyncEngine, SyncScheduler, TwitterBookmarksConnector,
+  loadSyncState, saveSyncState,
 } from '@spool/core'
 import type { ConnectorStatus, AuthStatus } from '@spool/core'
 import { setupTray } from './tray.js'
@@ -390,6 +391,15 @@ ipcMain.handle('connector:sync-now', (_e, { id }: { id: string }) => {
 
 ipcMain.handle('connector:get-status', () => {
   return syncScheduler.getStatus()
+})
+
+ipcMain.handle('connector:set-enabled', (_e, { id, enabled }: { id: string; enabled: boolean }) => {
+  const state = loadSyncState(db, id)
+  saveSyncState(db, { ...state, enabled })
+  if (enabled) {
+    syncScheduler.triggerNow(id, 'both')
+  }
+  return { ok: true }
 })
 
 ipcMain.handle('connector:get-capture-count', (_e, { connectorId }: { connectorId: string }) => {

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -384,7 +384,7 @@ ipcMain.handle('connector:check-auth', async (_e, { id }: { id: string }): Promi
 })
 
 ipcMain.handle('connector:sync-now', (_e, { id }: { id: string }) => {
-  syncScheduler.triggerNow(id)
+  syncScheduler.triggerNow(id, 'both')
   return { ok: true }
 })
 

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import type { FragmentResult, Session, Message, StatusInfo, SyncResult, SearchResult, OpenCLISetupStatus, OpenCLISource, PlatformInfo, CapturedItem } from '@spool/core'
+import type { FragmentResult, Session, Message, StatusInfo, SyncResult, SearchResult, OpenCLISetupStatus, OpenCLISource, PlatformInfo, CapturedItem, ConnectorStatus, AuthStatus, SchedulerStatus } from '@spool/core'
 import type { SearchSortOrder } from '../shared/searchSort.js'
 
 export interface AgentInfo {
@@ -159,6 +159,31 @@ const api = {
       const handler = (_: Electron.IpcRendererEvent, data: unknown) => cb(data as { phase: string; message: string })
       ipcRenderer.on('opencli:capture-progress', handler)
       return () => ipcRenderer.removeListener('opencli:capture-progress', handler)
+    },
+  },
+
+  // ── Connectors ──
+
+  connectors: {
+    list: (): Promise<ConnectorStatus[]> =>
+      ipcRenderer.invoke('connector:list'),
+
+    checkAuth: (id: string): Promise<AuthStatus> =>
+      ipcRenderer.invoke('connector:check-auth', { id }),
+
+    syncNow: (id: string): Promise<{ ok: boolean }> =>
+      ipcRenderer.invoke('connector:sync-now', { id }),
+
+    getStatus: (): Promise<SchedulerStatus> =>
+      ipcRenderer.invoke('connector:get-status'),
+
+    getCaptureCount: (connectorId: string): Promise<number> =>
+      ipcRenderer.invoke('connector:get-capture-count', { connectorId }),
+
+    onEvent: (cb: (event: { type: string; connectorId?: string; progress?: unknown; result?: unknown; code?: string; message?: string }) => void) => {
+      const handler = (_: Electron.IpcRendererEvent, data: unknown) => cb(data as any)
+      ipcRenderer.on('connector:event', handler)
+      return () => ipcRenderer.removeListener('connector:event', handler)
     },
   },
 

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -174,6 +174,9 @@ const api = {
     syncNow: (id: string): Promise<{ ok: boolean }> =>
       ipcRenderer.invoke('connector:sync-now', { id }),
 
+    setEnabled: (id: string, enabled: boolean): Promise<{ ok: boolean }> =>
+      ipcRenderer.invoke('connector:set-enabled', { id, enabled }),
+
     getStatus: (): Promise<SchedulerStatus> =>
       ipcRenderer.invoke('connector:get-status'),
 

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -106,20 +106,42 @@ export default function App() {
   }, [])
 
   const refreshCaptureSources = useCallback(() => {
-    if (!window.spool?.opencli) return
-    Promise.all([
-      window.spool.opencli.listSources(),
-      window.spool.opencli.availablePlatforms(),
-    ]).then(([sources, platforms]) => {
-      setCaptureSources(
-        sources
-          .filter(s => s.syncCount > 0)
-          .map(s => ({
-            label: platforms.find(p => p.platform === s.platform && p.command === s.command)?.label ?? `${s.platform} ${s.command}`,
-            count: s.syncCount,
-          }))
+    const promises: Promise<Array<{ label: string; count: number }>>[] = []
+
+    // OpenCLI sources
+    if (window.spool?.opencli) {
+      promises.push(
+        Promise.all([
+          window.spool.opencli.listSources(),
+          window.spool.opencli.availablePlatforms(),
+        ]).then(([sources, platforms]) =>
+          sources
+            .filter(s => s.syncCount > 0)
+            .map(s => ({
+              label: platforms.find(p => p.platform === s.platform && p.command === s.command)?.label ?? `${s.platform} ${s.command}`,
+              count: s.syncCount,
+            }))
+        )
       )
-    }).catch(console.error)
+    }
+
+    // Native connectors
+    if (window.spool?.connectors) {
+      promises.push(
+        window.spool.connectors.list().then(async connectors => {
+          const results: Array<{ label: string; count: number }> = []
+          for (const c of connectors) {
+            const count = await window.spool.connectors.getCaptureCount(c.id)
+            if (count > 0) results.push({ label: c.label, count })
+          }
+          return results
+        })
+      )
+    }
+
+    Promise.all(promises)
+      .then(results => setCaptureSources(results.flat()))
+      .catch(console.error)
   }, [])
 
   useEffect(() => {

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -6,14 +6,13 @@ import HomeView from './components/HomeView.js'
 import SessionDetail from './components/SessionDetail.js'
 import StatusBar from './components/StatusBar.js'
 import AiAnswerCard from './components/AiAnswerCard.js'
-import OnboardingFlow from './components/OnboardingFlow.js'
-import SourcesPanel from './components/SourcesPanel.js'
 import CaptureUrlModal from './components/CaptureUrlModal.js'
 import SettingsPanel from './components/SettingsPanel.js'
 import { getSessionResumeCommandPrefix } from '../shared/resumeCommand.js'
 import { DEFAULT_SEARCH_SORT_ORDER, type SearchSortOrder } from '../shared/searchSort.js'
 
 type View = 'search' | 'session'
+type SettingsTab = 'general' | 'connectors' | 'agent'
 
 interface AgentInfo {
   id: string
@@ -46,11 +45,10 @@ export default function App() {
   const [aiToolCalls, setAiToolCalls] = useState<Map<string, { title: string; status: string; kind?: string }>>(new Map())
   const aiAnswerRef = useRef('')
 
-  // OpenCLI modal state
-  const [showOnboarding, setShowOnboarding] = useState(false)
-  const [showSourcesPanel, setShowSourcesPanel] = useState(false)
-  const [showCaptureModal, setShowCaptureModal] = useState(false)
+  // Settings & modals
   const [showSettings, setShowSettings] = useState(false)
+  const [settingsTab, setSettingsTab] = useState<SettingsTab>('general')
+  const [showCaptureModal, setShowCaptureModal] = useState(false)
   const [captureSources, setCaptureSources] = useState<Array<{ label: string; count: number }>>([])
   const [defaultSearchSort, setDefaultSearchSort] = useState<SearchSortOrder>(DEFAULT_SEARCH_SORT_ORDER)
   const [resumeToastCommand, setResumeToastCommand] = useState<string | null>(null)
@@ -106,42 +104,15 @@ export default function App() {
   }, [])
 
   const refreshCaptureSources = useCallback(() => {
-    const promises: Promise<Array<{ label: string; count: number }>>[] = []
-
-    // OpenCLI sources
-    if (window.spool?.opencli) {
-      promises.push(
-        Promise.all([
-          window.spool.opencli.listSources(),
-          window.spool.opencli.availablePlatforms(),
-        ]).then(([sources, platforms]) =>
-          sources
-            .filter(s => s.syncCount > 0)
-            .map(s => ({
-              label: platforms.find(p => p.platform === s.platform && p.command === s.command)?.label ?? `${s.platform} ${s.command}`,
-              count: s.syncCount,
-            }))
-        )
-      )
-    }
-
-    // Native connectors
-    if (window.spool?.connectors) {
-      promises.push(
-        window.spool.connectors.list().then(async connectors => {
-          const results: Array<{ label: string; count: number }> = []
-          for (const c of connectors) {
-            const count = await window.spool.connectors.getCaptureCount(c.id)
-            if (count > 0) results.push({ label: c.label, count })
-          }
-          return results
-        })
-      )
-    }
-
-    Promise.all(promises)
-      .then(results => setCaptureSources(results.flat()))
-      .catch(console.error)
+    if (!window.spool?.connectors) return
+    window.spool.connectors.list().then(async connectors => {
+      const results: Array<{ label: string; count: number }> = []
+      for (const c of connectors) {
+        const count = await window.spool.connectors.getCaptureCount(c.id)
+        if (count > 0) results.push({ label: c.label, count })
+      }
+      setCaptureSources(results)
+    }).catch(console.error)
   }, [])
 
   useEffect(() => {
@@ -190,18 +161,15 @@ export default function App() {
   const doAiSearch = useCallback(async () => {
     if (!query.trim() || !window.spool?.aiSearch) return
 
-    // First fetch FTS results for context (if we don't have them yet)
     const ftsResults = results.length > 0 ? results : (window.spool ? await window.spool.search(query, 20) : [])
     if (ftsResults.length > 0 && results.length === 0) setResults(ftsResults)
 
-    // Reset AI state
     aiAnswerRef.current = ''
     setAiAnswer('')
     setAiError(null)
     setAiStreaming(true)
     setAiToolCalls(new Map())
 
-    // Fire AI query
     window.spool.aiSearch(query, aiAgent, ftsResults).catch((err) => {
       setAiError(String(err))
       setAiStreaming(false)
@@ -211,12 +179,10 @@ export default function App() {
   const handleQueryChange = useCallback((q: string) => {
     setQuery(q)
     if (!q.trim()) setHomeMode(true)
-    // Only auto-search in Fast mode; AI mode waits for Enter
     if (searchMode === 'fast') {
       if (searchTimer.current) clearTimeout(searchTimer.current)
       searchTimer.current = setTimeout(() => doSearch(q), 200)
     }
-    // Clear AI answer when query changes
     if (aiAnswer || aiError) {
       setAiAnswer('')
       setAiError(null)
@@ -236,7 +202,6 @@ export default function App() {
   const handleModeChange = useCallback((mode: SearchMode) => {
     setSearchMode(mode)
     if (mode === 'fast') {
-      // Clear AI state, re-run FTS if there's a query
       setAiAnswer('')
       setAiError(null)
       setAiStreaming(false)
@@ -244,7 +209,6 @@ export default function App() {
       aiAnswerRef.current = ''
       if (query.trim()) doSearch(query)
     } else {
-      // Switching to AI: clear FTS results, user will press Enter to search
       setResults([])
       setIsSearching(false)
     }
@@ -266,19 +230,9 @@ export default function App() {
     setView('search'); setSelectedSession(null); setTargetMessageId(null)
   }, [])
 
-  const handleConnectClick = useCallback(async () => {
-    if (!window.spool?.opencli) return
-    const setupDone = await window.spool.opencli.getSetupValue('onboarding_complete')
-    if (setupDone === 'true') {
-      setShowSourcesPanel(true)
-    } else {
-      setShowOnboarding(true)
-    }
-  }, [])
-
-  const handleOnboardingComplete = useCallback(() => {
-    setShowOnboarding(false)
-    setShowSourcesPanel(true)
+  const handleConnectClick = useCallback(() => {
+    setSettingsTab('connectors')
+    setShowSettings(true)
   }, [])
 
   const handleCaptured = useCallback(() => {
@@ -294,7 +248,7 @@ export default function App() {
     toastTimer.current = setTimeout(() => setResumeToastCommand(null), 3200)
   }, [])
 
-  const activeAgentInfo = availableAgents.find(a => a.id === aiAgent)
+  const activeAgentInfo = availableAgents.find(a => a.id === aiAgent) ?? availableAgents[0]
   const activeAgentName = activeAgentInfo?.name ?? aiAgent
   const activeAgentMode = activeAgentInfo?.acpMode
   const hasAgents = availableAgents.length > 0
@@ -333,7 +287,6 @@ export default function App() {
                 mode={searchMode}
                 onModeChange={hasAgents ? handleModeChange : undefined}
               />
-              {/* Agent selector — AI mode only */}
               {searchMode === 'ai' && availableAgents.length > 0 && (
                 <AgentSelector
                   agents={availableAgents}
@@ -348,7 +301,6 @@ export default function App() {
                 <SessionDetail sessionUuid={selectedSession} targetMessageId={targetMessageId} onCopySessionId={handleCopySessionId} />
               ) : (
                 <div className="h-full flex flex-col overflow-hidden">
-                  {/* AI answer card — shown above results in AI mode */}
                   {searchMode === 'ai' && (aiAnswer || aiStreaming || aiError) && (
                     <AiAnswerCard
                       answer={aiAnswer}
@@ -360,13 +312,11 @@ export default function App() {
                       toolCalls={aiToolCalls}
                     />
                   )}
-                  {/* Show "Sources used" label in AI mode */}
                   {searchMode === 'ai' && results.length > 0 && (aiAnswer || aiStreaming) && (
                     <div className="px-4 pt-2 pb-1 text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.04em]">
                       Sources used
                     </div>
                   )}
-                  {/* AI mode: show prompt hint when no query submitted yet */}
                   {searchMode === 'ai' && !aiAnswer && !aiStreaming && !aiError && results.length === 0 && query.trim() ? (
                     <div className="flex flex-col items-center justify-center h-full text-warm-faint dark:text-dark-muted gap-2 pb-12">
                       <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="opacity-40">
@@ -397,8 +347,7 @@ export default function App() {
         searchMode={searchMode}
         aiAgent={activeAgentName}
         aiAgentMode={activeAgentMode}
-        onSourcesClick={() => setShowSourcesPanel(true)}
-        onSettingsClick={() => setShowSettings(true)}
+        onSettingsClick={() => { setSettingsTab('general'); setShowSettings(true) }}
       />
 
       {resumeToastCommand && (
@@ -406,19 +355,6 @@ export default function App() {
       )}
 
       {/* Modals */}
-      {showOnboarding && (
-        <OnboardingFlow
-          onClose={() => setShowOnboarding(false)}
-          onComplete={handleOnboardingComplete}
-        />
-      )}
-      {showSourcesPanel && (
-        <SourcesPanel
-          onClose={() => { setShowSourcesPanel(false); refreshCaptureSources() }}
-          claudeCount={status?.claudeSessions ?? null}
-          codexCount={status?.codexSessions ?? null}
-        />
-      )}
       {showCaptureModal && (
         <CaptureUrlModal
           onClose={() => setShowCaptureModal(false)}
@@ -426,7 +362,12 @@ export default function App() {
         />
       )}
       {showSettings && (
-        <SettingsPanel onClose={() => { setShowSettings(false); refreshAgents() }} />
+        <SettingsPanel
+          onClose={() => { setShowSettings(false); refreshAgents(); refreshCaptureSources() }}
+          initialTab={settingsTab}
+          claudeCount={status?.claudeSessions ?? null}
+          codexCount={status?.codexSessions ?? null}
+        />
       )}
     </div>
   )

--- a/packages/app/src/renderer/components/HomeView.tsx
+++ b/packages/app/src/renderer/components/HomeView.tsx
@@ -12,7 +12,7 @@ interface Props {
   codexCount: number | null
   captureSources: Array<{ label: string; count: number }>
   mode: SearchMode
-  onModeChange: (mode: SearchMode) => void
+  onModeChange?: (mode: SearchMode) => void
   onConnectClick: () => void
 }
 

--- a/packages/app/src/renderer/components/SettingsPanel.tsx
+++ b/packages/app/src/renderer/components/SettingsPanel.tsx
@@ -1,5 +1,10 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback, type ReactNode } from 'react'
+import type { ConnectorStatus } from '@spool/core'
 import { DEFAULT_SEARCH_SORT_ORDER, SEARCH_SORT_OPTIONS, type SearchSortOrder } from '../../shared/searchSort.js'
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+type SettingsTab = 'general' | 'connectors' | 'agent'
 
 /** Must match SUPPORTED_TERMINALS in main/terminal.ts */
 const TERMINAL_OPTIONS = [
@@ -34,7 +39,12 @@ interface AgentsConfig {
 
 interface Props {
   onClose: () => void
+  initialTab?: SettingsTab
+  claudeCount: number | null
+  codexCount: number | null
 }
+
+type Theme = 'system' | 'light' | 'dark'
 
 const MODE_LABELS: Record<string, string> = {
   extension: 'ACP Extension',
@@ -51,30 +61,439 @@ const SDK_MODEL_OPTIONS = [
   { value: 'claude-opus-4-5-20251101', label: 'Claude Opus 4.5' },
 ] as const
 
-export default function SettingsPanel({ onClose }: Props) {
+function formatSyncTime(iso: string | null): string {
+  if (!iso) return 'never synced'
+  const utcIso = iso.endsWith('Z') ? iso : iso + 'Z'
+  const diff = Date.now() - new Date(utcIso).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+// ── Sidebar tabs ───────────────────────────────────────────────────────────
+
+const TABS: { id: SettingsTab; label: string; icon: ReactNode }[] = [
+  {
+    id: 'general',
+    label: 'General',
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/>
+      </svg>
+    ),
+  },
+  {
+    id: 'connectors',
+    label: 'Connectors',
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 2v6M12 18v4M4.93 4.93l4.24 4.24M14.83 14.83l4.24 4.24M2 12h6M18 12h4M4.93 19.07l4.24-4.24M14.83 9.17l4.24-4.24"/>
+      </svg>
+    ),
+  },
+  {
+    id: 'agent',
+    label: 'Agent',
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 3l1.912 5.813a2 2 0 001.275 1.275L21 12l-5.813 1.912a2 2 0 00-1.275 1.275L12 21l-1.912-5.813a2 2 0 00-1.275-1.275L3 12l5.813-1.912a2 2 0 001.275-1.275L12 3z"/>
+      </svg>
+    ),
+  },
+]
+
+// ── Main component ─────────────────────────────────────────────────────────
+
+export default function SettingsPanel({ onClose, initialTab = 'general', claudeCount, codexCount }: Props) {
+  const [tab, setTab] = useState<SettingsTab>(initialTab)
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="w-[640px] h-[480px] bg-warm-bg dark:bg-dark-bg border border-warm-border dark:border-dark-border rounded-[10px] shadow-xl overflow-hidden flex">
+        {/* Sidebar */}
+        <div className="w-[160px] flex-none bg-warm-surface dark:bg-dark-surface border-r border-warm-border dark:border-dark-border flex flex-col py-3">
+          <div className="px-4 mb-3">
+            <h2 className="text-sm font-semibold text-warm-text dark:text-dark-text">Settings</h2>
+          </div>
+          {TABS.map(t => (
+            <button
+              key={t.id}
+              onClick={() => setTab(t.id)}
+              className={`flex items-center gap-2 px-4 py-1.5 text-[12px] transition-colors ${
+                tab === t.id
+                  ? 'text-accent dark:text-accent-dark bg-accent-bg dark:bg-[#2A1800] font-medium'
+                  : 'text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text'
+              }`}
+            >
+              {t.icon}
+              {t.label}
+            </button>
+          ))}
+          <div className="flex-1" />
+          <div className="px-4 py-2 text-[10px] text-warm-faint dark:text-dark-muted">
+            All data stays local in ~/.spool/
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 flex flex-col min-w-0">
+          <div className="flex items-center justify-between px-5 py-3 border-b border-warm-border dark:border-dark-border">
+            <h3 className="text-sm font-medium text-warm-text dark:text-dark-text">
+              {TABS.find(t => t.id === tab)?.label}
+            </h3>
+            <button onClick={onClose} className="text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition-colors">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto px-5 py-4">
+            {tab === 'general' && <GeneralTab />}
+            {tab === 'connectors' && <ConnectorsTab claudeCount={claudeCount} codexCount={codexCount} />}
+            {tab === 'agent' && <AgentTab />}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── General Tab ────────────────────────────────────────────────────────────
+
+function GeneralTab() {
+  const [theme, setTheme] = useState<Theme>('system')
+  const [config, setConfig] = useState<AgentsConfig>({})
+
+  useEffect(() => {
+    if (!window.spool) return
+    window.spool.getTheme().then(t => { if (t) setTheme(t) }).catch(console.error)
+    window.spool.getAgentsConfig().then(setConfig).catch(console.error)
+  }, [])
+
+  const updateTheme = (t: Theme) => {
+    setTheme(t)
+    window.spool?.setTheme(t)
+  }
+
+  const updateConfig = async (patch: Partial<AgentsConfig>) => {
+    const next: AgentsConfig = { ...config, ...patch }
+    setConfig(next)
+    try { await window.spool.setAgentsConfig(next) } catch {}
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Theme */}
+      <Section title="Theme">
+        <div className="flex gap-2">
+          {(['system', 'light', 'dark'] as Theme[]).map(t => (
+            <button
+              key={t}
+              onClick={() => updateTheme(t)}
+              className={`px-3 py-1.5 text-xs rounded-[6px] border transition-colors capitalize ${
+                theme === t
+                  ? 'bg-accent-bg dark:bg-[#2A1800] border-accent/30 dark:border-accent-dark/30 text-accent dark:text-accent-dark font-medium'
+                  : 'bg-warm-surface dark:bg-dark-surface border-warm-border dark:border-dark-border text-warm-muted dark:text-dark-muted hover:border-warm-border2 dark:hover:border-dark-border2'
+              }`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      </Section>
+
+      {/* Search */}
+      <Section title="Search">
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-xs text-warm-muted dark:text-dark-muted">Default sort</span>
+          <SmallSelect
+            value={config.defaultSearchSort ?? DEFAULT_SEARCH_SORT_ORDER}
+            onChange={(v) => updateConfig({ defaultSearchSort: v as SearchSortOrder })}
+            options={SEARCH_SORT_OPTIONS.map(o => ({ value: o.value, label: o.label }))}
+          />
+        </div>
+      </Section>
+
+      {/* Terminal */}
+      <Section title="Terminal">
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-xs text-warm-muted dark:text-dark-muted">Session resume</span>
+          <SmallSelect
+            value={(config as any).terminal ?? ''}
+            onChange={(v) => updateConfig({ terminal: v || undefined } as any)}
+            options={TERMINAL_OPTIONS.map(o => ({ value: o.value, label: o.label }))}
+          />
+        </div>
+        <p className="text-[11px] text-warm-faint dark:text-dark-muted mt-2">
+          Which terminal to open when resuming a session.
+        </p>
+      </Section>
+
+      {/* Data */}
+      <Section title="Data">
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-warm-muted dark:text-dark-muted">Database</span>
+          <span className="text-[11px] font-mono text-warm-faint dark:text-dark-muted">~/.spool/spool.db</span>
+        </div>
+      </Section>
+
+      {/* About */}
+      <Section title="About">
+        <p className="text-xs text-warm-muted dark:text-dark-muted">
+          Spool — a local search engine for your thinking.
+        </p>
+      </Section>
+    </div>
+  )
+}
+
+// ── Connectors Tab ─────────────────────────────────────────────────────────
+
+function ConnectorsTab({ claudeCount, codexCount }: { claudeCount: number | null; codexCount: number | null }) {
+  const [connectors, setConnectors] = useState<ConnectorStatus[]>([])
+  const [connectorCounts, setConnectorCounts] = useState<Record<string, number>>({})
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [syncingConnector, setSyncingConnector] = useState<string | null>(null)
+  const [syncProgress, setSyncProgress] = useState<Record<string, { added: number; phase: string }>>({})
+  const [syncError, setSyncError] = useState<string | null>(null)
+
+  const loadConnectors = useCallback(async () => {
+    if (!window.spool?.connectors) return
+    const list = await window.spool.connectors.list()
+    setConnectors(list)
+    const counts: Record<string, number> = {}
+    for (const c of list) {
+      counts[c.id] = await window.spool.connectors.getCaptureCount(c.id)
+    }
+    setConnectorCounts(counts)
+  }, [])
+
+  useEffect(() => { loadConnectors() }, [loadConnectors])
+
+  // Listen for connector sync events
+  useEffect(() => {
+    if (!window.spool?.connectors) return () => {}
+    const off = window.spool.connectors.onEvent((event) => {
+      if (event.type === 'sync-start') {
+        setSyncingConnector(event.connectorId ?? null)
+        if (event.connectorId) setSyncProgress(prev => ({ ...prev, [event.connectorId!]: { added: 0, phase: 'starting' } }))
+      } else if (event.type === 'sync-progress') {
+        const p = event.progress as { connectorId: string; phase: string; added: number } | undefined
+        if (p) setSyncProgress(prev => ({ ...prev, [p.connectorId]: { added: p.added, phase: p.phase } }))
+      } else if (event.type === 'sync-complete' || event.type === 'sync-error') {
+        setSyncingConnector(null)
+        if (event.connectorId) setSyncProgress(prev => { const next = { ...prev }; delete next[event.connectorId!]; return next })
+        loadConnectors()
+      }
+    })
+    return off
+  }, [loadConnectors])
+
+  const handleSync = async (connectorId: string) => {
+    if (!window.spool?.connectors) return
+    setSyncingConnector(connectorId)
+    setSyncError(null)
+    try { await window.spool.connectors.syncNow(connectorId) } catch (err) {
+      setSyncError(`${connectorId}: ${err instanceof Error ? err.message : String(err)}`)
+      setSyncingConnector(null)
+    }
+  }
+
+  const handleToggleEnabled = async (connectorId: string, enabled: boolean) => {
+    if (!window.spool?.connectors) return
+    await window.spool.connectors.setEnabled(connectorId, enabled)
+    await loadConnectors()
+  }
+
+  const selected = connectors.find(c => c.id === selectedId)
+
+  // ── Detail view (drill-down) ──
+  if (selected) {
+    const isSyncing = syncingConnector === selected.id || selected.syncing
+    const progress = syncProgress[selected.id]
+    return (
+      <div className="space-y-5">
+        {/* Back button */}
+        <button
+          onClick={() => setSelectedId(null)}
+          className="flex items-center gap-1.5 text-xs text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition-colors"
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M7.5 2.5L4 6l3.5 3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          Back
+        </button>
+
+        {/* Connector header */}
+        <div className="flex items-center gap-3">
+          <span
+            className={`w-3 h-3 rounded-full flex-none ${isSyncing ? 'animate-pulse' : ''}`}
+            style={{ background: selected.enabled ? selected.color : '#888' }}
+          />
+          <div>
+            <h4 className="text-xs font-medium text-warm-text dark:text-dark-text">{selected.label}</h4>
+            <p className="text-[11px] text-warm-faint dark:text-dark-muted">{selected.description}</p>
+          </div>
+        </div>
+
+        {/* Status */}
+        <div className="px-3 py-2.5 bg-warm-surface dark:bg-dark-surface border border-warm-border dark:border-dark-border rounded-[8px] space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-warm-muted dark:text-dark-muted">Status</span>
+            <span className={`text-[11px] font-medium ${selected.enabled ? 'text-green-500' : 'text-warm-faint dark:text-dark-muted'}`}>
+              {!selected.enabled
+                ? 'Disabled'
+                : isSyncing
+                  ? 'Syncing...'
+                  : selected.state.lastErrorCode?.startsWith('AUTH_')
+                    ? 'Needs login'
+                    : 'Connected'}
+            </span>
+          </div>
+          {selected.enabled && (connectorCounts[selected.id] ?? 0) > 0 && (
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-warm-muted dark:text-dark-muted">Items</span>
+              <span className="text-[11px] font-mono text-warm-faint dark:text-dark-muted">
+                {connectorCounts[selected.id]} · {formatSyncTime(selected.state.lastForwardSyncAt)}
+              </span>
+            </div>
+          )}
+          {isSyncing && progress && (
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-warm-muted dark:text-dark-muted">Progress</span>
+              <span className="text-[11px] text-warm-faint dark:text-dark-muted">
+                {progress.added} new · {progress.phase === 'forward' ? 'fetching' : 'backfilling'}...
+              </span>
+            </div>
+          )}
+          {selected.enabled && !selected.state.tailComplete && !isSyncing && (
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-warm-muted dark:text-dark-muted">History</span>
+              <span className="text-[11px] text-warm-faint dark:text-dark-muted">syncing in background</span>
+            </div>
+          )}
+        </div>
+
+        {/* Enable toggle */}
+        <div className="flex items-center justify-between px-3 py-2.5 bg-warm-surface dark:bg-dark-surface border border-warm-border dark:border-dark-border rounded-[8px]">
+          <span className="text-xs text-warm-muted dark:text-dark-muted">Enabled</span>
+          <button
+            onClick={() => handleToggleEnabled(selected.id, !selected.enabled)}
+            className={`relative w-8 h-[18px] rounded-full transition-colors ${
+              selected.enabled ? 'bg-accent dark:bg-accent-dark' : 'bg-warm-border2 dark:bg-dark-border'
+            }`}
+          >
+            <span className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white shadow-sm transition-transform ${
+              selected.enabled ? 'left-[16px]' : 'left-[2px]'
+            }`} />
+          </button>
+        </div>
+
+        {/* Sync button */}
+        {selected.enabled && (
+          <button
+            onClick={() => handleSync(selected.id)}
+            disabled={isSyncing}
+            className="w-full py-2 text-xs font-medium text-accent dark:text-accent-dark border border-accent/30 dark:border-accent-dark/30 rounded-[8px] hover:bg-accent-bg dark:hover:bg-[#2A1800] disabled:opacity-50 transition-colors"
+          >
+            {isSyncing ? 'Syncing...' : 'Sync now'}
+          </button>
+        )}
+
+        {syncError && (
+          <div className="px-3 py-2 bg-red-500/10 border border-red-500/20 rounded-[6px]">
+            <p className="text-xs text-red-500">{syncError}</p>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // ── List view ──
+  return (
+    <div className="space-y-5">
+      <Section title="Agent Sessions">
+        <BuiltInSource name="Claude Code" color="#6B5B8A" count={claudeCount} />
+        <BuiltInSource name="Codex CLI" color="#1A6B3C" count={codexCount} />
+      </Section>
+
+      <Section title="Data Sources">
+        {connectors.length === 0 && (
+          <p className="text-xs text-warm-faint dark:text-dark-muted">No connectors available.</p>
+        )}
+        {connectors.map(c => {
+          const isSyncing = syncingConnector === c.id || c.syncing
+          const progress = syncProgress[c.id]
+          return (
+            <button
+              key={c.id}
+              onClick={() => setSelectedId(c.id)}
+              className="w-full flex items-center gap-3 py-2.5 px-2 rounded-[6px] text-left hover:bg-warm-surface/50 dark:hover:bg-dark-surface/50 transition-colors"
+            >
+              <span
+                className={`w-2 h-2 rounded-full flex-none ${isSyncing ? 'animate-pulse' : ''}`}
+                style={{ background: c.enabled ? c.color : '#888' }}
+              />
+              <div className="flex-1 min-w-0">
+                <span className={`text-xs ${c.enabled ? 'text-warm-text dark:text-dark-text' : 'text-warm-muted dark:text-dark-muted'}`}>
+                  {c.label}
+                </span>
+                <span className="text-[11px] text-warm-faint dark:text-dark-muted ml-2">
+                  {!c.enabled
+                    ? 'Not connected'
+                    : isSyncing && progress
+                      ? `${progress.added} new · ${progress.phase === 'forward' ? 'fetching' : 'backfilling'}...`
+                      : (connectorCounts[c.id] ?? 0) > 0
+                        ? `${connectorCounts[c.id]} items · ${formatSyncTime(c.state.lastForwardSyncAt)}`
+                        : c.state.lastErrorCode
+                          ? c.state.lastErrorMessage ?? 'Error'
+                          : 'Not synced yet'}
+                </span>
+              </div>
+              {c.enabled && !isSyncing && c.state.lastErrorCode?.startsWith('AUTH_') && (
+                <span className="text-[10px] text-amber-500 font-medium">needs login</span>
+              )}
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="text-warm-faint dark:text-dark-muted">
+                <path d="M4.5 2.5L8 6l-3.5 3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </button>
+          )
+        })}
+      </Section>
+
+      {syncError && (
+        <div className="px-3 py-2 bg-red-500/10 border border-red-500/20 rounded-[6px]">
+          <p className="text-xs text-red-500">{syncError}</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Agent Tab ──────────────────────────────────────────────────────────────
+
+function AgentTab() {
   const [agents, setAgents] = useState<AgentInfo[]>([])
   const [config, setConfig] = useState<AgentsConfig>({})
-  const [dbPath] = useState('~/.spool/spool.db')
 
   useEffect(() => {
     if (!window.spool) return
     Promise.all([
       window.spool.getAiAgents(),
       window.spool.getAgentsConfig(),
-    ]).then(([a, c]) => {
-      setAgents(a)
-      setConfig(c)
-    }).catch(console.error)
+    ]).then(([a, c]) => { setAgents(a); setConfig(c) }).catch(console.error)
   }, [])
 
-  // SDK agent is always selectable; CLI agents need binary
   const sdkAgent = agents.find(a => a.acpMode === 'sdk')
   const cliAgents = agents.filter(a => a.acpMode !== 'sdk')
   const sdkConfigured = !!config.sdkAgent?.apiKey
 
-  // The selected default: explicit config > first available
   const selectableIds = new Set([
-    ...(sdkAgent ? [sdkAgent.id] : []),  // SDK always selectable
+    ...(sdkAgent ? [sdkAgent.id] : []),
     ...cliAgents.filter(a => a.status === 'ready').map(a => a.id),
   ])
   const selectedId = config.defaultAgent && selectableIds.has(config.defaultAgent)
@@ -84,264 +503,192 @@ export default function SettingsPanel({ onClose }: Props) {
   const updateConfig = async (patch: Partial<AgentsConfig>) => {
     const next: AgentsConfig = { ...config, ...patch }
     setConfig(next)
-    try {
-      await window.spool.setAgentsConfig(next)
-    } catch (err) {
-      console.error('Failed to save config:', err)
-    }
+    try { await window.spool.setAgentsConfig(next) } catch {}
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="w-[500px] max-h-[80vh] bg-warm-bg dark:bg-dark-bg border border-warm-border dark:border-dark-border rounded-[10px] shadow-xl overflow-hidden flex flex-col">
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-warm-border dark:border-dark-border">
-          <h2 className="text-base font-semibold text-warm-text dark:text-dark-text">Settings</h2>
-          <button onClick={onClose} className="text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition-colors">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
+    <div className="space-y-6">
+      {/* Built-in Agent */}
+      {sdkAgent && (
+        <Section title="Built-in Agent">
+          <button
+            onClick={() => updateConfig({ defaultAgent: sdkAgent.id })}
+            className={`w-full flex items-center gap-3 px-3 py-2.5 border text-left transition-colors ${
+              selectedId === sdkAgent.id ? 'rounded-t-[8px] border-b-0 bg-accent-bg dark:bg-[#2A1800] border-accent/30 dark:border-accent-dark/30' : 'rounded-[8px] bg-warm-surface dark:bg-dark-surface border-warm-border dark:border-dark-border hover:border-warm-border2 dark:hover:border-dark-border2'
+            }`}
+          >
+            <RadioDot selected={selectedId === sdkAgent.id} />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-medium text-warm-text dark:text-dark-text">Built-in</span>
+                <span className="text-[9px] font-mono text-warm-faint dark:text-dark-muted px-1.5 py-0.5 bg-warm-surface2 dark:bg-dark-surface2 rounded">
+                  Requires API Key
+                </span>
+              </div>
+              <span className="block text-[11px] font-mono text-warm-faint dark:text-dark-muted truncate">
+                {sdkConfigured ? `${config.sdkAgent?.model || 'claude-sonnet-4-6'} via API` : 'No CLI needed — just add your API key'}
+              </span>
+            </div>
+            <span className={`text-[10px] font-medium flex-none ${sdkConfigured ? 'text-green-500' : 'text-amber-500 dark:text-amber-400'}`}>
+              {sdkConfigured ? 'ready' : 'needs key'}
+            </span>
           </button>
-        </div>
 
-        <div className="flex-1 overflow-y-auto px-5 py-4">
-          {/* ── Built-in Agent ── */}
-          {sdkAgent && (
-            <div className="mb-5">
-              <h3 className="text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.04em] uppercase mb-3">
-                Built-in Agent
-              </h3>
-              <button
-                onClick={() => updateConfig({ defaultAgent: sdkAgent.id })}
-                className={`w-full flex items-center gap-3 px-3 py-2.5 border text-left transition-colors ${
-                  selectedId === sdkAgent.id ? 'rounded-t-[8px] border-b-0 bg-accent-bg dark:bg-[#2A1800] border-accent/30 dark:border-accent-dark/30' : 'rounded-[8px] bg-warm-surface dark:bg-dark-surface border-warm-border dark:border-dark-border hover:border-warm-border2 dark:hover:border-dark-border2'
-                }`}
-              >
-                <span className={`w-4 h-4 rounded-full border-2 flex-none flex items-center justify-center ${
-                  selectedId === sdkAgent.id ? 'border-accent dark:border-accent-dark' : 'border-warm-border2 dark:border-dark-border2'
-                }`}>
-                  {selectedId === sdkAgent.id && <span className="w-2 h-2 rounded-full bg-accent dark:bg-accent-dark" />}
-                </span>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium text-warm-text dark:text-dark-text">Built-in</span>
-                    <span className="text-[9px] font-mono text-warm-faint dark:text-dark-muted px-1.5 py-0.5 bg-warm-surface2 dark:bg-dark-surface2 rounded">
-                      Requires API Key
-                    </span>
-                  </div>
-                  <span className="block text-[11px] font-mono text-warm-faint dark:text-dark-muted truncate">
-                    {sdkConfigured ? `${config.sdkAgent?.model || 'claude-sonnet-4-6'} via API` : 'No CLI needed — just add your API key'}
-                  </span>
-                </div>
-                <span className={`text-[10px] font-medium flex-none ${
-                  sdkConfigured ? 'text-green-500' : 'text-amber-500 dark:text-amber-400'
-                }`}>
-                  {sdkConfigured ? 'ready' : 'needs key'}
-                </span>
-              </button>
-
-              {/* Inline config — always visible when selected */}
-              {selectedId === sdkAgent.id && (
-                <div className="px-3 py-3 bg-accent-bg dark:bg-[#2A1800] border border-t-0 border-accent/30 dark:border-accent-dark/30 rounded-b-[8px] space-y-2.5">
-                  <div className="flex items-center gap-3">
-                    <span className="text-[11px] text-warm-muted dark:text-dark-muted w-16 flex-none">API Key</span>
-                    <input
-                      type="password"
-                      value={config.sdkAgent?.apiKey ?? ''}
-                      onChange={(e) => updateConfig({ sdkAgent: { ...config.sdkAgent, apiKey: e.target.value } })}
-                      placeholder="sk-ant-..."
-                      className="flex-1 h-7 rounded-[6px] border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg px-2.5 text-[11px] font-mono text-warm-text dark:text-dark-text outline-none transition-colors focus:border-accent placeholder:text-warm-faint/50 dark:placeholder:text-dark-muted/50"
-                    />
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <span className="text-[11px] text-warm-muted dark:text-dark-muted w-16 flex-none">Model</span>
-                    <div className="relative flex-1">
-                      <select
-                        value={config.sdkAgent?.model ?? 'claude-sonnet-4-6'}
-                        onChange={(e) => updateConfig({ sdkAgent: { ...config.sdkAgent, model: e.target.value } })}
-                        className="appearance-none w-full h-7 rounded-[6px] border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg pl-2.5 pr-7 text-[11px] font-mono text-warm-text dark:text-dark-text outline-none transition-colors focus:border-accent"
-                      >
-                        {SDK_MODEL_OPTIONS.map(opt => (
-                          <option key={opt.value} value={opt.value}>{opt.label}</option>
-                        ))}
-                      </select>
-                      <svg aria-hidden="true" viewBox="0 0 12 12" className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-warm-muted dark:text-dark-muted" fill="none">
-                        <path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-                      </svg>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <span className="text-[11px] text-warm-muted dark:text-dark-muted w-16 flex-none">Base URL</span>
-                    <input
-                      type="text"
-                      value={config.sdkAgent?.baseURL ?? ''}
-                      onChange={(e) => updateConfig({ sdkAgent: { ...config.sdkAgent, baseURL: e.target.value || undefined } })}
-                      placeholder="Default (Anthropic API)"
-                      className="flex-1 h-7 rounded-[6px] border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg px-2.5 text-[11px] font-mono text-warm-text dark:text-dark-text outline-none transition-colors focus:border-accent placeholder:text-warm-faint/50 dark:placeholder:text-dark-muted/50"
-                    />
-                  </div>
-                  <p className="text-[10px] text-warm-faint dark:text-dark-muted leading-relaxed">
-                    Runs directly via API — no CLI install needed. Override Base URL for OpenRouter or other providers.
-                  </p>
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* ── Installed Agents ── */}
-          <div className="mb-6">
-            <h3 className="text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.04em] uppercase mb-3">
-              Installed Agents
-            </h3>
-            <div className="space-y-1.5">
-              {cliAgents.map(agent => {
-                const isReady = agent.status === 'ready'
-                const isSelected = agent.id === selectedId
-                return (
-                  <button
-                    key={agent.id}
-                    onClick={() => isReady && updateConfig({ defaultAgent: agent.id })}
-                    disabled={!isReady}
-                    className={`w-full flex items-center gap-3 px-3 py-2.5 border rounded-[8px] text-left transition-colors ${
-                      isSelected
-                        ? 'bg-accent-bg dark:bg-[#2A1800] border-accent/30 dark:border-accent-dark/30'
-                        : isReady
-                          ? 'bg-warm-surface dark:bg-dark-surface border-warm-border dark:border-dark-border hover:border-warm-border2 dark:hover:border-dark-border2'
-                          : 'bg-warm-bg dark:bg-dark-bg border-warm-border/50 dark:border-dark-border/50 opacity-50 cursor-not-allowed'
-                    }`}
-                  >
-                    <span className={`w-4 h-4 rounded-full border-2 flex-none flex items-center justify-center ${
-                      isSelected ? 'border-accent dark:border-accent-dark' : 'border-warm-border2 dark:border-dark-border2'
-                    }`}>
-                      {isSelected && <span className="w-2 h-2 rounded-full bg-accent dark:bg-accent-dark" />}
-                    </span>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className={`text-sm font-medium ${
-                          isReady ? 'text-warm-text dark:text-dark-text' : 'text-warm-faint dark:text-dark-muted'
-                        }`}>{agent.name}</span>
-                        <span className="text-[9px] font-mono text-warm-faint dark:text-dark-muted px-1.5 py-0.5 bg-warm-surface2 dark:bg-dark-surface2 rounded">
-                          {MODE_LABELS[agent.acpMode] ?? agent.acpMode}
-                        </span>
-                      </div>
-                      <span className="block text-[11px] font-mono text-warm-faint dark:text-dark-muted truncate">
-                        {isReady ? agent.path : `${agent.id} — not found in PATH`}
-                      </span>
-                    </div>
-                    <span className={`text-[10px] font-medium flex-none ${
-                      isReady ? 'text-green-500' : 'text-warm-faint dark:text-dark-muted'
-                    }`}>
-                      {isReady ? 'ready' : 'not found'}
-                    </span>
-                  </button>
-                )
-              })}
-            </div>
-            <p className="text-[11px] text-warm-faint dark:text-dark-muted mt-2">
-              Agents detected on your system.
-              Add custom agents in <span className="font-mono">~/.spool/agents.json</span>.
-            </p>
-          </div>
-
-          {/* Data */}
-          <div className="mb-6">
-            <h3 className="text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.04em] uppercase mb-3">
-              Data
-            </h3>
-            <div className="px-3 py-2.5 bg-warm-surface dark:bg-dark-surface border border-warm-border dark:border-dark-border rounded-[8px]">
-              <div className="flex items-center justify-between">
-                <span className="text-xs text-warm-muted dark:text-dark-muted">Database</span>
-                <span className="text-[11px] font-mono text-warm-faint dark:text-dark-muted">{dbPath}</span>
-              </div>
-            </div>
-            <p className="text-[11px] text-warm-faint dark:text-dark-muted mt-2">
-              All data stays local. Sessions are indexed from agent history directories.
-            </p>
-          </div>
-
-          {/* Search */}
-          <div className="mb-6">
-            <h3 className="text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.04em] uppercase mb-3">
-              Search
-            </h3>
-            <div className="px-3 py-2.5 bg-warm-surface dark:bg-dark-surface border border-warm-border dark:border-dark-border rounded-[8px]">
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-xs text-warm-muted dark:text-dark-muted">Default sort</span>
-                <div className="relative flex-none">
+          {selectedId === sdkAgent.id && (
+            <div className="px-3 py-3 bg-accent-bg dark:bg-[#2A1800] border border-t-0 border-accent/30 dark:border-accent-dark/30 rounded-b-[8px] space-y-2.5">
+              <ConfigRow label="API Key">
+                <input
+                  type="password"
+                  value={config.sdkAgent?.apiKey ?? ''}
+                  onChange={(e) => updateConfig({ sdkAgent: { ...config.sdkAgent, apiKey: e.target.value } })}
+                  placeholder="sk-ant-..."
+                  className="flex-1 h-7 rounded-[6px] border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg px-2.5 text-[11px] font-mono text-warm-text dark:text-dark-text outline-none transition-colors focus:border-accent placeholder:text-warm-faint/50 dark:placeholder:text-dark-muted/50"
+                />
+              </ConfigRow>
+              <ConfigRow label="Model">
+                <div className="relative flex-1">
                   <select
-                    value={config.defaultSearchSort ?? DEFAULT_SEARCH_SORT_ORDER}
-                    onChange={(e) => updateConfig({ defaultSearchSort: e.target.value as SearchSortOrder })}
-                    aria-label="Default search sort"
-                    className="appearance-none h-8 rounded-full border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg pl-3 pr-9 text-xs font-medium text-warm-text dark:text-dark-text outline-none transition-colors hover:border-accent/50 hover:bg-warm-surface2 dark:hover:bg-dark-surface2 focus:border-accent"
+                    value={config.sdkAgent?.model ?? 'claude-sonnet-4-6'}
+                    onChange={(e) => updateConfig({ sdkAgent: { ...config.sdkAgent, model: e.target.value } })}
+                    className="appearance-none w-full h-7 rounded-[6px] border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg pl-2.5 pr-7 text-[11px] font-mono text-warm-text dark:text-dark-text outline-none transition-colors focus:border-accent"
                   >
-                    {SEARCH_SORT_OPTIONS.map(option => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
-                  <svg
-                    aria-hidden="true"
-                    viewBox="0 0 12 12"
-                    className="pointer-events-none absolute right-3 top-1/2 h-3 w-3 -translate-y-1/2 text-warm-muted dark:text-dark-muted"
-                    fill="none"
-                  >
-                    <path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-                  </svg>
-                </div>
-              </div>
-            </div>
-            <p className="text-[11px] text-warm-faint dark:text-dark-muted mt-2">
-              Choose which sort order new search results should use by default.
-            </p>
-          </div>
-
-          {/* Terminal */}
-          <div className="mb-6">
-            <h3 className="text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.04em] uppercase mb-3">
-              Terminal
-            </h3>
-            <div className="px-3 py-2.5 bg-warm-surface dark:bg-dark-surface border border-warm-border dark:border-dark-border rounded-[8px]">
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-xs text-warm-muted dark:text-dark-muted">Session resume</span>
-                <div className="relative flex-none">
-                  <select
-                    value={config.terminal ?? ''}
-                    onChange={(e) => updateConfig({ terminal: e.target.value || undefined })}
-                    aria-label="Terminal for session resume"
-                    className="appearance-none h-8 rounded-full border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg pl-3 pr-9 text-xs font-medium text-warm-text dark:text-dark-text outline-none transition-colors hover:border-accent/50 hover:bg-warm-surface2 dark:hover:bg-dark-surface2 focus:border-accent"
-                  >
-                    {TERMINAL_OPTIONS.map(opt => (
+                    {SDK_MODEL_OPTIONS.map(opt => (
                       <option key={opt.value} value={opt.value}>{opt.label}</option>
                     ))}
                   </select>
-                  <svg
-                    aria-hidden="true"
-                    viewBox="0 0 12 12"
-                    className="pointer-events-none absolute right-3 top-1/2 h-3 w-3 -translate-y-1/2 text-warm-muted dark:text-dark-muted"
-                    fill="none"
-                  >
-                    <path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-                  </svg>
+                  <ChevronDown />
                 </div>
-              </div>
+              </ConfigRow>
+              <ConfigRow label="Base URL">
+                <input
+                  type="text"
+                  value={config.sdkAgent?.baseURL ?? ''}
+                  onChange={(e) => updateConfig({ sdkAgent: { ...config.sdkAgent, baseURL: e.target.value || undefined } })}
+                  placeholder="Default (Anthropic API)"
+                  className="flex-1 h-7 rounded-[6px] border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg px-2.5 text-[11px] font-mono text-warm-text dark:text-dark-text outline-none transition-colors focus:border-accent placeholder:text-warm-faint/50 dark:placeholder:text-dark-muted/50"
+                />
+              </ConfigRow>
+              <p className="text-[10px] text-warm-faint dark:text-dark-muted leading-relaxed">
+                Runs directly via API — no CLI install needed. Override Base URL for OpenRouter or other providers.
+              </p>
             </div>
-            <p className="text-[11px] text-warm-faint dark:text-dark-muted mt-2">
-              Which terminal to open when resuming a session. Auto-detect checks for running third-party terminals.
-            </p>
-          </div>
+          )}
+        </Section>
+      )}
 
-          {/* About */}
-          <div>
-            <h3 className="text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.04em] uppercase mb-3">
-              About
-            </h3>
-            <p className="text-xs text-warm-muted dark:text-dark-muted">
-              Spool — a local search engine for your thinking.
-            </p>
-          </div>
+      {/* Installed Agents */}
+      <Section title="Installed Agents">
+        <div className="space-y-1.5">
+          {cliAgents.map(agent => {
+            const isReady = agent.status === 'ready'
+            const isSelected = agent.id === selectedId
+            return (
+              <button
+                key={agent.id}
+                onClick={() => isReady && updateConfig({ defaultAgent: agent.id })}
+                disabled={!isReady}
+                className={`w-full flex items-center gap-3 px-3 py-2.5 border rounded-[8px] text-left transition-colors ${
+                  isSelected
+                    ? 'bg-accent-bg dark:bg-[#2A1800] border-accent/30 dark:border-accent-dark/30'
+                    : isReady
+                      ? 'bg-warm-surface dark:bg-dark-surface border-warm-border dark:border-dark-border hover:border-warm-border2 dark:hover:border-dark-border2'
+                      : 'bg-warm-bg dark:bg-dark-bg border-warm-border/50 dark:border-dark-border/50 opacity-50 cursor-not-allowed'
+                }`}
+              >
+                <RadioDot selected={isSelected} />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className={`text-xs font-medium ${isReady ? 'text-warm-text dark:text-dark-text' : 'text-warm-faint dark:text-dark-muted'}`}>
+                      {agent.name}
+                    </span>
+                    <span className="text-[9px] font-mono text-warm-faint dark:text-dark-muted px-1.5 py-0.5 bg-warm-surface2 dark:bg-dark-surface2 rounded">
+                      {MODE_LABELS[agent.acpMode] ?? agent.acpMode}
+                    </span>
+                  </div>
+                  <span className="block text-[11px] font-mono text-warm-faint dark:text-dark-muted truncate">
+                    {isReady ? agent.path : `${agent.id} — not found in PATH`}
+                  </span>
+                </div>
+                <span className={`text-[10px] font-medium flex-none ${isReady ? 'text-green-500' : 'text-warm-faint dark:text-dark-muted'}`}>
+                  {isReady ? 'ready' : 'not found'}
+                </span>
+              </button>
+            )
+          })}
         </div>
-      </div>
+        <p className="text-[11px] text-warm-faint dark:text-dark-muted mt-2">
+          Agents detected on your system.
+          Add custom agents in <span className="font-mono">~/.spool/agents.json</span>.
+        </p>
+      </Section>
     </div>
+  )
+}
+
+// ── Shared components ──────────────────────────────────────────────────────
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div>
+      <h4 className="text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.04em] uppercase mb-2">
+        {title}
+      </h4>
+      {children}
+    </div>
+  )
+}
+
+function BuiltInSource({ name, color, count }: { name: string; color: string; count: number | null }) {
+  return (
+    <div className="flex items-center gap-3 py-1.5">
+      <span className="w-2 h-2 rounded-full flex-none" style={{ background: color }} />
+      <span className="flex-1 text-xs text-warm-text dark:text-dark-text">{name}</span>
+      <span className="text-[11px] text-warm-faint dark:text-dark-muted tabular-nums font-mono">
+        {count === null ? '...' : `${count} sessions`}
+      </span>
+      <span className="text-[10px] text-green-500 font-medium">auto</span>
+    </div>
+  )
+}
+
+function RadioDot({ selected }: { selected: boolean }) {
+  return (
+    <span className={`w-4 h-4 rounded-full border-2 flex-none flex items-center justify-center ${
+      selected ? 'border-accent dark:border-accent-dark' : 'border-warm-border2 dark:border-dark-border2'
+    }`}>
+      {selected && <span className="w-2 h-2 rounded-full bg-accent dark:bg-accent-dark" />}
+    </span>
+  )
+}
+
+function ConfigRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-[11px] text-warm-muted dark:text-dark-muted w-16 flex-none">{label}</span>
+      {children}
+    </div>
+  )
+}
+
+function SmallSelect({ value, onChange, options }: { value: string; onChange: (v: string) => void; options: { value: string; label: string }[] }) {
+  return (
+    <div className="relative flex-none">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="appearance-none h-7 rounded-[6px] border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface pl-2.5 pr-7 text-xs text-warm-text dark:text-dark-text outline-none transition-colors hover:border-warm-border2 dark:hover:border-dark-border2 focus:border-accent"
+      >
+        {options.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+      </select>
+      <ChevronDown />
+    </div>
+  )
+}
+
+function ChevronDown() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 12 12" className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-warm-muted dark:text-dark-muted" fill="none">
+      <path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
   )
 }

--- a/packages/app/src/renderer/components/SourcesPanel.tsx
+++ b/packages/app/src/renderer/components/SourcesPanel.tsx
@@ -233,14 +233,9 @@ export default function SourcesPanel({ onClose, claudeCount, codexCount }: Props
                       </button>
                     </div>
                     {isSyncing && progress && (
-                      <div className="ml-5 mt-1">
-                        <div className="h-1 rounded-full bg-warm-border dark:bg-dark-border overflow-hidden">
-                          <div
-                            className="h-full rounded-full bg-accent dark:bg-accent-dark transition-all duration-300"
-                            style={{ width: `${Math.min((progress.page / 50) * 100, 100)}%` }}
-                          />
-                        </div>
-                        <span className="text-[10px] text-warm-faint dark:text-dark-muted mt-0.5 block">
+                      <div className="ml-5 mt-1 flex items-center gap-2">
+                        <div className="h-1 w-3 rounded-full bg-accent dark:bg-accent-dark animate-pulse" />
+                        <span className="text-[10px] text-warm-faint dark:text-dark-muted">
                           {progress.phase === 'forward' ? 'Fetching new items' : 'Backfilling history'}...
                         </span>
                       </div>

--- a/packages/app/src/renderer/components/SourcesPanel.tsx
+++ b/packages/app/src/renderer/components/SourcesPanel.tsx
@@ -151,6 +151,12 @@ export default function SourcesPanel({ onClose, claudeCount, codexCount }: Props
     }
   }
 
+  const handleEnableConnector = async (connectorId: string) => {
+    if (!window.spool?.connectors) return
+    await window.spool.connectors.setEnabled(connectorId, true)
+    await loadConnectors()
+  }
+
   const handleSync = async (src: OpenCLISource) => {
     if (!window.spool?.opencli) return
     setSyncing(src.id)
@@ -205,32 +211,45 @@ export default function SourcesPanel({ onClose, claudeCount, codexCount }: Props
                     <div className="flex items-center gap-3">
                       <span
                         className="w-2 h-2 rounded-full flex-none"
-                        style={{ background: c.color }}
+                        style={{ background: c.enabled ? c.color : '#888' }}
                       />
                       <div className="flex-1 min-w-0">
-                        <span className="text-sm text-warm-text dark:text-dark-text">
+                        <span className={`text-sm ${c.enabled ? 'text-warm-text dark:text-dark-text' : 'text-warm-muted dark:text-dark-muted'}`}>
                           {c.label}
                         </span>
                         <span className="text-xs text-warm-faint dark:text-dark-muted ml-2">
-                          {isSyncing && progress
-                            ? `page ${progress.page} · ${progress.added} new`
-                            : (connectorCounts[c.id] ?? 0) > 0
-                              ? `${connectorCounts[c.id]} items · ${formatSyncTime(c.state.lastForwardSyncAt)}${!c.state.tailComplete ? ' · syncing history' : ''}`
-                              : c.state.lastErrorCode
-                                ? c.state.lastErrorMessage ?? 'Error'
-                                : 'Not synced yet'}
+                          {!c.enabled
+                            ? 'Not connected'
+                            : isSyncing && progress
+                              ? `page ${progress.page} · ${progress.added} new`
+                              : (connectorCounts[c.id] ?? 0) > 0
+                                ? `${connectorCounts[c.id]} items · ${formatSyncTime(c.state.lastForwardSyncAt)}${!c.state.tailComplete ? ' · syncing history' : ''}`
+                                : c.state.lastErrorCode
+                                  ? c.state.lastErrorMessage ?? 'Error'
+                                  : 'Not synced yet'}
                         </span>
                       </div>
-                      {!isSyncing && c.state.lastErrorCode?.startsWith('AUTH_') && (
-                        <span className="text-[10px] text-amber-500 font-medium">needs login</span>
+                      {!c.enabled ? (
+                        <button
+                          onClick={() => handleEnableConnector(c.id)}
+                          className="text-[11px] text-accent dark:text-accent-dark hover:underline"
+                        >
+                          Connect
+                        </button>
+                      ) : (
+                        <>
+                          {!isSyncing && c.state.lastErrorCode?.startsWith('AUTH_') && (
+                            <span className="text-[10px] text-amber-500 font-medium">needs login</span>
+                          )}
+                          <button
+                            onClick={() => handleConnectorSync(c.id)}
+                            disabled={isSyncing}
+                            className="text-[11px] text-accent dark:text-accent-dark hover:underline disabled:opacity-50 opacity-0 group-hover:opacity-100 transition-opacity"
+                          >
+                            {isSyncing ? 'Syncing...' : 'Sync'}
+                          </button>
+                        </>
                       )}
-                      <button
-                        onClick={() => handleConnectorSync(c.id)}
-                        disabled={isSyncing}
-                        className="text-[11px] text-accent dark:text-accent-dark hover:underline disabled:opacity-50 opacity-0 group-hover:opacity-100 transition-opacity"
-                      >
-                        {isSyncing ? 'Syncing...' : 'Sync'}
-                      </button>
                     </div>
                     {isSyncing && progress && (
                       <div className="ml-5 mt-1 flex items-center gap-2">

--- a/packages/app/src/renderer/components/SourcesPanel.tsx
+++ b/packages/app/src/renderer/components/SourcesPanel.tsx
@@ -215,7 +215,7 @@ export default function SourcesPanel({ onClose, claudeCount, codexCount }: Props
                           {isSyncing && progress
                             ? `page ${progress.page} · ${progress.added} new`
                             : (connectorCounts[c.id] ?? 0) > 0
-                              ? `${connectorCounts[c.id]} items · ${formatSyncTime(c.state.lastForwardSyncAt)}`
+                              ? `${connectorCounts[c.id]} items · ${formatSyncTime(c.state.lastForwardSyncAt)}${!c.state.tailComplete ? ' · syncing history' : ''}`
                               : c.state.lastErrorCode
                                 ? c.state.lastErrorMessage ?? 'Error'
                                 : 'Not synced yet'}

--- a/packages/app/src/renderer/components/SourcesPanel.tsx
+++ b/packages/app/src/renderer/components/SourcesPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import type { OpenCLISource, PlatformInfo } from '@spool/core'
+import type { OpenCLISource, PlatformInfo, ConnectorStatus } from '@spool/core'
 
 interface Props {
   onClose: () => void
@@ -54,8 +54,12 @@ function formatSyncTime(iso: string | null): string {
 export default function SourcesPanel({ onClose, claudeCount, codexCount }: Props) {
   const [sources, setSources] = useState<OpenCLISource[]>([])
   const [platforms, setPlatforms] = useState<PlatformInfo[]>([])
+  const [connectors, setConnectors] = useState<ConnectorStatus[]>([])
+  const [connectorCounts, setConnectorCounts] = useState<Record<string, number>>({})
   const [showPicker, setShowPicker] = useState(false)
   const [syncing, setSyncing] = useState<number | null>(null)
+  const [syncingConnector, setSyncingConnector] = useState<string | null>(null)
+  const [syncProgress, setSyncProgress] = useState<Record<string, { page: number; added: number; phase: string }>>({})
   const [syncError, setSyncError] = useState<string | null>(null)
   const [filter, setFilter] = useState('')
 
@@ -71,7 +75,48 @@ export default function SourcesPanel({ onClose, claudeCount, codexCount }: Props
     setPlatforms(list)
   }, [])
 
-  useEffect(() => { loadSources(); loadPlatforms() }, [loadSources, loadPlatforms])
+  const loadConnectors = useCallback(async () => {
+    if (!window.spool?.connectors) return
+    const list = await window.spool.connectors.list()
+    setConnectors(list)
+    // Load real capture counts from DB
+    const counts: Record<string, number> = {}
+    for (const c of list) {
+      counts[c.id] = await window.spool.connectors.getCaptureCount(c.id)
+    }
+    setConnectorCounts(counts)
+  }, [])
+
+  useEffect(() => { loadSources(); loadPlatforms(); loadConnectors() }, [loadSources, loadPlatforms, loadConnectors])
+
+  // Listen for connector sync events to update status
+  useEffect(() => {
+    if (!window.spool?.connectors) return () => {}
+    const off = window.spool.connectors.onEvent((event) => {
+      if (event.type === 'sync-start') {
+        setSyncingConnector(event.connectorId ?? null)
+        setSyncProgress(prev => {
+          const next = { ...prev }
+          if (event.connectorId) next[event.connectorId] = { page: 0, added: 0, phase: 'starting' }
+          return next
+        })
+      } else if (event.type === 'sync-progress') {
+        const p = event.progress as { connectorId: string; phase: string; page: number; added: number } | undefined
+        if (p) {
+          setSyncProgress(prev => ({ ...prev, [p.connectorId]: { page: p.page, added: p.added, phase: p.phase } }))
+        }
+      } else if (event.type === 'sync-complete' || event.type === 'sync-error') {
+        setSyncingConnector(null)
+        setSyncProgress(prev => {
+          const next = { ...prev }
+          if (event.connectorId) delete next[event.connectorId]
+          return next
+        })
+        loadConnectors()
+      }
+    })
+    return off
+  }, [loadConnectors])
 
   /** Resolve a friendly label for a connected source */
   const sourceLabel = useCallback((src: OpenCLISource) => {
@@ -91,6 +136,19 @@ export default function SourcesPanel({ onClose, claudeCount, codexCount }: Props
     if (!window.spool?.opencli) return
     await window.spool.opencli.removeSource(id)
     await loadSources()
+  }
+
+  const handleConnectorSync = async (connectorId: string) => {
+    if (!window.spool?.connectors) return
+    setSyncingConnector(connectorId)
+    setSyncError(null)
+    try {
+      await window.spool.connectors.syncNow(connectorId)
+      // Status updates come via events
+    } catch (err) {
+      setSyncError(`${connectorId}: ${err instanceof Error ? err.message : String(err)}`)
+      setSyncingConnector(null)
+    }
   }
 
   const handleSync = async (src: OpenCLISource) => {
@@ -132,6 +190,73 @@ export default function SourcesPanel({ onClose, claudeCount, codexCount }: Props
             <BuiltInSource name="Claude Code" color={PLATFORM_COLORS['claude']!} count={claudeCount} />
             <BuiltInSource name="Codex CLI" color={PLATFORM_COLORS['codex']!} count={codexCount} />
           </div>
+
+          {/* Native Connectors */}
+          {connectors.length > 0 && (
+            <div className="mb-5">
+              <h3 className="text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.04em] uppercase mb-2">
+                Connectors
+              </h3>
+              {connectors.map(c => {
+                const isSyncing = syncingConnector === c.id || c.syncing
+                const progress = syncProgress[c.id]
+                return (
+                  <div key={c.id} className="py-2.5 group">
+                    <div className="flex items-center gap-3">
+                      <span
+                        className="w-2 h-2 rounded-full flex-none"
+                        style={{ background: c.color }}
+                      />
+                      <div className="flex-1 min-w-0">
+                        <span className="text-sm text-warm-text dark:text-dark-text">
+                          {c.label}
+                        </span>
+                        <span className="text-xs text-warm-faint dark:text-dark-muted ml-2">
+                          {isSyncing && progress
+                            ? `page ${progress.page} · ${progress.added} new`
+                            : (connectorCounts[c.id] ?? 0) > 0
+                              ? `${connectorCounts[c.id]} items · ${formatSyncTime(c.state.lastForwardSyncAt)}`
+                              : c.state.lastErrorCode
+                                ? c.state.lastErrorMessage ?? 'Error'
+                                : 'Not synced yet'}
+                        </span>
+                      </div>
+                      {!isSyncing && c.state.lastErrorCode?.startsWith('AUTH_') && (
+                        <span className="text-[10px] text-amber-500 font-medium">needs login</span>
+                      )}
+                      <button
+                        onClick={() => handleConnectorSync(c.id)}
+                        disabled={isSyncing}
+                        className="text-[11px] text-accent dark:text-accent-dark hover:underline disabled:opacity-50 opacity-0 group-hover:opacity-100 transition-opacity"
+                      >
+                        {isSyncing ? 'Syncing...' : 'Sync'}
+                      </button>
+                    </div>
+                    {isSyncing && progress && (
+                      <div className="ml-5 mt-1">
+                        <div className="h-1 rounded-full bg-warm-border dark:bg-dark-border overflow-hidden">
+                          <div
+                            className="h-full rounded-full bg-accent dark:bg-accent-dark transition-all duration-300"
+                            style={{ width: `${Math.min((progress.page / 50) * 100, 100)}%` }}
+                          />
+                        </div>
+                        <span className="text-[10px] text-warm-faint dark:text-dark-muted mt-0.5 block">
+                          {progress.phase === 'forward' ? 'Fetching new items' : 'Backfilling history'}...
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+              {connectors.some(c => c.state.lastErrorCode) && (
+                <div className="mt-2 px-3 py-2 bg-amber-500/10 border border-amber-500/20 rounded-[6px]">
+                  <p className="text-xs text-amber-600 dark:text-amber-400">
+                    {connectors.find(c => c.state.lastErrorCode)?.state.lastErrorMessage}
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Sync Error */}
           {syncError && (

--- a/packages/app/src/renderer/components/StatusBar.tsx
+++ b/packages/app/src/renderer/components/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useState } from 'react'
 import type { StatusInfo } from '@spool/core'
 import type { SearchMode } from './SearchBar.js'
 
@@ -7,30 +7,7 @@ interface Props {
   searchMode?: SearchMode
   aiAgent?: string
   aiAgentMode?: string
-  onSourcesClick?: () => void
   onSettingsClick?: () => void
-}
-
-type Theme = 'system' | 'light' | 'dark'
-const themeCycle: Theme[] = ['system', 'light', 'dark']
-const themeIcons: Record<Theme, ReactNode> = {
-  system: (
-    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-      <circle cx="8" cy="8" r="5"/>
-      <path d="M8 3V1M8 15v-2M13 8h2M1 8h2M11.5 4.5l1-1M3.5 12.5l1-1M11.5 11.5l1 1M3.5 3.5l1 1"/>
-    </svg>
-  ),
-  light: (
-    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-      <circle cx="8" cy="8" r="4"/>
-      <path d="M8 2V0M8 16v-2M14 8h2M0 8h2M12 4l1.5-1.5M2.5 13.5L4 12M12 12l1.5 1.5M2.5 2.5L4 4"/>
-    </svg>
-  ),
-  dark: (
-    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-      <path d="M13.5 8.5a6 6 0 01-6-6A6 6 0 108.5 14.5a6 6 0 005-6z"/>
-    </svg>
-  ),
 }
 
 interface UpdateStatus {
@@ -39,9 +16,8 @@ interface UpdateStatus {
   percent?: number
 }
 
-export default function StatusBar({ syncStatus, searchMode = 'fast', aiAgent, aiAgentMode, onSourcesClick, onSettingsClick }: Props) {
+export default function StatusBar({ syncStatus, searchMode = 'fast', aiAgent, aiAgentMode, onSettingsClick }: Props) {
   const [status, setStatus] = useState<StatusInfo | null>(null)
-  const [theme, setTheme] = useState<Theme>('system')
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null)
 
   useEffect(() => {
@@ -50,26 +26,12 @@ export default function StatusBar({ syncStatus, searchMode = 'fast', aiAgent, ai
   }, [syncStatus])
 
   useEffect(() => {
-    if (!window.spool) return
-    window.spool.getTheme().then(t => { if (t) setTheme(t) }).catch(console.error)
-  }, [])
-
-  useEffect(() => {
     if (!window.spool?.onUpdateStatus) return () => {}
     return window.spool.onUpdateStatus((data) => {
-      // On error, clear the update state so UI doesn't get stuck on "Updating…"
       if (data.status === 'error') setUpdateStatus(null)
       else setUpdateStatus(data)
     })
   }, [])
-
-  const cycleTheme = () => {
-    if (!window.spool) return
-    const idx = themeCycle.indexOf(theme)
-    const next: Theme = themeCycle[(idx + 1) % themeCycle.length] ?? 'system'
-    setTheme(next)
-    window.spool.setTheme(next)
-  }
 
   const isAiMode = searchMode === 'ai'
   const statusText = isAiMode
@@ -116,13 +78,6 @@ export default function StatusBar({ syncStatus, searchMode = 'fast', aiAgent, ai
           </button>
         )}
         <button
-          onClick={cycleTheme}
-          title={`Theme: ${theme}`}
-          className="text-warm-faint hover:text-warm-text dark:text-dark-muted dark:hover:text-dark-text transition-colors"
-        >
-          {themeIcons[theme]}
-        </button>
-        <button
           onClick={onSettingsClick}
           title="Settings"
           className="text-warm-faint hover:text-warm-text dark:text-dark-muted dark:hover:text-dark-text transition-colors"
@@ -130,12 +85,6 @@ export default function StatusBar({ syncStatus, searchMode = 'fast', aiAgent, ai
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/>
           </svg>
-        </button>
-        <button
-          onClick={onSourcesClick}
-          className="text-[11px] text-warm-faint hover:text-warm-text dark:text-dark-muted dark:hover:text-dark-text transition-colors"
-        >
-          Sources +
         </button>
       </div>
     </div>

--- a/packages/cli/src/commands/connector-sync.ts
+++ b/packages/cli/src/commands/connector-sync.ts
@@ -1,0 +1,95 @@
+import { Command } from 'commander'
+import {
+  getDB,
+  ConnectorRegistry,
+  SyncEngine,
+  TwitterBookmarksConnector,
+  loadSyncState,
+  saveSyncState,
+} from '@spool/core'
+import type { SyncState } from '@spool/core'
+
+export const connectorSyncCommand = new Command('connector-sync')
+  .description('Sync a connector until fully complete')
+  .argument('[connector-id]', 'Connector ID (default: twitter-bookmarks)', 'twitter-bookmarks')
+  .option('--reset', 'Delete all data for this connector and sync from scratch')
+  .option('--delay <ms>', 'Delay between page requests in ms', '600')
+  .action(async (connectorId: string, opts: { reset?: boolean; delay?: string }) => {
+    const db = getDB()
+    const registry = new ConnectorRegistry()
+    registry.register(new TwitterBookmarksConnector())
+
+    if (!registry.has(connectorId)) {
+      console.error(`Unknown connector: ${connectorId}`)
+      console.error(`Available: ${registry.list().map(c => c.id).join(', ')}`)
+      process.exit(1)
+    }
+
+    const connector = registry.get(connectorId)
+
+    // Check auth first
+    const auth = await connector.checkAuth()
+    if (!auth.ok) {
+      console.error(`Auth failed: ${auth.message}`)
+      if (auth.hint) console.error(`Hint: ${auth.hint}`)
+      process.exit(1)
+    }
+
+    // Reset if requested
+    if (opts.reset) {
+      console.log(`Resetting ${connectorId}...`)
+      db.prepare(
+        `DELETE FROM captures WHERE json_extract(metadata, '$.connectorId') = ?`,
+      ).run(connectorId)
+      db.prepare('DELETE FROM connector_sync_state WHERE connector_id = ?').run(connectorId)
+      console.log('Data cleared.')
+    }
+
+    const engine = new SyncEngine(db)
+    const delayMs = parseInt(opts.delay ?? '600', 10)
+    const startedAt = Date.now()
+
+    console.log(`Syncing ${connector.label}... (Ctrl+C to stop)`)
+
+    // Handle graceful shutdown
+    let aborted = false
+    const controller = new AbortController()
+    process.on('SIGINT', () => {
+      if (aborted) process.exit(1) // second Ctrl+C = force quit
+      console.log('\nStopping after current page...')
+      aborted = true
+      controller.abort()
+    })
+
+    const result = await engine.sync(connector, {
+      direction: 'both',
+      delayMs,
+      maxMinutes: 0, // no time limit
+      signal: controller.signal,
+      onProgress: (p) => {
+        const elapsed = ((Date.now() - startedAt) / 1000).toFixed(0)
+        process.stdout.write(
+          `\r  ${p.phase} page ${p.page} · ${p.added} new · ${elapsed}s elapsed`,
+        )
+      },
+    })
+
+    process.stdout.write('\n')
+
+    // Final count from DB
+    const row = db.prepare(
+      `SELECT COUNT(*) as cnt FROM captures WHERE platform = ? AND json_extract(metadata, '$.connectorId') = ?`,
+    ).get(connector.platform, connectorId) as { cnt: number }
+
+    console.log(`Done.`)
+    console.log(`  stop reason: ${result.stopReason}`)
+    console.log(`  pages fetched: ${result.pages}`)
+    console.log(`  new items: ${result.added}`)
+    console.log(`  total in DB: ${row.cnt}`)
+
+    if (result.error) {
+      console.error(`  error [${result.error.code}]: ${result.error.message}`)
+    }
+
+    process.exit(result.error ? 1 : 0)
+  })

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { statusCommand } from './commands/status.js'
 import { showCommand } from './commands/show.js'
 import { captureCommand } from './commands/capture.js'
 import { sourcesCommand } from './commands/sources.js'
+import { connectorSyncCommand } from './commands/connector-sync.js'
 
 program
   .name('spool')
@@ -19,5 +20,6 @@ program.addCommand(statusCommand)
 program.addCommand(showCommand)
 program.addCommand(captureCommand)
 program.addCommand(sourcesCommand)
+program.addCommand(connectorSyncCommand)
 
 program.parse()

--- a/packages/core/src/connectors/registry.ts
+++ b/packages/core/src/connectors/registry.ts
@@ -1,0 +1,37 @@
+import type { Connector } from './types.js'
+
+/**
+ * In-memory registry of available connectors.
+ *
+ * Connectors are registered at app startup. The registry is the single source
+ * of truth for "what connectors exist" — the scheduler and UI both read from it.
+ */
+export class ConnectorRegistry {
+  private connectors = new Map<string, Connector>()
+
+  register(connector: Connector): void {
+    if (this.connectors.has(connector.id)) {
+      throw new Error(`Connector "${connector.id}" is already registered`)
+    }
+    this.connectors.set(connector.id, connector)
+  }
+
+  get(id: string): Connector {
+    const connector = this.connectors.get(id)
+    if (!connector) throw new Error(`Connector "${id}" not found`)
+    return connector
+  }
+
+  has(id: string): boolean {
+    return this.connectors.has(id)
+  }
+
+  list(): Connector[] {
+    return Array.from(this.connectors.values())
+  }
+
+  /** List connectors for a specific platform. */
+  listByPlatform(platform: string): Connector[] {
+    return this.list().filter(c => c.platform === platform)
+  }
+}

--- a/packages/core/src/connectors/sync-engine.ts
+++ b/packages/core/src/connectors/sync-engine.ts
@@ -235,6 +235,112 @@ export class SyncEngine {
     }
   }
 
+  /**
+   * Fetch pages in a loop until a stop condition is met.
+   * Handles errors gracefully: saves progress and returns instead of throwing.
+   */
+  private async fetchLoop(
+    connector: Connector,
+    state: SyncState,
+    opts: SyncOptions & { phase: 'forward' | 'backfill' },
+    sourceId: number,
+    startCursor: string | null,
+    startedAt: number,
+  ): Promise<{ added: number; pages: number; stopReason: string; error?: { code: string; message: string } }> {
+    const delayMs = opts.delayMs ?? 1200
+    const maxMinutes = opts.maxMinutes ?? 0
+    const stalePageLimit = opts.stalePageLimit ?? 3
+    const checkpointEvery = 25
+
+    let cursor = startCursor
+    let added = 0
+    let pages = 0
+    let stalePages = 0
+
+    for (let page = 0; ; page++) {
+      if (maxMinutes > 0 && this.isTimedOut(startedAt, maxMinutes)) {
+        return { added, pages, stopReason: 'timeout' }
+      }
+      if (opts.signal?.aborted) {
+        return { added, pages, stopReason: 'cancelled' }
+      }
+
+      let result
+      try {
+        result = await connector.fetchPage(cursor)
+      } catch (err) {
+        // Save progress before returning — don't throw, don't lose work
+        console.error(`[sync-engine] ${connector.id} ${opts.phase} page ${page + 1} error:`, err instanceof Error ? err.message : err)
+        saveSyncState(this.db, state)
+        return {
+          added, pages,
+          stopReason: `error: ${err instanceof SyncError ? err.code : 'CONNECTOR_ERROR'}`,
+          error: {
+            code: err instanceof SyncError ? err.code : 'CONNECTOR_ERROR',
+            message: err instanceof Error ? err.message : String(err),
+          },
+        }
+      }
+      pages++
+
+      if (result.items.length === 0 && !result.nextCursor) {
+        if (opts.phase === 'backfill') state.tailComplete = true
+        return { added, pages, stopReason: opts.phase === 'backfill' ? 'backfill_complete' : 'end_of_data' }
+      }
+
+      // Tag items with connectorId
+      for (const item of result.items) {
+        (item.metadata as Record<string, unknown>)['connectorId'] = connector.id
+      }
+
+      const { newCount } = this.db.transaction(() =>
+        upsertItems(this.db, sourceId, result.items),
+      )()
+      added += newCount
+
+      // Track head (forward) or tail (backfill)
+      if (opts.phase === 'forward') {
+        const firstItem = result.items[0]
+        if (firstItem && firstItem.platformId) state.headItemId = firstItem.platformId
+      }
+
+      opts.onProgress?.({
+        connectorId: connector.id,
+        phase: opts.phase,
+        page: page + 1,
+        fetched: result.items.length,
+        added,
+        running: true,
+      })
+
+      // Stale page detection: stop when we keep seeing only known data
+      if (newCount === 0) stalePages++
+      else stalePages = 0
+      if (stalePages >= stalePageLimit) {
+        if (opts.phase === 'backfill') state.tailComplete = true
+        return { added, pages, stopReason: opts.phase === 'forward' ? 'caught_up' : 'backfill_complete' }
+      }
+
+      if (!result.nextCursor) {
+        if (opts.phase === 'backfill') state.tailComplete = true
+        return { added, pages, stopReason: opts.phase === 'backfill' ? 'backfill_complete' : 'end_of_data' }
+      }
+
+      cursor = result.nextCursor
+
+      // Update cursor in state for resume
+      if (opts.phase === 'forward') state.tailCursor = cursor
+      else state.tailCursor = cursor
+
+      // Checkpoint periodically (crash safety)
+      if (pages % checkpointEvery === 0) {
+        saveSyncState(this.db, state)
+      }
+
+      await this.delay(delayMs)
+    }
+  }
+
   private async syncPersistent(
     connector: Connector,
     state: SyncState,
@@ -242,152 +348,31 @@ export class SyncEngine {
     startedAt: number,
   ): Promise<ConnectorSyncResult> {
     const direction = opts.direction ?? 'both'
-    const delayMs = opts.delayMs ?? 600
-    const maxMinutes = opts.maxMinutes ?? 5
-    const stalePageLimit = opts.stalePageLimit ?? 3
     const sourceId = getSourceId(this.db)
 
     let totalAdded = 0
     let totalPages = 0
     let stopReason = 'complete'
+    let lastError: { code: string; message: string } | undefined
 
     // ── Phase 1: Forward sync ───────────────────────────────────────
     if (direction === 'forward' || direction === 'both') {
-      const forwardMax = opts.forwardMaxPages ?? 50
-      let cursor: string | null = null // start from newest
-      let stalePages = 0
-
-      for (let page = 0; page < forwardMax; page++) {
-        if (this.isTimedOut(startedAt, maxMinutes)) {
-          stopReason = 'timeout'
-          break
-        }
-        if (opts.signal?.aborted) {
-          stopReason = 'cancelled'
-          break
-        }
-
-        let result
-        try {
-          result = await connector.fetchPage(cursor)
-        } catch (err) {
-          console.error(`[sync-engine] ${connector.id} forward page ${page + 1} fetch error:`, err)
-          throw err
-        }
-        totalPages++
-        console.log(`[sync-engine] ${connector.id} forward page ${page + 1}: ${result.items.length} items, cursor=${result.nextCursor ? 'yes' : 'no'}`)
-
-        if (result.items.length === 0 && !result.nextCursor) {
-          stopReason = 'end_of_data'
-          break
-        }
-
-        // Tag items with connectorId in metadata
-        for (const item of result.items) {
-          (item.metadata as Record<string, unknown>)['connectorId'] = connector.id
-        }
-
-        const { newCount } = this.db.transaction(() =>
-          upsertItems(this.db, sourceId, result.items),
-        )()
-        totalAdded += newCount
-
-        // Update head to track the newest item we've seen
-        const firstItem = result.items[0]
-        if (firstItem && firstItem.platformId) {
-          state.headItemId = firstItem.platformId
-        }
-
-        opts.onProgress?.({
-          connectorId: connector.id,
-          phase: 'forward',
-          page: page + 1,
-          fetched: result.items.length,
-          added: totalAdded,
-          running: true,
-        })
-
-        // Stop conditions
-        if (newCount === 0) stalePages++
-        else stalePages = 0
-
-        if (stalePages >= stalePageLimit) {
-          stopReason = 'caught_up'
-          break
-        }
-        if (!result.nextCursor) {
-          stopReason = 'end_of_data'
-          break
-        }
-
-        cursor = result.nextCursor
-
-        // After forward phase, record tail cursor so backfill continues from here
-        state.tailCursor = cursor
-
-        if (page < forwardMax - 1) await this.delay(delayMs)
-      }
-
+      const fwd = await this.fetchLoop(connector, state, { ...opts, phase: 'forward' }, sourceId, null, startedAt)
+      totalAdded += fwd.added
+      totalPages += fwd.pages
+      stopReason = fwd.stopReason
+      if (fwd.error) lastError = fwd.error
       state.lastForwardSyncAt = new Date().toISOString()
     }
 
-    // ── Phase 2: Backfill ───────────────────────────────────────────
-    if (!state.tailComplete && (direction === 'backfill' || direction === 'both')) {
-      const backfillMax = opts.backfillMaxPages ?? 10
-      let cursor = state.tailCursor
-
-      for (let page = 0; page < backfillMax; page++) {
-        if (this.isTimedOut(startedAt, maxMinutes)) {
-          stopReason = 'timeout'
-          break
-        }
-        if (opts.signal?.aborted) {
-          stopReason = 'cancelled'
-          break
-        }
-
-        const result = await connector.fetchPage(cursor)
-        totalPages++
-
-        if (result.items.length === 0 && !result.nextCursor) {
-          state.tailComplete = true
-          stopReason = 'backfill_complete'
-          break
-        }
-
-        for (const item of result.items) {
-          (item.metadata as Record<string, unknown>)['connectorId'] = connector.id
-        }
-
-        const { newCount } = this.db.transaction(() =>
-          upsertItems(this.db, sourceId, result.items),
-        )()
-        totalAdded += newCount
-
-        opts.onProgress?.({
-          connectorId: connector.id,
-          phase: 'backfill',
-          page: page + 1,
-          fetched: result.items.length,
-          added: totalAdded,
-          running: true,
-        })
-
-        if (!result.nextCursor) {
-          state.tailComplete = true
-          stopReason = 'backfill_complete'
-          break
-        }
-
-        state.tailCursor = result.nextCursor
-        cursor = result.nextCursor
-
-        // Checkpoint state every page during backfill (crash safety)
-        saveSyncState(this.db, state)
-
-        if (page < backfillMax - 1) await this.delay(delayMs)
-      }
-
+    // ── Phase 2: Backfill — runs until complete ─────────────────────
+    // Only run backfill if forward didn't error out
+    if (!lastError && !state.tailComplete && (direction === 'backfill' || direction === 'both')) {
+      const bf = await this.fetchLoop(connector, state, { ...opts, phase: 'backfill' }, sourceId, state.tailCursor, startedAt)
+      totalAdded += bf.added
+      totalPages += bf.pages
+      stopReason = bf.stopReason
+      if (bf.error) lastError = bf.error
       state.lastBackfillSyncAt = new Date().toISOString()
     }
 
@@ -405,7 +390,7 @@ export class SyncEngine {
       running: false,
     })
 
-    return {
+    const ret: ConnectorSyncResult = {
       connectorId: connector.id,
       added: totalAdded,
       total: state.totalSynced,
@@ -413,6 +398,10 @@ export class SyncEngine {
       direction,
       stopReason,
     }
+    if (lastError) {
+      ret.error = { code: lastError.code as SyncErrorCode, message: lastError.message }
+    }
+    return ret
   }
 
   private async syncEphemeral(
@@ -421,9 +410,8 @@ export class SyncEngine {
     opts: SyncOptions,
     startedAt: number,
   ): Promise<ConnectorSyncResult> {
-    const maxPages = opts.forwardMaxPages ?? 5
     const delayMs = opts.delayMs ?? 600
-    const maxMinutes = opts.maxMinutes ?? 5
+    const maxMinutes = opts.maxMinutes ?? 0
     const sourceId = getSourceId(this.db)
 
     // Ephemeral: delete old items and fetch fresh
@@ -434,8 +422,8 @@ export class SyncEngine {
     let totalPages = 0
     let stopReason = 'complete'
 
-    for (let page = 0; page < maxPages; page++) {
-      if (this.isTimedOut(startedAt, maxMinutes)) {
+    for (let page = 0; ; page++) {
+      if (maxMinutes > 0 && this.isTimedOut(startedAt, maxMinutes)) {
         stopReason = 'timeout'
         break
       }
@@ -458,7 +446,7 @@ export class SyncEngine {
 
       if (!result.nextCursor) break
       cursor = result.nextCursor
-      if (page < maxPages - 1) await this.delay(delayMs)
+      await this.delay(delayMs)
     }
 
     state.totalSynced = totalAdded

--- a/packages/core/src/connectors/sync-engine.ts
+++ b/packages/core/src/connectors/sync-engine.ts
@@ -1,0 +1,485 @@
+import type Database from 'better-sqlite3'
+import { randomUUID } from 'node:crypto'
+import type {
+  Connector,
+  SyncState,
+  SyncOptions,
+  ConnectorSyncResult,
+  SyncProgress,
+  SyncErrorCode,
+} from './types.js'
+import { SyncError } from './types.js'
+import type { CapturedItem } from '../types.js'
+
+// ── Sync State Persistence ──────────────────────────────────────────────────
+
+export function loadSyncState(db: Database.Database, connectorId: string): SyncState {
+  const row = db.prepare('SELECT * FROM connector_sync_state WHERE connector_id = ?')
+    .get(connectorId) as Record<string, unknown> | undefined
+
+  if (!row) {
+    return {
+      connectorId,
+      headCursor: null,
+      headItemId: null,
+      tailCursor: null,
+      tailComplete: false,
+      lastForwardSyncAt: null,
+      lastBackfillSyncAt: null,
+      totalSynced: 0,
+      consecutiveErrors: 0,
+      enabled: true,
+      configJson: {},
+      lastErrorCode: null,
+      lastErrorMessage: null,
+    }
+  }
+
+  let configJson: Record<string, unknown> = {}
+  try { configJson = JSON.parse(row['config_json'] as string) } catch {}
+
+  return {
+    connectorId,
+    headCursor: row['head_cursor'] as string | null,
+    headItemId: row['head_item_id'] as string | null,
+    tailCursor: row['tail_cursor'] as string | null,
+    tailComplete: Boolean(row['tail_complete']),
+    lastForwardSyncAt: row['last_forward_sync_at'] as string | null,
+    lastBackfillSyncAt: row['last_backfill_sync_at'] as string | null,
+    totalSynced: row['total_synced'] as number,
+    consecutiveErrors: row['consecutive_errors'] as number,
+    enabled: Boolean(row['enabled']),
+    configJson,
+    lastErrorCode: row['last_error_code'] as SyncErrorCode | null,
+    lastErrorMessage: row['last_error_message'] as string | null,
+  }
+}
+
+export function saveSyncState(db: Database.Database, state: SyncState): void {
+  db.prepare(`
+    INSERT INTO connector_sync_state
+      (connector_id, head_cursor, head_item_id, tail_cursor, tail_complete,
+       last_forward_sync_at, last_backfill_sync_at, total_synced,
+       consecutive_errors, enabled, config_json, last_error_code, last_error_message)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(connector_id) DO UPDATE SET
+      head_cursor = excluded.head_cursor,
+      head_item_id = excluded.head_item_id,
+      tail_cursor = excluded.tail_cursor,
+      tail_complete = excluded.tail_complete,
+      last_forward_sync_at = excluded.last_forward_sync_at,
+      last_backfill_sync_at = excluded.last_backfill_sync_at,
+      total_synced = excluded.total_synced,
+      consecutive_errors = excluded.consecutive_errors,
+      enabled = excluded.enabled,
+      config_json = excluded.config_json,
+      last_error_code = excluded.last_error_code,
+      last_error_message = excluded.last_error_message
+  `).run(
+    state.connectorId,
+    state.headCursor, state.headItemId,
+    state.tailCursor, state.tailComplete ? 1 : 0,
+    state.lastForwardSyncAt, state.lastBackfillSyncAt,
+    state.totalSynced, state.consecutiveErrors,
+    state.enabled ? 1 : 0,
+    JSON.stringify(state.configJson),
+    state.lastErrorCode, state.lastErrorMessage,
+  )
+}
+
+// ── Item Upsert ─────────────────────────────────────────────────────────────
+
+interface UpsertResult {
+  newCount: number
+  updatedCount: number
+}
+
+function upsertItems(
+  db: Database.Database,
+  sourceId: number,
+  items: CapturedItem[],
+): UpsertResult {
+  let newCount = 0
+  let updatedCount = 0
+
+  const checkStmt = db.prepare(
+    'SELECT id FROM captures WHERE platform = ? AND platform_id = ?',
+  )
+  const updateStmt = db.prepare(`
+    UPDATE captures SET
+      title = ?, content_text = ?, author = ?, metadata = ?,
+      captured_at = ?, raw_json = ?, thumbnail_url = ?
+    WHERE id = ?
+  `)
+  const insertStmt = db.prepare(`
+    INSERT INTO captures
+      (source_id, opencli_src_id, capture_uuid, url, title, content_text,
+       author, platform, platform_id, content_type, thumbnail_url,
+       metadata, captured_at, raw_json)
+    VALUES (?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+
+  for (const item of items) {
+    if (item.platformId) {
+      const existing = checkStmt.get(item.platform, item.platformId) as
+        | { id: number }
+        | undefined
+      if (existing) {
+        updateStmt.run(
+          item.title, item.contentText, item.author,
+          JSON.stringify(item.metadata), item.capturedAt, item.rawJson,
+          item.thumbnailUrl, existing.id,
+        )
+        updatedCount++
+        continue
+      }
+    }
+
+    insertStmt.run(
+      sourceId, randomUUID(), item.url, item.title, item.contentText,
+      item.author, item.platform, item.platformId, item.contentType,
+      item.thumbnailUrl, JSON.stringify(item.metadata), item.capturedAt,
+      item.rawJson,
+    )
+    newCount++
+  }
+
+  return { newCount, updatedCount }
+}
+
+function deleteConnectorItems(db: Database.Database, connectorId: string): void {
+  // connectorId format is e.g. 'twitter-bookmarks', platform is 'twitter'
+  // We need the connector to know which platform+content_type to delete.
+  // For now, delete by matching connector_id pattern in metadata or by platform.
+  // Since we store connector_id in captures metadata, let's use a convention:
+  // captures from connectors have metadata.connectorId set.
+  db.prepare(
+    `DELETE FROM captures WHERE json_extract(metadata, '$.connectorId') = ?`,
+  ).run(connectorId)
+}
+
+// ── Sync Engine ─────────────────────────────────────────────────────────────
+
+function getSourceId(db: Database.Database): number {
+  // Reuse the 'opencli' source for now — captures table needs a source_id FK.
+  // All connector items share this source_id; the connector_id in metadata
+  // and connector_sync_state table distinguish them.
+  const row = db.prepare("SELECT id FROM sources WHERE name = 'opencli'").get() as
+    | { id: number }
+    | undefined
+  if (!row) throw new Error("Source 'opencli' not found in DB")
+  return row.id
+}
+
+function hasKnownItem(
+  db: Database.Database,
+  platform: string,
+  items: CapturedItem[],
+): boolean {
+  if (items.length === 0) return false
+  const stmt = db.prepare(
+    'SELECT 1 FROM captures WHERE platform = ? AND platform_id = ? LIMIT 1',
+  )
+  for (const item of items) {
+    if (item.platformId && stmt.get(platform, item.platformId)) return true
+  }
+  return false
+}
+
+export class SyncEngine {
+  constructor(private db: Database.Database) {}
+
+  loadState(connectorId: string): SyncState {
+    return loadSyncState(this.db, connectorId)
+  }
+
+  async sync(connector: Connector, opts: SyncOptions = {}): Promise<ConnectorSyncResult> {
+    const state = loadSyncState(this.db, connector.id)
+    const startedAt = Date.now()
+
+    try {
+      const result = connector.ephemeral
+        ? await this.syncEphemeral(connector, state, opts, startedAt)
+        : await this.syncPersistent(connector, state, opts, startedAt)
+
+      // Success: clear error state
+      state.consecutiveErrors = 0
+      state.lastErrorCode = null
+      state.lastErrorMessage = null
+      saveSyncState(this.db, state)
+
+      return result
+    } catch (err) {
+      const syncErr = err instanceof SyncError
+        ? err
+        : new SyncError(
+            'CONNECTOR_ERROR' as SyncErrorCode,
+            err instanceof Error ? err.message : String(err),
+            err,
+          )
+
+      state.consecutiveErrors += 1
+      state.lastErrorCode = syncErr.code
+      state.lastErrorMessage = syncErr.message
+      saveSyncState(this.db, state)
+
+      return {
+        connectorId: connector.id,
+        added: 0,
+        total: state.totalSynced,
+        pages: 0,
+        direction: opts.direction ?? 'both',
+        stopReason: `error: ${syncErr.code}`,
+        error: { code: syncErr.code, message: syncErr.message },
+      }
+    }
+  }
+
+  private async syncPersistent(
+    connector: Connector,
+    state: SyncState,
+    opts: SyncOptions,
+    startedAt: number,
+  ): Promise<ConnectorSyncResult> {
+    const direction = opts.direction ?? 'both'
+    const delayMs = opts.delayMs ?? 600
+    const maxMinutes = opts.maxMinutes ?? 5
+    const stalePageLimit = opts.stalePageLimit ?? 3
+    const sourceId = getSourceId(this.db)
+
+    let totalAdded = 0
+    let totalPages = 0
+    let stopReason = 'complete'
+
+    // ── Phase 1: Forward sync ───────────────────────────────────────
+    if (direction === 'forward' || direction === 'both') {
+      const forwardMax = opts.forwardMaxPages ?? 50
+      let cursor: string | null = null // start from newest
+      let stalePages = 0
+
+      for (let page = 0; page < forwardMax; page++) {
+        if (this.isTimedOut(startedAt, maxMinutes)) {
+          stopReason = 'timeout'
+          break
+        }
+        if (opts.signal?.aborted) {
+          stopReason = 'cancelled'
+          break
+        }
+
+        let result
+        try {
+          result = await connector.fetchPage(cursor)
+        } catch (err) {
+          console.error(`[sync-engine] ${connector.id} forward page ${page + 1} fetch error:`, err)
+          throw err
+        }
+        totalPages++
+        console.log(`[sync-engine] ${connector.id} forward page ${page + 1}: ${result.items.length} items, cursor=${result.nextCursor ? 'yes' : 'no'}`)
+
+        if (result.items.length === 0 && !result.nextCursor) {
+          stopReason = 'end_of_data'
+          break
+        }
+
+        // Tag items with connectorId in metadata
+        for (const item of result.items) {
+          (item.metadata as Record<string, unknown>)['connectorId'] = connector.id
+        }
+
+        const { newCount } = this.db.transaction(() =>
+          upsertItems(this.db, sourceId, result.items),
+        )()
+        totalAdded += newCount
+
+        // Update head to track the newest item we've seen
+        const firstItem = result.items[0]
+        if (firstItem && firstItem.platformId) {
+          state.headItemId = firstItem.platformId
+        }
+
+        opts.onProgress?.({
+          connectorId: connector.id,
+          phase: 'forward',
+          page: page + 1,
+          fetched: result.items.length,
+          added: totalAdded,
+          running: true,
+        })
+
+        // Stop conditions
+        if (newCount === 0) stalePages++
+        else stalePages = 0
+
+        if (stalePages >= stalePageLimit) {
+          stopReason = 'caught_up'
+          break
+        }
+        if (!result.nextCursor) {
+          stopReason = 'end_of_data'
+          break
+        }
+
+        cursor = result.nextCursor
+
+        // After forward phase, record tail cursor so backfill continues from here
+        state.tailCursor = cursor
+
+        if (page < forwardMax - 1) await this.delay(delayMs)
+      }
+
+      state.lastForwardSyncAt = new Date().toISOString()
+    }
+
+    // ── Phase 2: Backfill ───────────────────────────────────────────
+    if (!state.tailComplete && (direction === 'backfill' || direction === 'both')) {
+      const backfillMax = opts.backfillMaxPages ?? 10
+      let cursor = state.tailCursor
+
+      for (let page = 0; page < backfillMax; page++) {
+        if (this.isTimedOut(startedAt, maxMinutes)) {
+          stopReason = 'timeout'
+          break
+        }
+        if (opts.signal?.aborted) {
+          stopReason = 'cancelled'
+          break
+        }
+
+        const result = await connector.fetchPage(cursor)
+        totalPages++
+
+        if (result.items.length === 0 && !result.nextCursor) {
+          state.tailComplete = true
+          stopReason = 'backfill_complete'
+          break
+        }
+
+        for (const item of result.items) {
+          (item.metadata as Record<string, unknown>)['connectorId'] = connector.id
+        }
+
+        const { newCount } = this.db.transaction(() =>
+          upsertItems(this.db, sourceId, result.items),
+        )()
+        totalAdded += newCount
+
+        opts.onProgress?.({
+          connectorId: connector.id,
+          phase: 'backfill',
+          page: page + 1,
+          fetched: result.items.length,
+          added: totalAdded,
+          running: true,
+        })
+
+        if (!result.nextCursor) {
+          state.tailComplete = true
+          stopReason = 'backfill_complete'
+          break
+        }
+
+        state.tailCursor = result.nextCursor
+        cursor = result.nextCursor
+
+        // Checkpoint state every page during backfill (crash safety)
+        saveSyncState(this.db, state)
+
+        if (page < backfillMax - 1) await this.delay(delayMs)
+      }
+
+      state.lastBackfillSyncAt = new Date().toISOString()
+    }
+
+    state.totalSynced += totalAdded
+    saveSyncState(this.db, state)
+
+    console.log(`[sync-engine] ${connector.id} done: added=${totalAdded} pages=${totalPages} reason=${stopReason}`)
+
+    opts.onProgress?.({
+      connectorId: connector.id,
+      phase: 'forward',
+      page: totalPages,
+      fetched: 0,
+      added: totalAdded,
+      running: false,
+    })
+
+    return {
+      connectorId: connector.id,
+      added: totalAdded,
+      total: state.totalSynced,
+      pages: totalPages,
+      direction,
+      stopReason,
+    }
+  }
+
+  private async syncEphemeral(
+    connector: Connector,
+    state: SyncState,
+    opts: SyncOptions,
+    startedAt: number,
+  ): Promise<ConnectorSyncResult> {
+    const maxPages = opts.forwardMaxPages ?? 5
+    const delayMs = opts.delayMs ?? 600
+    const maxMinutes = opts.maxMinutes ?? 5
+    const sourceId = getSourceId(this.db)
+
+    // Ephemeral: delete old items and fetch fresh
+    this.db.transaction(() => deleteConnectorItems(this.db, connector.id))()
+
+    let cursor: string | null = null
+    let totalAdded = 0
+    let totalPages = 0
+    let stopReason = 'complete'
+
+    for (let page = 0; page < maxPages; page++) {
+      if (this.isTimedOut(startedAt, maxMinutes)) {
+        stopReason = 'timeout'
+        break
+      }
+      if (opts.signal?.aborted) {
+        stopReason = 'cancelled'
+        break
+      }
+
+      const result = await connector.fetchPage(cursor)
+      totalPages++
+
+      for (const item of result.items) {
+        (item.metadata as Record<string, unknown>)['connectorId'] = connector.id
+      }
+
+      this.db.transaction(() => {
+        const { newCount } = upsertItems(this.db, sourceId, result.items)
+        totalAdded += newCount
+      })()
+
+      if (!result.nextCursor) break
+      cursor = result.nextCursor
+      if (page < maxPages - 1) await this.delay(delayMs)
+    }
+
+    state.totalSynced = totalAdded
+    state.lastForwardSyncAt = new Date().toISOString()
+    saveSyncState(this.db, state)
+
+    return {
+      connectorId: connector.id,
+      added: totalAdded,
+      total: totalAdded,
+      pages: totalPages,
+      direction: 'forward',
+      stopReason,
+    }
+  }
+
+  private isTimedOut(startedAt: number, maxMinutes: number): boolean {
+    return Date.now() - startedAt > maxMinutes * 60_000
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms))
+  }
+}

--- a/packages/core/src/connectors/sync-engine.ts
+++ b/packages/core/src/connectors/sync-engine.ts
@@ -28,7 +28,7 @@ export function loadSyncState(db: Database.Database, connectorId: string): SyncS
       lastBackfillSyncAt: null,
       totalSynced: 0,
       consecutiveErrors: 0,
-      enabled: true,
+      enabled: false,
       configJson: {},
       lastErrorCode: null,
       lastErrorMessage: null,

--- a/packages/core/src/connectors/sync-scheduler.ts
+++ b/packages/core/src/connectors/sync-scheduler.ts
@@ -1,0 +1,250 @@
+import type {
+  Connector,
+  SyncJob,
+  SyncJobPriority,
+  ConnectorSyncResult,
+  ScheduleConfig,
+  SchedulerStatus,
+  ConnectorStatus,
+  SyncProgress,
+} from './types.js'
+import { DEFAULT_SCHEDULE, SyncErrorCode } from './types.js'
+import type { ConnectorRegistry } from './registry.js'
+import { SyncEngine, loadSyncState } from './sync-engine.js'
+import type Database from 'better-sqlite3'
+
+export type SchedulerEvent =
+  | { type: 'sync-start'; connectorId: string }
+  | { type: 'sync-progress'; progress: SyncProgress }
+  | { type: 'sync-complete'; result: ConnectorSyncResult }
+  | { type: 'sync-error'; connectorId: string; code: SyncErrorCode; message: string }
+
+export type SchedulerEventHandler = (event: SchedulerEvent) => void
+
+export class SyncScheduler {
+  private engine: SyncEngine
+  private config: ScheduleConfig
+  private queue: SyncJob[] = []
+  private running = new Map<string, AbortController>()
+  private timer: ReturnType<typeof setInterval> | null = null
+  private started = false
+  private eventHandlers: SchedulerEventHandler[] = []
+
+  constructor(
+    private db: Database.Database,
+    private registry: ConnectorRegistry,
+    config?: Partial<ScheduleConfig>,
+  ) {
+    this.engine = new SyncEngine(db)
+    this.config = { ...DEFAULT_SCHEDULE, ...config }
+  }
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  start(): void {
+    if (this.started) return
+    this.started = true
+
+    // Queue immediate forward sync for all enabled connectors
+    this.queueAll('both', 80)
+
+    // Start the tick loop (check every 30 seconds)
+    this.timer = setInterval(() => this.tick(), 30_000)
+    // Run first tick immediately
+    this.tick()
+  }
+
+  stop(): void {
+    this.started = false
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    // Abort all running syncs
+    for (const [, controller] of this.running) {
+      controller.abort()
+    }
+    this.running.clear()
+    this.queue = []
+  }
+
+  /** Manually trigger sync for a specific connector. */
+  triggerNow(connectorId: string, direction: 'forward' | 'backfill' | 'both' = 'both'): void {
+    this.enqueue({ connectorId, direction, priority: 100, queuedAt: Date.now() })
+    this.tick()
+  }
+
+  /** Notify the scheduler that the system woke from sleep. */
+  onWake(): void {
+    this.queueAll('forward', 60)
+    this.tick()
+  }
+
+  /** Subscribe to scheduler events. */
+  on(handler: SchedulerEventHandler): () => void {
+    this.eventHandlers.push(handler)
+    return () => {
+      this.eventHandlers = this.eventHandlers.filter(h => h !== handler)
+    }
+  }
+
+  // ── Status ────────────────────────────────────────────────────────────────
+
+  getStatus(): SchedulerStatus {
+    const connectors: ConnectorStatus[] = this.registry.list().map(c => {
+      const state = loadSyncState(this.db, c.id)
+      return {
+        id: c.id,
+        label: c.label,
+        platform: c.platform,
+        color: c.color,
+        enabled: state.enabled,
+        syncing: this.running.has(c.id),
+        state,
+      }
+    })
+
+    return { running: this.started, connectors }
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────────────
+
+  private emit(event: SchedulerEvent): void {
+    for (const handler of this.eventHandlers) {
+      try { handler(event) } catch {}
+    }
+  }
+
+  private queueAll(direction: 'forward' | 'backfill' | 'both', priority: SyncJobPriority): void {
+    for (const connector of this.registry.list()) {
+      const state = loadSyncState(this.db, connector.id)
+      if (!state.enabled) continue
+      this.enqueue({ connectorId: connector.id, direction, priority, queuedAt: Date.now() })
+    }
+  }
+
+  private enqueue(job: SyncJob): void {
+    // Don't queue if already queued or running
+    if (this.running.has(job.connectorId)) return
+    if (this.queue.some(j => j.connectorId === job.connectorId)) {
+      // Replace with higher priority if applicable
+      this.queue = this.queue.map(j =>
+        j.connectorId === job.connectorId && job.priority > j.priority ? job : j,
+      )
+      return
+    }
+    this.queue.push(job)
+    this.queue.sort((a, b) => b.priority - a.priority)
+  }
+
+  private tick(): void {
+    if (!this.started) return
+
+    // Check if any connectors are due for scheduled sync
+    const now = Date.now()
+    for (const connector of this.registry.list()) {
+      const state = loadSyncState(this.db, connector.id)
+      if (!state.enabled) continue
+
+      // Skip if in backoff due to errors
+      if (state.consecutiveErrors > 0) {
+        const backoffMs = this.getBackoffMs(state.consecutiveErrors)
+        const lastAttempt = state.lastForwardSyncAt ?? state.lastBackfillSyncAt
+        if (lastAttempt && now - new Date(lastAttempt).getTime() < backoffMs) {
+          continue
+        }
+      }
+
+      // Skip if needsReauth
+      if (state.lastErrorCode?.startsWith('AUTH_')) continue
+
+      // Forward sync due?
+      const lastForward = state.lastForwardSyncAt
+        ? new Date(state.lastForwardSyncAt).getTime()
+        : 0
+      if (now - lastForward >= this.config.forwardIntervalMs) {
+        this.enqueue({
+          connectorId: connector.id,
+          direction: 'forward',
+          priority: 40,
+          queuedAt: now,
+        })
+      }
+
+      // Backfill due?
+      if (!state.tailComplete) {
+        const lastBackfill = state.lastBackfillSyncAt
+          ? new Date(state.lastBackfillSyncAt).getTime()
+          : 0
+        if (now - lastBackfill >= this.config.backfillIntervalMs) {
+          this.enqueue({
+            connectorId: connector.id,
+            direction: 'backfill',
+            priority: 20,
+            queuedAt: now,
+          })
+        }
+      }
+    }
+
+    // Run jobs up to concurrency limit
+    while (this.running.size < this.config.concurrency && this.queue.length > 0) {
+      const job = this.queue.shift()!
+      this.runJob(job)
+    }
+  }
+
+  private async runJob(job: SyncJob): Promise<void> {
+    if (!this.registry.has(job.connectorId)) return
+
+    const connector = this.registry.get(job.connectorId)
+    const controller = new AbortController()
+    this.running.set(job.connectorId, controller)
+
+    this.emit({ type: 'sync-start', connectorId: job.connectorId })
+
+    try {
+      const result = await this.engine.sync(connector, {
+        direction: job.direction,
+        forwardMaxPages: this.config.forwardMaxPages,
+        backfillMaxPages: this.config.backfillMaxPages,
+        delayMs: this.config.pageDelayMs,
+        maxMinutes: this.config.maxMinutesPerRun,
+        signal: controller.signal,
+        onProgress: (progress) => {
+          this.emit({ type: 'sync-progress', progress })
+        },
+      })
+
+      this.emit({ type: 'sync-complete', result })
+
+      if (result.error) {
+        this.emit({
+          type: 'sync-error',
+          connectorId: job.connectorId,
+          code: result.error.code as SyncErrorCode,
+          message: result.error.message,
+        })
+      }
+    } catch (err) {
+      this.emit({
+        type: 'sync-error',
+        connectorId: job.connectorId,
+        code: SyncErrorCode.CONNECTOR_ERROR,
+        message: err instanceof Error ? err.message : String(err),
+      })
+    } finally {
+      this.running.delete(job.connectorId)
+      // Trigger next tick to pick up queued jobs
+      if (this.queue.length > 0) {
+        // Use setTimeout to avoid stack overflow from recursive tick
+        setTimeout(() => this.tick(), 0)
+      }
+    }
+  }
+
+  private getBackoffMs(consecutiveErrors: number): number {
+    const idx = Math.min(consecutiveErrors - 1, this.config.retryBackoffMs.length - 1)
+    return this.config.retryBackoffMs[idx] ?? this.config.retryBackoffMs.at(-1) ?? 60_000
+  }
+}

--- a/packages/core/src/connectors/sync-scheduler.ts
+++ b/packages/core/src/connectors/sync-scheduler.ts
@@ -96,6 +96,7 @@ export class SyncScheduler {
       return {
         id: c.id,
         label: c.label,
+        description: c.description,
         platform: c.platform,
         color: c.color,
         enabled: state.enabled,

--- a/packages/core/src/connectors/sync-scheduler.ts
+++ b/packages/core/src/connectors/sync-scheduler.ts
@@ -206,8 +206,6 @@ export class SyncScheduler {
     try {
       const result = await this.engine.sync(connector, {
         direction: job.direction,
-        forwardMaxPages: this.config.forwardMaxPages,
-        backfillMaxPages: this.config.backfillMaxPages,
         delayMs: this.config.pageDelayMs,
         maxMinutes: this.config.maxMinutesPerRun,
         signal: controller.signal,

--- a/packages/core/src/connectors/twitter-bookmarks/chrome-cookies.ts
+++ b/packages/core/src/connectors/twitter-bookmarks/chrome-cookies.ts
@@ -1,0 +1,231 @@
+/**
+ * Chrome cookie extraction for X/Twitter authentication.
+ *
+ * Adapted from fieldtheory-cli (https://github.com/afar1/fieldtheory-cli).
+ * Reads Chrome's encrypted cookie database on macOS, decrypts auth_token and
+ * ct0 (CSRF) cookies for x.com using the macOS Keychain.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, unlinkSync, copyFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir, platform, homedir } from 'node:os'
+import { pbkdf2Sync, createDecipheriv, randomUUID } from 'node:crypto'
+import { SyncError, SyncErrorCode } from '../types.js'
+
+export interface ChromeCookieResult {
+  csrfToken: string
+  cookieHeader: string
+}
+
+function getMacOSChromeKey(): Buffer {
+  const candidates = [
+    { service: 'Chrome Safe Storage', account: 'Chrome' },
+    { service: 'Chrome Safe Storage', account: 'Google Chrome' },
+    { service: 'Google Chrome Safe Storage', account: 'Chrome' },
+    { service: 'Google Chrome Safe Storage', account: 'Google Chrome' },
+    { service: 'Chromium Safe Storage', account: 'Chromium' },
+    { service: 'Brave Safe Storage', account: 'Brave' },
+    { service: 'Brave Browser Safe Storage', account: 'Brave Browser' },
+  ]
+
+  for (const candidate of candidates) {
+    try {
+      const password = execFileSync(
+        'security',
+        ['find-generic-password', '-w', '-s', candidate.service, '-a', candidate.account],
+        { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] },
+      ).trim()
+      if (password) {
+        return pbkdf2Sync(password, 'saltysalt', 1003, 16, 'sha1')
+      }
+    } catch {
+      // Try the next known browser/keychain naming pair.
+    }
+  }
+
+  throw new SyncError(
+    SyncErrorCode.AUTH_KEYCHAIN_DENIED,
+    'Could not read a browser Safe Storage password from the macOS Keychain.',
+  )
+}
+
+function sanitizeCookieValue(name: string, value: string): string {
+  const cleaned = value.replace(/\0+$/g, '').trim()
+  if (!cleaned) {
+    throw new SyncError(
+      SyncErrorCode.AUTH_COOKIE_DECRYPT_FAILED,
+      `Cookie ${name} was empty after decryption. Try closing Chrome completely and retrying.`,
+    )
+  }
+  if (!/^[\x21-\x7E]+$/.test(cleaned)) {
+    throw new SyncError(
+      SyncErrorCode.AUTH_COOKIE_DECRYPT_FAILED,
+      `Could not decrypt the ${name} cookie. Try closing Chrome or using a different profile.`,
+    )
+  }
+  return cleaned
+}
+
+export function decryptCookieValue(encryptedValue: Buffer, key: Buffer, dbVersion = 0): string {
+  if (encryptedValue.length === 0) return ''
+
+  if (encryptedValue[0] === 0x76 && encryptedValue[1] === 0x31 && encryptedValue[2] === 0x30) {
+    const iv = Buffer.alloc(16, 0x20) // 16 spaces
+    const ciphertext = encryptedValue.subarray(3)
+    const decipher = createDecipheriv('aes-128-cbc', key, iv)
+    let decrypted = decipher.update(ciphertext)
+    decrypted = Buffer.concat([decrypted, decipher.final()])
+
+    // Chrome DB version >= 24 (Chrome ~130+) prepends SHA256(host_key) to plaintext
+    if (dbVersion >= 24 && decrypted.length > 32) {
+      decrypted = decrypted.subarray(32)
+    }
+
+    return decrypted.toString('utf8')
+  }
+
+  return encryptedValue.toString('utf8')
+}
+
+interface RawCookie {
+  name: string
+  host_key: string
+  encrypted_value_hex: string
+  value: string
+}
+
+function queryDbVersion(dbPath: string): number {
+  const tryQuery = (p: string) =>
+    execFileSync('sqlite3', [p, "SELECT value FROM meta WHERE key='version';"], {
+      encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000,
+    }).trim()
+
+  try {
+    return parseInt(tryQuery(dbPath), 10) || 0
+  } catch {
+    const tmpDb = join(tmpdir(), `spool-meta-${randomUUID()}.db`)
+    try {
+      copyFileSync(dbPath, tmpDb)
+      return parseInt(tryQuery(tmpDb), 10) || 0
+    } catch {
+      return 0
+    } finally {
+      try { unlinkSync(tmpDb) } catch {}
+    }
+  }
+}
+
+function queryCookies(
+  dbPath: string,
+  domain: string,
+  names: string[],
+): { cookies: RawCookie[]; dbVersion: number } {
+  if (!existsSync(dbPath)) {
+    throw new SyncError(
+      SyncErrorCode.AUTH_CHROME_NOT_FOUND,
+      `Chrome Cookies database not found at: ${dbPath}`,
+    )
+  }
+
+  const safeDomain = domain.replace(/'/g, "''")
+  const nameList = names.map(n => `'${n.replace(/'/g, "''")}'`).join(',')
+  const sql = `SELECT name, host_key, hex(encrypted_value) as encrypted_value_hex, value FROM cookies WHERE host_key LIKE '%${safeDomain}' AND name IN (${nameList});`
+
+  const tryQuery = (path: string): string =>
+    execFileSync('sqlite3', ['-json', path, sql], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    }).trim()
+
+  let output: string
+  try {
+    output = tryQuery(dbPath)
+  } catch {
+    const tmpDb = join(tmpdir(), `spool-cookies-${randomUUID()}.db`)
+    try {
+      copyFileSync(dbPath, tmpDb)
+      output = tryQuery(tmpDb)
+    } catch (e2: unknown) {
+      throw new SyncError(
+        SyncErrorCode.AUTH_COOKIE_DECRYPT_FAILED,
+        `Could not read Chrome Cookies database at ${dbPath}. ${e2 instanceof Error ? e2.message : ''}`,
+        e2,
+      )
+    } finally {
+      try { unlinkSync(tmpDb) } catch {}
+    }
+  }
+
+  const dbVersion = queryDbVersion(dbPath)
+
+  if (!output || output === '[]') return { cookies: [], dbVersion }
+  try {
+    return { cookies: JSON.parse(output), dbVersion }
+  } catch {
+    return { cookies: [], dbVersion }
+  }
+}
+
+/** Detect the default Chrome user-data directory for the current OS. */
+export function detectChromeUserDataDir(): string {
+  const os = platform()
+  const home = homedir()
+  if (os === 'darwin') return join(home, 'Library', 'Application Support', 'Google', 'Chrome')
+  if (os === 'linux') return join(home, '.config', 'google-chrome')
+  if (os === 'win32') return join(home, 'AppData', 'Local', 'Google', 'Chrome', 'User Data')
+  throw new SyncError(
+    SyncErrorCode.AUTH_CHROME_NOT_FOUND,
+    `Unsupported platform for Chrome cookie extraction: ${os}`,
+  )
+}
+
+export function extractChromeXCookies(
+  chromeUserDataDir?: string,
+  profileDirectory = 'Default',
+): ChromeCookieResult {
+  const os = platform()
+  if (os !== 'darwin') {
+    throw new SyncError(
+      SyncErrorCode.AUTH_CHROME_NOT_FOUND,
+      `Direct cookie extraction is currently supported on macOS only (detected: ${os}).`,
+    )
+  }
+
+  const dataDir = chromeUserDataDir ?? detectChromeUserDataDir()
+  const dbPath = join(dataDir, profileDirectory, 'Cookies')
+  const key = getMacOSChromeKey()
+
+  let result = queryCookies(dbPath, '.x.com', ['ct0', 'auth_token'])
+  if (result.cookies.length === 0) {
+    result = queryCookies(dbPath, '.twitter.com', ['ct0', 'auth_token'])
+  }
+
+  const decrypted = new Map<string, string>()
+  for (const cookie of result.cookies) {
+    const hexVal = cookie.encrypted_value_hex
+    if (hexVal && hexVal.length > 0) {
+      const buf = Buffer.from(hexVal, 'hex')
+      decrypted.set(cookie.name, decryptCookieValue(buf, key, result.dbVersion))
+    } else if (cookie.value) {
+      decrypted.set(cookie.name, cookie.value)
+    }
+  }
+
+  const ct0 = decrypted.get('ct0')
+  const authToken = decrypted.get('auth_token')
+
+  if (!ct0) {
+    throw new SyncError(
+      SyncErrorCode.AUTH_NOT_LOGGED_IN,
+      `No ct0 CSRF cookie found for x.com in Chrome (profile: "${profileDirectory}"). Log into X in Chrome and retry.`,
+    )
+  }
+
+  const cookieParts = [`ct0=${sanitizeCookieValue('ct0', ct0)}`]
+  if (authToken) cookieParts.push(`auth_token=${sanitizeCookieValue('auth_token', authToken)}`)
+  const cookieHeader = cookieParts.join('; ')
+
+  return { csrfToken: sanitizeCookieValue('ct0', ct0), cookieHeader }
+}

--- a/packages/core/src/connectors/twitter-bookmarks/graphql-fetch.ts
+++ b/packages/core/src/connectors/twitter-bookmarks/graphql-fetch.ts
@@ -1,0 +1,290 @@
+/**
+ * Twitter/X GraphQL Bookmarks API client.
+ *
+ * Adapted from fieldtheory-cli (https://github.com/afar1/fieldtheory-cli).
+ * Uses X's internal GraphQL API (same as x.com browser) to fetch bookmarks.
+ */
+
+import { SyncError, SyncErrorCode } from '../types.js'
+import type { CapturedItem } from '../../types.js'
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+const X_PUBLIC_BEARER =
+  'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA'
+
+const BOOKMARKS_QUERY_ID = 'Z9GWmP0kP2dajyckAaDUBw'
+const BOOKMARKS_OPERATION = 'Bookmarks'
+
+const GRAPHQL_FEATURES = {
+  graphql_timeline_v2_bookmark_timeline: true,
+  rweb_tipjar_consumption_enabled: true,
+  responsive_web_graphql_exclude_directive_enabled: true,
+  verified_phone_label_enabled: false,
+  creator_subscriptions_tweet_preview_api_enabled: true,
+  responsive_web_graphql_timeline_navigation_enabled: true,
+  responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+  communities_web_enable_tweet_community_results_fetch: true,
+  c9s_tweet_anatomy_moderator_badge_enabled: true,
+  articles_preview_enabled: true,
+  responsive_web_edit_tweet_api_enabled: true,
+  tweetypie_unmention_optimization_enabled: true,
+  responsive_web_uc_gql_enabled: true,
+  vibe_api_enabled: true,
+  responsive_web_text_conversations_enabled: false,
+  freedom_of_speech_not_reach_fetch_enabled: true,
+  longform_notetweets_rich_text_read_enabled: true,
+  longform_notetweets_inline_media_enabled: true,
+  responsive_web_enhance_cards_enabled: false,
+  tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+  responsive_web_media_download_video_enabled: false,
+}
+
+// ── URL & Headers ───────────────────────────────────────────────────────────
+
+function buildUrl(cursor?: string): string {
+  const variables: Record<string, unknown> = { count: 20 }
+  if (cursor) variables.cursor = cursor
+  const params = new URLSearchParams({
+    variables: JSON.stringify(variables),
+    features: JSON.stringify(GRAPHQL_FEATURES),
+  })
+  return `https://x.com/i/api/graphql/${BOOKMARKS_QUERY_ID}/${BOOKMARKS_OPERATION}?${params}`
+}
+
+function buildHeaders(csrfToken: string, cookieHeader?: string): Record<string, string> {
+  return {
+    authorization: `Bearer ${X_PUBLIC_BEARER}`,
+    'x-csrf-token': csrfToken,
+    'x-twitter-auth-type': 'OAuth2Session',
+    'x-twitter-active-user': 'yes',
+    'content-type': 'application/json',
+    'user-agent':
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36',
+    cookie: cookieHeader ?? `ct0=${csrfToken}`,
+  }
+}
+
+// ── Response Parsing ────────────────────────────────────────────────────────
+
+interface BookmarkPageResult {
+  items: CapturedItem[]
+  nextCursor: string | null
+}
+
+/** Convert a single tweet result from GraphQL to CapturedItem. */
+function convertTweetToItem(tweetResult: any, now: string): CapturedItem | null {
+  const tweet = tweetResult.tweet ?? tweetResult
+  const legacy = tweet?.legacy
+  if (!legacy) return null
+
+  const tweetId = legacy.id_str ?? tweet?.rest_id
+  if (!tweetId) return null
+
+  const userResult = tweet?.core?.user_results?.result
+  const authorHandle =
+    userResult?.core?.screen_name ?? userResult?.legacy?.screen_name
+  const authorName =
+    userResult?.core?.name ?? userResult?.legacy?.name
+  const authorProfileImageUrl =
+    userResult?.avatar?.image_url ??
+    userResult?.legacy?.profile_image_url_https ??
+    userResult?.legacy?.profile_image_url
+
+  // Extract media URLs
+  const mediaEntities =
+    legacy?.extended_entities?.media ?? legacy?.entities?.media ?? []
+  const media: string[] = mediaEntities
+    .map((m: any) => m.media_url_https ?? m.media_url)
+    .filter(Boolean)
+  const mediaObjects = mediaEntities.map((m: any) => ({
+    type: m.type,
+    url: m.media_url_https ?? m.media_url,
+    expandedUrl: m.expanded_url,
+    width: m.original_info?.width,
+    height: m.original_info?.height,
+    altText: m.ext_alt_text,
+  }))
+
+  // Extract expanded URLs (skip t.co wrappers)
+  const urlEntities = legacy?.entities?.urls ?? []
+  const links: string[] = urlEntities
+    .map((u: any) => u.expanded_url)
+    .filter((u: string | undefined) => u && !u.includes('t.co'))
+
+  // Build author snapshot for metadata
+  const authorSnapshot = userResult
+    ? {
+        id: userResult.rest_id,
+        handle: authorHandle,
+        name: authorName,
+        profileImageUrl: authorProfileImageUrl,
+        bio: userResult?.legacy?.description,
+        followerCount: userResult?.legacy?.followers_count,
+        followingCount: userResult?.legacy?.friends_count,
+        isVerified: Boolean(
+          userResult?.is_blue_verified ?? userResult?.legacy?.verified,
+        ),
+        location:
+          typeof userResult?.location === 'object'
+            ? userResult.location.location
+            : userResult?.legacy?.location,
+      }
+    : undefined
+
+  const engagement = {
+    likeCount: legacy.favorite_count,
+    repostCount: legacy.retweet_count,
+    replyCount: legacy.reply_count,
+    quoteCount: legacy.quote_count,
+    bookmarkCount: legacy.bookmark_count,
+    viewCount: tweet?.views?.count ? Number(tweet.views.count) : undefined,
+  }
+
+  const text = legacy.full_text ?? legacy.text ?? ''
+  const url = `https://x.com/${authorHandle ?? '_'}/status/${tweetId}`
+
+  return {
+    url,
+    title: text.length > 120 ? text.slice(0, 117) + '...' : text,
+    contentText: text,
+    author: authorHandle ?? null,
+    platform: 'twitter',
+    platformId: tweetId,
+    contentType: 'tweet',
+    thumbnailUrl: authorProfileImageUrl ?? null,
+    metadata: {
+      authorSnapshot,
+      engagement,
+      media,
+      mediaObjects,
+      links,
+      language: legacy.lang,
+      conversationId: legacy.conversation_id_str,
+      inReplyToStatusId: legacy.in_reply_to_status_id_str,
+      quotedStatusId: legacy.quoted_status_id_str,
+      postedAt: legacy.created_at,
+      sourceApp: legacy.source,
+    },
+    capturedAt: legacy.created_at
+      ? new Date(legacy.created_at).toISOString()
+      : now,
+    rawJson: JSON.stringify(tweetResult),
+  }
+}
+
+/** Parse the full GraphQL bookmarks response. */
+export function parseBookmarksResponse(json: any, now?: string): BookmarkPageResult {
+  const ts = now ?? new Date().toISOString()
+  const instructions =
+    json?.data?.bookmark_timeline_v2?.timeline?.instructions ?? []
+  const entries: any[] = []
+  for (const inst of instructions) {
+    if (inst.type === 'TimelineAddEntries' && Array.isArray(inst.entries)) {
+      entries.push(...inst.entries)
+    }
+  }
+
+  const items: CapturedItem[] = []
+  let nextCursor: string | null = null
+
+  for (const entry of entries) {
+    if (entry.entryId?.startsWith('cursor-bottom')) {
+      nextCursor = entry.content?.value ?? null
+      continue
+    }
+
+    const tweetResult = entry?.content?.itemContent?.tweet_results?.result
+    if (!tweetResult) continue
+
+    const item = convertTweetToItem(tweetResult, ts)
+    if (item) items.push(item)
+  }
+
+  return { items, nextCursor }
+}
+
+// ── Fetch with Retry ────────────────────────────────────────────────────────
+
+export async function fetchBookmarkPage(
+  csrfToken: string,
+  cursor: string | null,
+  cookieHeader?: string,
+): Promise<BookmarkPageResult> {
+  let lastError: Error | undefined
+
+  for (let attempt = 0; attempt < 4; attempt++) {
+    let response: Response
+    try {
+      response = await fetch(
+        buildUrl(cursor ?? undefined),
+        { headers: buildHeaders(csrfToken, cookieHeader) },
+      )
+    } catch (err) {
+      // Network-level error
+      const message = err instanceof Error ? err.message : String(err)
+      if (message.includes('ENOTFOUND') || message.includes('ENETUNREACH')) {
+        throw new SyncError(SyncErrorCode.NETWORK_OFFLINE, message, err)
+      }
+      if (message.includes('ETIMEDOUT') || message.includes('timeout')) {
+        throw new SyncError(SyncErrorCode.NETWORK_TIMEOUT, message, err)
+      }
+      throw new SyncError(SyncErrorCode.CONNECTOR_ERROR, message, err)
+    }
+
+    if (response.status === 429) {
+      const waitSec = Math.min(15 * Math.pow(2, attempt), 120)
+      lastError = new Error(`Rate limited (429) on attempt ${attempt + 1}`)
+      await new Promise(r => setTimeout(r, waitSec * 1000))
+      continue
+    }
+
+    if (response.status >= 500) {
+      lastError = new Error(`Server error (${response.status}) on attempt ${attempt + 1}`)
+      await new Promise(r => setTimeout(r, 5000 * (attempt + 1)))
+      continue
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      throw new SyncError(
+        SyncErrorCode.AUTH_SESSION_EXPIRED,
+        `X API returned ${response.status}. Your session may have expired.`,
+      )
+    }
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '')
+      throw new SyncError(
+        SyncErrorCode.API_UNEXPECTED_STATUS,
+        `X GraphQL API returned ${response.status}: ${text.slice(0, 300)}`,
+      )
+    }
+
+    let json: unknown
+    try {
+      json = await response.json()
+    } catch (err) {
+      throw new SyncError(
+        SyncErrorCode.API_PARSE_ERROR,
+        'Failed to parse X GraphQL response as JSON',
+        err,
+      )
+    }
+
+    try {
+      return parseBookmarksResponse(json)
+    } catch (err) {
+      throw new SyncError(
+        SyncErrorCode.API_PARSE_ERROR,
+        `Failed to parse bookmarks from GraphQL response: ${err instanceof Error ? err.message : String(err)}`,
+        err,
+      )
+    }
+  }
+
+  // All retries exhausted
+  if (lastError?.message.includes('429')) {
+    throw new SyncError(SyncErrorCode.API_RATE_LIMITED, 'Rate limited after 4 retry attempts.')
+  }
+  throw new SyncError(SyncErrorCode.API_SERVER_ERROR, 'Server errors after 4 retry attempts.')
+}

--- a/packages/core/src/connectors/twitter-bookmarks/index.ts
+++ b/packages/core/src/connectors/twitter-bookmarks/index.ts
@@ -1,0 +1,83 @@
+import type { Connector, AuthStatus, PageResult } from '../types.js'
+import { SyncError, SyncErrorCode } from '../types.js'
+import { extractChromeXCookies, detectChromeUserDataDir } from './chrome-cookies.js'
+import { fetchBookmarkPage } from './graphql-fetch.js'
+import type { ChromeCookieResult } from './chrome-cookies.js'
+
+export class TwitterBookmarksConnector implements Connector {
+  readonly id = 'twitter-bookmarks'
+  readonly platform = 'twitter'
+  readonly label = 'X Bookmarks'
+  readonly description = 'Your saved tweets on X'
+  readonly color = '#1DA1F2'
+  readonly ephemeral = false
+
+  private chromeUserDataDir: string | undefined
+  private chromeProfileDirectory: string
+  private cachedCookies: ChromeCookieResult | null = null
+
+  constructor(opts?: {
+    chromeUserDataDir?: string
+    chromeProfileDirectory?: string
+  }) {
+    this.chromeUserDataDir = opts?.chromeUserDataDir
+    this.chromeProfileDirectory = opts?.chromeProfileDirectory ?? 'Default'
+  }
+
+  async checkAuth(): Promise<AuthStatus> {
+    try {
+      const dataDir = this.chromeUserDataDir ?? detectChromeUserDataDir()
+      extractChromeXCookies(dataDir, this.chromeProfileDirectory)
+      return { ok: true }
+    } catch (err) {
+      if (err instanceof SyncError) {
+        return {
+          ok: false,
+          error: err.code,
+          message: err.message,
+          hint: err.message,
+        }
+      }
+      return {
+        ok: false,
+        error: SyncErrorCode.AUTH_UNKNOWN,
+        message: err instanceof Error ? err.message : String(err),
+        hint: 'Check that Chrome is installed and you are logged into X.',
+      }
+    }
+  }
+
+  async fetchPage(cursor: string | null): Promise<PageResult> {
+    // Extract cookies fresh for each sync cycle (they may expire)
+    // Cache within a single sync run to avoid re-reading DB on every page
+    if (!this.cachedCookies) {
+      try {
+        const dataDir = this.chromeUserDataDir ?? detectChromeUserDataDir()
+        this.cachedCookies = extractChromeXCookies(dataDir, this.chromeProfileDirectory)
+      } catch (err) {
+        if (err instanceof SyncError) throw err
+        throw new SyncError(
+          SyncErrorCode.AUTH_UNKNOWN,
+          err instanceof Error ? err.message : String(err),
+          err,
+        )
+      }
+    }
+
+    const result = await fetchBookmarkPage(
+      this.cachedCookies.csrfToken,
+      cursor,
+      this.cachedCookies.cookieHeader,
+    )
+
+    return {
+      items: result.items,
+      nextCursor: result.nextCursor,
+    }
+  }
+
+  /** Clear cached cookies (call between sync cycles). */
+  clearCookieCache(): void {
+    this.cachedCookies = null
+  }
+}

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -284,6 +284,7 @@ export interface SyncJob {
 export interface ConnectorStatus {
   id: string
   label: string
+  description: string
   platform: string
   color: string
   enabled: boolean

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -208,13 +208,9 @@ export interface SyncState {
 export interface SyncOptions {
   /** Which direction to sync. Default: 'both'. */
   direction?: 'forward' | 'backfill' | 'both'
-  /** Max pages for forward sync. Default: 50. */
-  forwardMaxPages?: number
-  /** Max pages for backfill. Default: 10. */
-  backfillMaxPages?: number
   /** Delay between page requests in ms. Default: 600. */
   delayMs?: number
-  /** Max runtime in minutes. Default: 5. */
+  /** Max runtime in minutes. 0 = unlimited. Default: 0 (no limit). */
   maxMinutes?: number
   /** Consecutive pages with 0 new items before stopping forward sync. Default: 3. */
   stalePageLimit?: number
@@ -257,13 +253,13 @@ export interface ScheduleConfig {
   concurrency: number
   /** Default delay between pages. Default: 600ms. */
   pageDelayMs: number
-  /** Max pages per forward sync. Default: 50. */
-  forwardMaxPages: number
-  /** Max pages per backfill cycle. Default: 10. */
-  backfillMaxPages: number
   /** Retry backoff sequence in ms. */
   retryBackoffMs: number[]
-  /** Max time for a single sync run in minutes. Default: 5. */
+  /**
+   * Max time for a single scheduled sync run in minutes.
+   * Only applies to scheduler-initiated syncs.
+   * 0 = unlimited (used by CLI full sync). Default: 10.
+   */
   maxMinutesPerRun: number
 }
 
@@ -271,9 +267,7 @@ export const DEFAULT_SCHEDULE: ScheduleConfig = {
   forwardIntervalMs: 15 * 60_000,
   backfillIntervalMs: 60 * 60_000,
   concurrency: 1,
-  pageDelayMs: 600,
-  forwardMaxPages: 50,
-  backfillMaxPages: 50,
+  pageDelayMs: 1200,
   retryBackoffMs: [60_000, 300_000, 1_800_000, 7_200_000],
   maxMinutesPerRun: 10,
 }

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -1,0 +1,303 @@
+import type { CapturedItem } from '../types.js'
+
+// ── Error Types ─────────────────────────────────────────────────────────────
+
+/**
+ * Enumerated sync error codes.
+ *
+ * Every error that can occur during sync maps to one of these codes so the UI
+ * can display a specific, actionable message and we can track failure patterns.
+ */
+export enum SyncErrorCode {
+  // ── Auth ────────────────────────────────────────────────────────────
+  /** Chrome is not installed or the Cookies DB was not found. */
+  AUTH_CHROME_NOT_FOUND = 'AUTH_CHROME_NOT_FOUND',
+  /** The user is not logged into the platform in Chrome. */
+  AUTH_NOT_LOGGED_IN = 'AUTH_NOT_LOGGED_IN',
+  /** Chrome cookie decryption failed (wrong profile, Chrome open, etc). */
+  AUTH_COOKIE_DECRYPT_FAILED = 'AUTH_COOKIE_DECRYPT_FAILED',
+  /** macOS Keychain access denied or password not found. */
+  AUTH_KEYCHAIN_DENIED = 'AUTH_KEYCHAIN_DENIED',
+  /** Session expired mid-sync (401/403 from API). */
+  AUTH_SESSION_EXPIRED = 'AUTH_SESSION_EXPIRED',
+  /** Generic auth failure not covered above. */
+  AUTH_UNKNOWN = 'AUTH_UNKNOWN',
+
+  // ── Network / API ──────────────────────────────────────────────────
+  /** Rate limited by the platform (429). Retry later. */
+  API_RATE_LIMITED = 'API_RATE_LIMITED',
+  /** Platform returned a server error (5xx). */
+  API_SERVER_ERROR = 'API_SERVER_ERROR',
+  /** Network unreachable or DNS failure. */
+  NETWORK_OFFLINE = 'NETWORK_OFFLINE',
+  /** Request timed out. */
+  NETWORK_TIMEOUT = 'NETWORK_TIMEOUT',
+  /** API response could not be parsed (schema change?). */
+  API_PARSE_ERROR = 'API_PARSE_ERROR',
+  /** API returned an unexpected status code. */
+  API_UNEXPECTED_STATUS = 'API_UNEXPECTED_STATUS',
+
+  // ── Sync engine ────────────────────────────────────────────────────
+  /** Exceeded max pages per sync cycle. */
+  SYNC_MAX_PAGES = 'SYNC_MAX_PAGES',
+  /** Exceeded max runtime per sync cycle. */
+  SYNC_TIMEOUT = 'SYNC_TIMEOUT',
+  /** Sync was cancelled (app quit, user abort). */
+  SYNC_CANCELLED = 'SYNC_CANCELLED',
+
+  // ── Storage ────────────────────────────────────────────────────────
+  /** Database write failed. */
+  DB_WRITE_ERROR = 'DB_WRITE_ERROR',
+
+  // ── Connector ──────────────────────────────────────────────────────
+  /** A connector-specific error not covered by other codes. */
+  CONNECTOR_ERROR = 'CONNECTOR_ERROR',
+}
+
+/**
+ * Human-readable hints for each error code.
+ * Shown in the sync UI so the user knows what happened and how to fix it.
+ */
+export const SYNC_ERROR_HINTS: Record<SyncErrorCode, string> = {
+  [SyncErrorCode.AUTH_CHROME_NOT_FOUND]:
+    'Chrome is not installed, or the cookies database was not found. Install Google Chrome and open it at least once.',
+  [SyncErrorCode.AUTH_NOT_LOGGED_IN]:
+    'You are not logged into this platform in Chrome. Open Chrome, log in, then retry.',
+  [SyncErrorCode.AUTH_COOKIE_DECRYPT_FAILED]:
+    'Could not decrypt Chrome cookies. Try closing Chrome completely and retrying. If using a non-default profile, check your connector settings.',
+  [SyncErrorCode.AUTH_KEYCHAIN_DENIED]:
+    'Could not read the Chrome encryption key from macOS Keychain. You may need to grant access in System Settings > Privacy > Keychain.',
+  [SyncErrorCode.AUTH_SESSION_EXPIRED]:
+    'Your session expired during sync. Open Chrome, visit the platform to refresh your login, then retry.',
+  [SyncErrorCode.AUTH_UNKNOWN]:
+    'Authentication failed for an unknown reason. Check that you are logged in via Chrome and retry.',
+  [SyncErrorCode.API_RATE_LIMITED]:
+    'The platform rate-limited requests. Spool will retry automatically after a cooldown.',
+  [SyncErrorCode.API_SERVER_ERROR]:
+    'The platform returned a server error. This is usually temporary — Spool will retry later.',
+  [SyncErrorCode.NETWORK_OFFLINE]:
+    'No internet connection. Spool will sync when connectivity is restored.',
+  [SyncErrorCode.NETWORK_TIMEOUT]:
+    'The request timed out. Check your internet connection. Spool will retry later.',
+  [SyncErrorCode.API_PARSE_ERROR]:
+    'The platform returned an unexpected response format. This may indicate an API change — check for Spool updates.',
+  [SyncErrorCode.API_UNEXPECTED_STATUS]:
+    'The platform returned an unexpected HTTP status. This may be temporary — Spool will retry later.',
+  [SyncErrorCode.SYNC_MAX_PAGES]:
+    'Sync stopped after reaching the page limit. Remaining data will be fetched in the next cycle.',
+  [SyncErrorCode.SYNC_TIMEOUT]:
+    'Sync stopped after reaching the time limit. Remaining data will be fetched in the next cycle.',
+  [SyncErrorCode.SYNC_CANCELLED]:
+    'Sync was cancelled. It will resume in the next cycle.',
+  [SyncErrorCode.DB_WRITE_ERROR]:
+    'Failed to write to the local database. Check disk space and permissions for ~/.spool/',
+  [SyncErrorCode.CONNECTOR_ERROR]:
+    'The connector encountered an error. Check the error details below.',
+}
+
+export class SyncError extends Error {
+  public readonly code: SyncErrorCode
+  public override readonly cause?: unknown
+
+  constructor(
+    code: SyncErrorCode,
+    message?: string,
+    cause?: unknown,
+  ) {
+    super(message ?? SYNC_ERROR_HINTS[code])
+    this.name = 'SyncError'
+    this.code = code
+    this.cause = cause
+  }
+
+  /** Whether this error indicates the connector needs re-authentication. */
+  get needsReauth(): boolean {
+    return this.code.startsWith('AUTH_')
+  }
+
+  /** Whether this error is transient and the sync can be retried. */
+  get retryable(): boolean {
+    switch (this.code) {
+      case SyncErrorCode.API_RATE_LIMITED:
+      case SyncErrorCode.API_SERVER_ERROR:
+      case SyncErrorCode.NETWORK_OFFLINE:
+      case SyncErrorCode.NETWORK_TIMEOUT:
+      case SyncErrorCode.SYNC_MAX_PAGES:
+      case SyncErrorCode.SYNC_TIMEOUT:
+      case SyncErrorCode.SYNC_CANCELLED:
+        return true
+      default:
+        return false
+    }
+  }
+}
+
+// ── Auth ─────────────────────────────────────────────────────────────────────
+
+export interface AuthStatus {
+  ok: boolean
+  error?: SyncErrorCode
+  message?: string
+  /** Actionable guidance for the user. */
+  hint?: string
+}
+
+// ── Connector ────────────────────────────────────────────────────────────────
+
+export interface PageResult {
+  items: CapturedItem[]
+  /** Cursor for the next page. null = no more data. */
+  nextCursor: string | null
+}
+
+export interface Connector {
+  /** Unique identifier, e.g. 'twitter-bookmarks'. */
+  readonly id: string
+  /** Platform name for grouping, e.g. 'twitter'. */
+  readonly platform: string
+  /** Human-readable label, e.g. 'X Bookmarks'. */
+  readonly label: string
+  /** Short description for the connector picker. */
+  readonly description: string
+  /** UI color for badges/dots. */
+  readonly color: string
+  /** Ephemeral = cache (full-replace), persistent = user-owned (dual-frontier). */
+  readonly ephemeral: boolean
+
+  /** Check if authentication / prerequisites are available. */
+  checkAuth(opts?: Record<string, string>): Promise<AuthStatus>
+
+  /**
+   * Fetch one page of data.
+   *
+   * The sync engine calls this repeatedly, following nextCursor.
+   * The connector handles API-level retries (429, 5xx) internally.
+   * If retries are exhausted, throw a SyncError.
+   *
+   * @param cursor - null for the first (newest) page
+   */
+  fetchPage(cursor: string | null): Promise<PageResult>
+}
+
+// ── Sync State ───────────────────────────────────────────────────────────────
+
+export interface SyncState {
+  connectorId: string
+  // Head frontier (newest end)
+  headCursor: string | null
+  headItemId: string | null
+  // Tail frontier (oldest end)
+  tailCursor: string | null
+  tailComplete: boolean
+  // Metadata
+  lastForwardSyncAt: string | null
+  lastBackfillSyncAt: string | null
+  totalSynced: number
+  consecutiveErrors: number
+  enabled: boolean
+  /** Per-connector config overrides (e.g. Chrome profile). */
+  configJson: Record<string, unknown>
+  /** Last error code, null if last sync succeeded. */
+  lastErrorCode: SyncErrorCode | null
+  /** Last error message for UI display. */
+  lastErrorMessage: string | null
+}
+
+// ── Sync Options & Results ───────────────────────────────────────────────────
+
+export interface SyncOptions {
+  /** Which direction to sync. Default: 'both'. */
+  direction?: 'forward' | 'backfill' | 'both'
+  /** Max pages for forward sync. Default: 50. */
+  forwardMaxPages?: number
+  /** Max pages for backfill. Default: 10. */
+  backfillMaxPages?: number
+  /** Delay between page requests in ms. Default: 600. */
+  delayMs?: number
+  /** Max runtime in minutes. Default: 5. */
+  maxMinutes?: number
+  /** Consecutive pages with 0 new items before stopping forward sync. Default: 3. */
+  stalePageLimit?: number
+  /** AbortSignal for cancellation. */
+  signal?: AbortSignal
+  /** Progress callback. */
+  onProgress?: (progress: SyncProgress) => void
+}
+
+export interface SyncProgress {
+  connectorId: string
+  phase: 'forward' | 'backfill'
+  page: number
+  fetched: number
+  added: number
+  running: boolean
+}
+
+export interface ConnectorSyncResult {
+  connectorId: string
+  added: number
+  total: number
+  pages: number
+  direction: 'forward' | 'backfill' | 'both'
+  stopReason: string
+  error?: {
+    code: SyncErrorCode
+    message: string
+  }
+}
+
+// ── Scheduler ────────────────────────────────────────────────────────────────
+
+export interface ScheduleConfig {
+  /** Forward sync interval in ms. Default: 15 min. */
+  forwardIntervalMs: number
+  /** Backfill interval in ms. Default: 60 min. */
+  backfillIntervalMs: number
+  /** Max concurrent connector syncs. Default: 1. */
+  concurrency: number
+  /** Default delay between pages. Default: 600ms. */
+  pageDelayMs: number
+  /** Max pages per forward sync. Default: 50. */
+  forwardMaxPages: number
+  /** Max pages per backfill cycle. Default: 10. */
+  backfillMaxPages: number
+  /** Retry backoff sequence in ms. */
+  retryBackoffMs: number[]
+  /** Max time for a single sync run in minutes. Default: 5. */
+  maxMinutesPerRun: number
+}
+
+export const DEFAULT_SCHEDULE: ScheduleConfig = {
+  forwardIntervalMs: 15 * 60_000,
+  backfillIntervalMs: 60 * 60_000,
+  concurrency: 1,
+  pageDelayMs: 600,
+  forwardMaxPages: 50,
+  backfillMaxPages: 10,
+  retryBackoffMs: [60_000, 300_000, 1_800_000, 7_200_000],
+  maxMinutesPerRun: 5,
+}
+
+export type SyncJobPriority = 100 | 80 | 60 | 40 | 20
+
+export interface SyncJob {
+  connectorId: string
+  direction: 'forward' | 'backfill' | 'both'
+  priority: SyncJobPriority
+  queuedAt: number
+}
+
+export interface ConnectorStatus {
+  id: string
+  label: string
+  platform: string
+  color: string
+  enabled: boolean
+  syncing: boolean
+  state: SyncState
+}
+
+export interface SchedulerStatus {
+  running: boolean
+  connectors: ConnectorStatus[]
+}

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -273,9 +273,9 @@ export const DEFAULT_SCHEDULE: ScheduleConfig = {
   concurrency: 1,
   pageDelayMs: 600,
   forwardMaxPages: 50,
-  backfillMaxPages: 10,
+  backfillMaxPages: 50,
   retryBackoffMs: [60_000, 300_000, 1_800_000, 7_200_000],
-  maxMinutesPerRun: 5,
+  maxMinutesPerRun: 10,
 }
 
 export type SyncJobPriority = 100 | 80 | 60 | 40 | 20

--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -180,5 +180,23 @@ function runMigrations(db: Database.Database): void {
       key   TEXT PRIMARY KEY,
       value TEXT NOT NULL
     );
+
+    -- ── Connector sync state ────────────────────────────────────────────────
+
+    CREATE TABLE IF NOT EXISTS connector_sync_state (
+      connector_id        TEXT PRIMARY KEY,
+      head_cursor         TEXT,
+      head_item_id        TEXT,
+      tail_cursor         TEXT,
+      tail_complete       INTEGER NOT NULL DEFAULT 0,
+      last_forward_sync_at  TEXT,
+      last_backfill_sync_at TEXT,
+      total_synced        INTEGER NOT NULL DEFAULT 0,
+      consecutive_errors  INTEGER NOT NULL DEFAULT 0,
+      enabled             INTEGER NOT NULL DEFAULT 1,
+      config_json         TEXT NOT NULL DEFAULT '{}',
+      last_error_code     TEXT,
+      last_error_message  TEXT
+    );
   `)
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,3 +11,29 @@ export { detectPlatform, parseOpenCLIOutput, parseOpenCLIItem } from './opencli/
 export { SYNC_STRATEGIES, getStrategy, getStrategiesForPlatform, getStrategyPlatforms } from './opencli/strategies.js'
 export type { SyncStrategy } from './opencli/strategies.js'
 export { resolveSystemBinary, cachedResolve, clearResolveCache } from './util/resolve-bin.js'
+
+// ── Connector framework ─────────────────────────────────────────────────────
+export { ConnectorRegistry } from './connectors/registry.js'
+export { SyncEngine, loadSyncState, saveSyncState } from './connectors/sync-engine.js'
+export { SyncScheduler } from './connectors/sync-scheduler.js'
+export type { SchedulerEvent, SchedulerEventHandler } from './connectors/sync-scheduler.js'
+export { TwitterBookmarksConnector } from './connectors/twitter-bookmarks/index.js'
+export {
+  SyncError,
+  SyncErrorCode,
+  SYNC_ERROR_HINTS,
+  DEFAULT_SCHEDULE,
+} from './connectors/types.js'
+export type {
+  Connector,
+  AuthStatus,
+  PageResult,
+  SyncState,
+  SyncOptions,
+  ConnectorSyncResult,
+  SyncProgress,
+  SyncJob,
+  ScheduleConfig,
+  ConnectorStatus,
+  SchedulerStatus,
+} from './connectors/types.js'

--- a/packages/core/src/opencli/strategies.ts
+++ b/packages/core/src/opencli/strategies.ts
@@ -31,32 +31,7 @@ export interface SyncStrategy {
  * returns a collection of items suitable for indexing.
  */
 export const SYNC_STRATEGIES: SyncStrategy[] = [
-  // ── Twitter / X ────────────────────────────────────────────────
-  {
-    platform: 'twitter',
-    command: 'bookmarks',
-    args: ['--limit', '100'],
-    label: 'X Bookmarks',
-    description: 'Your saved tweets on X',
-  },
-  {
-    platform: 'twitter',
-    command: 'timeline',
-    label: 'X Timeline',
-    description: 'Your home timeline on X',
-  },
-  {
-    platform: 'twitter',
-    command: 'notifications',
-    label: 'X Notifications',
-    description: 'Your recent notifications on X',
-  },
-  {
-    platform: 'twitter',
-    command: 'following',
-    label: 'X Following',
-    description: 'Accounts you follow on X',
-  },
+  // Twitter / X: removed — handled natively by TwitterBookmarksConnector
 
   // ── Hacker News ────────────────────────────────────────────────
   {


### PR DESCRIPTION
## Summary

- Replace OpenCLI-based Twitter bookmark fetching with a native connector using X's internal GraphQL API, authenticated via Chrome cookie extraction (macOS)
- Introduce a universal connector framework: `Connector` interface → `SyncEngine` (dual-frontier) → `SyncScheduler` (priority queue + lifecycle events + backoff)
- 16 enumerated `SyncErrorCode` values with user-facing hints for actionable error display
- Live sync progress in SourcesPanel: progress bar, page count, phase indicator

## New files

```
packages/core/src/connectors/
├── types.ts                          -- Connector interface, SyncError, error codes
├── registry.ts                       -- ConnectorRegistry
├── sync-engine.ts                    -- Dual-frontier sync (forward + backfill)
├── sync-scheduler.ts                 -- Priority queue scheduler with backoff
└── twitter-bookmarks/
    ├── index.ts                      -- TwitterBookmarksConnector
    ├── chrome-cookies.ts             -- Chrome cookie extraction (from fieldtheory-cli)
    └── graphql-fetch.ts              -- GraphQL fetch + parse (from fieldtheory-cli)

docs/
├── twitter-bookmark-native.md        -- Original plan
└── connector-sync-architecture.md    -- Architecture doc
```

## Test plan

- [x] Core package type-checks clean, all tests pass
- [x] Twitter auth + fetch verified end-to-end (real Chrome cookies, real API)
- [x] Forward sync paginates correctly (1000+ bookmarks across 50+ pages)
- [x] Incremental sync stops at known items on subsequent runs
- [x] SourcesPanel shows X Bookmarks with real capture count from DB
- [x] Sync progress displays in real-time (page count, new items, progress bar)

## Known limitations

- Chrome cookie extraction is macOS-only for now
- Search results are limited to top 20 (pre-existing, not specific to this PR)
- `totalSynced` in sync state may lag behind actual DB count after crashes (UI reads from DB directly as workaround)

🤖 Generated with [Claude Code](https://claude.com/claude-code)