### PR TITLE
fix: bundled connectors not loaded in dev mode for fresh users

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -9,7 +9,7 @@
     "rebuild:native:electron": "electron-rebuild -f -w better-sqlite3",
     "build:core": "pnpm --filter @spool/core build",
     "prebuild:connectors": "bash ../../scripts/build-bundled-connectors.sh",
-    "dev": "pnpm run build:core && pnpm run rebuild:native && electron-vite dev",
+    "dev": "pnpm run build:core && bash ../../scripts/build-bundled-connectors.sh --build-only && pnpm run rebuild:native && electron-vite dev",
     "build": "pnpm run build:core && pnpm run prebuild:connectors && electron-vite build && electron-builder --publish never",
     "build:mac": "pnpm run build:core && pnpm run prebuild:connectors && electron-vite build && electron-builder --mac --arm64",
     "build:linux": "pnpm run build:core && pnpm run prebuild:connectors && electron-vite build && electron-builder --linux",
@@ -50,7 +50,9 @@
       {
         "from": "dist/bundled-connectors",
         "to": "bundled-connectors",
-        "filter": ["*.tgz"]
+        "filter": [
+          "*.tgz"
+        ]
       }
     ],
     "asarUnpack": [
@@ -129,6 +131,7 @@
     "electron-builder": "^26.0.12",
     "electron-vite": "^3.1.0",
     "tailwindcss": "^4.1.4",
-    "vite": "^6.3.3"
+    "vite": "^6.3.3",
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/app/src/main/dev-connectors.test.ts
+++ b/packages/app/src/main/dev-connectors.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, readlinkSync, lstatSync, rmSync, symlinkSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { readBundledList, ensureSymlink, linkDevConnectors } from './dev-connectors.js'
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'dev-connectors-test-'))
+}
+
+const tempDirs: string[] = []
+afterEach(() => {
+  for (const d of tempDirs) rmSync(d, { recursive: true, force: true })
+  tempDirs.length = 0
+})
+
+function tmp(): string {
+  const d = makeTempDir()
+  tempDirs.push(d)
+  return d
+}
+
+// ── readBundledList ──────────────────────────────────────────────────────────
+
+describe('readBundledList', () => {
+  it('parses single plugin', () => {
+    const dir = tmp()
+    const script = join(dir, 'build.sh')
+    writeFileSync(script, `
+FIRST_PARTY_PLUGINS=(
+  "@spool-lab/connector-twitter-bookmarks"
+)
+`)
+    expect(readBundledList(script)).toEqual(new Set(['@spool-lab/connector-twitter-bookmarks']))
+  })
+
+  it('parses multiple plugins', () => {
+    const dir = tmp()
+    const script = join(dir, 'build.sh')
+    writeFileSync(script, `
+FIRST_PARTY_PLUGINS=(
+  "@spool-lab/connector-twitter-bookmarks"
+  "@spool-lab/connector-hackernews-hot"
+)
+`)
+    expect(readBundledList(script)).toEqual(new Set([
+      '@spool-lab/connector-twitter-bookmarks',
+      '@spool-lab/connector-hackernews-hot',
+    ]))
+  })
+
+  it('returns empty set for missing file', () => {
+    expect(readBundledList('/nonexistent/path')).toEqual(new Set())
+  })
+
+  it('returns empty set for script without FIRST_PARTY_PLUGINS', () => {
+    const dir = tmp()
+    const script = join(dir, 'build.sh')
+    writeFileSync(script, 'echo hello')
+    expect(readBundledList(script)).toEqual(new Set())
+  })
+})
+
+// ── ensureSymlink ────────────────────────────────────────────────────────────
+
+describe('ensureSymlink', () => {
+  it('creates a symlink', () => {
+    const dir = tmp()
+    const target = join(dir, 'target')
+    mkdirSync(target)
+    const link = join(dir, 'link')
+
+    ensureSymlink(target, link)
+
+    expect(lstatSync(link).isSymbolicLink()).toBe(true)
+    expect(readlinkSync(link)).toBe(target)
+  })
+
+  it('is idempotent when target matches', () => {
+    const dir = tmp()
+    const target = join(dir, 'target')
+    mkdirSync(target)
+    const link = join(dir, 'link')
+
+    ensureSymlink(target, link)
+    ensureSymlink(target, link)
+
+    expect(readlinkSync(link)).toBe(target)
+  })
+
+  it('replaces symlink when target differs', () => {
+    const dir = tmp()
+    const oldTarget = join(dir, 'old')
+    const newTarget = join(dir, 'new')
+    mkdirSync(oldTarget)
+    mkdirSync(newTarget)
+    const link = join(dir, 'link')
+
+    symlinkSync(oldTarget, link)
+    ensureSymlink(newTarget, link)
+
+    expect(readlinkSync(link)).toBe(newTarget)
+  })
+
+  it('replaces regular directory with symlink', () => {
+    const dir = tmp()
+    const target = join(dir, 'target')
+    mkdirSync(target)
+    const link = join(dir, 'link')
+    mkdirSync(link)
+
+    ensureSymlink(target, link)
+
+    expect(lstatSync(link).isSymbolicLink()).toBe(true)
+    expect(readlinkSync(link)).toBe(target)
+  })
+})
+
+// ── linkDevConnectors ────────────────────────────────────────────────────────
+
+describe('linkDevConnectors', () => {
+  function setupWorkspace(dir: string, connectors: Array<{ name: string; id: string }>) {
+    // scripts/build-bundled-connectors.sh
+    mkdirSync(join(dir, 'scripts'), { recursive: true })
+    const pluginList = connectors
+      .filter(c => c.name === '@spool-lab/connector-twitter-bookmarks')
+      .map(c => `  "${c.name}"`)
+      .join('\n')
+    writeFileSync(join(dir, 'scripts', 'build-bundled-connectors.sh'), `
+FIRST_PARTY_PLUGINS=(
+${pluginList}
+)
+`)
+
+    // packages/connector-sdk
+    mkdirSync(join(dir, 'packages', 'connector-sdk'), { recursive: true })
+    writeFileSync(join(dir, 'packages', 'connector-sdk', 'package.json'), '{"name":"@spool/connector-sdk"}')
+
+    // packages/connectors/<name>
+    for (const c of connectors) {
+      const shortName = c.name.replace('@spool-lab/connector-', '')
+      const connDir = join(dir, 'packages', 'connectors', shortName)
+      mkdirSync(connDir, { recursive: true })
+      writeFileSync(join(connDir, 'package.json'), JSON.stringify({
+        name: c.name,
+        spool: { type: 'connector', id: c.id },
+      }))
+    }
+  }
+
+  it('only links bundled connectors', () => {
+    const workspace = tmp()
+    const spoolDir = tmp()
+
+    setupWorkspace(workspace, [
+      { name: '@spool-lab/connector-twitter-bookmarks', id: 'twitter-bookmarks' },
+      { name: '@spool-lab/connector-hackernews-hot', id: 'hackernews-hot' },
+      { name: '@spool-lab/connector-typeless', id: 'typeless' },
+    ])
+
+    linkDevConnectors(spoolDir, workspace)
+
+    const nm = join(spoolDir, 'connectors', 'node_modules', '@spool-lab')
+    // twitter-bookmarks should be linked
+    expect(lstatSync(join(nm, 'connector-twitter-bookmarks')).isSymbolicLink()).toBe(true)
+    // others should NOT exist
+    expect(() => lstatSync(join(nm, 'connector-hackernews-hot'))).toThrow()
+    expect(() => lstatSync(join(nm, 'connector-typeless'))).toThrow()
+  })
+
+  it('symlinks connector-sdk for peer dep resolution', () => {
+    const workspace = tmp()
+    const spoolDir = tmp()
+
+    setupWorkspace(workspace, [
+      { name: '@spool-lab/connector-twitter-bookmarks', id: 'twitter-bookmarks' },
+    ])
+
+    linkDevConnectors(spoolDir, workspace)
+
+    const sdkLink = join(spoolDir, 'connectors', 'node_modules', '@spool', 'connector-sdk')
+    expect(lstatSync(sdkLink).isSymbolicLink()).toBe(true)
+    expect(readlinkSync(sdkLink)).toBe(join(workspace, 'packages', 'connector-sdk'))
+  })
+
+  it('no-ops when workspace has no connectors dir', () => {
+    const workspace = tmp()
+    const spoolDir = tmp()
+
+    // No packages/connectors dir
+    linkDevConnectors(spoolDir, workspace)
+
+    expect(() => lstatSync(join(spoolDir, 'connectors'))).toThrow()
+  })
+})

