### PR TITLE
Add inline session find and session-to-search handoff

### DIFF
--- a/packages/app/e2e/fast-search.spec.ts
+++ b/packages/app/e2e/fast-search.spec.ts
@@ -64,3 +64,63 @@ test('search for non-existent keyword shows no results', async () => {
   await expect(window.locator('text=No results')).toBeVisible({ timeout: 5000 })
   await expect(window.locator('[data-testid="fragment-row"]')).toHaveCount(0)
 })
+
+test('session page can submit a new search without returning home first', async () => {
+  const { window } = ctx
+
+  await search(window, 'XYLOPHONE_CANARY_42')
+  await window.locator('[data-testid="fragment-row"]').first().click()
+  await expect(window.locator('[data-testid="session-detail"]')).toBeVisible()
+
+  const input = window.locator('[data-testid="search-input"]')
+  await input.fill('TROMBONE_CANARY_99')
+  await input.press('Enter')
+
+  await expect(window.locator('[data-testid="session-detail"]')).toHaveCount(0)
+  await expect(window.locator('[data-testid="fragment-row"]').first()).toContainText('TROMBONE_CANARY_99')
+})
+
+test('session page supports cmd or ctrl + f find-in-page', async () => {
+  const { window } = ctx
+
+  await search(window, 'XYLOPHONE_CANARY_42')
+  await window.locator('[data-testid="fragment-row"]').first().click()
+  await expect(window.locator('[data-testid="session-detail"]')).toBeVisible()
+
+  await window.keyboard.press(process.platform === 'darwin' ? 'Meta+f' : 'Control+f')
+
+  const findInput = window.locator('[data-testid="session-find-input"]')
+  await expect(findInput).toBeVisible()
+  await expect(findInput).toBeFocused()
+
+  await findInput.fill('XYLOPHONE')
+  await window.locator('[data-testid="session-detail"]').click()
+  await window.keyboard.press(process.platform === 'darwin' ? 'Meta+f' : 'Control+f')
+  await expect(findInput).toBeFocused()
+  await findInput.type('_CANARY_42')
+  await expect(findInput).toHaveValue('XYLOPHONE_CANARY_42')
+  await expect(window.locator('[data-testid="session-find-status"]')).toContainText(/\d+\s*\/\s*\d+/, { timeout: 5000 })
+  await expect(window.locator('[data-testid="session-find-active-match"]').first()).toContainText('XYLOPHONE_CANARY_42')
+})
+
+test('session find supports cmd or ctrl + arrow navigation', async () => {
+  const { window } = ctx
+
+  await search(window, 'XYLOPHONE_CANARY_42')
+  await window.locator('[data-testid="fragment-row"]').first().click()
+  await expect(window.locator('[data-testid="session-detail"]')).toBeVisible()
+
+  await window.keyboard.press(process.platform === 'darwin' ? 'Meta+f' : 'Control+f')
+
+  const findInput = window.locator('[data-testid="session-find-input"]')
+  const status = window.locator('[data-testid="session-find-status"]')
+
+  await findInput.fill('the')
+  await expect(status).toContainText(/1\s*\/\s*[2-9]\d*/, { timeout: 5000 })
+
+  await window.keyboard.press(process.platform === 'darwin' ? 'Meta+ArrowRight' : 'Control+ArrowRight')
+  await expect(status).toContainText(/2\s*\/\s*[2-9]\d*/, { timeout: 5000 })
+
+  await window.keyboard.press(process.platform === 'darwin' ? 'Meta+ArrowLeft' : 'Control+ArrowLeft')
+  await expect(status).toContainText(/1\s*\/\s*[2-9]\d*/, { timeout: 5000 })
+})

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -202,7 +202,11 @@ export default function App() {
   }, [doSearch, searchMode, aiAnswer, aiError])
 
   const handleSubmit = useCallback(() => {
-    if (query.trim()) setHomeMode(false)
+    if (!query.trim()) return
+    setHomeMode(false)
+    setSelectedSession(null)
+    setTargetMessageId(null)
+    setView('search')
     if (searchMode === 'ai') {
       doAiSearch()
     } else {
@@ -219,7 +223,13 @@ export default function App() {
       setAiStreaming(false)
       setAiToolCalls(new Map())
       aiAnswerRef.current = ''
-      if (query.trim()) doSearch(query)
+      if (query.trim()) {
+        setHomeMode(false)
+        setSelectedSession(null)
+        setTargetMessageId(null)
+        setView('search')
+        doSearch(query)
+      }
     } else {
       // Switching to AI: clear FTS results, user will press Enter to search
       setResults([])

--- a/packages/app/src/renderer/components/MessageBubble.tsx
+++ b/packages/app/src/renderer/components/MessageBubble.tsx
@@ -1,18 +1,35 @@
+import type { ReactNode } from 'react'
 import type { Message } from '@spool/core'
+
+export type FindRange = {
+  start: number
+  end: number
+}
 
 interface Props {
   message: Message
+  findRanges?: FindRange[]
+  matchIndexOffset?: number
+  activeMatchIndex?: number
+  onActiveMatchRef?: (node: HTMLElement | null) => void
 }
 
-export default function MessageBubble({ message }: Props) {
+export default function MessageBubble({
+  message,
+  findRanges = [],
+  matchIndexOffset = 0,
+  activeMatchIndex = -1,
+  onActiveMatchRef,
+}: Props) {
   const isUser = message.role === 'user'
   const isSystem = message.role === 'system'
+  const contentText = message.contentText || (isSystem ? '(summary)' : '')
 
   if (isSystem) {
     return (
       <div className="px-4 py-2">
         <div className="bg-neutral-100 dark:bg-neutral-800/60 rounded px-3 py-2 text-xs text-neutral-500 dark:text-neutral-400 italic">
-          {message.contentText || '(summary)'}
+          {renderHighlightedText(contentText, findRanges, matchIndexOffset, activeMatchIndex, onActiveMatchRef)}
         </div>
       </div>
     )
@@ -39,13 +56,58 @@ export default function MessageBubble({ message }: Props) {
             </div>
           )}
           <p className="text-sm text-neutral-800 dark:text-neutral-200 leading-relaxed whitespace-pre-wrap break-words select-text cursor-text">
-            {message.contentText || <span className="text-neutral-400 italic">(tool use)</span>}
+            {message.contentText
+              ? renderHighlightedText(contentText, findRanges, matchIndexOffset, activeMatchIndex, onActiveMatchRef)
+              : <span className="text-neutral-400 italic">(tool use)</span>}
           </p>
           <p className="text-[10px] text-neutral-400 mt-1">{formatTime(message.timestamp)}</p>
         </div>
       </div>
     </div>
   )
+}
+
+function renderHighlightedText(
+  text: string,
+  ranges: FindRange[],
+  matchIndexOffset: number,
+  activeMatchIndex: number,
+  onActiveMatchRef?: (node: HTMLElement | null) => void,
+): ReactNode {
+  if (!ranges.length) return text
+
+  const parts: ReactNode[] = []
+  let cursor = 0
+
+  ranges.forEach((range, localIndex) => {
+    if (range.start > cursor) {
+      parts.push(text.slice(cursor, range.start))
+    }
+
+    const matchText = text.slice(range.start, range.end)
+    const globalIndex = matchIndexOffset + localIndex
+    const isActive = globalIndex === activeMatchIndex
+
+    parts.push(
+      <mark
+        key={`${globalIndex}-${range.start}-${range.end}`}
+        ref={isActive ? onActiveMatchRef ?? null : null}
+        data-testid={isActive ? 'session-find-active-match' : undefined}
+        className="font-semibold transition-colors"
+        style={{ color: 'var(--color-accent)', background: 'transparent' }}
+      >
+        {matchText}
+      </mark>,
+    )
+
+    cursor = range.end
+  })
+
+  if (cursor < text.length) {
+    parts.push(text.slice(cursor))
+  }
+
+  return parts
 }
 
 function formatTime(iso: string): string {

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { Session, Message } from '@spool/core'
-import MessageBubble from './MessageBubble.js'
+import MessageBubble, { type FindRange } from './MessageBubble.js'
+import SessionFindBar from './SessionFindBar.js'
 
 type Props = {
   sessionUuid: string
@@ -12,8 +13,63 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
   const [session, setSession] = useState<Session | null>(null)
   const [messages, setMessages] = useState<Message[]>([])
   const [loading, setLoading] = useState(true)
-  const [showHighlight, setShowHighlight] = useState(false)
+  const [showFindBar, setShowFindBar] = useState(false)
+  const [findFocusNonce, setFindFocusNonce] = useState(0)
+  const [findResultNonce, setFindResultNonce] = useState(0)
+  const [findQuery, setFindQuery] = useState('')
+  const [activeMatchIndex, setActiveMatchIndex] = useState(0)
   const targetRef = useRef<HTMLDivElement | null>(null)
+  const activeFindMatchRef = useRef<HTMLElement | null>(null)
+  const isMacLike = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform)
+
+  const normalizedFindQuery = findQuery.trim().toLocaleLowerCase()
+  const {
+    messageFindRanges,
+    totalFindMatches,
+  } = useMemo(() => {
+    let offset = 0
+    const rangesByMessage = new Map<number, { ranges: FindRange[]; offset: number }>()
+
+    for (const message of messages) {
+      const ranges = normalizedFindQuery
+        ? getFindRanges(message.contentText || (message.role === 'system' ? '(summary)' : ''), normalizedFindQuery)
+        : []
+      rangesByMessage.set(message.id, { ranges, offset })
+      offset += ranges.length
+    }
+
+    return {
+      messageFindRanges: rangesByMessage,
+      totalFindMatches: offset,
+    }
+  }, [messages, normalizedFindQuery])
+
+  const activeMatchOrdinal = totalFindMatches > 0 ? activeMatchIndex + 1 : 0
+
+  const clearFind = useCallback(() => {
+    setFindQuery('')
+    setActiveMatchIndex(0)
+  }, [])
+
+  const closeFindBar = useCallback(() => {
+    setShowFindBar(false)
+    clearFind()
+  }, [clearFind])
+
+  const runFind = useCallback((query: string) => {
+    setFindQuery(query)
+    setActiveMatchIndex(0)
+  }, [])
+
+  const findNext = useCallback(() => {
+    if (totalFindMatches === 0) return
+    setActiveMatchIndex((value) => (value + 1) % totalFindMatches)
+  }, [totalFindMatches])
+
+  const findPrevious = useCallback(() => {
+    if (totalFindMatches === 0) return
+    setActiveMatchIndex((value) => (value - 1 + totalFindMatches) % totalFindMatches)
+  }, [totalFindMatches])
 
   useEffect(() => {
     setLoading(true)
@@ -29,11 +85,90 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
   useEffect(() => {
     if (!loading && targetMessageId && targetRef.current) {
       targetRef.current.scrollIntoView({ behavior: 'instant', block: 'center' })
-      setShowHighlight(true)
-      const timer = setTimeout(() => setShowHighlight(false), 2000)
-      return () => clearTimeout(timer)
     }
   }, [loading, targetMessageId])
+
+  useEffect(() => {
+    setShowFindBar(false)
+    setFindFocusNonce(0)
+    setFindResultNonce(0)
+    clearFind()
+  }, [sessionUuid, clearFind])
+
+  useEffect(() => {
+    if (!normalizedFindQuery || totalFindMatches === 0) {
+      setActiveMatchIndex(0)
+      return
+    }
+
+    setActiveMatchIndex((value) => Math.min(value, totalFindMatches - 1))
+  }, [normalizedFindQuery, totalFindMatches])
+
+  useEffect(() => {
+    if (!showFindBar) return
+    setFindResultNonce((value) => value + 1)
+  }, [showFindBar, totalFindMatches, activeMatchIndex])
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      const hasPrimaryModifier = isMacLike
+        ? event.metaKey && !event.ctrlKey
+        : event.ctrlKey && !event.metaKey
+
+      const isFindShortcut = (event.metaKey || event.ctrlKey)
+        && !event.altKey
+        && !event.shiftKey
+        && event.key.toLowerCase() === 'f'
+
+      const isFindPreviousShortcut = showFindBar
+        && hasPrimaryModifier
+        && !event.altKey
+        && !event.shiftKey
+        && event.key === 'ArrowLeft'
+
+      const isFindNextShortcut = showFindBar
+        && hasPrimaryModifier
+        && !event.altKey
+        && !event.shiftKey
+        && event.key === 'ArrowRight'
+
+      if (isFindShortcut) {
+        event.preventDefault()
+        setShowFindBar(true)
+        setFindFocusNonce((value) => value + 1)
+        return
+      }
+
+      if (isFindPreviousShortcut) {
+        event.preventDefault()
+        findPrevious()
+        return
+      }
+
+      if (isFindNextShortcut) {
+        event.preventDefault()
+        findNext()
+        return
+      }
+
+      if (event.key === 'Escape' && showFindBar) {
+        event.preventDefault()
+        closeFindBar()
+      }
+    }
+
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [closeFindBar, findNext, findPrevious, isMacLike, showFindBar])
+
+  useEffect(() => {
+    if (!showFindBar || totalFindMatches === 0) return
+    activeFindMatchRef.current?.scrollIntoView({ block: 'center', inline: 'nearest' })
+  }, [showFindBar, activeMatchIndex, totalFindMatches])
+
+  const bindActiveFindMatch = useCallback((node: HTMLElement | null) => {
+    activeFindMatchRef.current = node
+  }, [])
 
   if (loading) {
     return (
@@ -58,7 +193,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
   }
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full" data-testid="session-detail">
       {/* Session header */}
       <div className="flex items-end justify-between gap-3 flex-none px-4 py-2 border-b border-neutral-100 dark:border-neutral-800">
         <div className="min-w-0 flex-1">
@@ -83,19 +218,39 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
         </button>
       </div>
 
+      <SessionFindBar
+        visible={showFindBar}
+        focusNonce={findFocusNonce}
+        resultNonce={findResultNonce}
+        query={findQuery}
+        matches={totalFindMatches}
+        activeMatchOrdinal={activeMatchOrdinal}
+        onChange={runFind}
+        onNext={findNext}
+        onPrevious={findPrevious}
+        onClose={closeFindBar}
+      />
+
       {/* Messages */}
       <div className="flex-1 overflow-y-auto divide-y divide-neutral-50 dark:divide-neutral-800/50">
-        {messages.map((msg) => (
+        {messages.map((msg) => {
+          const matchState = messageFindRanges.get(msg.id)
+
+          return (
           <div
             key={msg.id}
             ref={msg.id === targetMessageId ? targetRef : undefined}
-            className={msg.id === targetMessageId
-              ? `transition-colors duration-700 ${showHighlight ? 'bg-accent/10 dark:bg-accent-dark/10' : ''}`
-              : undefined}
           >
-            <MessageBubble message={msg} />
+            <MessageBubble
+              message={msg}
+              findRanges={showFindBar ? matchState?.ranges : undefined}
+              matchIndexOffset={matchState?.offset}
+              activeMatchIndex={showFindBar ? activeMatchIndex : -1}
+              onActiveMatchRef={bindActiveFindMatch}
+            />
           </div>
-        ))}
+          )
+        })}
         {messages.length === 0 && (
           <div className="flex items-center justify-center h-32 text-neutral-400">
             <p className="text-sm">No messages to display.</p>
@@ -108,4 +263,21 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
 
 function formatDate(iso: string): string {
   try { return new Date(iso).toLocaleString() } catch { return iso }
+}
+
+function getFindRanges(text: string, normalizedQuery: string): FindRange[] {
+  if (!normalizedQuery || !text) return []
+
+  const lowerText = text.toLocaleLowerCase()
+  const ranges: FindRange[] = []
+  let fromIndex = 0
+
+  while (fromIndex < lowerText.length) {
+    const index = lowerText.indexOf(normalizedQuery, fromIndex)
+    if (index === -1) break
+    ranges.push({ start: index, end: index + normalizedQuery.length })
+    fromIndex = index + Math.max(normalizedQuery.length, 1)
+  }
+
+  return ranges
 }

--- a/packages/app/src/renderer/components/SessionFindBar.tsx
+++ b/packages/app/src/renderer/components/SessionFindBar.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+type Props = {
+  visible: boolean
+  focusNonce: number
+  resultNonce: number
+  query: string
+  matches: number
+  activeMatchOrdinal: number
+  onChange: (query: string) => void
+  onNext: () => void
+  onPrevious: () => void
+  onClose: () => void
+}
+
+export default function SessionFindBar({
+  visible,
+  focusNonce,
+  resultNonce,
+  query,
+  matches,
+  activeMatchOrdinal,
+  onChange,
+  onNext,
+  onPrevious,
+  onClose,
+}: Props) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const selectionRef = useRef<{ start: number; end: number } | null>(null)
+  const previousShortcutLabel = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform) ? '⌘←' : 'Ctrl+←'
+  const nextShortcutLabel = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform) ? '⌘→' : 'Ctrl+→'
+
+  const rememberSelection = useCallback((input: HTMLInputElement) => {
+    const start = input.selectionStart ?? input.value.length
+    const end = input.selectionEnd ?? start
+    selectionRef.current = { start, end }
+  }, [])
+
+  const focusInput = useCallback((mode: 'end' | 'preserve') => {
+    const input = inputRef.current
+    if (!input) return
+
+    input.focus()
+
+    if (mode === 'preserve' && selectionRef.current) {
+      const start = Math.min(selectionRef.current.start, input.value.length)
+      const end = Math.min(selectionRef.current.end, input.value.length)
+      input.setSelectionRange(start, end)
+      return
+    }
+
+    const caret = input.value.length
+    input.setSelectionRange(caret, caret)
+    selectionRef.current = { start: caret, end: caret }
+  }, [])
+
+  useEffect(() => {
+    if (!visible) return
+    requestAnimationFrame(() => {
+      focusInput('end')
+    })
+  }, [visible, focusNonce, focusInput])
+
+  useEffect(() => {
+    if (!visible) return
+    const input = inputRef.current
+    if (!input || document.activeElement === input) return
+    requestAnimationFrame(() => {
+      focusInput('preserve')
+    })
+  }, [visible, resultNonce, focusInput])
+
+  if (!visible) return null
+
+  const hasQuery = query.trim().length > 0
+  const hasMatches = matches > 0
+  const statusLabel = !hasQuery
+    ? 'Type to find in this session'
+    : hasMatches
+      ? `${activeMatchOrdinal} / ${matches}`
+      : 'No matches'
+
+  return (
+    <div className="flex items-center gap-2 border-b border-warm-border dark:border-dark-border px-4 py-2 bg-warm-surface/70 dark:bg-dark-surface/70 backdrop-blur-sm">
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(event) => {
+          rememberSelection(event.currentTarget)
+          onChange(event.target.value)
+        }}
+        onClick={(event) => rememberSelection(event.currentTarget)}
+        onKeyUp={(event) => rememberSelection(event.currentTarget)}
+        onSelect={(event) => rememberSelection(event.currentTarget)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault()
+            if (event.shiftKey) {
+              onPrevious()
+            } else {
+              onNext()
+            }
+            rememberSelection(event.currentTarget)
+          } else if (event.key === 'Escape') {
+            event.preventDefault()
+            onClose()
+          }
+        }}
+        placeholder="Find in session…"
+        className="min-w-0 flex-1 rounded-full border border-warm-border dark:border-dark-border bg-warm-bg/90 dark:bg-dark-bg px-3 py-1.5 text-sm text-warm-text dark:text-dark-text outline-none placeholder:text-warm-faint dark:placeholder:text-dark-muted transition-[border-color,box-shadow,background-color] focus:border-accent/45 dark:focus:border-accent-dark/55 focus:bg-white dark:focus:bg-dark-surface2 focus:shadow-[0_0_0_3px_rgba(200,90,0,0.08)] dark:focus:shadow-[0_0_0_3px_rgba(240,112,32,0.12)]"
+        autoComplete="off"
+        spellCheck={false}
+        data-testid="session-find-input"
+      />
+      <span
+        className="min-w-24 text-right text-xs text-warm-muted dark:text-dark-muted"
+        data-testid="session-find-status"
+      >
+        {statusLabel}
+      </span>
+      <button
+        type="button"
+        onClick={onPrevious}
+        disabled={!hasQuery || !hasMatches}
+        className="rounded-full border border-warm-border dark:border-dark-border px-2 py-1 text-xs text-warm-muted dark:text-dark-muted transition-colors enabled:hover:text-warm-text enabled:hover:border-accent enabled:dark:hover:text-dark-text disabled:opacity-40"
+        aria-label={`Previous match (${previousShortcutLabel})`}
+        title={`Previous match (${previousShortcutLabel})`}
+      >
+        Prev
+      </button>
+      <button
+        type="button"
+        onClick={onNext}
+        disabled={!hasQuery || !hasMatches}
+        className="rounded-full border border-warm-border dark:border-dark-border px-2 py-1 text-xs text-warm-muted dark:text-dark-muted transition-colors enabled:hover:text-warm-text enabled:hover:border-accent enabled:dark:hover:text-dark-text disabled:opacity-40"
+        aria-label={`Next match (${nextShortcutLabel})`}
+        title={`Next match (${nextShortcutLabel})`}
+      >
+        Next
+      </button>
+      <button
+        type="button"
+        onClick={onClose}
+        className="rounded-full border border-warm-border dark:border-dark-border px-2 py-1 text-xs text-warm-muted dark:text-dark-muted transition-colors hover:text-warm-text hover:border-accent dark:hover:text-dark-text"
+        aria-label="Close find in session"
+      >
+        Close
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- allow the top search bar to run a fresh search while a session detail is open
- add an inline session find bar with `Cmd/Ctrl+F` plus `Cmd/Ctrl+ArrowLeft/ArrowRight` navigation
- render inline session matches with the existing accent text treatment and remove the temporary session-open fade highlight

## Testing
- `node node_modules/electron-vite/bin/electron-vite.js build`
- `node node_modules/@playwright/test/cli.js test --config e2e/playwright.config.ts e2e/fast-search.spec.ts`

Closes #42
