### PR TITLE
refactor(core): migrate SyncScheduler internals to Effect

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, Menu, nativeTheme, nativeImage, net } from 'electron'
+import { app, BrowserWindow, ipcMain, Menu, nativeTheme, nativeImage, net, powerMonitor } from 'electron'
 import { join } from 'node:path'
 import { Worker } from 'node:worker_threads'
 import {
@@ -223,6 +223,12 @@ app.whenReady().then(() => {
   })
   syncScheduler.start()
 
+  // Wake from sleep: reschedule a forward pass immediately instead of waiting
+  // up to 30s for the next periodic tick.
+  powerMonitor.on('resume', () => {
+    syncScheduler?.onWake()
+  })
+
   // Initial sync in worker thread (non-blocking)
   runSyncWorker().then(() => {
     watcher.start()
@@ -262,6 +268,14 @@ app.on('window-all-closed', () => {
   }
   // On macOS, keep app running in tray
   app.dock?.hide()
+})
+
+// Graceful shutdown: cancel in-flight syncs cooperatively so the engine can
+// record stopReason='cancelled' and partial progress before the runtime tears
+// down. Without this the tick fiber and runJob fibers are abandoned at process
+// death and state updates for the current cycle are lost.
+app.on('before-quit', () => {
+  syncScheduler?.stop()
 })
 
 // ── IPC Handlers ──────────────────────────────────────────────────────────────

--- a/packages/core/src/connectors/sync-engine.ts
+++ b/packages/core/src/connectors/sync-engine.ts
@@ -271,7 +271,7 @@ export class SyncEngine {
     return Effect.gen(function* () {
       const state = yield* Effect.sync(() => loadSyncState(db, connector.id))
       const startedAt = yield* Clock.currentTimeMillis
-      const cancel = yield* Deferred.make<void>()
+      const cancel = opts.cancel ?? (yield* Deferred.make<void>())
       yield* bridgeAbortSignal(opts.signal, cancel)
 
       const body = connector.ephemeral

--- a/packages/core/src/connectors/sync-scheduler.effect.test.ts
+++ b/packages/core/src/connectors/sync-scheduler.effect.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { Duration, Effect, ManagedRuntime, TestClock, TestContext } from 'effect'
 import Database from 'better-sqlite3'
-import { SyncScheduler } from './sync-scheduler.js'
+import { SyncScheduler, type SchedulerEvent } from './sync-scheduler.js'
 import { ConnectorRegistry } from './registry.js'
 import { SyncError, SyncErrorCode } from './types.js'
 import type { Connector, AuthStatus, FetchContext, PageResult } from './types.js'
@@ -276,6 +276,37 @@ describe('SyncScheduler contract (effect)', () => {
       expect(backfillCalls).toHaveLength(0)
     })
 
+    it('triggerNow during running sync is a no-op (enqueue dedupes)', async () => {
+      let fetchCount = 0
+      let release: () => void = () => {}
+      const connector = createTestConnector('dedupe', async () => {
+        fetchCount++
+        await new Promise<void>((resolve) => { release = resolve })
+        return { items: [makeItem('d-1')], nextCursor: null }
+      })
+      registry.register(connector)
+      setState(db, { connectorId: 'dedupe', tailComplete: true })
+
+      scheduler = new SyncScheduler(
+        db,
+        registry,
+        { forwardIntervalMs: 999_999_999, pageDelayMs: 0, maxMinutesPerRun: 1 },
+        runtime,
+      )
+      scheduler.start()
+      await flush(runtime, 100)
+
+      expect(fetchCount).toBe(1) // startup sync in flight, parked
+
+      scheduler.triggerNow('dedupe', 'forward')
+      await flush(runtime, 100)
+
+      expect(fetchCount).toBe(1) // no new sync — enqueue sees running.has(id) and no-ops
+
+      release()
+      await flush(runtime, 100) // let cleanup run
+    })
+
     it('triggerNow runs immediately with highest priority', async () => {
       const fetchCalls: number[] = []
       const connector = createTestConnector('manual', async () => {
@@ -304,6 +335,109 @@ describe('SyncScheduler contract (effect)', () => {
       await flush(runtime, 100)
 
       expect(fetchCalls.length).toBeGreaterThan(afterStartup)
+    })
+  })
+
+  describe('Concurrency', () => {
+    it('semaphore caps simultaneous syncs at config.concurrency', async () => {
+      const inFlight = new Set<string>()
+      let maxInFlight = 0
+      const gates = new Map<string, () => void>()
+      const makeSlow = (id: string): Connector =>
+        createTestConnector(id, async () => {
+          inFlight.add(id)
+          maxInFlight = Math.max(maxInFlight, inFlight.size)
+          await new Promise<void>((resolve) => gates.set(id, resolve))
+          inFlight.delete(id)
+          return { items: [makeItem(`${id}-1`)], nextCursor: null }
+        })
+
+      for (const id of ['c1', 'c2', 'c3', 'c4']) {
+        registry.register(makeSlow(id))
+        setState(db, { connectorId: id, tailComplete: true })
+      }
+
+      scheduler = new SyncScheduler(
+        db,
+        registry,
+        {
+          forwardIntervalMs: 1_000,
+          pageDelayMs: 0,
+          maxMinutesPerRun: 1,
+          concurrency: 2,
+        },
+        runtime,
+      )
+      scheduler.start()
+
+      // Let all 4 runJob fibers be forked and block on fetchPage
+      await flush(runtime, 100)
+
+      expect(maxInFlight).toBe(2)
+      expect(inFlight.size).toBe(2)
+
+      // Release the 2 currently in flight — next 2 should pick up permits
+      for (const id of Array.from(inFlight)) gates.get(id)!()
+      await flush(runtime, 100)
+      expect(maxInFlight).toBe(2) // still capped
+
+      // Release remaining so afterEach can clean up
+      for (const [, r] of gates) r()
+      await flush(runtime, 100)
+    })
+  })
+
+  describe('Cancellation', () => {
+    it('stop() causes in-flight sync to return with stopReason=cancelled and no sync-error', async () => {
+      const events: SchedulerEvent[] = []
+      let page = 0
+      const connector = createTestConnector('cancel-me', async () => {
+        page++
+        // Page 1: returns with nextCursor so the engine continues into the
+        // inter-page delay. Page 2+: never called — the inter-page
+        // interruptibleSleep observes the cancel Deferred and the next loop
+        // iteration returns cancelled before fetchPage runs again.
+        return {
+          items: [makeItem(`c-${page}`)],
+          nextCursor: `cursor-${page + 1}`,
+        }
+      })
+      registry.register(connector)
+      setState(db, { connectorId: 'cancel-me', tailComplete: true })
+
+      scheduler = new SyncScheduler(
+        db,
+        registry,
+        {
+          forwardIntervalMs: 999_999_999,
+          // Large enough that the inter-page sleep is still pending when
+          // stop() fires. flush(100) below doesn't advance virtual time past
+          // this, so the race in interruptibleSleep is waiting on Deferred.
+          pageDelayMs: 60_000,
+          maxMinutesPerRun: 5,
+        },
+        runtime,
+      )
+      scheduler.on((event) => events.push(event))
+      scheduler.start()
+
+      // Let page 1 run, upsert, then enter interruptibleSleep(60_000).
+      await flush(runtime, 100)
+      expect(page).toBeGreaterThanOrEqual(1)
+
+      scheduler.stop()
+      // Drain: Deferred.succeed wakes the sleep race, loop iteration checks
+      // Deferred.isDone, returns cancelled, persistent sync wraps result,
+      // runJob emits sync-complete via Effect.sync before the fiber finishes.
+      await flush(runtime, 100)
+
+      const completes = events.filter((e) => e.type === 'sync-complete')
+      const errors = events.filter((e) => e.type === 'sync-error')
+      expect(completes).toHaveLength(1)
+      expect(
+        completes[0]!.type === 'sync-complete' && completes[0]!.result.stopReason,
+      ).toBe('cancelled')
+      expect(errors).toHaveLength(0)
     })
   })
 })

--- a/packages/core/src/connectors/sync-scheduler.effect.test.ts
+++ b/packages/core/src/connectors/sync-scheduler.effect.test.ts
@@ -381,8 +381,8 @@ describe('SyncScheduler contract (effect)', () => {
       await flush(runtime, 100)
       expect(maxInFlight).toBe(2) // still capped
 
-      // Release remaining so afterEach can clean up
-      for (const [, r] of gates) r()
+      // Release second wave
+      for (const id of Array.from(inFlight)) gates.get(id)!()
       await flush(runtime, 100)
     })
   })
@@ -393,10 +393,6 @@ describe('SyncScheduler contract (effect)', () => {
       let page = 0
       const connector = createTestConnector('cancel-me', async () => {
         page++
-        // Page 1: returns with nextCursor so the engine continues into the
-        // inter-page delay. Page 2+: never called — the inter-page
-        // interruptibleSleep observes the cancel Deferred and the next loop
-        // iteration returns cancelled before fetchPage runs again.
         return {
           items: [makeItem(`c-${page}`)],
           nextCursor: `cursor-${page + 1}`,
@@ -410,9 +406,7 @@ describe('SyncScheduler contract (effect)', () => {
         registry,
         {
           forwardIntervalMs: 999_999_999,
-          // Large enough that the inter-page sleep is still pending when
-          // stop() fires. flush(100) below doesn't advance virtual time past
-          // this, so the race in interruptibleSleep is waiting on Deferred.
+          // long enough that the inter-page sleep is still pending when stop() fires
           pageDelayMs: 60_000,
           maxMinutesPerRun: 5,
         },
@@ -421,14 +415,10 @@ describe('SyncScheduler contract (effect)', () => {
       scheduler.on((event) => events.push(event))
       scheduler.start()
 
-      // Let page 1 run, upsert, then enter interruptibleSleep(60_000).
       await flush(runtime, 100)
       expect(page).toBeGreaterThanOrEqual(1)
 
       scheduler.stop()
-      // Drain: Deferred.succeed wakes the sleep race, loop iteration checks
-      // Deferred.isDone, returns cancelled, persistent sync wraps result,
-      // runJob emits sync-complete via Effect.sync before the fiber finishes.
       await flush(runtime, 100)
 
       const completes = events.filter((e) => e.type === 'sync-complete')

--- a/packages/core/src/connectors/sync-scheduler.effect.test.ts
+++ b/packages/core/src/connectors/sync-scheduler.effect.test.ts
@@ -1,14 +1,18 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { Duration, Effect, ManagedRuntime, TestClock, TestContext } from 'effect'
 import Database from 'better-sqlite3'
 import { SyncScheduler } from './sync-scheduler.js'
 import { ConnectorRegistry } from './registry.js'
 import { SyncError, SyncErrorCode } from './types.js'
-import type { Connector, AuthStatus, FetchContext, PageResult, SchedulerEvent } from './types.js'
+import type { Connector, AuthStatus, FetchContext, PageResult } from './types.js'
 import { createTestDB, makeItem, setState } from './test-helpers.js'
 
 // ── Test Helpers ────────────────────────────────────────────────────────────
 
-function createTestConnector(id: string, fetchPageFn?: (ctx: FetchContext) => Promise<PageResult>): Connector {
+function createTestConnector(
+  id: string,
+  fetchPageFn?: (ctx: FetchContext) => Promise<PageResult>,
+): Connector {
   return {
     id,
     platform: 'test',
@@ -17,27 +21,52 @@ function createTestConnector(id: string, fetchPageFn?: (ctx: FetchContext) => Pr
     color: '#000',
     ephemeral: false,
     async checkAuth(): Promise<AuthStatus> { return { ok: true } },
-    fetchPage: fetchPageFn ?? (async () => ({ items: [makeItem(`${id}-1`)], nextCursor: null })),
+    fetchPage:
+      fetchPageFn ?? (async () => ({ items: [makeItem(`${id}-1`)], nextCursor: null })),
+  }
+}
+
+/**
+ * Build a test runtime whose default Clock is TestClock. The scheduler's
+ * tick fiber and per-job runJob fibers all run in this runtime so
+ * `runtime.runPromise(TestClock.adjust(...))` advances time deterministically.
+ */
+function makeTestRuntime() {
+  return ManagedRuntime.make(TestContext.TestContext)
+}
+
+/**
+ * TestClock advance + microtask drain. The scheduler forks real Promise-based
+ * fetchPage calls, so after advancing virtual time we need to yield to the JS
+ * microtask/macrotask queues a few times so the forked runJob fibers can
+ * progress through their await boundaries before we assert.
+ */
+async function flush(runtime: ReturnType<typeof makeTestRuntime>, ms: number): Promise<void> {
+  await runtime.runPromise(TestClock.adjust(Duration.millis(ms)))
+  for (let i = 0; i < 5; i++) {
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    await runtime.runPromise(Effect.sleep(Duration.zero))
   }
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
 
-describe('SyncScheduler contract', () => {
+describe('SyncScheduler contract (effect)', () => {
   let db: InstanceType<typeof Database>
   let registry: ConnectorRegistry
   let scheduler: SyncScheduler | undefined
+  let runtime: ReturnType<typeof makeTestRuntime>
 
   beforeEach(() => {
-    vi.useFakeTimers()
     db = createTestDB()
     registry = new ConnectorRegistry()
+    runtime = makeTestRuntime()
     scheduler = undefined
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     scheduler?.stop()
-    vi.useRealTimers()
+    await runtime.dispose()
   })
 
   describe('Backoff', () => {
@@ -50,21 +79,24 @@ describe('SyncScheduler contract', () => {
       registry.register(connector)
       setState(db, { connectorId: 'auth-fail' })
 
-      scheduler = new SyncScheduler(db, registry, {
-        forwardIntervalMs: 1_000,
-        retryBackoffMs: [1_000],
-        pageDelayMs: 0,
-        maxMinutesPerRun: 1,
-      })
+      scheduler = new SyncScheduler(
+        db,
+        registry,
+        {
+          forwardIntervalMs: 1_000,
+          retryBackoffMs: [1_000],
+          pageDelayMs: 0,
+          maxMinutesPerRun: 1,
+        },
+        runtime,
+      )
       scheduler.start()
 
-      // Startup fires first sync which fails with AUTH error
-      await vi.advanceTimersByTimeAsync(100)
+      await flush(runtime, 100)
       expect(fetchCalls).toHaveLength(1)
 
-      // AUTH errors should never be retried
-      await vi.advanceTimersByTimeAsync(120_000)
-
+      // AUTH errors never retry — advance far past any configured backoff
+      await flush(runtime, 120_000)
       expect(fetchCalls).toHaveLength(1)
     })
 
@@ -77,29 +109,33 @@ describe('SyncScheduler contract', () => {
       registry.register(connector)
       setState(db, { connectorId: 'backoff-test' })
 
-      scheduler = new SyncScheduler(db, registry, {
-        forwardIntervalMs: 1_000,
-        backfillIntervalMs: 999_999_999,
-        retryBackoffMs: [5_000, 60_000],
-        pageDelayMs: 0,
-        maxMinutesPerRun: 1,
-      })
+      scheduler = new SyncScheduler(
+        db,
+        registry,
+        {
+          forwardIntervalMs: 1_000,
+          backfillIntervalMs: 999_999_999,
+          retryBackoffMs: [5_000, 60_000],
+          pageDelayMs: 0,
+          maxMinutesPerRun: 1,
+        },
+        runtime,
+      )
       scheduler.start()
 
-      // Startup fires immediately
-      await vi.advanceTimersByTimeAsync(100)
+      await flush(runtime, 100)
       expect(fetchCalls).toHaveLength(1)
 
-      // t=30s: tick fires, backoff=5s has elapsed (30>5), retry → consecutiveErrors=2
-      await vi.advanceTimersByTimeAsync(30_000)
+      // t=30s: tick fires, backoff=5s has elapsed (30>5), retry → errors=2
+      await flush(runtime, 30_000)
       expect(fetchCalls).toHaveLength(2)
 
-      // t=60s: tick fires, 30s since last error, backoff=60s → 30<60, skip
-      await vi.advanceTimersByTimeAsync(30_000)
+      // t=60s: 30s since last error, backoff=60s → skip
+      await flush(runtime, 30_000)
       expect(fetchCalls).toHaveLength(2)
 
-      // t=90s: tick fires, 60s since last error at t=30s → 60>=60, retry
-      await vi.advanceTimersByTimeAsync(30_000)
+      // t=90s: 60s since last error → retry
+      await flush(runtime, 30_000)
       expect(fetchCalls).toHaveLength(3)
     })
 
@@ -112,24 +148,28 @@ describe('SyncScheduler contract', () => {
       registry.register(connector)
       setState(db, { connectorId: 'backoff-base' })
 
-      scheduler = new SyncScheduler(db, registry, {
-        forwardIntervalMs: 1_000,
-        retryBackoffMs: [60_000],
-        pageDelayMs: 0,
-        maxMinutesPerRun: 1,
-      })
+      scheduler = new SyncScheduler(
+        db,
+        registry,
+        {
+          forwardIntervalMs: 1_000,
+          retryBackoffMs: [60_000],
+          pageDelayMs: 0,
+          maxMinutesPerRun: 1,
+        },
+        runtime,
+      )
       scheduler.start()
 
-      // Startup fires first sync
-      await vi.advanceTimersByTimeAsync(100)
+      await flush(runtime, 100)
       expect(fetchCalls).toHaveLength(1)
 
       // t=30s: only 30s since lastErrorAt, backoff=60s → skip
-      await vi.advanceTimersByTimeAsync(30_000)
+      await flush(runtime, 30_000)
       expect(fetchCalls).toHaveLength(1)
 
       // t=60s: 60s since lastErrorAt → retry
-      await vi.advanceTimersByTimeAsync(30_000)
+      await flush(runtime, 30_000)
       expect(fetchCalls).toHaveLength(2)
     })
 
@@ -142,24 +182,29 @@ describe('SyncScheduler contract', () => {
       registry.register(connector)
       setState(db, { connectorId: 'recovery' })
 
-      scheduler = new SyncScheduler(db, registry, {
-        forwardIntervalMs: 1_000,
-        retryBackoffMs: [5_000],
-        pageDelayMs: 0,
-        maxMinutesPerRun: 1,
-      })
+      scheduler = new SyncScheduler(
+        db,
+        registry,
+        {
+          forwardIntervalMs: 1_000,
+          retryBackoffMs: [5_000],
+          pageDelayMs: 0,
+          maxMinutesPerRun: 1,
+        },
+        runtime,
+      )
       scheduler.start()
 
-      // Startup sync fails
-      await vi.advanceTimersByTimeAsync(100)
-
-      // Switch to success before next tick
+      await flush(runtime, 100)
       shouldFail = false
 
       // t=30s: backoff=5s elapsed, retry fires — now succeeds
-      await vi.advanceTimersByTimeAsync(30_000)
+      await flush(runtime, 30_000)
 
-      const state = db.prepare('SELECT consecutive_errors, last_error_at FROM connector_sync_state WHERE connector_id = ?')
+      const state = db
+        .prepare(
+          'SELECT consecutive_errors, last_error_at FROM connector_sync_state WHERE connector_id = ?',
+        )
         .get('recovery') as { consecutive_errors: number; last_error_at: string | null }
       expect(state.consecutive_errors).toBe(0)
       expect(state.last_error_at).toBeNull()
@@ -176,22 +221,26 @@ describe('SyncScheduler contract', () => {
       registry.register(connector)
       setState(db, { connectorId: 'interval-test' })
 
-      scheduler = new SyncScheduler(db, registry, {
-        forwardIntervalMs: 10_000,
-        backfillIntervalMs: 999_999_999,
-        pageDelayMs: 0,
-        maxMinutesPerRun: 1,
-      })
+      scheduler = new SyncScheduler(
+        db,
+        registry,
+        {
+          forwardIntervalMs: 10_000,
+          backfillIntervalMs: 999_999_999,
+          pageDelayMs: 0,
+          maxMinutesPerRun: 1,
+        },
+        runtime,
+      )
       scheduler.start()
 
-      // Startup fires immediately
-      await vi.advanceTimersByTimeAsync(100)
+      await flush(runtime, 100)
       expect(fetchCalls.length).toBeGreaterThanOrEqual(1)
 
       fetchCalls.length = 0
 
-      // t=30s: tick fires, 30s > 10s forwardIntervalMs → forward due
-      await vi.advanceTimersByTimeAsync(30_000)
+      // t=30s: 30s > 10s forwardIntervalMs → forward due
+      await flush(runtime, 30_000)
       expect(fetchCalls.length).toBeGreaterThanOrEqual(1)
     })
 
@@ -207,20 +256,23 @@ describe('SyncScheduler contract', () => {
         tailComplete: true,
       })
 
-      scheduler = new SyncScheduler(db, registry, {
-        forwardIntervalMs: 999_999_999,
-        backfillIntervalMs: 1_000,
-        pageDelayMs: 0,
-        maxMinutesPerRun: 1,
-      })
+      scheduler = new SyncScheduler(
+        db,
+        registry,
+        {
+          forwardIntervalMs: 999_999_999,
+          backfillIntervalMs: 1_000,
+          pageDelayMs: 0,
+          maxMinutesPerRun: 1,
+        },
+        runtime,
+      )
       scheduler.start()
 
-      // Startup fires 'both', engine skips backfill when tailComplete
-      await vi.advanceTimersByTimeAsync(100)
+      await flush(runtime, 100)
+      await flush(runtime, 90_000)
 
-      await vi.advanceTimersByTimeAsync(90_000)
-
-      const backfillCalls = phases.filter(p => p === 'backfill')
+      const backfillCalls = phases.filter((p) => p === 'backfill')
       expect(backfillCalls).toHaveLength(0)
     })
 
@@ -233,20 +285,23 @@ describe('SyncScheduler contract', () => {
       registry.register(connector)
       setState(db, { connectorId: 'manual' })
 
-      scheduler = new SyncScheduler(db, registry, {
-        forwardIntervalMs: 999_999_999,
-        pageDelayMs: 0,
-        maxMinutesPerRun: 1,
-      })
+      scheduler = new SyncScheduler(
+        db,
+        registry,
+        {
+          forwardIntervalMs: 999_999_999,
+          pageDelayMs: 0,
+          maxMinutesPerRun: 1,
+        },
+        runtime,
+      )
       scheduler.start()
 
-      // Startup fires
-      await vi.advanceTimersByTimeAsync(100)
+      await flush(runtime, 100)
       const afterStartup = fetchCalls.length
 
-      // Manual trigger
       scheduler.triggerNow('manual', 'forward')
-      await vi.advanceTimersByTimeAsync(100)
+      await flush(runtime, 100)
 
       expect(fetchCalls.length).toBeGreaterThan(afterStartup)
     })

--- a/packages/core/src/connectors/sync-scheduler.ts
+++ b/packages/core/src/connectors/sync-scheduler.ts
@@ -1,8 +1,6 @@
 import type {
-  Connector,
   SyncJob,
   SyncJobPriority,
-  ConnectorSyncResult,
   ScheduleConfig,
   SchedulerStatus,
   ConnectorStatus,
@@ -12,11 +10,22 @@ import { DEFAULT_SCHEDULE, SyncErrorCode } from './types.js'
 import type { ConnectorRegistry } from './registry.js'
 import { SyncEngine, loadSyncState } from './sync-engine.js'
 import type Database from 'better-sqlite3'
+import {
+  Clock,
+  Deferred,
+  Duration,
+  Effect,
+  Fiber,
+  Layer,
+  ManagedRuntime,
+  pipe,
+  Schedule,
+} from 'effect'
 
 export type SchedulerEvent =
   | { type: 'sync-start'; connectorId: string }
   | { type: 'sync-progress'; progress: SyncProgress }
-  | { type: 'sync-complete'; result: ConnectorSyncResult }
+  | { type: 'sync-complete'; result: import('./types.js').ConnectorSyncResult }
   | { type: 'sync-error'; connectorId: string; code: SyncErrorCode; message: string }
 
 export type SchedulerEventHandler = (event: SchedulerEvent) => void
@@ -25,18 +34,28 @@ export class SyncScheduler {
   private engine: SyncEngine
   private config: ScheduleConfig
   private queue: SyncJob[] = []
-  private running = new Map<string, AbortController>()
-  private timer: ReturnType<typeof setInterval> | null = null
+  // Per-job cancel tokens. Fired by stop() so in-flight syncs wind down
+  // cooperatively (engine checks Deferred.isDone at every loop yield point).
+  private running = new Map<string, Deferred.Deferred<void>>()
+  private tickFiber: Fiber.RuntimeFiber<void, never> | null = null
   private started = false
   private eventHandlers: SchedulerEventHandler[] = []
+  // Effect runtime. Production: Layer.empty (default clock). Tests inject
+  // ManagedRuntime.make(TestContext.TestContext) to gain TestClock.
+  private runtime: ManagedRuntime.ManagedRuntime<never, never>
+  // Concurrency gate. Created on start() so config.concurrency is honored
+  // even if the config were swapped between start/stop cycles.
+  private semaphore: Effect.Semaphore | null = null
 
   constructor(
     private db: Database.Database,
     private registry: ConnectorRegistry,
     config?: Partial<ScheduleConfig>,
+    runtime?: ManagedRuntime.ManagedRuntime<never, never>,
   ) {
     this.engine = new SyncEngine(db)
     this.config = { ...DEFAULT_SCHEDULE, ...config }
+    this.runtime = runtime ?? ManagedRuntime.make(Layer.empty)
   }
 
   // ── Lifecycle ─────────────────────────────────────────────────────────────
@@ -45,39 +64,53 @@ export class SyncScheduler {
     if (this.started) return
     this.started = true
 
-    // Queue immediate forward sync for all enabled connectors
+    this.semaphore = Effect.runSync(Effect.makeSemaphore(this.config.concurrency))
+
+    // Queue immediate forward sync for all enabled connectors synchronously
+    // so observers of the queue right after start() see it populated.
     this.queueAll('both', 80)
 
-    // Start the tick loop (check every 30 seconds)
-    this.timer = setInterval(() => this.tick(), 30_000)
-    // Run first tick immediately
-    this.tick()
+    // Tick fiber: first run happens inside a bootstrap so the 30s Schedule
+    // doesn't delay startup, then Effect.repeat drives the cadence.
+    const tickProgram = pipe(
+      this.tickOnceEffect(),
+      Effect.repeat(Schedule.spaced(Duration.seconds(30))),
+      Effect.asVoid,
+      Effect.catchAllCause((cause) =>
+        Effect.logError('scheduler tick fiber crashed', cause),
+      ),
+    )
+    this.tickFiber = this.runtime.runFork(tickProgram)
   }
 
   stop(): void {
     this.started = false
-    if (this.timer) {
-      clearInterval(this.timer)
-      this.timer = null
+    if (this.tickFiber) {
+      // Fire-and-forget interrupt. The fiber respects Effect interruption at
+      // its next yield point. runJob fibers are siblings (not children), so
+      // this does NOT cascade to in-flight syncs — they unwind via the
+      // per-job Deferred below.
+      this.runtime.runFork(Fiber.interrupt(this.tickFiber))
+      this.tickFiber = null
     }
-    // Abort all running syncs
-    for (const [, controller] of this.running) {
-      controller.abort()
+    for (const [, deferred] of this.running) {
+      Effect.runSync(Deferred.succeed(deferred, void 0))
     }
     this.running.clear()
     this.queue = []
+    this.semaphore = null
   }
 
   /** Manually trigger sync for a specific connector. */
   triggerNow(connectorId: string, direction: 'forward' | 'backfill' | 'both' = 'both'): void {
     this.enqueue({ connectorId, direction, priority: 100, queuedAt: Date.now() })
-    this.tick()
+    this.runtime.runFork(this.tickOnceEffect())
   }
 
   /** Notify the scheduler that the system woke from sleep. */
   onWake(): void {
     this.queueAll('forward', 60)
-    this.tick()
+    this.runtime.runFork(this.tickOnceEffect())
   }
 
   /** Subscribe to scheduler events. */
@@ -138,110 +171,142 @@ export class SyncScheduler {
     this.queue.sort((a, b) => b.priority - a.priority)
   }
 
-  private tick(): void {
-    if (!this.started) return
+  /**
+   * One pass of the scheduling decision loop: read Clock, scan connectors for
+   * due syncs, enqueue them, and fork runJob fibers for as many queued jobs as
+   * the semaphore will allow. Called from the tick fiber's repeat loop and
+   * from triggerNow()/onWake() as an immediate poke.
+   */
+  private tickOnceEffect(): Effect.Effect<void> {
+    const self = this
+    return Effect.gen(function* () {
+      if (!self.started) return
 
-    // Check if any connectors are due for scheduled sync
-    const now = Date.now()
-    for (const connector of this.registry.list()) {
-      const state = loadSyncState(this.db, connector.id)
-      if (!state.enabled) continue
+      const now = yield* Clock.currentTimeMillis
 
-      // Skip if in backoff due to errors.
-      // Use lastErrorAt (when the error occurred) as the backoff base, not
-      // lastForwardSyncAt/lastBackfillSyncAt (which may be from an earlier
-      // successful sync and would under-count the backoff window).
-      if (state.consecutiveErrors > 0 && state.lastErrorAt) {
-        const backoffMs = this.getBackoffMs(state.consecutiveErrors)
-        if (now - new Date(state.lastErrorAt).getTime() < backoffMs) {
-          continue
+      for (const connector of self.registry.list()) {
+        const state = loadSyncState(self.db, connector.id)
+        if (!state.enabled) continue
+
+        // Skip if in backoff due to errors.
+        if (state.consecutiveErrors > 0 && state.lastErrorAt) {
+          const backoffMs = self.getBackoffMs(state.consecutiveErrors)
+          if (now - new Date(state.lastErrorAt).getTime() < backoffMs) continue
         }
-      }
 
-      // Skip if needsReauth
-      if (state.lastErrorCode?.startsWith('AUTH_')) continue
+        // Skip if needsReauth
+        if (state.lastErrorCode?.startsWith('AUTH_')) continue
 
-      // Forward sync due?
-      const lastForward = state.lastForwardSyncAt
-        ? new Date(state.lastForwardSyncAt).getTime()
-        : 0
-      if (now - lastForward >= this.config.forwardIntervalMs) {
-        this.enqueue({
-          connectorId: connector.id,
-          direction: 'forward',
-          priority: 40,
-          queuedAt: now,
-        })
-      }
-
-      // Backfill due?
-      if (!state.tailComplete) {
-        const lastBackfill = state.lastBackfillSyncAt
-          ? new Date(state.lastBackfillSyncAt).getTime()
+        const lastForward = state.lastForwardSyncAt
+          ? new Date(state.lastForwardSyncAt).getTime()
           : 0
-        if (now - lastBackfill >= this.config.backfillIntervalMs) {
-          this.enqueue({
+        if (now - lastForward >= self.config.forwardIntervalMs) {
+          self.enqueue({
             connectorId: connector.id,
-            direction: 'backfill',
-            priority: 20,
+            direction: 'forward',
+            priority: 40,
             queuedAt: now,
           })
         }
-      }
-    }
 
-    // Run jobs up to concurrency limit
-    while (this.running.size < this.config.concurrency && this.queue.length > 0) {
-      const job = this.queue.shift()!
-      this.runJob(job)
-    }
+        if (!state.tailComplete) {
+          const lastBackfill = state.lastBackfillSyncAt
+            ? new Date(state.lastBackfillSyncAt).getTime()
+            : 0
+          if (now - lastBackfill >= self.config.backfillIntervalMs) {
+            self.enqueue({
+              connectorId: connector.id,
+              direction: 'backfill',
+              priority: 20,
+              queuedAt: now,
+            })
+          }
+        }
+      }
+
+      // Drain queue up to concurrency limit. The semaphore is the *real* gate
+      // on how many jobs run simultaneously; this loop just submits as many
+      // fibers as we have queued work for.
+      while (self.queue.length > 0 && self.running.size < self.config.concurrency) {
+        const job = self.queue.shift()!
+        // Fork as a sibling of the tick fiber, NOT a child — stop()'s
+        // interrupt of the tick fiber must not cascade and short-circuit
+        // in-flight sync state persistence.
+        yield* Effect.sync(() => self.runtime.runFork(self.runJobEffect(job)))
+      }
+    })
   }
 
-  private async runJob(job: SyncJob): Promise<void> {
-    if (!this.registry.has(job.connectorId)) return
+  /**
+   * Build the Effect that runs a single sync job. Wraps the inner body with
+   * `semaphore.withPermits(1)` so at most `config.concurrency` jobs execute in
+   * parallel.
+   */
+  private runJobEffect(job: SyncJob): Effect.Effect<void> {
+    const self = this
+    const semaphore = this.semaphore
+    if (!semaphore) return Effect.void
 
-    const connector = this.registry.get(job.connectorId)
-    const controller = new AbortController()
-    this.running.set(job.connectorId, controller)
+    const body = Effect.gen(function* () {
+      if (!self.registry.has(job.connectorId)) return
+      const connector = self.registry.get(job.connectorId)
 
-    this.emit({ type: 'sync-start', connectorId: job.connectorId })
+      const cancel = yield* Deferred.make<void>()
+      yield* Effect.sync(() => {
+        self.running.set(job.connectorId, cancel)
+      })
 
-    try {
-      const result = await this.engine.sync(connector, {
+      yield* Effect.sync(() =>
+        self.emit({ type: 'sync-start', connectorId: job.connectorId }),
+      )
+
+      const result = yield* self.engine.syncEffect(connector, {
         direction: job.direction,
-        delayMs: this.config.pageDelayMs,
-        maxMinutes: this.config.maxMinutesPerRun,
-        signal: controller.signal,
+        delayMs: self.config.pageDelayMs,
+        maxMinutes: self.config.maxMinutesPerRun,
+        cancel,
         onProgress: (progress) => {
-          this.emit({ type: 'sync-progress', progress })
+          self.emit({ type: 'sync-progress', progress })
         },
       })
 
-      this.emit({ type: 'sync-complete', result })
-
-      if (result.error) {
-        this.emit({
-          type: 'sync-error',
-          connectorId: job.connectorId,
-          code: result.error.code as SyncErrorCode,
-          message: result.error.message,
-        })
-      }
-    } catch (err) {
-      this.emit({
-        type: 'sync-error',
-        connectorId: job.connectorId,
-        code: SyncErrorCode.CONNECTOR_ERROR,
-        message: err instanceof Error ? err.message : String(err),
+      yield* Effect.sync(() => {
+        self.emit({ type: 'sync-complete', result })
+        if (result.error) {
+          self.emit({
+            type: 'sync-error',
+            connectorId: job.connectorId,
+            code: result.error.code as SyncErrorCode,
+            message: result.error.message,
+          })
+        }
       })
-    } finally {
-      this.running.delete(job.connectorId)
-      // Trigger next tick to pick up queued jobs
-      if (this.queue.length > 0) {
-        // Use setTimeout to avoid stack overflow from recursive tick
-        setTimeout(() => this.tick(), 0)
-      }
-    }
+    })
+
+    return pipe(
+      semaphore.withPermits(1)(body),
+      Effect.ensuring(
+        Effect.sync(() => {
+          self.running.delete(job.connectorId)
+          // When a permit frees up, immediately try to drain more queued work
+          // instead of waiting 30s for the next periodic tick.
+          if (self.queue.length > 0 && self.started) {
+            self.runtime.runFork(self.tickOnceEffect())
+          }
+        }),
+      ),
+      // Defect in the forked fiber must not take down the runtime.
+      Effect.catchAllCause((cause) =>
+        Effect.sync(() => {
+          self.emit({
+            type: 'sync-error',
+            connectorId: job.connectorId,
+            code: SyncErrorCode.CONNECTOR_ERROR,
+            message: `runJob defect: ${cause.toString()}`,
+          })
+        }),
+      ),
+    )
   }
 
   private getBackoffMs(consecutiveErrors: number): number {

--- a/packages/core/src/connectors/sync-scheduler.ts
+++ b/packages/core/src/connectors/sync-scheduler.ts
@@ -1,4 +1,5 @@
 import type {
+  ConnectorSyncResult,
   SyncJob,
   SyncJobPriority,
   ScheduleConfig,
@@ -23,10 +24,12 @@ import {
   Schedule,
 } from 'effect'
 
+type Direction = SyncJob['direction']
+
 export type SchedulerEvent =
   | { type: 'sync-start'; connectorId: string }
   | { type: 'sync-progress'; progress: SyncProgress }
-  | { type: 'sync-complete'; result: import('./types.js').ConnectorSyncResult }
+  | { type: 'sync-complete'; result: ConnectorSyncResult }
   | { type: 'sync-error'; connectorId: string; code: SyncErrorCode; message: string }
 
 export type SchedulerEventHandler = (event: SchedulerEvent) => void
@@ -39,14 +42,10 @@ export class SyncScheduler {
   // cooperatively (engine checks Deferred.isDone at every loop yield point).
   private running = new Map<string, Deferred.Deferred<void>>()
   private tickFiber: Fiber.RuntimeFiber<void, never> | null = null
-  private started = false
   private eventHandlers: SchedulerEventHandler[] = []
-  // Effect runtime. Production: Layer.empty (default clock). Tests inject
-  // ManagedRuntime.make(TestContext.TestContext) to gain TestClock.
+  // Production: Layer.empty. Tests inject TestContext.TestContext for TestClock.
   private runtime: ManagedRuntime.ManagedRuntime<never, never>
-  // Concurrency gate. Created on start() so config.concurrency is honored
-  // even if the config were swapped between start/stop cycles.
-  private semaphore: Effect.Semaphore | null = null
+  private semaphore: Effect.Semaphore
 
   constructor(
     private db: Database.Database,
@@ -57,22 +56,18 @@ export class SyncScheduler {
     this.engine = new SyncEngine(db)
     this.config = { ...DEFAULT_SCHEDULE, ...config }
     this.runtime = runtime ?? ManagedRuntime.make(Layer.empty)
+    this.semaphore = Effect.runSync(Effect.makeSemaphore(this.config.concurrency))
   }
 
   // ── Lifecycle ─────────────────────────────────────────────────────────────
 
   start(): void {
-    if (this.started) return
-    this.started = true
+    if (this.tickFiber) return
 
-    this.semaphore = Effect.runSync(Effect.makeSemaphore(this.config.concurrency))
-
-    // Queue immediate forward sync for all enabled connectors synchronously
-    // so observers of the queue right after start() see it populated.
+    // Queue immediate forward sync synchronously so observers of the queue
+    // right after start() see it populated.
     this.queueAll('both', 80)
 
-    // Tick fiber: first run happens inside a bootstrap so the 30s Schedule
-    // doesn't delay startup, then Effect.repeat drives the cadence.
     const tickProgram = pipe(
       this.tickOnceEffect(),
       Effect.repeat(Schedule.spaced(Duration.seconds(30))),
@@ -87,11 +82,9 @@ export class SyncScheduler {
   }
 
   stop(): void {
-    this.started = false
     if (this.tickFiber) {
-      // Fire-and-forget interrupt. The fiber respects Effect interruption at
-      // its next yield point. runJob fibers are siblings (not children), so
-      // this does NOT cascade to in-flight syncs — they unwind via the
+      // Fire-and-forget interrupt. runJob fibers are siblings (not children),
+      // so this does NOT cascade to in-flight syncs — they unwind via the
       // per-job Deferred below.
       this.runtime.runFork(Fiber.interrupt(this.tickFiber))
       this.tickFiber = null
@@ -101,19 +94,18 @@ export class SyncScheduler {
     }
     this.running.clear()
     this.queue = []
-    this.semaphore = null
   }
 
   /** Manually trigger sync for a specific connector. */
-  triggerNow(connectorId: string, direction: 'forward' | 'backfill' | 'both' = 'both'): void {
+  triggerNow(connectorId: string, direction: Direction = 'both'): void {
     this.enqueue({ connectorId, direction, priority: 100, queuedAt: Date.now() })
-    this.runtime.runFork(this.tickOnceEffect())
+    this.poke()
   }
 
   /** Notify the scheduler that the system woke from sleep. */
   onWake(): void {
     this.queueAll('forward', 60)
-    this.runtime.runFork(this.tickOnceEffect())
+    this.poke()
   }
 
   /** Subscribe to scheduler events. */
@@ -141,7 +133,7 @@ export class SyncScheduler {
       }
     })
 
-    return { running: this.started, connectors }
+    return { running: this.tickFiber !== null, connectors }
   }
 
   // ── Internal ──────────────────────────────────────────────────────────────
@@ -152,7 +144,11 @@ export class SyncScheduler {
     }
   }
 
-  private queueAll(direction: 'forward' | 'backfill' | 'both', priority: SyncJobPriority): void {
+  private poke(): void {
+    this.runtime.runFork(this.tickOnceEffect())
+  }
+
+  private queueAll(direction: Direction, priority: SyncJobPriority): void {
     for (const connector of this.registry.list()) {
       const state = loadSyncState(this.db, connector.id)
       if (!state.enabled) continue
@@ -161,10 +157,8 @@ export class SyncScheduler {
   }
 
   private enqueue(job: SyncJob): void {
-    // Don't queue if already queued or running
     if (this.running.has(job.connectorId)) return
     if (this.queue.some(j => j.connectorId === job.connectorId)) {
-      // Replace with higher priority if applicable
       this.queue = this.queue.map(j =>
         j.connectorId === job.connectorId && job.priority > j.priority ? job : j,
       )
@@ -174,16 +168,10 @@ export class SyncScheduler {
     this.queue.sort((a, b) => b.priority - a.priority)
   }
 
-  /**
-   * One pass of the scheduling decision loop: read Clock, scan connectors for
-   * due syncs, enqueue them, and fork runJob fibers for as many queued jobs as
-   * the semaphore will allow. Called from the tick fiber's repeat loop and
-   * from triggerNow()/onWake() as an immediate poke.
-   */
   private tickOnceEffect(): Effect.Effect<void> {
     const self = this
     return Effect.gen(function* () {
-      if (!self.started) return
+      if (self.tickFiber === null) return
 
       const now = yield* Clock.currentTimeMillis
 
@@ -191,13 +179,11 @@ export class SyncScheduler {
         const state = loadSyncState(self.db, connector.id)
         if (!state.enabled) continue
 
-        // Skip if in backoff due to errors.
         if (state.consecutiveErrors > 0 && state.lastErrorAt) {
           const backoffMs = self.getBackoffMs(state.consecutiveErrors)
           if (now - new Date(state.lastErrorAt).getTime() < backoffMs) continue
         }
 
-        // Skip if needsReauth
         if (state.lastErrorCode?.startsWith('AUTH_')) continue
 
         const lastForward = state.lastForwardSyncAt
@@ -227,28 +213,23 @@ export class SyncScheduler {
         }
       }
 
-      // Drain queue up to concurrency limit. The semaphore is the *real* gate
-      // on how many jobs run simultaneously; this loop just submits as many
-      // fibers as we have queued work for.
-      while (self.queue.length > 0 && self.running.size < self.config.concurrency) {
-        const job = self.queue.shift()!
-        // Fork as a sibling of the tick fiber, NOT a child — stop()'s
-        // interrupt of the tick fiber must not cascade and short-circuit
-        // in-flight sync state persistence.
-        yield* Effect.sync(() => self.runtime.runFork(self.runJobEffect(job)))
-      }
+      yield* Effect.sync(() => self.drainQueue())
     })
   }
 
-  /**
-   * Build the Effect that runs a single sync job. Wraps the inner body with
-   * `semaphore.withPermits(1)` so at most `config.concurrency` jobs execute in
-   * parallel.
-   */
+  // Drain queued work up to concurrency. The semaphore is the *real* gate on
+  // how many jobs run simultaneously; this loop just submits fibers.
+  // Fork as siblings of the tick fiber, NOT children — stop()'s interrupt of
+  // the tick fiber must not cascade and short-circuit in-flight state persistence.
+  private drainQueue(): void {
+    while (this.queue.length > 0 && this.running.size < this.config.concurrency) {
+      const job = this.queue.shift()!
+      this.runtime.runFork(this.runJobEffect(job))
+    }
+  }
+
   private runJobEffect(job: SyncJob): Effect.Effect<void> {
     const self = this
-    const semaphore = this.semaphore
-    if (!semaphore) return Effect.void
 
     const body = Effect.gen(function* () {
       if (!self.registry.has(job.connectorId)) return
@@ -287,18 +268,17 @@ export class SyncScheduler {
     })
 
     return pipe(
-      semaphore.withPermits(1)(body),
+      this.semaphore.withPermits(1)(body),
       Effect.ensuring(
         Effect.sync(() => {
           self.running.delete(job.connectorId)
-          // When a permit frees up, immediately try to drain more queued work
-          // instead of waiting 30s for the next periodic tick.
-          if (self.queue.length > 0 && self.started) {
-            self.runtime.runFork(self.tickOnceEffect())
+          // Drain remaining queue immediately rather than waiting 30s for the
+          // next periodic tick. Skips the connector rescan in tickOnceEffect.
+          if (self.queue.length > 0 && self.tickFiber !== null) {
+            self.drainQueue()
           }
         }),
       ),
-      // Defect in the forked fiber must not take down the runtime.
       Effect.catchAllCause((cause) =>
         Cause.isInterruptedOnly(cause)
           ? Effect.void

--- a/packages/core/src/connectors/sync-scheduler.ts
+++ b/packages/core/src/connectors/sync-scheduler.ts
@@ -11,6 +11,7 @@ import type { ConnectorRegistry } from './registry.js'
 import { SyncEngine, loadSyncState } from './sync-engine.js'
 import type Database from 'better-sqlite3'
 import {
+  Cause,
   Clock,
   Deferred,
   Duration,
@@ -77,7 +78,9 @@ export class SyncScheduler {
       Effect.repeat(Schedule.spaced(Duration.seconds(30))),
       Effect.asVoid,
       Effect.catchAllCause((cause) =>
-        Effect.logError('scheduler tick fiber crashed', cause),
+        Cause.isInterruptedOnly(cause)
+          ? Effect.void
+          : Effect.logError('scheduler tick fiber crashed', cause),
       ),
     )
     this.tickFiber = this.runtime.runFork(tickProgram)
@@ -297,14 +300,16 @@ export class SyncScheduler {
       ),
       // Defect in the forked fiber must not take down the runtime.
       Effect.catchAllCause((cause) =>
-        Effect.sync(() => {
-          self.emit({
-            type: 'sync-error',
-            connectorId: job.connectorId,
-            code: SyncErrorCode.CONNECTOR_ERROR,
-            message: `runJob defect: ${cause.toString()}`,
-          })
-        }),
+        Cause.isInterruptedOnly(cause)
+          ? Effect.void
+          : Effect.sync(() => {
+              self.emit({
+                type: 'sync-error',
+                connectorId: job.connectorId,
+                code: SyncErrorCode.CONNECTOR_ERROR,
+                message: `runJob defect: ${Cause.pretty(cause)}`,
+              })
+            }),
       ),
     )
   }

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -231,11 +231,10 @@ export interface SyncOptions {
   /** AbortSignal for cancellation. */
   signal?: AbortSignal
   /**
-   * Optional externally-managed cancellation signal. When provided,
-   * syncEffect uses this Deferred instead of creating its own, so callers
-   * (e.g. SyncScheduler) can cancel from outside the Effect. If both
-   * `signal` and `cancel` are provided, `signal` is bridged into `cancel`
-   * (both paths fire cancellation).
+   * Caller-owned cancellation Deferred. When provided, syncEffect uses this
+   * instead of creating its own — allowing callers like SyncScheduler to
+   * cancel from outside. If `signal` is also set, it is bridged into this
+   * Deferred.
    */
   cancel?: Deferred.Deferred<void>
   /** Progress callback. */

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -1,4 +1,5 @@
 import { Data } from 'effect'
+import type { Deferred } from 'effect'
 import type { CapturedItem } from '../types.js'
 
 // ── Error Types ─────────────────────────────────────────────────────────────
@@ -229,6 +230,14 @@ export interface SyncOptions {
   stalePageLimit?: number
   /** AbortSignal for cancellation. */
   signal?: AbortSignal
+  /**
+   * Optional externally-managed cancellation signal. When provided,
+   * syncEffect uses this Deferred instead of creating its own, so callers
+   * (e.g. SyncScheduler) can cancel from outside the Effect. If both
+   * `signal` and `cancel` are provided, `signal` is bridged into `cancel`
+   * (both paths fire cancellation).
+   */
+  cancel?: Deferred.Deferred<void>
   /** Progress callback. */
   onProgress?: (progress: SyncProgress) => void
 }


### PR DESCRIPTION
## Summary

Rewrites `SyncScheduler` internals to use Effect primitives (`Fiber`, `Semaphore`, `Deferred`, `Schedule`) while keeping the public class API Promise/callback-shaped so the Electron IPC layer is not forced to know about Effect. This is the last structural step in the connector subsystem's Effect migration — after this, the entire `connectors/` subsystem runs Effect internally and exposes Promise/callback seams only at the connector plugin boundary (`fetchPage` still returns `Promise<PageResult>`) and at the scheduler class boundary.

Prior work in the same migration that already landed: #55 (`SyncError → Data.TaggedError`), #56 (engine sync loop → `Effect.gen`), #57 (engine time + cancellation → `Clock` + `Deferred`).

**Also included:** a small fix in `packages/app/src/main/index.ts` wiring `SyncScheduler` into Electron's lifecycle. Before this PR, `stop()` was never called and `onWake()` was dead code. Both are now connected.

## What Effect actually bought us

Not just ticking a box — each primitive replaces code that had a concrete defect, race, or untestable path in the old implementation.

### 1. `Effect.Semaphore` replaces a manual `while (running.size < n)` counter

**Before:** `tick()` synchronously submitted fire-and-forget promises up to `config.concurrency`, then `runJob`'s `finally` block called `setTimeout(() => tick(), 0)` to pick up the next queued job. If the runtime crashed between acquiring a slot and the `finally` running, the counter drifted and stayed drifted until restart.

**After:** `semaphore.withPermits(1)` is the single gate. `Effect.ensuring` releases the permit on success, error, **and interruption** — the last of which is what manual counters bungle most often, because JS `try/finally` does not run when a fiber is interrupted between yield points. Structured concurrency guarantees the release is tied to the fiber's `Exit`.

### 2. `Deferred<void>` replaces `AbortController` — and silently fixed a real cancel bug

**Before:** each job had an `AbortController`; `stop()` called `.abort()` on all of them. The engine checked `signal.aborted` at known points. This cannot be awaited from inside `Effect.sleep`, so the inter-page delay was a real `setTimeout` running outside Effect's scheduler — meaning `TestClock.adjust` could not drive it.

**After:** `Deferred<void>` is Effect-native. `interruptibleSleep(pageDelayMs, cancel)` becomes `Effect.race(Effect.sleep(ms), Deferred.await(cancel))`, and both branches are owned by the same fiber scheduler. `TestClock` can drive it deterministically.

> **Silent correctness fix:** this PR's first commit extends `SyncOptions.cancel?: Deferred<void>`. Before this change, `syncEffect` always allocated its own internal `Deferred` and ignored any caller-owned cancel path — so `scheduler.stop()` firing a Deferred had **no effect** on in-flight syncs. The old behavior happened to look correct because `AbortController` shutdown was wired through `bridgeAbortSignal`, but once the engine moved to Deferred-based cancel in #57 the scheduler's shutdown became inert. The new `stop() causes in-flight sync to return with stopReason='cancelled'` test catches this regression.

### 3. `Effect.repeat(Schedule.spaced)` replaces `setInterval`

**Before:** a `setInterval(() => tick(), 30_000)` drove the periodic scan, and a separate `setTimeout(() => tick(), 0)` in `runJob`'s finally fired follow-up ticks when permits freed. Two independent timer paths, each vulnerable to `setInterval` drift under CPU pressure.

**After:** a single forked fiber runs `tickOnceEffect()` in a loop. `Schedule.spaced` computes the next run relative to the previous completion, so the cadence self-corrects for tick body duration. `Effect.ensuring` in `runJobEffect` calls a new `drainQueue()` directly (no full rescan) when a permit frees — eliminating the `setTimeout` cascade entirely and turning what used to be an `O(N²/K)` `loadSyncState` storm under burst load into an `O(N)` per-tick scan + `O(1)` per-completion drain.

### 4. `Fiber.interrupt` gives us a single, structured shutdown path

**Before:** `stop()` cleared `started`, cleared the timer, called `.abort()` on every controller, cleared `running`, cleared `queue` — in an order that was easy to get wrong. Ad-hoc async cleanup inside `runJob`'s `finally` raced `stop()`'s `running.clear()` and the two fought over the map.

**After:** `stop()` interrupts the tick fiber and fires per-job Deferreds. Everything else is a consequence — runJob fibers observe their Deferreds, return normally, and their `Effect.ensuring` blocks run in the right order because Effect's structured concurrency enforces it. `running.delete(id)` on a missing key is a no-op, so the race with `running.clear()` is benign. The whole shutdown path is ~30% shorter and has zero ordering footguns.

### 5. `ManagedRuntime(TestContext.TestContext)` unlocks the test shape we actually want

**Before:** the scheduler test file used `vi.useFakeTimers()` to intercept `setInterval` / `setTimeout` and fired them manually with `advanceTimersByTimeAsync(30_000)`. This could not drive the engine's `Effect.sleep` at all, so tests could only check "does the scheduler's outer loop wake up" and could not observe what happened to the engine when cancel fired during an inter-page sleep.

**After:** both scheduler and engine share a `ManagedRuntime` whose default Clock is a `TestClock`. `TestClock.adjust(Duration.seconds(30))` advances `Schedule.spaced` *and* `interruptibleSleep` in one coherent virtual-time jump. The new cancellation test asserts:

> When `stop()` is called mid-sync while the engine is parked in `interruptibleSleep`, the `Deferred.succeed` wakes the race, the engine observes `Deferred.isDone(cancel)` at the next loop iteration, returns a `ConnectorSyncResult` with `stopReason='cancelled'`, the `sync-complete` event fires with that result, and **zero** `sync-error` events are emitted.

This test was **impossible** to write with fake timers because the cancel signal and the inter-page sleep had to share a fiber scheduler.

### 6. `Cause.isInterruptedOnly` — the guard that keeps production logs clean

When Effect's runtime interrupts a fiber, the `Cause` is `Cause.Interrupted`. A naive `catchAllCause` would treat this as a real error — emit a spurious `sync-error` event to the renderer and break structured concurrency by recovering from the interrupt. Both the tick fiber and runJob fibers guard with:

```ts
Cause.isInterruptedOnly(cause) ? Effect.void : <error path>
```

Without this guard, every normal `app.before-quit → stop()` shutdown would log "scheduler tick fiber crashed" in the Electron main process.

### 7. What was **not** migrated, and why

Three things stayed deliberately un-Effectified:

- **The queue** remains a plain `SyncJob[]` array, not `Queue.unbounded`. `Queue` is FIFO and does not support priority-replace; our dedupe logic (same `connectorId`, keep the higher-priority entry) is core behavior for `triggerNow` vs periodic ticks.
- **`retryBackoffMs`** stays as a flat array. The default sequence is `[1m, 5m, 30m, 2h]`, which is not strictly exponential, and — more fundamentally — our backoff is a **wall-clock gate checked at tick time**, not a fiber-sleeping retry. `Schedule.exponential` is for `Effect.retry(effect, schedule)` where a fiber sleeps and re-runs; our fiber returns failure, persists `lastErrorAt`, and the *next* tick decides whether to re-enqueue. The two models are not equivalent and `Schedule` cannot express ours.
- **Connector-internal 429/5xx retry** stays inside the connector. Each connector's retry semantics differ (Twitter uses `X-RateLimit-Reset`, Slack uses `Retry-After`), and the plugin boundary is `Promise<PageResult>` so `Schedule` values can't cross it.

## Electron lifecycle fix (`packages/app/src/main/index.ts`)

Before this PR, `syncScheduler.start()` was called on app ready but `stop()` was called **nowhere**, and `onWake()` had no `powerMonitor` listener — it was dead code. Two consequences:

1. **Quit:** Cmd+Q / SIGTERM tore down the process while the tick fiber and in-flight runJob fibers were still live. Current-cycle state updates (cursor advances, `consecutiveErrors` resets) for any in-flight Twitter sync were silently lost. Next startup re-synced from the prior checkpoint so data was never wrong, just a wasted round-trip every time.
2. **Sleep/wake:** after a laptop resumed from sleep, the scheduler waited up to 30s for its next periodic tick before checking if anything was due.

This PR adds three lines to `index.ts`:

```ts
app.on('before-quit', () => syncScheduler?.stop())
powerMonitor.on('resume', () => syncScheduler?.onWake())
```

On quit, `stop()` fires all per-job cancel Deferreds — the engine returns with `stopReason='cancelled'` and persists partial progress before the runtime disposes. The `Cause.isInterruptedOnly` guard (from §6 above) is **what keeps this path silent** in logs; without it, every clean shutdown would log "scheduler tick fiber crashed".

## Commits

| # | Commit | Purpose |
|---|--------|---------|
| 1 | `c7a3a14` | `feat`: extend `SyncOptions` with `cancel?: Deferred<void>` so `syncEffect` honors a caller-owned cancel token |
| 2 | `68f5bb3` | `refactor`: scheduler Effect-ization (Semaphore / Deferred / Fiber / Schedule) + new `sync-scheduler.effect.test.ts` with 7 semantic-parity tests |
| 3 | `98a4f61` | `fix`: `Cause.isInterruptedOnly` guards in both tick-fiber and runJob-fiber `catchAllCause` handlers |
| 4 | `592d914` | `test`: 3 new tests covering concurrency semaphore cap, stop-mid-sync cancel, triggerNow dedupe |
| 5 | `64ca7a4` | `test`: tighten concurrency release-loop, trim over-commented engine narration |
| 6 | `a1420ca` | `chore`: simplify pass after multi-agent review — drop `started` boolean (derive from `tickFiber`), non-null semaphore in constructor, extract `drainQueue` / `poke` helpers, trim narration comments |
| 7 | `28e4e8c` | `fix(app)`: wire `stop()` to `before-quit` and `onWake()` to `powerMonitor.resume` |

## Tests

- **75/75** tests in `@spool/core` pass, including:
  - 10 new scheduler Effect tests (`sync-scheduler.effect.test.ts`)
  - 3 pre-existing sync-engine Effect tests (from #57)
  - 4 pre-existing observability tests (from #56)
  - Full pre-existing engine contract suite unchanged
- `tsc --noEmit` clean in `@spool/core` and `@spool/app`
- **Manual smoke:** Electron dev app was rebuilt against this branch, Twitter bookmarks connector ran a full sync cycle successfully, no spurious events or crash logs

## Test plan

- [x] `pnpm --filter @spool/core test` — expect 75/75 green
- [x] `pnpm --filter @spool/core exec tsc --noEmit` — expect clean
- [x] `cd packages/app && npx tsc --noEmit` — expect clean
- [x] Electron dev app: startup sync fires — verified via `[sync-engine] twitter-bookmarks done: added=0 pages=1 reason=reached_since` on `pnpm dev` boot
- [x] Electron dev app: clean exit on SIGTERM — process exited in <1s, zero `scheduler tick fiber crashed` / `runJob defect` logs. Note: this exit path trivially has nothing to cancel when no sync is in flight; the non-trivial "interrupt mid-`interruptibleSleep`" case is covered by unit test #8 under `TestClock`.
- [x] Manual: system sleep/wake (Apple menu → Sleep → wake) — confirm an immediate sync fires on resume instead of waiting for the next 30s tick. Requires real OS-level sleep, not scriptable.

## Non-goals (explicit)

- No changes to the connector plugin interface (`fetchPage` still returns `Promise<PageResult>`)
- No changes to the pre-existing engine contract tests
- No changes to the scheduler's IPC event shape
- No new UI affordances (per-connector cancel button, pause/resume)
- No unification of connector-internal 429/5xx retry into engine-level `Schedule`