--- a/packages/app/src/main/dev-connectors.ts
+++ b/packages/app/src/main/dev-connectors.ts
@@ -1,0 +1,58 @@
+import { existsSync, lstatSync, mkdirSync, readFileSync, readlinkSync, readdirSync, rmSync, symlinkSync } from 'node:fs'
+import { join } from 'node:path'
+
+export function readBundledList(scriptPath: string): Set<string> {
+  try {
+    const content = readFileSync(scriptPath, 'utf8')
+    const match = content.match(/FIRST_PARTY_PLUGINS=\(([\s\S]*?)\)/)
+    if (!match) return new Set()
+    const names = match[1]!.match(/"([^"]+)"/g)?.map(s => s.slice(1, -1)) ?? []
+    return new Set(names)
+  } catch {
+    return new Set()
+  }
+}
+
+export function ensureSymlink(target: string, linkPath: string): void {
+  try {
+    const stat = lstatSync(linkPath)
+    if (stat.isSymbolicLink() && readlinkSync(linkPath) === target) return
+    rmSync(linkPath, { recursive: true, force: true })
+  } catch {
+    // Doesn't exist, proceed
+  }
+  symlinkSync(target, linkPath)
+}
+
+export function linkDevConnectors(spoolDir: string, workspaceRoot: string): void {
+  const connectorsParent = join(workspaceRoot, 'packages', 'connectors')
+  if (!existsSync(connectorsParent)) return
+
+  const bundled = readBundledList(join(workspaceRoot, 'scripts', 'build-bundled-connectors.sh'))
+  if (bundled.size === 0) return
+
+  const nodeModules = join(spoolDir, 'connectors', 'node_modules')
+
+  const sdkSource = join(workspaceRoot, 'packages', 'connector-sdk')
+  const sdkScopeDir = join(nodeModules, '@spool')
+  mkdirSync(sdkScopeDir, { recursive: true })
+  ensureSymlink(sdkSource, join(sdkScopeDir, 'connector-sdk'))
+
+  for (const entry of readdirSync(connectorsParent)) {
+    const pkgDir = join(connectorsParent, entry)
+    const pkgJsonPath = join(pkgDir, 'package.json')
+    if (!existsSync(pkgJsonPath)) continue
+
+    let pkg: any
+    try { pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8')) } catch { continue }
+    if (pkg?.spool?.type !== 'connector') continue
+    if (!bundled.has(pkg.name)) continue
+
+    const name: string = pkg.name
+    const segments = name.startsWith('@') ? name.split('/') : [name]
+    const linkPath = join(nodeModules, ...segments)
+    mkdirSync(join(nodeModules, ...segments.slice(0, -1)), { recursive: true })
+    ensureSymlink(pkgDir, linkPath)
+    console.log(`[dev] linked bundled connector ${name}`)
+  }
+}

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, dialog, ipcMain, Menu, Notification, nativeTheme, nativeImage, net, powerMonitor } from 'electron'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { homedir } from 'node:os'
 import { readdirSync, readFileSync, existsSync } from 'node:fs'
 import { Worker } from 'node:worker_threads'
