### PR TITLE
feat: add connector uninstall support

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, dialog, ipcMain, Menu, Notification, nativeTheme, nativeImage, net, powerMonitor } from 'electron'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
+import { readdirSync, readFileSync, existsSync } from 'node:fs'
 import { Worker } from 'node:worker_threads'
 import {
   getDB, Syncer, SpoolWatcher,
@@ -8,7 +9,7 @@ import {
   ConnectorRegistry, SyncScheduler,
   loadSyncState, saveSyncState,
   loadConnectors, makeFetchCapability, makeChromeCookiesCapability, makeLogCapabilityFor, makeSqliteCapability,
-  TrustStore, downloadAndInstall, resolveNpmPackage,
+  TrustStore, downloadAndInstall, uninstallConnector, resolveNpmPackage,
 } from '@spool/core'
 import type { AuthStatus, ConnectorStatus, FragmentResult, SchedulerEvent, SearchResult, SessionSource } from '@spool/core'
 import { setupTray } from './tray.js'
@@ -63,6 +64,7 @@ let trustStore: TrustStore | null = null
 let isSyncActive = false
 let proxyFetch: typeof globalThis.fetch
 let spoolDir: string
+const bundledConnectorIds = new Set<string>()
 
 type CachedSearchValue = SearchResult[] | FragmentResult[]
 
@@ -375,7 +377,7 @@ app.whenReady().then(async () => {
   spoolDir = join(homedir(), '.spool')
   trustStore = new TrustStore(spoolDir)
 
-  await loadConnectors({
+  const loadReport = await loadConnectors({
     bundledConnectorsDir,
     connectorsDir: join(spoolDir, 'connectors'),
     capabilityImpls: {
@@ -392,6 +394,20 @@ app.whenReady().then(async () => {
     },
     trustStore,
   })
+
+  // Track which connectors came from bundled tarballs
+  const bundledNames = new Set([...loadReport.bundleReport.extracted, ...loadReport.bundleReport.skipped])
+  for (const result of loadReport.loadResults) {
+    if (result.status === 'loaded' && bundledNames.has(result.name)) {
+      // Find the connector ID from the installed package
+      const segs = result.name.startsWith('@') ? result.name.split('/') : [result.name]
+      const pkgPath = join(spoolDir, 'connectors', 'node_modules', ...segs, 'package.json')
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+        if (pkg.spool?.id) bundledConnectorIds.add(pkg.spool.id)
+      } catch {}
+    }
+  }
 
   syncScheduler = new SyncScheduler(db, connectorRegistry)
   syncScheduler.on((event: SchedulerEvent) => {
@@ -617,7 +633,10 @@ ipcMain.handle('spool:install-update', () => {
 // ── Connector Handlers ──────────────────────────────────────────────────
 
 ipcMain.handle('connector:list', (): ConnectorStatus[] => {
-  return syncScheduler.getStatus().connectors
+  return syncScheduler.getStatus().connectors.map(c => ({
+    ...c,
+    bundled: bundledConnectorIds.has(c.id),
+  }))
 })
 
 ipcMain.handle('connector:check-auth', async (_e, { id }: { id: string }): Promise<AuthStatus> => {
@@ -640,6 +659,64 @@ ipcMain.handle('connector:set-enabled', (_e, { id, enabled }: { id: string; enab
   if (enabled) {
     syncScheduler.triggerNow(id, 'both')
   }
+  return { ok: true }
+})
+
+ipcMain.handle('connector:uninstall', (_e, { id }: { id: string }) => {
+  const connectorsDir = join(spoolDir, 'connectors')
+
+  // Find the package name by scanning installed packages
+  const nodeModules = join(connectorsDir, 'node_modules')
+  let packageName: string | null = null
+
+  if (existsSync(nodeModules)) {
+    for (const entry of readdirSync(nodeModules)) {
+      if (entry.startsWith('.')) continue
+      const dirs = entry.startsWith('@')
+        ? readdirSync(join(nodeModules, entry)).map(s => join(entry, s))
+        : [entry]
+      for (const dir of dirs) {
+        const pkgPath = join(nodeModules, dir, 'package.json')
+        if (!existsSync(pkgPath)) continue
+        try {
+          const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+          if (pkg.spool?.id === id) {
+            packageName = pkg.name
+            break
+          }
+        } catch {}
+      }
+      if (packageName) break
+    }
+  }
+
+  if (!packageName) {
+    return { ok: false, error: `No installed package found for connector "${id}"` }
+  }
+
+  // Get platform before removing from registry
+  if (!connectorRegistry.has(id)) {
+    return { ok: false, error: `Connector "${id}" not found in registry` }
+  }
+  const platform = connectorRegistry.get(id).platform
+
+  // Remove from registry (stops scheduler from picking it up)
+  connectorRegistry.remove(id)
+
+  // Delete files and mark .do-not-restore
+  uninstallConnector(packageName, connectorsDir)
+
+  // Clean up DB atomically
+  db.transaction(() => {
+    db.prepare(
+      "DELETE FROM captures WHERE platform = ? AND json_extract(metadata, '$.connectorId') = ?",
+    ).run(platform, id)
+    db.prepare('DELETE FROM connector_sync_state WHERE connector_id = ?').run(id)
+  })()
+
+  // Notify renderer
+  mainWindow?.webContents.send('connector:event', { type: 'uninstalled', connectorId: id })
+
   return { ok: true }
 })
 

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -150,6 +150,9 @@ const api = {
     getCaptureCount: (connectorId: string): Promise<number> =>
       ipcRenderer.invoke('connector:get-capture-count', { connectorId }),
 
+    uninstall: (id: string): Promise<{ ok: boolean }> =>
+      ipcRenderer.invoke('connector:uninstall', { id }),
+
     onEvent: (cb: (event: { type: string; connectorId?: string; progress?: unknown; result?: unknown; code?: string; message?: string; name?: string; version?: string }) => void) => {
       const handler = (_: Electron.IpcRendererEvent, data: unknown) => cb(data as any)
       ipcRenderer.on('connector:event', handler)

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -140,6 +140,8 @@ export default function App() {
         if (toastTimer.current) clearTimeout(toastTimer.current)
         toastTimer.current = setTimeout(() => setConnectorToast(null), 4000)
         refreshCaptureSourcesRef.current()
+      } else if (event.type === 'uninstalled') {
+        refreshCaptureSourcesRef.current()
       }
     })
   }, [])

--- a/packages/app/src/renderer/components/SettingsPanel.tsx
+++ b/packages/app/src/renderer/components/SettingsPanel.tsx
@@ -475,6 +475,25 @@ function ConnectorsTab({ claudeCount, codexCount, geminiCount }: { claudeCount: 
             <p className="text-xs text-red-500">{syncError}</p>
           </div>
         )}
+
+        {/* Uninstall (hidden for bundled connectors) */}
+        {!selected.bundled && (
+          <button
+            onClick={async () => {
+              const count = connectorCounts[selected.id] ?? 0
+              const msg = count > 0
+                ? `Uninstall "${selected.label}"?\n\nThis will permanently delete ${count} synced item${count === 1 ? '' : 's'} and remove the connector. You can reinstall it later from spool.pro/connectors.`
+                : `Uninstall "${selected.label}"?\n\nThis will remove the connector. You can reinstall it later from spool.pro/connectors.`
+              if (!confirm(msg)) return
+              await window.spool?.connectors.uninstall(selected.id)
+              setSelectedId(null)
+              await loadConnectors()
+            }}
+            className="w-full py-2 text-xs font-medium text-red-500 border border-red-500/20 rounded-[8px] hover:bg-red-500/10 transition-colors"
+          >
+            Uninstall
+          </button>
+        )}
       </div>
     )
   }

--- a/packages/core/src/connectors/npm-install.ts
+++ b/packages/core/src/connectors/npm-install.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, createWriteStream } from 'node:fs'
+import { mkdirSync, createWriteStream, existsSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import { tmpdir } from 'node:os'
@@ -76,4 +76,23 @@ export async function downloadAndInstall(
   await tar.extract({ file: tmpPath, cwd: installPath, strip: 1 })
 
   return { name: info.name, version: info.version, installPath }
+}
+
+export function uninstallConnector(
+  packageName: string,
+  connectorsDir: string,
+): void {
+  const nameSegments = packageName.startsWith('@') ? packageName.split('/') : [packageName]
+  const installPath = join(connectorsDir, 'node_modules', ...nameSegments)
+
+  rmSync(installPath, { recursive: true, force: true })
+
+  // Prevent bundled connectors from being re-extracted on next startup
+  const doNotRestorePath = join(connectorsDir, '.do-not-restore')
+  const lines = existsSync(doNotRestorePath)
+    ? readFileSync(doNotRestorePath, 'utf8').split('\n').map(l => l.trim()).filter(Boolean)
+    : []
+  const entries = new Set(lines)
+  entries.add(packageName)
+  writeFileSync(doNotRestorePath, [...entries].join('\n') + '\n')
 }

--- a/packages/core/src/connectors/registry.ts
+++ b/packages/core/src/connectors/registry.ts
@@ -23,6 +23,10 @@ export class ConnectorRegistry {
     return this.connectors.has(id)
   }
 
+  remove(id: string): boolean {
+    return this.connectors.delete(id)
+  }
+
   list(): Connector[] {
     return Array.from(this.connectors.values())
   }

--- a/packages/core/src/connectors/sync-scheduler.ts
+++ b/packages/core/src/connectors/sync-scheduler.ts
@@ -129,6 +129,7 @@ export class SyncScheduler {
         color: c.color,
         enabled: state.enabled,
         syncing: this.running.has(c.id),
+        bundled: false,
         state,
       }
     })

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -156,6 +156,7 @@ export interface ConnectorStatus {
   color: string
   enabled: boolean
   syncing: boolean
+  bundled: boolean
   state: SyncState
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,7 +35,7 @@ export type {
   SchedulerStatus,
 } from './connectors/types.js'
 
-export { downloadAndInstall, resolveNpmPackage, registryUrl } from './connectors/npm-install.js'
+export { downloadAndInstall, uninstallConnector, resolveNpmPackage, registryUrl } from './connectors/npm-install.js'
 
 // ── Plugin loader ──────────────────────────────────────────────────────────
 export { loadConnectors } from './connectors/loader.js'


### PR DESCRIPTION
## Summary

- Add Uninstall button to connector detail view in Settings
- Confirmation dialog shows synced item count and warns data will be deleted
- Uninstall removes: package files, registry entry, captures, sync state
- Bundled connectors marked in `.do-not-restore` to prevent re-extraction
- Source pills on home screen refresh after uninstall

## Changes

| File | Change |
|------|--------|
| `registry.ts` | Add `remove()` method |
| `npm-install.ts` | Add `uninstallConnector()` |
| `main/index.ts` | `connector:uninstall` IPC handler |
| `preload/index.ts` | Expose `uninstall()` API |
| `SettingsPanel.tsx` | Uninstall button with confirmation |
| `App.tsx` | Refresh pills on `uninstalled` event |

## Test plan

- [x] Install HN connector via spool.pro
- [x] Verify Uninstall button appears in connector detail
- [x] Click Uninstall — confirm dialog shows item count
- [x] After uninstall: connector gone from list, pill gone from home, data deleted from DB
- [x] Restart app — connector stays uninstalled (`.do-not-restore`)
- [x] Reinstall via spool.pro works after uninstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)