### PR TITLE
fix: compact Available Connectors row layout

### DIFF
--- a/packages/app/src/renderer/components/SettingsPanel.tsx
+++ b/packages/app/src/renderer/components/SettingsPanel.tsx
@@ -740,10 +740,12 @@ function ConnectorsTab({ claudeCount, codexCount, geminiCount }: { claudeCount: 
                 style={{ background: pkg.color }}
               />
               <div className="flex-1 min-w-0 leading-4">
-                <span className="text-xs text-warm-muted dark:text-dark-muted">{pkg.label}</span>
-                {meta && (
-                  <span className="text-[11px] text-warm-faint dark:text-dark-muted ml-2">{meta}</span>
-                )}
+                <div className="flex items-baseline gap-2 min-w-0">
+                  <span className="text-xs text-warm-muted dark:text-dark-muted flex-none">{pkg.label}</span>
+                  {meta && (
+                    <span className="text-[11px] text-warm-faint dark:text-dark-muted truncate min-w-0" title={meta}>{meta}</span>
+                  )}
+                </div>
                 {installErrors[pkg.name] && installingPackage !== pkg.name && (
                   <div className="text-[10px] text-red-400 mt-0.5">{installErrors[pkg.name]}</div>
                 )}

--- a/packages/app/src/renderer/components/SettingsPanel.tsx
+++ b/packages/app/src/renderer/components/SettingsPanel.tsx
@@ -729,43 +729,35 @@ function ConnectorsTab({ claudeCount, codexCount, geminiCount }: { claudeCount: 
         {!registryLoading && !registryError && discoverPackages.length === 0 && (
           <p className="text-[11px] text-warm-faint dark:text-dark-muted">All connectors installed</p>
         )}
-        {!registryLoading && !registryError && discoverPackages.map(pkg => (
-          <div
-            key={pkg.name}
-            className="flex items-center gap-3 py-2.5"
-          >
-            <span
-              className="w-2 h-2 rounded-full flex-none opacity-50"
-              style={{ background: pkg.color }}
-            />
-            <div className="flex-1 min-w-0 leading-4">
-              <span className="text-xs text-warm-muted dark:text-dark-muted">{pkg.label}</span>
-              {pkg.subs.length > 1 ? (
-                <div className="mt-1 space-y-0.5">
-                  {pkg.subs.map((sub, i) => (
-                    <div key={i} className="flex items-baseline gap-1.5 text-[11px]">
-                      <span className="text-warm-faint dark:text-dark-faint">·</span>
-                      <span className="text-warm-muted dark:text-dark-muted">{stripLabelPrefix(sub.label, pkg.label)}</span>
-                      <span className="text-warm-faint dark:text-dark-faint">{sub.description}</span>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <span className="text-[11px] text-warm-faint dark:text-dark-faint ml-2">{pkg.description}</span>
-              )}
-              {installErrors[pkg.name] && installingPackage !== pkg.name && (
-                <div className="text-[10px] text-red-400 mt-0.5">{installErrors[pkg.name]}</div>
-              )}
+        {!registryLoading && !registryError && discoverPackages.map(pkg => {
+          const meta = pkg.subs.length > 1
+            ? pkg.subs.map(s => stripLabelPrefix(s.label, pkg.label)).join(', ')
+            : pkg.description
+          return (
+            <div key={pkg.name} className="flex items-center gap-3 py-2.5">
+              <span
+                className="w-2 h-2 rounded-full flex-none opacity-50"
+                style={{ background: pkg.color }}
+              />
+              <div className="flex-1 min-w-0 leading-4">
+                <span className="text-xs text-warm-muted dark:text-dark-muted">{pkg.label}</span>
+                {meta && (
+                  <span className="text-[11px] text-warm-faint dark:text-dark-muted ml-2">{meta}</span>
+                )}
+                {installErrors[pkg.name] && installingPackage !== pkg.name && (
+                  <div className="text-[10px] text-red-400 mt-0.5">{installErrors[pkg.name]}</div>
+                )}
+              </div>
+              <button
+                onClick={() => handleInstall(pkg.name)}
+                disabled={installingPackage === pkg.name}
+                className="text-[11px] font-medium text-accent dark:text-accent-dark hover:underline disabled:opacity-50 flex-none"
+              >
+                {installingPackage === pkg.name ? 'Installing…' : 'Install'}
+              </button>
             </div>
-            <button
-              onClick={() => handleInstall(pkg.name)}
-              disabled={installingPackage === pkg.name}
-              className="text-[11px] font-medium text-accent dark:text-accent-dark hover:underline disabled:opacity-50 flex-none"
-            >
-              {installingPackage === pkg.name ? 'Installing…' : 'Install'}
-            </button>
-          </div>
-        ))}
+          )
+        })}
       </Section>
 
       {syncError && (


### PR DESCRIPTION
## Summary
- Render Available Connectors rows in a compact single-line layout matching the Data Sources group style above
- Join sub-connectors into a comma-separated faint meta line; drop the multi-row `· Stars` / `· Notifications` rendering
- Fix the leading dot misalignment when a package has multiple sub-connectors
- Truncate long meta (long descriptions or many sub-connectors) to a single line with ellipsis so the Install button never gets pushed

## Test plan
- [x] Local `pnpm -F @spool/app dev`, open Settings → Connectors and check the Available Connectors section
- [x] Verified both single-sub (shows description) and multi-sub (shows comma-joined sub labels) cases
- [x] Verified long-description and many-sub-connector rows truncate cleanly with a tooltip for full text

🤖 Generated with [Claude Code](https://claude.com/claude-code)