@@ -18,6 +18,7 @@ import { setupTray } from './tray.js'
 import { AcpManager } from './acp.js'
 import { setupAutoUpdater, downloadUpdate, quitAndInstall } from './updater.js'
 import { openTerminal } from './terminal.js'
+import { linkDevConnectors } from './dev-connectors.js'
 import { getSessionResumeCommand } from '../shared/resumeCommand.js'
 import { resolveResumeWorkingDirectory } from './sessionResume.js'
 import { loadUIPreferences, saveThemeEditor, saveThemeSource } from './uiPreferences.js'
@@ -372,6 +373,10 @@ app.whenReady().then(async () => {
 
   spoolDir = join(homedir(), '.spool')
   trustStore = new TrustStore(spoolDir)
+
+  if (isDev) {
+    linkDevConnectors(spoolDir, resolve(process.cwd(), '../..'))
+  }
 
   const loadReport = await loadConnectors({
     bundledConnectorsDir,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       vite:
         specifier: ^6.3.3
         version: 6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@22.19.17)(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
 
   packages/cli:
     dependencies:
@@ -1624,6 +1627,9 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
@@ -1635,20 +1641,46 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
@@ -1949,6 +1981,10 @@ packages:
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chalk@4.1.2:
@@ -2363,6 +2399,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -3422,6 +3461,9 @@ packages:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
 
@@ -3934,6 +3976,9 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
@@ -4055,6 +4100,10 @@ packages:
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -4355,6 +4404,47 @@ packages:
       '@types/node':
         optional: true
       '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -5858,9 +5948,26 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
   '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
+
+  '@vitest/mocker@4.1.4(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -5870,11 +5977,20 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
   '@vitest/runner@3.2.4':
     dependencies:
       '@vitest/utils': 3.2.4
       pathe: 2.0.3
       strip-literal: 3.1.0
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
 
   '@vitest/snapshot@3.2.4':
     dependencies:
@@ -5882,15 +5998,30 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
+
+  '@vitest/spy@4.1.4': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@xmldom/xmldom@0.8.11': {}
 
@@ -6349,6 +6480,8 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -6770,6 +6903,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -8310,6 +8445,8 @@ snapshots:
   object-keys@1.1.1:
     optional: true
 
+  obug@2.1.1: {}
+
   ofetch@1.5.1:
     dependencies:
       destr: 2.0.5
@@ -8981,6 +9118,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  std-env@4.0.0: {}
+
   stream-replace-string@2.0.0: {}
 
   string-width@4.2.3:
@@ -9124,6 +9263,8 @@ snapshots:
   tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.4: {}
 
@@ -9407,6 +9548,33 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vitest@4.1.4(@types/node@22.19.17)(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - msw
 
   wcwidth@1.0.1:
     dependencies:

--- a/scripts/build-bundled-connectors.sh
+++ b/scripts/build-bundled-connectors.sh
@@ -13,19 +13,30 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="$REPO_ROOT/packages/app/dist/bundled-connectors"
+BUILD_ONLY=false
+if [[ "${1:-}" == "--build-only" ]]; then
+  BUILD_ONLY=true
+fi
 
 FIRST_PARTY_PLUGINS=(
   "@spool-lab/connector-twitter-bookmarks"
 )
+
+for plugin in "${FIRST_PARTY_PLUGINS[@]}"; do
+  echo "==> Building $plugin"
+  pnpm --filter "$plugin" build
+done
+
+if [[ "$BUILD_ONLY" == true ]]; then
+  echo "==> Build-only mode, skipping pack"
+  exit 0
+fi
 
 echo "==> Preparing $OUT_DIR"
 mkdir -p "$OUT_DIR"
 rm -f "$OUT_DIR"/*.tgz
 
 for plugin in "${FIRST_PARTY_PLUGINS[@]}"; do
-  echo "==> Building $plugin"
-  pnpm --filter "$plugin" build
-
   echo "==> Packing $plugin"
   pkg_dir="$(pnpm --filter "$plugin" exec pwd)"
   (cd "$pkg_dir" && pnpm pack --pack-destination "$OUT_DIR")


### PR DESCRIPTION
## Summary

- When a new developer clones the repo and runs `pnpm run dev`, bundled connectors (e.g. X Bookmarks) appeared under **Available Connectors** instead of **Data Sources**, because the dev script never built or extracted bundled connector tarballs into `~/.spool/connectors/`
- In dev mode, workspace connector packages are now symlinked directly into the connectors dir, so the existing loader discovers them without tarballs
- Only connectors listed in `FIRST_PARTY_PLUGINS` (in `build-bundled-connectors.sh`) are linked — single source of truth for both dev and production
- Added `--build-only` flag to `build-bundled-connectors.sh` so the dev script can build connector `dist/` without packing tarballs

## Test plan

- [x] Fresh dev environment (`rm -rf ~/.spool/connectors`): X Bookmarks shows in Data Sources, HN/Typeless in Available
- [x] Production build (`pnpm run build:mac`): app installs and shows same correct layout
- [x] Unit tests: 11 cases covering `readBundledList`, `ensureSymlink`, `linkDevConnectors`
- [x] Idempotent: re-running dev doesn't duplicate or break symlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)