### PR TITLE
feat: head-side dual-frontier sync contract (Phase A.1)

### DIFF
--- a/docs/connector-developer-guide.md
+++ b/docs/connector-developer-guide.md
@@ -14,7 +14,7 @@ A connector does NOT:
 - Write to the database (the engine handles upserts)
 - Handle retries or backoff (the scheduler handles this)
 
-Your job is simple: **given a cursor, return one page of items.**
+Your job is simple: **given a `FetchContext`, return one page of items.** Most connectors only need the `cursor` field — `sinceItemId` and `phase` are optional hints.
 
 ---
 
@@ -32,7 +32,7 @@ interface Connector {
   readonly ephemeral: boolean  // true = cache (full-replace), false = user data (incremental)
 
   checkAuth(opts?: Record<string, string>): Promise<AuthStatus>
-  fetchPage(cursor: string | null): Promise<PageResult>
+  fetchPage(ctx: FetchContext): Promise<PageResult>
 }
 ```
 
@@ -67,11 +67,20 @@ interface AuthStatus {
 - Always provide a `hint` on failure. The hint is shown directly in the UI. Write it as an instruction the user can act on.
 - Never throw. Always return an `AuthStatus` object.
 
-#### `fetchPage(cursor: string | null): Promise<PageResult>`
+#### `fetchPage(ctx: FetchContext): Promise<PageResult>`
 
 The core data fetching method. Called repeatedly by the sync engine to paginate through the platform's data.
 
 ```typescript
