### PR TITLE
feat: add dev-install script for macOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,16 @@ pnpm run rebuild:native:electron  # Electron app / Playwright e2e
 
 If you hit a `NODE_MODULE_VERSION` mismatch, rerun the matching rebuild command and try again.
 
+## Installing a local build (macOS)
+
+To test a production build of the app locally — builds, installs to `/Applications/Spool.app`, and launches it:
+
+```bash
+pnpm dev:install:mac
+```
+
+Requires Apple Silicon. The script quits any running Spool instance before replacing the bundle and strips the quarantine attribute so Gatekeeper doesn't block the unsigned local build.
+
 ## Project structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "rebuild:native:electron": "pnpm --filter @spool/app run rebuild:native:electron",
     "lint": "turbo lint",
     "clean": "turbo clean",
-    "check:phantom-independence": "scripts/phantom-independence-check.sh"
+    "check:phantom-independence": "scripts/phantom-independence-check.sh",
+    "dev:install:mac": "scripts/dev-install-mac.sh"
   },
   "devDependencies": {
     "turbo": "^2.9.6",

--- a/scripts/dev-install-mac.sh
+++ b/scripts/dev-install-mac.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build Spool from source and install it into /Applications.
+# Intended for developer machines (Apple Silicon, unsigned local builds).
+# Run from repo root: bash scripts/dev-install-mac.sh
+
+[[ "$(uname)" == "Darwin" ]] || { echo "dev-install-mac: macOS only"; exit 1; }
+[[ "$(uname -m)" == "arm64" ]] || { echo "dev-install-mac: Apple Silicon only"; exit 1; }
+
+cd "$(dirname "$0")/.."
+
+APP_NAME="Spool"
+DEST="/Applications/${APP_NAME}.app"
+BUILT="packages/app/dist/mac-arm64/${APP_NAME}.app"
+
+echo "==> Quitting running ${APP_NAME}…"
+osascript -e "quit app \"${APP_NAME}\"" 2>/dev/null || true
+
+echo "==> Building (pnpm -F @spool/app build:mac)…"
+pnpm -F @spool/app build:mac
+
+[[ -d "$BUILT" ]] || { echo "dev-install-mac: build output not found at $BUILT"; exit 1; }
+
+echo "==> Installing to ${DEST}…"
+rm -rf "$DEST"
+cp -R "$BUILT" "$DEST"
+
+# Unsigned local builds trigger Gatekeeper; strip quarantine so `open` just works.
+xattr -rd com.apple.quarantine "$DEST" 2>/dev/null || true
+
+echo "==> Launching…"
+open "$DEST"


### PR DESCRIPTION
## Summary
Add a one-shot developer workflow for building and installing Spool from source on Apple Silicon macs, so contributors can quickly smoke-test a production build without copy-pasting commands.

- `scripts/dev-install-mac.sh` — builds via `pnpm -F @spool/app build:mac`, quits any running Spool, replaces `/Applications/Spool.app`, strips the `com.apple.quarantine` attribute (unsigned local builds would otherwise be blocked by Gatekeeper), then launches the app.
- `pnpm dev:install:mac` shortcut added to the root `package.json`.
- `CONTRIBUTING.md` gets a short section explaining when to use it.

## Design notes
- **Platform-specific naming on purpose.** The script is explicitly `dev-install-mac.sh` rather than a cross-platform script with `uname` branching. All current contributors are on macOS; a sibling `dev-install-linux.sh` can be added when we onboard a Linux developer, without touching the mac path.
- **Apple Silicon only.** Matches the existing `build:mac` target (`--arm64`). Fails fast with a clear error on Intel or non-Darwin.
- Not wired into CI — this is a local DX tool, not a release artifact. The production installer for end users still lives at `packages/landing/public/install.sh` and is unaffected.

## Test plan
- [x] Run `pnpm dev:install:mac` on a clean checkout on an M-series mac
- [x] Verify `/Applications/Spool.app` is replaced and launches without a Gatekeeper prompt
- [x] Re-run with Spool already open — it should quit and relaunch cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)