### PR TITLE
fix: parse version from DMG URL only once in install.sh

### DIFF
--- a/packages/landing/public/install.sh
+++ b/packages/landing/public/install.sh
@@ -27,7 +27,7 @@ DOWNLOAD_URL=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest"
 
 [[ -n "$DOWNLOAD_URL" ]] || err "Could not find DMG in latest release."
 
-VERSION=$(echo "$DOWNLOAD_URL" | grep -o '[0-9]*\.[0-9]*\.[0-9]*')
+VERSION=$(echo "$DOWNLOAD_URL" | grep -o '[0-9]*\.[0-9]*\.[0-9]*' | head -1)
 info "Downloading Spool ${VERSION}..."
 
 # ── Download ──


### PR DESCRIPTION
## Summary
- The release DMG URL contains the version twice (e.g. `.../v0.3.2/Spool-0.3.2-arm64.dmg`), so `grep -o '[0-9]*\.[0-9]*\.[0-9]*'` matched both occurrences and `VERSION` became a two-line string.
- Result: installer printed `Downloading Spool 0.3.2\n0.3.2...` and `Spool 0.3.2\n0.3.2 installed to ...`.
- Fix: pipe through `head -1` to take only the first match.

## Test plan
- [x] Re-run `curl -fsSL https://spool.pro/install.sh | bash` after deploy and confirm version prints on a single line