+interface FetchContext {
+  cursor: string | null         // Pagination cursor. null = start from newest.
+  sinceItemId: string | null    // Platform ID of newest known item. The engine
+                                // passes this during forward sync so you can
+                                // optimize if your API supports "since" filtering.
+                                // null during backfill or first-ever sync.
+  phase: 'forward' | 'backfill' // Which sync phase is requesting this page.
+}
+
 interface PageResult {
   items: CapturedItem[]    // Items on this page
   nextCursor: string | null // Cursor for next page, null = no more data
@@ -84,6 +93,7 @@ interface PageResult {
 - Items should be ordered newest-first within each page (this is how most APIs work naturally).
 - Throw `SyncError` on failures. The engine catches it, updates error state, and the scheduler handles backoff.
 - Keep pages small-ish (10–25 items). The engine adds a delay between pages to avoid rate limiting.
+- You can safely ignore `sinceItemId` and `phase` — just destructure `{ cursor }` and use it. The engine has its own early-exit logic that works regardless.
 
 ---
 
@@ -204,11 +214,12 @@ On a successful sync, `consecutiveErrors` resets to 0.
 ### Stop Conditions
 
 The sync engine stops a forward sync when ANY of:
-1. **Caught up**: 3 consecutive pages with 0 new items
-2. **End of data**: `nextCursor` is `null`
-3. **Time limit**: Exceeded `maxMinutes` (10 min for scheduler, unlimited for CLI)
-4. **Cancelled**: App is quitting or user aborted
-5. **Error**: `fetchPage()` threw
+1. **Reached since-anchor**: A page contains the item matching `sinceItemId` (caught up precisely — most efficient)
+2. **Caught up**: 3 consecutive pages with 0 new items (fallback when no anchor exists)
+3. **End of data**: `nextCursor` is `null`
+4. **Time limit**: Exceeded `maxMinutes` (10 min for scheduler, unlimited for CLI). Forward saves `headCursor` for resume.
+5. **Cancelled**: App is quitting or user aborted. Forward saves `headCursor` for resume.
+6. **Error**: `fetchPage()` threw. Forward saves `headCursor` for resume.
 
 ### Progress & Events
 
@@ -279,7 +290,7 @@ async checkAuth(): Promise<AuthStatus> {
   }
 }
 
-async fetchPage(cursor: string | null): Promise<PageResult> {
+async fetchPage({ cursor }: FetchContext): Promise<PageResult> {
   const cookies = extractChromeCookies('.example.com', ['session_id', 'csrf_token'])
   const response = await fetch('https://api.example.com/bookmarks', {
     headers: { Cookie: cookies.cookieHeader }
@@ -307,7 +318,7 @@ async checkAuth(): Promise<AuthStatus> {
   }
 }
 
-async fetchPage(cursor: string | null): Promise<PageResult> {
+async fetchPage({ cursor }: FetchContext): Promise<PageResult> {
   const page = cursor ? parseInt(cursor) : 1
   const { stdout } = await execAsync(`gh api /user/starred?per_page=30&page=${page}`)
   const repos = JSON.parse(stdout)
@@ -418,7 +429,7 @@ export default class GitHubStarsConnector implements Connector {
     }
   }
 
-  async fetchPage(cursor: string | null): Promise<PageResult> {
+  async fetchPage({ cursor }: FetchContext): Promise<PageResult> {
     const page = cursor ? parseInt(cursor) : 1
     const perPage = 30
 
@@ -523,9 +534,13 @@ Here's the full lifecycle of a connector, from installation to search results:
 3. SYNC CYCLE (for persistent connectors)
    SyncEngine.sync(connector)
      → loadState() from connector_sync_state table
-     → FORWARD PHASE: fetchPage(null) → fetchPage(cursor1) → ... → stop on stale
-     → BACKFILL PHASE: fetchPage(tailCursor) → ... → stop on budget or end
-     → saveState() with updated cursors
+     → FORWARD: fetchPage({ cursor: headCursor ?? null, sinceItemId, phase: 'forward' })
+       → stop on reached_since / stale / timeout / cancel / error
+       → interrupted? headCursor saved for resume next cycle
+       → completed but sinceItemId not hit? anchor invalidated, rebuilt next cycle
+     → BACKFILL: fetchPage({ cursor: tailCursor, sinceItemId: null, phase: 'backfill' })
+       → stop on end-of-history / budget
+     → saveState()
 
 4. ITEM PROCESSING (per page)
    For each item in PageResult:

--- a/docs/connector-sync-architecture.md
+++ b/docs/connector-sync-architecture.md
@@ -50,16 +50,24 @@ interface Connector {
 
   /**
    * Fetch one page of data.
-   * The sync engine calls this repeatedly with cursors to paginate.
-   *
-   * @param cursor - null for first page, otherwise the cursor from previous page
-   * @returns items on this page + cursor for next page (null = no more pages)
+   * The sync engine calls this repeatedly with FetchContext to paginate.
+   * The connector can use sinceItemId and phase to optimize fetching,
+   * or ignore them and just use the cursor (cursor-walking).
    */
-  fetchPage(cursor: string | null): Promise<PageResult>
+  fetchPage(ctx: FetchContext): Promise<PageResult>
+}
+
+interface FetchContext {
+  cursor: string | null         // Pagination cursor. null = start from newest.
+  sinceItemId: string | null    // Platform ID of newest known item (head anchor).
+                                // Forward passes this so the connector can
+                                // optimize (e.g. stop early). null during backfill
+                                // or when no anchor exists yet.
+  phase: 'forward' | 'backfill' // Which sync phase is requesting this page.
 }
 ```
 
-A connector only needs to implement two methods: `checkAuth()` and `fetchPage()`. Everything else — persistence, scheduling, retries, UI — is handled by the framework.
+A connector only needs to implement two methods: `checkAuth()` and `fetchPage()`. Everything else — persistence, scheduling, retries, UI — is handled by the framework. The `sinceItemId` and `phase` fields in `FetchContext` are informational — a connector can safely ignore them and just use `cursor`. The engine has its own early-exit logic that works regardless of whether the connector acts on these hints.
 
 ### Key Supporting Types
 
@@ -190,8 +198,14 @@ interface SyncState {
   connectorId: string
 
   // Head frontier
-  headCursor: string | null      // cursor to resume forward sync
-  headItemId: string | null      // platform_id of newest known item
+  headCursor: string | null      // Forward resume cursor. Non-null only when
+                                 // forward was interrupted (timeout/cancel/error).
+                                 // Cleared on normal completion.
+  headItemId: string | null      // Platform ID of newest known item (since anchor).
+                                 // Set from page 0 of a fresh forward (not a resumed one).
+                                 // Used as FetchContext.sinceItemId and as the engine's
+                                 // early-exit target. Cleared automatically if forward
+                                 // completes without hitting it (anchor invalidation).
 
   // Tail frontier
   tailCursor: string | null      // cursor to resume backfill
@@ -212,11 +226,13 @@ interface SyncState {
 ### Stop Conditions
 
 Forward sync stops when ANY of:
-1. **Stale pages**: 3 consecutive pages with 0 new items (caught up)
-2. **No cursor**: API returned `nextCursor: null` (end of data)
-3. **Budget**: Hit `maxPages` limit
-4. **Timeout**: Exceeded `maxMinutes`
-5. **Cancelled**: `AbortSignal` fired
+1. **Reached since-anchor**: A page contains the item matching `sinceItemId` (caught up precisely)
+2. **Stale pages**: 3 consecutive pages with 0 new items (fallback when no anchor exists)
+3. **No cursor**: API returned `nextCursor: null` (end of data)
+4. **Timeout**: Exceeded `maxMinutes` (forward interrupted, `headCursor` preserved for resume)
+5. **Cancelled**: `AbortSignal` fired (`headCursor` preserved)
+
+Conditions 1–3 are "normal completion" — `headCursor` is cleared. Conditions 4–5 are "interruption" — `headCursor` retains the current position so the next forward resumes where it stopped instead of re-fetching from the newest end.
 
 ### Ephemeral vs. Persistent
 
@@ -236,9 +252,9 @@ class SyncEngine {
 ### Checkpoint & Crash Safety
 
 The engine checkpoints state to DB every 25 pages. If the app crashes mid-sync:
-- Forward sync: may re-fetch some pages, but dedup by `(platform, platformId)` prevents duplicates
-- Backfill: resumes from last saved `tailCursor`
-- No data loss, at most some redundant API calls
+- Forward sync: resumes from last saved `headCursor`. Pages between the crash and the last checkpoint may be re-fetched, but dedup by `(platform, platformId)` prevents duplicates.
+- Backfill: resumes from last saved `tailCursor`.
+- No data loss, at most some redundant API calls.
 
 ---
 
@@ -583,7 +599,7 @@ packages/core/src/connectors/
 A minimal connector implementation:
 
 ```typescript
-import type { Connector, AuthStatus, PageResult } from '@spool/core'
+import type { Connector, AuthStatus, PageResult, FetchContext } from '@spool/core'
 
 export default class MyConnector implements Connector {
   readonly id = 'my-platform-bookmarks'
@@ -598,8 +614,11 @@ export default class MyConnector implements Connector {
     return { ok: true }
   }
 
-  async fetchPage(cursor: string | null): Promise<PageResult> {
-    // Fetch one page of data from the platform API
+  async fetchPage({ cursor }: FetchContext): Promise<PageResult> {
+    // Fetch one page of data from the platform API.
+    // sinceItemId and phase are available in FetchContext if your platform
+    // supports server-side "since" filtering — most connectors can ignore them
+    // and just use cursor. The engine handles early-exit on its own.
     const response = await fetchFromAPI(cursor)
     return {
       items: response.items.map(item => ({

--- a/packages/core/src/connectors/sync-engine.test.ts
+++ b/packages/core/src/connectors/sync-engine.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import Database from 'better-sqlite3'
+import { SyncEngine, loadSyncState } from './sync-engine.js'
+import type { Connector, FetchContext, PageResult, AuthStatus } from './types.js'
+import type { CapturedItem } from '../types.js'
+
+// ── Test Helpers ────────────────────────────────────────────────────────────
+
+function createTestDB(): InstanceType<typeof Database> {
+  const db = new Database(':memory:')
+  db.pragma('journal_mode = WAL')
+  db.pragma('foreign_keys = ON')
+
+  db.exec(`
+    CREATE TABLE sources (
+      id        INTEGER PRIMARY KEY,
+      name      TEXT NOT NULL UNIQUE,
+      base_path TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    INSERT INTO sources (name, base_path) VALUES ('claude', '~/.claude/projects');
+
+    CREATE TABLE captures (
+      id              INTEGER PRIMARY KEY,
+      source_id       INTEGER NOT NULL REFERENCES sources(id),
+      capture_uuid    TEXT NOT NULL UNIQUE,
+      url             TEXT NOT NULL,
+      title           TEXT NOT NULL DEFAULT '',
+      content_text    TEXT NOT NULL DEFAULT '',
+      author          TEXT,
+      platform        TEXT NOT NULL,
+      platform_id     TEXT,
+      content_type    TEXT NOT NULL DEFAULT 'page',
+      thumbnail_url   TEXT,
+      metadata        TEXT NOT NULL DEFAULT '{}',
+      captured_at     TEXT NOT NULL,
+      indexed_at      TEXT NOT NULL DEFAULT (datetime('now')),
+      raw_json        TEXT
+    );
+
+    CREATE TABLE connector_sync_state (
+      connector_id        TEXT PRIMARY KEY,
+      head_cursor         TEXT,
+      head_item_id        TEXT,
+      tail_cursor         TEXT,
+      tail_complete       INTEGER NOT NULL DEFAULT 0,
+      last_forward_sync_at  TEXT,
+      last_backfill_sync_at TEXT,
+      total_synced        INTEGER NOT NULL DEFAULT 0,
+      consecutive_errors  INTEGER NOT NULL DEFAULT 0,
+      enabled             INTEGER NOT NULL DEFAULT 1,
+      config_json         TEXT NOT NULL DEFAULT '{}',
+      last_error_code     TEXT,
+      last_error_message  TEXT
+    );
+  `)
+  return db
+}
+
+function makeItem(platformId: string): CapturedItem {
+  return {
+    url: `https://example.com/${platformId}`,
+    title: `Item ${platformId}`,
+    contentText: '',
+    author: null,
+    platform: 'test',
+    platformId,
+    contentType: 'post',
+    thumbnailUrl: null,
+    metadata: {},
+    capturedAt: new Date().toISOString(),
+    rawJson: null,
+  }
+}
+
+type FetchPageFn = (ctx: FetchContext) => Promise<PageResult>
+
+function createMockConnector(fetchPageFn: FetchPageFn): Connector {
+  return {
+    id: 'test-connector',
+    platform: 'test',
+    label: 'Test',
+    description: 'test connector',
+    color: '#000',
+    ephemeral: false,
+    async checkAuth(): Promise<AuthStatus> { return { ok: true } },
+    fetchPage: fetchPageFn,
+  }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('SyncEngine — dual-frontier', () => {
+  let db: InstanceType<typeof Database>
+  let engine: SyncEngine
+
+  beforeEach(() => {
+    db = createTestDB()
+    engine = new SyncEngine(db)
+  })
+
+  // ── A.1.1: FetchContext is passed correctly ─────────────────────────────
+
+  describe('FetchContext passing', () => {
+    it('passes sinceItemId and phase to connector during forward', async () => {
+      const calls: FetchContext[] = []
+      const connector = createMockConnector(async (ctx) => {
+        calls.push({ ...ctx })
+        return { items: [makeItem('#100')], nextCursor: null }
+      })
+
+      await engine.sync(connector, { direction: 'forward' })
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0].phase).toBe('forward')
+      expect(calls[0].sinceItemId).toBeNull()
+      expect(calls[0].cursor).toBeNull()
+    })
+
+    it('passes sinceItemId from previous forward cycle', async () => {
+      const calls: FetchContext[] = []
+      let callCount = 0
+      const connector = createMockConnector(async (ctx) => {
+        calls.push({ ...ctx })
+        callCount++
+        if (callCount === 1) {
+          return { items: [makeItem('#200'), makeItem('#199')], nextCursor: null }
+        }
+        // Second cycle: return the anchor item to trigger early-exit
+        return { items: [makeItem('#201'), makeItem('#200')], nextCursor: null }
+      })
+
+      // First sync: establishes headItemId = #200
+      await engine.sync(connector, { direction: 'forward' })
+      // Second sync: should pass sinceItemId = #200
+      await engine.sync(connector, { direction: 'forward' })
+
+      expect(calls[1].sinceItemId).toBe('#200')
+    })
+
+    it('passes null sinceItemId during backfill', async () => {
+      const calls: FetchContext[] = []
+      const connector = createMockConnector(async (ctx) => {
+        calls.push({ ...ctx })
+        return { items: [makeItem('#100')], nextCursor: null }
+      })
+
+      await engine.sync(connector, { direction: 'backfill' })
+
+      expect(calls[0].phase).toBe('backfill')
+      expect(calls[0].sinceItemId).toBeNull()
+    })
+  })
+
+  // ── A.1.2: tailCursor scope ─────────────────────────────────────────────
+
+  describe('tailCursor scope', () => {
+    it('forward writes tailCursor during initial sync (handoff to backfill)', async () => {
+      let callCount = 0
+      const connector = createMockConnector(async () => {
+        callCount++
+        if (callCount === 1) return { items: [makeItem('#100')], nextCursor: 'cur1' }
+        return { items: [makeItem('#99')], nextCursor: null }
+      })
+
+      await engine.sync(connector, { direction: 'forward' })
+      const state = loadSyncState(db, 'test-connector')
+      // tailCursor should be set from forward's page traversal (initial sync handoff)
+      expect(state.tailCursor).toBe('cur1')
+    })
+
+    it('forward does NOT overwrite tailCursor on subsequent cycles', async () => {
+      // Simulate: initial sync sets tailCursor deep, then forward runs again
+      let callCount = 0
+      const connector = createMockConnector(async () => {
+        callCount++
+        // Initial forward: 2 pages
+        if (callCount === 1) return { items: [makeItem('#100')], nextCursor: 'cur1' }
+        if (callCount === 2) return { items: [makeItem('#99')], nextCursor: null }
+        // Backfill: goes deeper
+        if (callCount === 3) return { items: [makeItem('#50')], nextCursor: 'deep-cursor' }
+        if (callCount === 4) return { items: [makeItem('#49')], nextCursor: null }
+        // Second forward: should NOT touch tailCursor
+        if (callCount === 5) return { items: [makeItem('#101'), makeItem('#100')], nextCursor: null }
+        return { items: [], nextCursor: null }
+      })
+
+      // Cycle 1: forward + backfill, tailCursor ends at backfill's position
+      await engine.sync(connector, { direction: 'both' })
+      const stateAfterCycle1 = loadSyncState(db, 'test-connector')
+      expect(stateAfterCycle1.tailCursor).toBe('deep-cursor')
+
+      // Cycle 2: forward only — tailCursor must stay at deep-cursor
+      await engine.sync(connector, { direction: 'forward' })
+      const stateAfterCycle2 = loadSyncState(db, 'test-connector')
+      expect(stateAfterCycle2.tailCursor).toBe('deep-cursor')
+    })
+  })
+
+  // ── A.1.3: headItemId write timing ──────────────────────────────────────
+
+  describe('headItemId write timing', () => {
+    it('sets headItemId from page 0 first item', async () => {
+      let callCount = 0
+      const connector = createMockConnector(async () => {
+        callCount++
+        if (callCount === 1) return { items: [makeItem('#200'), makeItem('#199')], nextCursor: 'c1' }
+        return { items: [makeItem('#198')], nextCursor: null }
+      })
+
+      await engine.sync(connector, { direction: 'forward' })
+      const state = loadSyncState(db, 'test-connector')
+      // headItemId should be #200 (page 0 first item), NOT #198 (last page first item)
+      expect(state.headItemId).toBe('#200')
+    })
+
+    it('does not update headItemId when resuming from headCursor', async () => {
+      // Set up state as if forward was interrupted: headItemId=#200, headCursor=mid-point
+      db.prepare(`
+        INSERT INTO connector_sync_state (connector_id, head_item_id, head_cursor, tail_cursor, enabled)
+        VALUES ('test-connector', '#200', 'resume-cur', 'tail-cur', 1)
+      `).run()
+
+      let callCount = 0
+      const connector = createMockConnector(async () => {
+        callCount++
+        // Resumed forward: starts from resume-cur, returns older items
+        if (callCount === 1) return { items: [makeItem('#195'), makeItem('#200')], nextCursor: null }
+        return { items: [], nextCursor: null }
+      })
+
+      await engine.sync(connector, { direction: 'forward' })
+      const state = loadSyncState(db, 'test-connector')
+      // headItemId should remain #200, NOT be overwritten by #195
+      expect(state.headItemId).toBe('#200')
+    })
+  })
+
+  // ── A.1.4: headCursor resume ────────────────────────────────────────────
+
+  describe('headCursor resume', () => {
+    it('clears headCursor on normal forward completion', async () => {
+      const connector = createMockConnector(async () => {
+        return { items: [makeItem('#100')], nextCursor: null }
+      })
+
+      await engine.sync(connector, { direction: 'forward' })
+      const state = loadSyncState(db, 'test-connector')
+      expect(state.headCursor).toBeNull()
+    })
+
+    it('preserves headCursor on timeout', async () => {
+      let callCount = 0
+      const connector = createMockConnector(async () => {
+        callCount++
+        // Return pages indefinitely
+        return { items: [makeItem(`#${100 + callCount}`)], nextCursor: `cur${callCount}` }
+      })
+
+      // maxMinutes=0.0001 (~6ms) to trigger timeout quickly
+      await engine.sync(connector, { direction: 'forward', maxMinutes: 0.0001, delayMs: 10 })
+      const state = loadSyncState(db, 'test-connector')
+      // headCursor should be preserved (non-null) for resume
+      expect(state.headCursor).not.toBeNull()
+    })
+
+    it('resumes forward from headCursor instead of null', async () => {
+      // Pre-set headCursor from a previous interrupted forward
+      db.prepare(`
+        INSERT INTO connector_sync_state (connector_id, head_item_id, head_cursor, enabled)
+        VALUES ('test-connector', '#200', 'resume-from-here', 1)
+      `).run()
+
+      const calls: FetchContext[] = []
+      const connector = createMockConnector(async (ctx) => {
+        calls.push({ ...ctx })
+        return { items: [makeItem('#198'), makeItem('#200')], nextCursor: null }
+      })
+
+      await engine.sync(connector, { direction: 'forward' })
+      // Should start from headCursor, not null
+      expect(calls[0].cursor).toBe('resume-from-here')
+    })
+  })
+
+  // ── A.1.5: early-exit on sinceItemId ────────────────────────────────────
+
+  describe('early-exit on sinceItemId', () => {
+    it('stops forward when page contains sinceItemId', async () => {
+      // Set up: headItemId = #200 from previous cycle
+      db.prepare(`
+        INSERT INTO connector_sync_state (connector_id, head_item_id, tail_cursor, enabled)
+        VALUES ('test-connector', '#200', 'some-tail', 1)
+      `).run()
+
+      let callCount = 0
+      const connector = createMockConnector(async () => {
+        callCount++
+        // Page 1 contains the anchor item #200
+        return { items: [makeItem('#202'), makeItem('#201'), makeItem('#200')], nextCursor: 'more' }
+      })
+
+      const result = await engine.sync(connector, { direction: 'forward' })
+      expect(result.stopReason).toBe('reached_since')
+      // Should only make 1 API call — no need to fetch more pages
+      expect(callCount).toBe(1)
+    })
+
+    it('falls back to stale-page detection when no anchor exists', async () => {
+      let callCount = 0
+      const connector = createMockConnector(async () => {
+        callCount++
+        // Return the same items every time (all already in DB after page 1)
+        return { items: [makeItem('#100')], nextCursor: `cur${callCount}` }
+      })
+
+      const result = await engine.sync(connector, { direction: 'forward', stalePageLimit: 3 })
+      expect(result.stopReason).toBe('caught_up')
+      // 1 page with new data + 3 stale pages = 4 total
+      expect(callCount).toBe(4)
+    })
+  })
+
+  // ── A.1.6: anchor invalidation ──────────────────────────────────────────
+
+  describe('anchor invalidation', () => {
+    it('clears headItemId when forward completes without hitting anchor', async () => {
+      // Set up: headItemId = #200 but that item was deleted from the platform
+      db.prepare(`
+        INSERT INTO connector_sync_state (connector_id, head_item_id, tail_cursor, enabled)
+        VALUES ('test-connector', '#200', 'some-tail', 1)
+      `).run()
+
+      const connector = createMockConnector(async () => {
+        // Returns items but never #200 — anchor is stale
+        return { items: [makeItem('#300')], nextCursor: null }
+      })
+
+      await engine.sync(connector, { direction: 'forward' })
+      const state = loadSyncState(db, 'test-connector')
+      // Anchor should be cleared since forward completed without hitting it
+      expect(state.headItemId).toBeNull()
+    })
+
+    it('does NOT clear headItemId when forward is interrupted by timeout', async () => {
+      // headCursor is set so this is a resumed forward — page 0 won't overwrite headItemId
+      db.prepare(`
+        INSERT INTO connector_sync_state (connector_id, head_item_id, head_cursor, enabled)
+        VALUES ('test-connector', '#200', 'resume-cur', 1)
+      `).run()
+
+      let callCount = 0
+      const connector = createMockConnector(async () => {
+        callCount++
+        return { items: [makeItem(`#${300 + callCount}`)], nextCursor: `cur${callCount}` }
+      })
+
+      await engine.sync(connector, { direction: 'forward', maxMinutes: 0.0001, delayMs: 10 })
+      const state = loadSyncState(db, 'test-connector')
+      // Anchor should be preserved — forward didn't complete, can't judge validity.
+      // headItemId stays #200 because this was a resumed forward (startCursor != null),
+      // so A.1.3 skips the page-0 update.
+      expect(state.headItemId).toBe('#200')
+    })
+
+    it('preserves headItemId when forward hits the anchor (reached_since)', async () => {
+      db.prepare(`
+        INSERT INTO connector_sync_state (connector_id, head_item_id, tail_cursor, enabled)
+        VALUES ('test-connector', '#200', 'some-tail', 1)
+      `).run()
+
+      const connector = createMockConnector(async () => {
+        return { items: [makeItem('#201'), makeItem('#200')], nextCursor: 'more' }
+      })
+
+      await engine.sync(connector, { direction: 'forward' })
+      const state = loadSyncState(db, 'test-connector')
+      // headItemId should be updated to #201 (page 0 first item, newer than #200)
+      expect(state.headItemId).toBe('#201')
+    })
+  })
+})

--- a/packages/core/src/connectors/sync-engine.ts
+++ b/packages/core/src/connectors/sync-engine.ts
@@ -2,6 +2,7 @@ import type Database from 'better-sqlite3'
 import { randomUUID } from 'node:crypto'
 import type {
   Connector,
+  FetchContext,
   SyncState,
   SyncOptions,
   ConnectorSyncResult,
@@ -251,6 +252,20 @@ export class SyncEngine {
     const stalePageLimit = opts.stalePageLimit ?? 3
     const checkpointEvery = 25
 
+    // Initial sync handoff: forward writes tailCursor ONLY on the very first sync
+    // (tailCursor still null, no prior forward interrupted = headCursor null).
+    // This lets backfill pick up where forward left off. On subsequent cycles,
+    // forward must NOT touch tailCursor — otherwise it overwrites backfill's
+    // deep progress with a shallow position near the newest end.
+    const isInitialSync = opts.phase === 'forward'
+      && state.tailCursor === null
+      && state.headCursor === null
+
+    // Capture the since-anchor at loop entry, before page-0 may update
+    // headItemId (A.1.3). This is the stop signal for forward early-exit:
+    // "stop when you reach this item — everything at or beyond it is already indexed."
+    const sinceItemId = opts.phase === 'forward' ? state.headItemId : null
+
     let cursor = startCursor
     let added = 0
     let pages = 0
@@ -266,7 +281,8 @@ export class SyncEngine {
 
       let result
       try {
-        result = await connector.fetchPage(cursor)
+        const fetchCtx: FetchContext = { cursor, sinceItemId, phase: opts.phase }
+        result = await connector.fetchPage(fetchCtx)
       } catch (err) {
         // Save progress before returning — don't throw, don't lose work
         console.error(`[sync-engine] ${connector.id} ${opts.phase} page ${page + 1} error:`, err instanceof Error ? err.message : err)
@@ -283,6 +299,7 @@ export class SyncEngine {
       pages++
 
       if (result.items.length === 0 && !result.nextCursor) {
+        if (opts.phase === 'forward') state.headCursor = null
         if (opts.phase === 'backfill') state.tailComplete = true
         return { added, pages, stopReason: opts.phase === 'backfill' ? 'backfill_complete' : 'end_of_data' }
       }
@@ -297,10 +314,20 @@ export class SyncEngine {
       )()
       added += newCount
 
-      // Track head (forward) or tail (backfill)
-      if (opts.phase === 'forward') {
+      // Update headItemId: the platform ID of the newest item we've ever seen.
+      // Only on forward, only on the first page (page 0), and only when NOT
+      // resuming from headCursor — a resumed forward is catching up to the
+      // existing anchor, not establishing a new one.
+      // Monotonic-forward check: only overwrite if we don't already have one,
+      // or if the new value is genuinely newer (i.e. different from current).
+      // On platforms with cursor-walking (no server-side since), the first page
+      // of a fresh forward always starts at the newest end, so page-0's first
+      // item is guaranteed to be >= the current headItemId.
+      if (opts.phase === 'forward' && page === 0 && startCursor === null) {
         const firstItem = result.items[0]
-        if (firstItem && firstItem.platformId) state.headItemId = firstItem.platformId
+        if (firstItem?.platformId && firstItem.platformId !== state.headItemId) {
+          state.headItemId = firstItem.platformId
+        }
       }
 
       opts.onProgress?.({
@@ -312,24 +339,51 @@ export class SyncEngine {
         running: true,
       })
 
+      // Early-exit: forward stops when it reaches the since-anchor (headItemId).
+      // This means we've caught up to the point where the last forward left off.
+      // Much more efficient than stale-page detection for small incremental syncs
+      // (e.g. 2 new bookmarks → 1 page instead of 3+ stale pages).
+      // Note: sinceItemId was already captured into headItemId before page 0's
+      // update (A.1.3 only updates headItemId on page 0 of a fresh forward),
+      // so we compare against the original anchor stored at fetchLoop entry.
+      if (opts.phase === 'forward' && sinceItemId) {
+        const hitAnchor = result.items.some(
+          item => item.platformId === sinceItemId,
+        )
+        if (hitAnchor) {
+          state.headCursor = null
+          return { added, pages, stopReason: 'reached_since' }
+        }
+      }
+
       // Stale page detection: stop when we keep seeing only known data
       if (newCount === 0) stalePages++
       else stalePages = 0
       if (stalePages >= stalePageLimit) {
+        if (opts.phase === 'forward') state.headCursor = null
         if (opts.phase === 'backfill') state.tailComplete = true
         return { added, pages, stopReason: opts.phase === 'forward' ? 'caught_up' : 'backfill_complete' }
       }
 
       if (!result.nextCursor) {
+        if (opts.phase === 'forward') state.headCursor = null
         if (opts.phase === 'backfill') state.tailComplete = true
         return { added, pages, stopReason: opts.phase === 'backfill' ? 'backfill_complete' : 'end_of_data' }
       }
 
       cursor = result.nextCursor
 
-      // Update cursor in state for resume
-      if (opts.phase === 'forward') state.tailCursor = cursor
-      else state.tailCursor = cursor
+      // Update cursors in state for resume.
+      if (opts.phase === 'forward') {
+        // Save forward progress so an interrupted cycle can resume here
+        // instead of re-fetching from the newest end.
+        state.headCursor = cursor
+        // Only write tailCursor during initial sync (handoff to backfill).
+        if (isInitialSync) state.tailCursor = cursor
+      } else {
+        // Backfill always tracks its own progress.
+        state.tailCursor = cursor
+      }
 
       // Checkpoint periodically (crash safety)
       if (pages % checkpointEvery === 0) {
@@ -355,13 +409,29 @@ export class SyncEngine {
     let lastError: { code: string; message: string } | undefined
 
     // ── Phase 1: Forward sync ───────────────────────────────────────
+    // Resume from headCursor if a previous forward was interrupted (timeout,
+    // cancel, error). Otherwise start from null (platform's newest end).
     if (direction === 'forward' || direction === 'both') {
-      const fwd = await this.fetchLoop(connector, state, { ...opts, phase: 'forward' }, sourceId, null, startedAt)
+      const hadAnchor = state.headItemId !== null
+      const fwd = await this.fetchLoop(connector, state, { ...opts, phase: 'forward' }, sourceId, state.headCursor ?? null, startedAt)
       totalAdded += fwd.added
       totalPages += fwd.pages
       stopReason = fwd.stopReason
       if (fwd.error) lastError = fwd.error
       state.lastForwardSyncAt = new Date().toISOString()
+
+      // Anchor invalidation recovery (Q3): if forward ran to completion
+      // (not interrupted) but never hit the since-anchor, the anchor is stale
+      // (e.g. user un-bookmarked that item). Clear it so next forward starts
+      // fresh and re-establishes the anchor from page 0.
+      const completedWithoutHit = hadAnchor
+        && fwd.stopReason !== 'reached_since'
+        && fwd.stopReason !== 'timeout'
+        && fwd.stopReason !== 'cancelled'
+        && !fwd.stopReason.startsWith('error')
+      if (completedWithoutHit) {
+        state.headItemId = null
+      }
     }
 
     // ── Phase 2: Backfill — runs until complete ─────────────────────
@@ -431,7 +501,7 @@ export class SyncEngine {
         break
       }
 
-      const result = await connector.fetchPage(cursor)
+      const result = await connector.fetchPage({ cursor, sinceItemId: null, phase: 'forward' })
       totalPages++
 
       for (const item of result.items) {

--- a/packages/core/src/connectors/twitter-bookmarks/index.ts
+++ b/packages/core/src/connectors/twitter-bookmarks/index.ts
@@ -1,4 +1,4 @@
-import type { Connector, AuthStatus, PageResult } from '../types.js'
+import type { Connector, AuthStatus, PageResult, FetchContext } from '../types.js'
 import { SyncError, SyncErrorCode } from '../types.js'
 import { extractChromeXCookies, detectChromeUserDataDir } from './chrome-cookies.js'
 import { fetchBookmarkPage } from './graphql-fetch.js'
@@ -47,7 +47,7 @@ export class TwitterBookmarksConnector implements Connector {
     }
   }
 
-  async fetchPage(cursor: string | null): Promise<PageResult> {
+  async fetchPage({ cursor }: FetchContext): Promise<PageResult> {
     // Extract cookies fresh for each sync cycle (they may expire)
     // Cache within a single sync run to avoid re-reading DB on every page
     if (!this.cachedCookies) {

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -150,6 +150,15 @@ export interface PageResult {
   nextCursor: string | null
 }
 
+export interface FetchContext {
+  /** Pagination cursor. null = start from the newest page. */
+  cursor: string | null
+  /** Platform ID of the newest known item (head anchor). null = no anchor. */
+  sinceItemId: string | null
+  /** Which sync phase is requesting this page. */
+  phase: 'forward' | 'backfill'
+}
+
 export interface Connector {
   /** Unique identifier, e.g. 'twitter-bookmarks'. */
   readonly id: string
@@ -173,10 +182,8 @@ export interface Connector {
    * The sync engine calls this repeatedly, following nextCursor.
    * The connector handles API-level retries (429, 5xx) internally.
    * If retries are exhausted, throw a SyncError.
-   *
-   * @param cursor - null for the first (newest) page
    */
-  fetchPage(cursor: string | null): Promise<PageResult>
+  fetchPage(ctx: FetchContext): Promise<PageResult>
 }
 
 // ── Sync State ───────────────────────────────────────────────────────────────

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export {
 export type {
   Connector,
   AuthStatus,
+  FetchContext,
   PageResult,
   SyncState,
   SyncOptions,


### PR DESCRIPTION
## Background

Spool's connector system was designed with a dual-frontier sync model (head + tail frontiers advancing independently), but the initial implementation in PR #39 only landed the tail side (backfill). The head side had four problems:

1. **`fetchPage` contract lacked context**: The signature was just `cursor: string | null` — the engine had no way to pass `sinceItemId` (the newest known item) to the connector. Forward sync couldn't stop efficiently: it relied on stale-page detection (3 consecutive pages of all-duplicates) instead of precise anchor matching (stop on 1 page).
2. **`headItemId` written on every page**: Each page overwrote it with that page's first item. After 20 pages, `headItemId` pointed to "the 380th newest item" instead of "the 1st newest item".
3. **`headCursor` never activated**: The architecture doc and DB schema both reserved a forward-resume cursor, but no code ever read or wrote it. In long-offline scenarios, accumulated new data couldn't be fetched incrementally across cycles.
4. **Forward corrupted `tailCursor`**: The initial-sync "handoff to backfill" logic lacked scope guards. On subsequent cycles, forward overwrote backfill's deep progress with a shallow position near the newest end, permanently stalling history completion.

## What this PR does

Implements Phase A.1 (head-side frontier complete landing), in dependency order:

| Step | Change | Problem solved |
|---|---|---|
| A.1.1 | Add `FetchContext` interface `{ cursor, sinceItemId, phase }`, change `fetchPage` signature to `(ctx: FetchContext)` | Contract lacked context |
| A.1.2 | Forward only writes `tailCursor` during initial sync (`tailCursor === null && headCursor === null`) | Forward corrupted tailCursor |
| A.1.3 | `headItemId` only written on page 0 + not resuming + monotonic-forward check | Written on every page |
| A.1.4 | Activate `headCursor`: written during forward, cleared on normal completion, preserved on interruption | headCursor never activated |
| A.1.5 | Engine early-exit: after upsert, check `platformId === sinceItemId`, stop on hit | Depends on A.1.1's sinceItemId |
| A.1.6 | Anchor invalidation recovery: forward completes without hitting sinceItemId → clear `headItemId` | User deleted the bookmarked item |
| A.1.7 | Twitter connector adapted to `FetchContext`, destructures `{ cursor }` and ignores new fields | Interface compatibility |

### Forward stop conditions (after this PR)

| Condition | stopReason | headCursor |
|---|---|---|
| Page contains sinceItemId | `reached_since` | cleared |
| 3 consecutive pages with 0 new items | `caught_up` | cleared |
| nextCursor = null | `end_of_data` | cleared |
| Timeout / cancel / error | `timeout` / `cancelled` / `error` | **preserved** (resume next cycle) |

### Anchor invalidation recovery

If the user un-bookmarks the item that `headItemId` points to, it disappears from the platform API. Forward runs a full pass without hitting `sinceItemId`. The engine then clears `headItemId` automatically — next forward starts fresh from null and re-establishes the anchor from page 0. Cost: one degraded cycle (falls back to stale-page detection), but only happens once.

## Tests

15 new tests in `sync-engine.test.ts` using in-memory SQLite + mock connector, covering all A.1.x behaviors:

- FetchContext passing (sinceItemId, phase, cursor values)
- tailCursor scope (initial sync handoff vs. subsequent cycles untouched)
- headItemId write timing (page 0 only, monotonic forward, skipped on resume)
- headCursor resume (cleared on normal completion, preserved on interruption, resumed from saved position)
- Early-exit (reached_since, fallback to stale-page when no anchor)
- Anchor invalidation (cleared when not hit on completion, preserved on interruption, updated when hit)

## Docs

- `connector-sync-architecture.md`: SyncState field comments, stop conditions, checkpoint & crash recovery, Writing a Connector example
- `connector-developer-guide.md`: FetchContext interface, fetchPage documentation, code examples, runtime lifecycle

## Not in this PR

- A.2 (backoff base fix, add `last_error_at` column) — decoupled from head-side, separate PR
- A.3 (`pageDelayMs` default consistency) — separate PR

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] 20/20 tests pass (15 new + 5 existing)
- [x] E2E: enable Twitter Bookmarks connector, verify forward sync hits `reached_since` and stops in 1 page on incremental sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)