### PR TITLE
fix: refresh source pills after connector install via deep link

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -67,6 +67,7 @@ export default function App() {
   const [connectorToast, setConnectorToast] = useState<string | null>(null)
   const [themeEditor, setThemeEditor] = useState<ThemeEditorStateV1>(() => defaultThemeEditorState())
   const themeHydrated = useRef(false)
+  const refreshCaptureSourcesRef = useRef<() => void>(() => {})
   const deferredResults = useDeferredValue(results)
   const [lastCompletedPreviewQuery, setLastCompletedPreviewQuery] = useState('')
 
@@ -138,6 +139,7 @@ export default function App() {
         setConnectorToast(`${event.name} v${event.version} installed`)
         if (toastTimer.current) clearTimeout(toastTimer.current)
         toastTimer.current = setTimeout(() => setConnectorToast(null), 4000)
+        refreshCaptureSourcesRef.current()
       }
     })
   }, [])
@@ -179,6 +181,7 @@ export default function App() {
       setCaptureSources(results)
     }).catch(console.error)
   }, [])
+  refreshCaptureSourcesRef.current = refreshCaptureSources
 
   useEffect(() => {
     if (!window.spool) return


### PR DESCRIPTION
## Summary

- After installing a connector via `spool://` deep link, the home screen source pills didn't update
- Root cause: the `installed` event handler in App.tsx didn't call `refreshCaptureSources()`
- Uses a ref to avoid adding `refreshCaptureSources` to useEffect deps (which caused a white screen due to effect re-registration timing)

## Test plan

- [x] Install a connector via deep link from spool.pro/connectors/
- [x] Verify toast appears
- [x] Verify source pills refresh on home screen (new connector shows if it has data)
- [x] Verify no white screen on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)