### PR TITLE
fix: unify pageDelayMs default between persistent and ephemeral sync

### DIFF
--- a/packages/core/src/connectors/sync-engine.ts
+++ b/packages/core/src/connectors/sync-engine.ts
@@ -9,7 +9,7 @@ import type {
   SyncProgress,
   SyncErrorCode,
 } from './types.js'
-import { SyncError } from './types.js'
+import { SyncError, DEFAULT_SCHEDULE } from './types.js'
 import type { CapturedItem } from '../types.js'
 
 // ── Sync State Persistence ──────────────────────────────────────────────────
@@ -261,7 +261,7 @@ export class SyncEngine {
     startCursor: string | null,
     startedAt: number,
   ): Promise<{ added: number; pages: number; stopReason: string; error?: { code: string; message: string } }> {
-    const delayMs = opts.delayMs ?? 1200
+    const delayMs = opts.delayMs ?? DEFAULT_SCHEDULE.pageDelayMs
     const maxMinutes = opts.maxMinutes ?? 0
     const stalePageLimit = opts.stalePageLimit ?? 3
     const checkpointEvery = 25
@@ -493,7 +493,7 @@ export class SyncEngine {
     opts: SyncOptions,
     startedAt: number,
   ): Promise<ConnectorSyncResult> {
-    const delayMs = opts.delayMs ?? 600
+    const delayMs = opts.delayMs ?? DEFAULT_SCHEDULE.pageDelayMs
     const maxMinutes = opts.maxMinutes ?? 0
     const sourceId = getSourceId(this.db)
 


### PR DESCRIPTION
## Problem

`syncEphemeral` used a hardcoded 600ms page delay while `fetchLoop` (used by persistent sync) used 1200ms. This inconsistency meant ephemeral connectors made API requests twice as fast as persistent ones, with no clear reason for the difference.

## Fix

Both now reference `DEFAULT_SCHEDULE.pageDelayMs` (1200ms) as the single source of truth. The `delayMs` option in `SyncOptions` still allows per-call overrides.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] 40/40 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)