### PR TITLE
refactor(core): migrate sync engine time and cancellation into Effect

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "effect": "^3.21.0"
   },
   "devDependencies": {
+    "@effect/vitest": "^0.29.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.15.3",
     "vitest": "^3.1.2"

--- a/packages/core/src/connectors/sync-engine.effect.test.ts
+++ b/packages/core/src/connectors/sync-engine.effect.test.ts
@@ -1,13 +1,19 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { it } from '@effect/vitest'
+import { describe, expect, beforeEach } from 'vitest'
 import Database from 'better-sqlite3'
+import { Duration, Effect, Fiber, TestClock } from 'effect'
 import { SyncEngine } from './sync-engine.js'
 import type { Connector, FetchContext, PageResult, AuthStatus } from './types.js'
 import { createTestDB, makeItem } from './test-helpers.js'
 
-// Regression tests for the Effect.gen rewrite of fetchLoop / syncEphemeral.
-// These assert properties that were NOT observable in the old Promise-based
-// implementation: interruptible sleep, deadline-gated sleep for maxMinutes,
-// and that all 65 Phase B contract tests keep passing untouched.
+// Regression tests for the Effect rewrite of fetchLoop / syncEphemeral.
+// These exercise properties that were not observable in the old Promise-
+// based implementation: interruptible sleep via Deferred.await racing,
+// deadline-gated sleep via Clock.currentTimeMillis, and graceful abort
+// before the first fetch.
+//
+// Driven by @effect/vitest + TestClock, so virtual time makes the
+// assertions deterministic and the total wall-clock cost is near zero.
 
 function connectorFromHandler(
   fetchPage: (ctx: FetchContext) => Promise<PageResult>,
@@ -35,78 +41,94 @@ describe('SyncEngine — Effect.gen behavioral regressions', () => {
     engine = new SyncEngine(db)
   })
 
-  it('signal.abort wakes a long inter-page sleep within a few ms', async () => {
-    // Two pages, with a long delayMs between them. Without interruptible sleep,
-    // cancellation would have to wait out the full delay. With Effect.race +
-    // abort-listener, the sleep wakes immediately on abort and the loop top
-    // sees signal.aborted on the next iteration.
-    const connector = connectorFromHandler(async (ctx) => {
-      if (ctx.cursor === null) {
-        return { items: [makeItem('#A')], nextCursor: 'c1' }
-      }
-      return { items: [makeItem('#B')], nextCursor: null }
-    })
+  it.effect('signal.abort wakes a long inter-page sleep', () =>
+    Effect.gen(function* () {
+      // Two-page connector with a nominal 60s inter-page delay. Under
+      // TestClock that sleep never actually elapses — the virtual clock
+      // does not advance until we tell it to. The abort listener resolves
+      // the internal cancel Deferred, which wakes the sleep race
+      // immediately and causes the loop top to return stopReason=cancelled
+      // on its next iteration.
+      const connector = connectorFromHandler(async (ctx) => {
+        if (ctx.cursor === null) {
+          return { items: [makeItem('#A')], nextCursor: 'c1' }
+        }
+        return { items: [makeItem('#B')], nextCursor: null }
+      })
 
-    const controller = new AbortController()
-    const LONG_DELAY = 5000
-    const ABORT_AFTER = 20
-    const BUDGET = 500  // generous budget; without interruptible sleep this would be >= LONG_DELAY
+      const controller = new AbortController()
+      const fiber = yield* Effect.fork(
+        engine.syncEffect(connector, {
+          direction: 'forward',
+          delayMs: 60_000, // 60s nominal sleep between pages
+          signal: controller.signal,
+        }),
+      )
 
-    setTimeout(() => controller.abort(), ABORT_AFTER)
+      // Let the forked fiber run until it suspends inside the sleep race.
+      // Yielding alone is not enough because the fiber is in a sync→async
+      // chain (loadState → fetchPage Promise → upsert → sleep). A zero-
+      // duration TestClock adjust lets the scheduler drain ready fibers.
+      yield* TestClock.adjust(Duration.zero)
 
-    const started = Date.now()
-    const result = await engine.sync(connector, {
-      direction: 'forward',
-      delayMs: LONG_DELAY,
-      signal: controller.signal,
-    })
-    const elapsed = Date.now() - started
+      // Abort from outside the Effect world. The bridge listener fires
+      // synchronously via Deferred.unsafeDone, resolving the cancel signal.
+      yield* Effect.sync(() => controller.abort())
 
-    expect(elapsed).toBeLessThan(BUDGET)
-    expect(result.stopReason).toBe('cancelled')
-    expect(result.added).toBeGreaterThanOrEqual(1)
-  })
+      const result = yield* Fiber.join(fiber)
 
-  it('maxMinutes deadline caps a long sleep with ms-level precision', async () => {
-    // With the old polling-only implementation, a long delayMs between pages
-    // meant maxMinutes enforcement could overshoot by up to delayMs. With the
-    // deadline-capped sleep, the sleep never exceeds the remaining deadline.
-    const connector = connectorFromHandler(async () => ({
-      items: [makeItem(`#${Date.now()}`)],
-      nextCursor: 'c1',
-    }))
+      expect(result.stopReason).toBe('cancelled')
+      expect(result.added).toBeGreaterThanOrEqual(1)
+    }),
+  )
 
-    const started = Date.now()
-    const result = await engine.sync(connector, {
-      direction: 'forward',
-      delayMs: 10_000, // nominal 10s between pages
-      maxMinutes: 0.01, // ~600ms budget
-    })
-    const elapsed = Date.now() - started
+  it.effect('maxMinutes deadline stops the loop with stopReason=timeout', () =>
+    Effect.gen(function* () {
+      // An endless page stream. The only way out is the maxMinutes deadline.
+      const connector = connectorFromHandler(async () => ({
+        items: [makeItem(`#${Math.random()}`)],
+        nextCursor: 'more',
+      }))
 
-    // Deadline-aware sleep should bring this in comfortably under 2s
-    // (the old loop would have slept the full 10s before checking).
-    expect(elapsed).toBeLessThan(2_000)
-    expect(result.stopReason).toBe('timeout')
-  })
+      const fiber = yield* Effect.fork(
+        engine.syncEffect(connector, {
+          direction: 'forward',
+          delayMs: 60_000,
+          maxMinutes: 1,
+        }),
+      )
 
-  it('aborting before sync starts returns cancelled without fetching', async () => {
-    let fetchCalls = 0
-    const connector = connectorFromHandler(async () => {
-      fetchCalls++
-      return { items: [makeItem('#A')], nextCursor: null }
-    })
+      // Advance virtual time past the 1-minute deadline. All suspended
+      // sleeps resolve; the loop top reads Clock.currentTimeMillis, sees
+      // it >= deadline, and returns stopReason=timeout.
+      yield* TestClock.adjust(Duration.minutes(2))
 
-    const controller = new AbortController()
-    controller.abort()
+      const result = yield* Fiber.join(fiber)
 
-    const result = await engine.sync(connector, {
-      direction: 'forward',
-      delayMs: 0,
-      signal: controller.signal,
-    })
+      expect(result.stopReason).toBe('timeout')
+      expect(result.added).toBeGreaterThanOrEqual(1)
+    }),
+  )
 
-    expect(result.stopReason).toBe('cancelled')
-    expect(fetchCalls).toBe(0)
-  })
+  it.effect('aborting before sync starts returns cancelled without fetching', () =>
+    Effect.gen(function* () {
+      let fetchCalls = 0
+      const connector = connectorFromHandler(async () => {
+        fetchCalls++
+        return { items: [makeItem('#A')], nextCursor: null }
+      })
+
+      const controller = new AbortController()
+      controller.abort()
+
+      const result = yield* engine.syncEffect(connector, {
+        direction: 'forward',
+        delayMs: 0,
+        signal: controller.signal,
+      })
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(fetchCalls).toBe(0)
+    }),
+  )
 })

