### PR TITLE
fix: use net.request for proxy-aware connector fetch

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, Menu, nativeTheme, nativeImage } from 'electron'
+import { app, BrowserWindow, ipcMain, Menu, nativeTheme, nativeImage, net } from 'electron'
 import { join } from 'node:path'
 import { Worker } from 'node:worker_threads'
 import {
@@ -182,7 +182,40 @@ app.whenReady().then(() => {
 
   // ── Connector framework ──────────────────────────────────────────────
   connectorRegistry = new ConnectorRegistry()
-  connectorRegistry.register(new TwitterBookmarksConnector())
+  // Use Electron's net.request for proxy support with full header control.
+  // net.fetch drops Cookie (forbidden header) and injects Sec-Fetch-* headers;
+  // net.request gives us raw control over what goes on the wire.
+  const proxyFetch: typeof globalThis.fetch = (input, init) => {
+    const url = input instanceof URL ? input.toString() : typeof input === 'string' ? input : input.url
+    const hdrs = (init?.headers ?? {}) as Record<string, string>
+    return new Promise((resolve, reject) => {
+      const req = net.request({ url, method: init?.method ?? 'GET' })
+      for (const [key, value] of Object.entries(hdrs)) {
+        req.setHeader(key, value)
+      }
+
+      req.on('response', (resp) => {
+        const chunks: Buffer[] = []
+        resp.on('data', (chunk: Buffer) => chunks.push(chunk))
+        resp.on('end', () => {
+          const body = Buffer.concat(chunks)
+          resolve(new Response(body, {
+            status: resp.statusCode,
+            statusText: resp.statusMessage,
+            headers: resp.headers as Record<string, string>,
+          }))
+        })
+      })
+      req.on('error', (err) => {
+        reject(err)
+      })
+      req.end()
+    })
+  }
+
+  connectorRegistry.register(new TwitterBookmarksConnector({
+    fetchFn: proxyFetch,
+  }))
 
   syncScheduler = new SyncScheduler(db, connectorRegistry)
   syncScheduler.on((event: SchedulerEvent) => {

--- a/packages/core/src/connectors/twitter-bookmarks/graphql-fetch.ts
+++ b/packages/core/src/connectors/twitter-bookmarks/graphql-fetch.ts
@@ -209,14 +209,18 @@ export function parseBookmarksResponse(json: any, now?: string): BookmarkPageRes
 export async function fetchBookmarkPage(
   csrfToken: string,
   cursor: string | null,
-  cookieHeader?: string,
+  opts?: {
+    cookieHeader?: string
+    fetchFn?: typeof globalThis.fetch
+  },
 ): Promise<BookmarkPageResult> {
+  const { cookieHeader, fetchFn = globalThis.fetch } = opts ?? {}
   let lastError: Error | undefined
 
   for (let attempt = 0; attempt < 4; attempt++) {
     let response: Response
     try {
-      response = await fetch(
+      response = await fetchFn(
         buildUrl(cursor ?? undefined),
         { headers: buildHeaders(csrfToken, cookieHeader) },
       )

--- a/packages/core/src/connectors/twitter-bookmarks/index.ts
+++ b/packages/core/src/connectors/twitter-bookmarks/index.ts
@@ -15,13 +15,16 @@ export class TwitterBookmarksConnector implements Connector {
   private chromeUserDataDir: string | undefined
   private chromeProfileDirectory: string
   private cachedCookies: ChromeCookieResult | null = null
+  private fetchFn: typeof globalThis.fetch
 
   constructor(opts?: {
     chromeUserDataDir?: string
     chromeProfileDirectory?: string
+    fetchFn?: typeof globalThis.fetch
   }) {
     this.chromeUserDataDir = opts?.chromeUserDataDir
     this.chromeProfileDirectory = opts?.chromeProfileDirectory ?? 'Default'
+    this.fetchFn = opts?.fetchFn ?? globalThis.fetch
   }
 
   async checkAuth(): Promise<AuthStatus> {
@@ -67,7 +70,7 @@ export class TwitterBookmarksConnector implements Connector {
     const result = await fetchBookmarkPage(
       this.cachedCookies.csrfToken,
       cursor,
-      this.cachedCookies.cookieHeader,
+      { cookieHeader: this.cachedCookies.cookieHeader, fetchFn: this.fetchFn },
     )
 
     return {


### PR DESCRIPTION
## Problem

Users behind a system proxy cannot sync X Bookmarks. The Electron main process uses Node's native `fetch` (undici), which does **not** respect system proxy settings — requests to `x.com:443` fail with `ConnectTimeoutError`.

## Why not `net.fetch`?

Electron's `net.fetch` uses Chromium's network stack (proxy-aware), but it enforces Fetch spec restrictions that break X API authentication:

1. **Silently drops the `Cookie` header** — `Cookie` is a [forbidden header name](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name). Chromium substitutes cookies from the session's cookie jar, which is empty for our isolated partition. Even injecting cookies into the jar with `credentials: 'include'` did not resolve the issue.
2. **Injects `Sec-Fetch-*` headers** — `Sec-Fetch-Site: cross-site` causes X/Twitter to return 403 (a same-origin browser request would send `same-origin`). These are also forbidden headers and cannot be overridden via fetch init.
3. **`webRequest.onBeforeSendHeaders` does not fire** for `net.fetch` calls from the main process — only for renderer `webContents` traffic. So there is no way to strip the injected headers.

## Solution

Use `net.request` (Chromium's lower-level HTTP API) wrapped in a fetch-compatible Promise interface:

- **Proxy support** — goes through Chromium's network stack, respects system proxy
- **Full header control** — `Cookie`, `User-Agent`, etc. are sent exactly as set; no `Sec-Fetch-*` injection
- **Injected via `fetchFn`** — the connector itself is unaware of Electron; it receives a standard `fetch`-shaped function. This keeps `@spool/core` environment-agnostic (works in CLI/Node with `globalThis.fetch`, in Electron with the `net.request` wrapper)

## Alternatives considered

| Approach | Why not |
|---|---|
| `net.fetch` + `session.fromPartition` + cookie jar injection | Chromium still adds `Sec-Fetch-*` → 403 |
| `net.fetch` + `webRequest.onBeforeSendHeaders` to strip `Sec-*` | `onBeforeSendHeaders` does not fire for main-process `net.fetch` |
| `undici.ProxyAgent` with Node fetch | Requires manual proxy resolution; adds dependency |
| `@vscode/proxy-agent` pattern | Heavy; requires switching from fetch to Node `http` module |

## Industry precedent

- [super-productivity](https://github.com/super-productivity/super-productivity) (13k+ stars) strips `Sec-Fetch-*` via `onBeforeSendHeaders` for Jira/GitHub integrations — works because their requests go through renderer `webContents`, not main-process `net.fetch`
- VS Code uses `@vscode/proxy-agent` to bypass Chromium's network stack entirely

## Changes

- **`packages/app/src/main/index.ts`** — `net.request` wrapper as `proxyFetch`, injected into connector
- **`packages/core/.../graphql-fetch.ts`** — accept `fetchFn` via opts object (replaces positional `cookieHeader` param)
- **`packages/core/.../index.ts`** — `TwitterBookmarksConnector` accepts and forwards `fetchFn`

## Test plan

- [x] `pnpm test:core` — 40/40 passing
- [x] Type check passing
- [x] Dev mode (`npx electron .`) — sync returns 200, bookmarks fetched
- [x] Production build (`build:mac`) — sync returns 200, bookmarks fetched
- [x] Verified with user behind system proxy


🤖 Generated with [Claude Code](https://claude.com/claude-code)