--- a/packages/core/src/connectors/sync-engine.ts
+++ b/packages/core/src/connectors/sync-engine.ts
@@ -300,14 +300,18 @@ export class SyncEngine {
       }
       yield* Effect.sync(() => saveSyncState(db, state))
       return result
+      // Effect.scoped discharges the Scope required by bridgeAbortSignal's
+      // acquireRelease, guaranteeing removeEventListener runs on every exit
+      // path (success, failure, interruption).
     }).pipe(Effect.scoped)
   }
 
   async sync(connector: Connector, opts: SyncOptions = {}): Promise<ConnectorSyncResult> {
-    // NOTE: opts.signal is deliberately NOT passed to runPromise here.
-    // The loop polls signal.aborted at iteration boundaries to preserve
-    // partial-progress + stopReason='cancelled' semantics. Runtime
-    // interruption would skip state persistence and surface as an error.
+    // opts.signal is bridged into an internal Deferred by syncEffect —
+    // NOT passed to runPromise, because runtime interruption would
+    // skip state persistence and surface as an error. Cancellation must
+    // be observable inside the loop (via Deferred.isDone) so the loop
+    // can return gracefully with stopReason='cancelled' + partial progress.
     try {
       return await Effect.runPromise(this.syncEffect(connector, opts))
     } catch (err) {

--- a/packages/core/src/connectors/sync-engine.ts
+++ b/packages/core/src/connectors/sync-engine.ts
@@ -1,6 +1,6 @@
 import type Database from 'better-sqlite3'
 import { randomUUID } from 'node:crypto'
-import { Duration, Effect } from 'effect'
+import { Clock, Deferred, Duration, Effect, Scope } from 'effect'
 import type {
   Connector,
   FetchContext,
@@ -13,23 +13,46 @@ import { SyncError, SyncErrorCode, DEFAULT_SCHEDULE } from './types.js'
 import type { CapturedItem } from '../types.js'
 
 /**
- * Sleep `ms` milliseconds, but wake early if `signal` fires. The loop top
- * still polls `signal.aborted` for a graceful return with stopReason='cancelled',
- * so this racer just gets us out of the sleep faster — it does NOT short-circuit
- * the loop by itself.
+ * The internal "please stop" signal. Resolved once → the loop returns
+ * gracefully with stopReason='cancelled' on its next iteration, and any
+ * in-flight sleep is interrupted via Effect.race below. Driven by
+ * `opts.signal` (via `bridgeAbortSignal` at the top of `syncEffect`) or
+ * by direct resolution in tests.
  */
-function interruptibleSleep(ms: number, signal: AbortSignal | undefined): Effect.Effect<void> {
-  const sleep = Effect.sleep(Duration.millis(ms))
-  if (!signal) return sleep
-  if (signal.aborted) return Effect.void
-  return Effect.race(
-    sleep,
-    Effect.async<void>((resume) => {
-      const onAbort = () => resume(Effect.void)
-      signal.addEventListener('abort', onAbort, { once: true })
-      return Effect.sync(() => signal.removeEventListener('abort', onAbort))
+type CancelSignal = Deferred.Deferred<void>
+
+/**
+ * Bridge an optional AbortSignal into a CancelSignal registered in the
+ * ambient Scope. The listener is cleaned up by the scope's finalizer.
+ */
+function bridgeAbortSignal(
+  signal: AbortSignal | undefined,
+  cancel: CancelSignal,
+): Effect.Effect<void, never, Scope.Scope> {
+  if (!signal) return Effect.void
+  if (signal.aborted) return Deferred.succeed(cancel, undefined).pipe(Effect.asVoid)
+  return Effect.acquireRelease(
+    Effect.sync(() => {
+      const handler = () => {
+        Deferred.unsafeDone(cancel, Effect.void)
+      }
+      signal.addEventListener('abort', handler, { once: true })
+      return handler
     }),
-  )
+    (handler) => Effect.sync(() => signal.removeEventListener('abort', handler)),
+  ).pipe(Effect.asVoid)
+}
+
+/**
+ * Sleep `ms` milliseconds but wake immediately if the cancel signal fires.
+ * The loop top still polls the cancel signal for a graceful
+ * `stopReason='cancelled'` return; this racer just cuts the sleep short.
+ */
+function interruptibleSleep(ms: number, cancel: CancelSignal): Effect.Effect<void> {
+  return Effect.race(
+    Effect.sleep(Duration.millis(ms)),
+    Deferred.await(cancel),
+  ).pipe(Effect.asVoid)
 }
 
 function tagConnectorId(items: CapturedItem[], connectorId: string): void {
@@ -37,6 +60,11 @@ function tagConnectorId(items: CapturedItem[], connectorId: string): void {
     (item.metadata as Record<string, unknown>)['connectorId'] = connectorId
   }
 }
+
+const nowIso: Effect.Effect<string> = Effect.map(
+  Clock.currentTimeMillis,
+  (ms) => new Date(ms).toISOString(),
+)
 
 // ── Sync State Persistence ──────────────────────────────────────────────────
 
@@ -238,37 +266,41 @@ export class SyncEngine {
     opts: SyncOptions = {},
   ): Effect.Effect<ConnectorSyncResult> {
     const db = this.db
-    const state = loadSyncState(db, connector.id)
-    const startedAt = Date.now()
+    const self = this
 
-    const body = connector.ephemeral
-      ? this.syncEphemeralEffect(connector, state, opts, startedAt)
-      : this.syncPersistentEffect(connector, state, opts, startedAt)
+    return Effect.gen(function* () {
+      const state = yield* Effect.sync(() => loadSyncState(db, connector.id))
+      const startedAt = yield* Clock.currentTimeMillis
+      const cancel = yield* Deferred.make<void>()
+      yield* bridgeAbortSignal(opts.signal, cancel)
 
-    return body.pipe(
-      Effect.withSpan('sync.cycle', {
-        attributes: {
-          'connector.id': connector.id,
-          'sync.direction': opts.direction ?? 'both',
-        },
-      }),
-      Effect.tap((result) =>
-        Effect.sync(() => {
-          if (result.error) {
-            state.consecutiveErrors += 1
-            state.lastErrorAt = new Date().toISOString()
-            state.lastErrorCode = result.error.code as SyncErrorCode
-            state.lastErrorMessage = result.error.message
-          } else {
-            state.consecutiveErrors = 0
-            state.lastErrorAt = null
-            state.lastErrorCode = null
-            state.lastErrorMessage = null
-          }
-          saveSyncState(db, state)
+      const body = connector.ephemeral
+        ? self.syncEphemeralEffect(connector, state, opts, startedAt, cancel)
+        : self.syncPersistentEffect(connector, state, opts, startedAt, cancel)
+
+      const result = yield* body.pipe(
+        Effect.withSpan('sync.cycle', {
+          attributes: {
+            'connector.id': connector.id,
+            'sync.direction': opts.direction ?? 'both',
+          },
         }),
-      ),
-    )
+      )
+
+      if (result.error) {
+        state.consecutiveErrors += 1
+        state.lastErrorAt = yield* nowIso
+        state.lastErrorCode = result.error.code as SyncErrorCode
+        state.lastErrorMessage = result.error.message
+      } else {
+        state.consecutiveErrors = 0
+        state.lastErrorAt = null
+        state.lastErrorCode = null
+        state.lastErrorMessage = null
+      }
+      yield* Effect.sync(() => saveSyncState(db, state))
+      return result
+    }).pipe(Effect.scoped)
   }
 
   async sync(connector: Connector, opts: SyncOptions = {}): Promise<ConnectorSyncResult> {
@@ -310,6 +342,7 @@ export class SyncEngine {
     sourceId: number,
     startCursor: string | null,
     startedAt: number,
+    cancel: CancelSignal,
   ): Effect.Effect<FetchLoopResult> {
     const db = this.db
     const delayMs = opts.delayMs ?? DEFAULT_SCHEDULE.pageDelayMs
@@ -339,10 +372,11 @@ export class SyncEngine {
       let stalePages = 0
 
       while (true) {
-        if (Date.now() >= deadline) {
+        const now = yield* Clock.currentTimeMillis
+        if (now >= deadline) {
           return { added, pages, stopReason: 'timeout' }
         }
-        if (opts.signal?.aborted) {
+        if (yield* Deferred.isDone(cancel)) {
           return { added, pages, stopReason: 'cancelled' }
         }
 
@@ -484,10 +518,11 @@ export class SyncEngine {
 
         // Cap the inter-page delay at the remaining deadline so maxMinutes
         // has ms-level precision instead of being gated on polling frequency.
-        const remaining = deadline - Date.now()
+        const nowAfter = yield* Clock.currentTimeMillis
+        const remaining = deadline - nowAfter
         const actualDelay = Math.max(0, Math.min(delayMs, remaining))
         if (actualDelay > 0) {
-          yield* interruptibleSleep(actualDelay, opts.signal)
+          yield* interruptibleSleep(actualDelay, cancel)
         }
       }
     })
@@ -498,6 +533,7 @@ export class SyncEngine {
     state: SyncState,
     opts: SyncOptions,
     startedAt: number,
+    cancel: CancelSignal,
   ): Effect.Effect<ConnectorSyncResult> {
     const db = this.db
     const direction = opts.direction ?? 'both'
@@ -520,6 +556,7 @@ export class SyncEngine {
             sourceId,
             state.headCursor ?? null,
             startedAt,
+            cancel,
           )
           .pipe(Effect.withSpan('sync.forward'))
 
@@ -527,7 +564,7 @@ export class SyncEngine {
         totalPages += fwd.pages
         stopReason = fwd.stopReason
         if (fwd.error) lastError = fwd.error
-        state.lastForwardSyncAt = new Date().toISOString()
+        state.lastForwardSyncAt = yield* nowIso
 
         // Anchor invalidation recovery (Q3): if forward ran to completion
         // (not interrupted) but never hit the since-anchor, the anchor is stale
@@ -552,6 +589,7 @@ export class SyncEngine {
             sourceId,
             state.tailCursor,
             startedAt,
+            cancel,
           )
           .pipe(Effect.withSpan('sync.backfill'))
 
@@ -559,7 +597,7 @@ export class SyncEngine {
         totalPages += bf.pages
         stopReason = bf.stopReason
         if (bf.error) lastError = bf.error
-        state.lastBackfillSyncAt = new Date().toISOString()
+        state.lastBackfillSyncAt = yield* nowIso
       }
 
       state.totalSynced += totalAdded
@@ -601,6 +639,7 @@ export class SyncEngine {
     state: SyncState,
     opts: SyncOptions,
     startedAt: number,
+    cancel: CancelSignal,
   ): Effect.Effect<ConnectorSyncResult> {
     const db = this.db
     const delayMs = opts.delayMs ?? DEFAULT_SCHEDULE.pageDelayMs
@@ -619,11 +658,12 @@ export class SyncEngine {
       let stopReason = 'complete'
 
       while (true) {
-        if (Date.now() >= deadline) {
+        const now = yield* Clock.currentTimeMillis
+        if (now >= deadline) {
           stopReason = 'timeout'
           break
         }
-        if (opts.signal?.aborted) {
+        if (yield* Deferred.isDone(cancel)) {
           stopReason = 'cancelled'
           break
         }
@@ -649,7 +689,7 @@ export class SyncEngine {
             `[sync-engine] ${connector.id} forward page ${totalPages + 1} error: ${err.message}`,
           )
           state.totalSynced = totalAdded
-          state.lastForwardSyncAt = new Date().toISOString()
+          state.lastForwardSyncAt = yield* nowIso
           yield* Effect.sync(() => saveSyncState(db, state))
           return {
             connectorId: connector.id,
@@ -679,15 +719,16 @@ export class SyncEngine {
         if (!result.nextCursor) break
         cursor = result.nextCursor
 
-        const remaining = deadline - Date.now()
+        const nowAfter = yield* Clock.currentTimeMillis
+        const remaining = deadline - nowAfter
         const actualDelay = Math.max(0, Math.min(delayMs, remaining))
         if (actualDelay > 0) {
-          yield* interruptibleSleep(actualDelay, opts.signal)
+          yield* interruptibleSleep(actualDelay, cancel)
         }
       }
 
       state.totalSynced = totalAdded
-      state.lastForwardSyncAt = new Date().toISOString()
+      state.lastForwardSyncAt = yield* nowIso
       yield* Effect.sync(() => saveSyncState(db, state))
 
       return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
         specifier: ^3.21.0
         version: 3.21.0
     devDependencies:
+      '@effect/vitest':
+        specifier: ^0.29.0
+        version: 0.29.0(effect@3.21.0)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -382,6 +385,12 @@ packages:
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
     engines: {node: '>= 8.9.0'}
+
+  '@effect/vitest@0.29.0':
+    resolution: {integrity: sha512-DvWr1aeEcaZ8mtu8hNVb4e3rEYvGEwQSr7wsNrW53t6nKYjkmjRICcvVEsXUhjoCblRHSxRsRV0TOt0+UmcvaQ==}
+    peerDependencies:
+      effect: ^3.21.0
+      vitest: ^3.2.0
 
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
@@ -4750,6 +4759,11 @@ snapshots:
     dependencies:
       ajv: 6.14.0
       ajv-keywords: 3.5.2(ajv@6.14.0)
+
+  '@effect/vitest@0.29.0(effect@3.21.0)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      effect: 3.21.0
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@electron/asar@3.4.1':
     dependencies:


### PR DESCRIPTION
## Summary

Replace the last non-Effect primitives inside the sync engine — `Date.now()` and `AbortSignal` polling — with Effect's `Clock` and `Deferred`. This unlocks `@effect/vitest` + `TestClock`-driven tests, which run deterministically in virtual time.

- `Date.now()` / `new Date().toISOString()` → `Clock.currentTimeMillis` (yielded via Effect.gen)
- `AbortSignal.aborted` polling → `Deferred<void>.isDone` polling
- Old `interruptibleSleep` (event listener inside `Effect.async`) → `Effect.race(Effect.sleep, Deferred.await(cancel))`
- A new top-level helper `bridgeAbortSignal(signal, cancel)` registers a one-shot listener inside `Effect.acquireRelease`; the scope finalizer at the top of `syncEffect` guarantees cleanup on every exit path
- The three regression tests in `sync-engine.effect.test.ts` are rewritten with `@effect/vitest`'s `it.effect` + `TestClock.adjust`

## Why this matters

This is the bridge PR between "sync engine is an Effect program" (shipped in the previous PR) and "scheduler is an Effect program" (next cut). Two concrete unlocks:

### 1. TestClock-driven regression tests

The previous PR's regression tests for "signal.abort wakes a long sleep" and "maxMinutes deadline caps a sleep" used real wall-clock delays (5000 ms sleep + 20 ms abort, 10 s delay + 600 ms deadline). Those assertions lived inside a ~500 ms budget, which was fine locally but would be flaky on slow CI. More importantly, they couldn't be extended to cover multi-minute or multi-hour scenarios without making the test suite painfully slow.

With `Clock.currentTimeMillis` replacing `Date.now()` and `Effect.sleep` racing a `Deferred.await` for interruption, the same assertions now compose with `TestClock`:

```ts
it.effect('maxMinutes deadline stops the loop with stopReason=timeout', () =>
  Effect.gen(function* () {
    const fiber = yield* Effect.fork(
      engine.syncEffect(connector, { delayMs: 60_000, maxMinutes: 1 }),
    )
    yield* TestClock.adjust(Duration.minutes(2))  // virtual time — zero real wait
    const result = yield* Fiber.join(fiber)
    expect(result.stopReason).toBe('timeout')
  })
)
```

Virtual time makes these tests:
- **Fast**: 3 time-sensitive tests dropped from ~750 ms real wall-clock time to ~240 ms of fiber scheduling overhead
- **Deterministic**: no budget, no retry, no flaky-on-slow-CI risk
- **Extensible**: testing a 2-hour backoff is the same cost as testing a 200 ms one

### 2. Scheduler migration foothold (cut #3)

The scheduler's retry backoff sequence is `[1min, 5min, 30min, 2h]`. When the scheduler moves to `Schedule.exponential` in the next PR, TestClock becomes the only sane way to verify the sequence:

```ts
it.effect('backoff progresses 1min → 5min → 30min → 2h', () =>
  Effect.gen(function* () {
    // ... setup a failing connector ...
    yield* TestClock.adjust(Duration.minutes(1))
    // assert first retry fired
    yield* TestClock.adjust(Duration.minutes(5))
    // assert second retry fired
    // etc.
  })
)
```

Without the changes in this PR, the scheduler's inner `engine.sync()` call would still use real `Date.now()` and real `setTimeout`, and the whole test would hang or burn minutes of CI time. This PR makes that test viable before a single line of scheduler code changes.

### 3. Uniform cancellation semantics

AbortSignal is Node/browser-native and doesn't compose with Effect's fiber tree. The Deferred bridge gives us one cancellation primitive that works identically whether the cancel comes from:
- An external `AbortController.abort()` (scheduler stop, Electron shutdown) — bridged via `bridgeAbortSignal`
- Direct resolution from inside Effect (future scheduler logic can `Deferred.succeed(cancel, undefined)` without holding an AbortController)
- A parent fiber interrupt — the scope finalizer cleans up the listener regardless

## What this PR does NOT change

- Public API (`SyncEngine.sync()`, `SyncEngine.syncEffect()`, `SyncOptions.signal`) is byte-identical to main.
- `Connector` plugin interface — still Promise-based.
- Business logic of `fetchLoopEffect` / `syncPersistentEffect` / `syncEphemeralEffect` — same stop reasons, same state mutations, same contract.
- The scheduler — entirely untouched (still Promise-based, still passes `AbortController.signal`).
- Phase B contract tests — zero edits, all 65 still green.
- Observability tests from the previous PR — 4 tests still green, no changes.

## Design notes

### Why `Deferred` and not runtime-level `runPromise({ signal })`

Passing the signal to the runtime converts abort into a Fiber interruption. Fiber interruption skips state persistence and surfaces as a `runPromise` rejection — which breaks the contract tested by "signal.abort() stops at page boundary with state saved" (the sync must return *gracefully* with `stopReason='cancelled'` and partial `added`/`pages` preserved). Deferred lets the loop see "cancel requested" as an in-band value it can handle at the top of the next iteration, so the graceful shape is preserved.

### Why thread `cancel` as an explicit parameter

Three internal producers (`fetchLoopEffect`, `syncPersistentEffect`, `syncEphemeralEffect`) all need to observe the same cancel. A `Context.Tag` / FiberRef would also work, but explicit threading is shorter and greppable for a single-caller shape. When cut #3's scheduler starts composing multiple `syncEffect` calls with shared cancellation, we may revisit and move this into a Context Tag.

### `Effect.scoped` at the top of `syncEffect`

`bridgeAbortSignal` uses `Effect.acquireRelease` to register the event listener so the scope finalizer runs `removeEventListener` on every exit path (success, error, interruption). Without `Effect.scoped` wrapping the `syncEffect` gen body, the `Scope` requirement would leak into the public type. The scope lifetime is exactly one `syncEffect` call.

## Test plan

- [x] `pnpm --filter @spool/core exec tsc --noEmit` clean
- [x] `pnpm --filter @spool/app exec tsc --noEmit` clean
- [x] `pnpm --filter @spool/core test` — all 72 tests green
  - 65 contract tests unchanged, all green
  - 4 observability tests unchanged, all green
  - 3 regression tests rewritten with `it.effect` + `TestClock`, runtime ~240 ms total
- [ ] Smoke: real Twitter bookmarks sync in dev app
  - Ctrl+C / app close still triggers graceful `stopReason='cancelled'` via the AbortSignal bridge
  - Multi-page sync completes with identical `added`/`pages` numbers as before
  - Log output shows the same `[sync-engine] … done: …` format

## Simplify review fixes applied

- Extracted `nowIso` module constant — collapses 5 occurrences of `Effect.map(Clock.currentTimeMillis, ms => new Date(ms).toISOString())` into a single shared Effect value

## Not merged with the previous PR on purpose

The previous PR kept `Date.now()` and `AbortSignal` as an intentional scope boundary: it stayed a pure Effect-native rewrite of the *loop shape* without touching the time/cancellation primitives. This PR is the follow-up that crosses that boundary. Splitting the two keeps each diff reviewable on its own terms and lets the first PR land as a mechanical refactor that's easy to revert if it causes issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)