### PR TITLE
feat: connector prerequisites system + Xiaohongshu connector

### DIFF
--- a/packages/app/electron.vite.config.ts
+++ b/packages/app/electron.vite.config.ts
@@ -4,7 +4,9 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import type { Plugin } from 'vite'
 
-const coreAlias = { '@spool/core': resolve(__dirname, '../core/dist/index.js') }
+const coreAlias = {
+  '@spool/core': resolve(__dirname, '../core/dist/index.js'),
+}
 
 // better-sqlite3 uses 'bindings' at runtime to locate the .node native addon.
 // It must NOT be bundled — it must stay as a real require() in the output.
@@ -37,7 +39,7 @@ export default defineConfig({
     resolve: { alias: coreAlias },
   },
   preload: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [externalizeDepsPlugin({ exclude: ['@spool/core'] })],
     build: {
       rollupOptions: {
         input: { index: resolve(__dirname, 'src/preload/index.ts') },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -31,6 +31,7 @@
     "bindings": "^1.5.0",
     "electron-updater": "^6.8.3",
     "file-uri-to-path": "^2.0.0",
+    "lucide-react": "^1.8.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "ws": "^8.20.0",

--- a/packages/app/src/main/dev-connectors.ts
+++ b/packages/app/src/main/dev-connectors.ts
@@ -24,6 +24,37 @@ export function ensureSymlink(target: string, linkPath: string): void {
   symlinkSync(target, linkPath)
 }
 
+/**
+ * Try to install a connector package from the workspace by symlinking.
+ * Returns the resolved name+version on success, or null if the package
+ * isn't in the workspace (caller should fall through to npm install).
+ */
+export function installFromWorkspace(
+  packageName: string,
+  spoolDir: string,
+  workspaceRoot: string,
+): { name: string; version: string } | null {
+  const connectorsParent = join(workspaceRoot, 'packages', 'connectors')
+  if (!existsSync(connectorsParent)) return null
+
+  for (const entry of readdirSync(connectorsParent)) {
+    const pkgDir = join(connectorsParent, entry)
+    const pkgJsonPath = join(pkgDir, 'package.json')
+    if (!existsSync(pkgJsonPath)) continue
+    let pkg: { name?: string; version?: string; spool?: { type?: string } }
+    try { pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8')) } catch { continue }
+    if (pkg.name !== packageName || pkg.spool?.type !== 'connector') continue
+
+    const nodeModules = join(spoolDir, 'connectors', 'node_modules')
+    const segments = packageName.startsWith('@') ? packageName.split('/') : [packageName]
+    mkdirSync(join(nodeModules, ...segments.slice(0, -1)), { recursive: true })
+    ensureSymlink(pkgDir, join(nodeModules, ...segments))
+    console.log(`[dev] symlinked workspace connector ${packageName}`)
+    return { name: packageName, version: pkg.version ?? '0.0.0' }
+  }
+  return null
+}
+
 export function linkDevConnectors(spoolDir: string, workspaceRoot: string): void {
   const connectorsParent = join(workspaceRoot, 'packages', 'connectors')
   if (!existsSync(connectorsParent)) return

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -503,18 +503,19 @@ app.whenReady().then(async () => {
   mainWindow = createWindow()
 
   mainWindow.on('focus', () => {
+    // Always re-check on focus, including for packages that are currently
+    // all-ok — extensions can be removed and CLIs uninstalled without our
+    // knowledge, and skipping the recheck would leave stale green status
+    // until the user manually clicks Re-check.
     for (const pkg of connectorRegistry.listPackages()) {
-      const cached = prerequisiteChecker.getCached(pkg.id)
-      if (!cached || cached.some(s => s.status !== 'ok')) {
-        const before = cached
-        prerequisiteChecker.check(pkg).then((after) => {
-          const changed = !before || before.length !== after.length ||
-            before.some((s, i) => s.status !== after[i]?.status)
-          if (changed) {
-            mainWindow?.webContents.send('connector:status-changed', { packageId: pkg.id })
-          }
-        }).catch(() => undefined)
-      }
+      const before = prerequisiteChecker.getCached(pkg.id)
+      prerequisiteChecker.check(pkg).then((after) => {
+        const changed = !before || before.length !== after.length ||
+          before.some((s, i) => s.status !== after[i]?.status)
+        if (changed) {
+          mainWindow?.webContents.send('connector:status-changed', { packageId: pkg.id })
+        }
+      }).catch(() => undefined)
     }
   })
 
@@ -834,6 +835,7 @@ ipcMain.handle('connector:list', (): ConnectorStatus[] => {
   }
   const result = syncScheduler.getStatus().connectors.map(c => {
     const pkgId = connIdToPackageId.get(c.id)
+    const pkg = pkgId ? connectorRegistry.getPackage(pkgId) : undefined
     const cached = pkgId ? prerequisiteChecker?.getCached(pkgId) : undefined
     const status: ConnectorStatus = {
       ...c,
@@ -842,7 +844,23 @@ ipcMain.handle('connector:list', (): ConnectorStatus[] => {
       packageName: pkgNameMap.get(c.id) ?? '',
     }
     if (pkgId !== undefined) status.packageId = pkgId
-    if (cached !== undefined) status.setup = cached
+    // Always send a setup array when the package declares prerequisites, so
+    // the UI can render the prereq card immediately. If we haven't checked
+    // yet, fill with pending steps from the manifest so the user sees the
+    // structure right away rather than nothing-then-flash.
+    if (cached !== undefined) {
+      status.setup = cached
+    } else if (pkg?.prerequisites && pkg.prerequisites.length > 0) {
+      status.setup = pkg.prerequisites.map(p => ({
+        id: p.id,
+        label: p.name,
+        kind: p.kind,
+        status: 'pending' as const,
+        ...(p.minVersion !== undefined ? { minVersion: p.minVersion } : {}),
+        ...(p.install ? { install: p.install } : {}),
+        ...(p.docsUrl ? { docsUrl: p.docsUrl } : {}),
+      }))
+    }
     return status
   })
   // Kick off background prereq checks for packages not yet cached so the

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -1,7 +1,8 @@
-import { app, BrowserWindow, dialog, ipcMain, Menu, Notification, nativeTheme, nativeImage, net, powerMonitor } from 'electron'
+import { app, BrowserWindow, clipboard, dialog, ipcMain, Menu, Notification, nativeTheme, nativeImage, net, powerMonitor, shell } from 'electron'
 import { join, resolve } from 'node:path'
 import { homedir } from 'node:os'
 import { readdirSync, readFileSync, existsSync } from 'node:fs'
+import { spawn, type ChildProcess } from 'node:child_process'
 import { Worker } from 'node:worker_threads'
 import {
   getDB, Syncer, SpoolWatcher,
@@ -11,6 +12,7 @@ import {
   loadConnectors, makeFetchCapability, makeChromeCookiesCapability, makeLogCapabilityFor, makeSqliteCapability, makeExecCapability,
   TrustStore, downloadAndInstall, uninstallConnector, resolveNpmPackage, checkForUpdates,
   fetchRegistry,
+  PrerequisiteChecker,
 } from '@spool/core'
 import type { UpdateInfo } from '@spool/core'
 import type { AuthStatus, ConnectorStatus, FragmentResult, SchedulerEvent, SearchResult, SessionSource } from '@spool/core'
@@ -18,7 +20,7 @@ import { setupTray } from './tray.js'
 import { AcpManager } from './acp.js'
 import { setupAutoUpdater, downloadUpdate, quitAndInstall } from './updater.js'
 import { openTerminal } from './terminal.js'
-import { linkDevConnectors } from './dev-connectors.js'
+import { linkDevConnectors, installFromWorkspace } from './dev-connectors.js'
 import { getSessionResumeCommand } from '../shared/resumeCommand.js'
 import { resolveResumeWorkingDirectory } from './sessionResume.js'
 import { loadUIPreferences, saveThemeEditor, saveThemeSource } from './uiPreferences.js'
@@ -69,6 +71,26 @@ let proxyFetch: typeof globalThis.fetch
 let spoolDir: string
 const bundledConnectorIds = new Set<string>()
 let updateCache = new Map<string, UpdateInfo>()
+let prerequisiteChecker: PrerequisiteChecker
+let execCapabilityImpl: ReturnType<typeof makeExecCapability>
+const runningInstalls = new Map<string, ChildProcess>()
+
+function makePrerequisitesFor(registry: ConnectorRegistry, checker: PrerequisiteChecker) {
+  return (packageId: string) => ({
+    check: () => {
+      const pkg = registry.getPackage(packageId)
+      if (!pkg) throw new Error(`Package "${packageId}" not found in registry`)
+      return checker.check(pkg)
+    },
+  })
+}
+
+function killChildWithEscalation(child: ChildProcess): void {
+  child.kill('SIGTERM')
+  setTimeout(() => {
+    if (!child.killed) child.kill('SIGKILL')
+  }, 5000)
+}
 
 type CachedSearchValue = SearchResult[] | FragmentResult[]
 
@@ -188,7 +210,12 @@ function installConnectorPackage(
   return withConnectorLock(async () => {
     try {
       const connectorsDir = join(spoolDir, 'connectors')
-      const result = await downloadAndInstall(packageName, connectorsDir, fetch)
+      // Dev-mode: if the package lives in this workspace, symlink it instead
+      // of hitting npm. Lets us test connectors before they're published.
+      const workspaceResult = !app.isPackaged
+        ? installFromWorkspace(packageName, spoolDir, resolve(process.cwd(), '..', '..'))
+        : null
+      const result = workspaceResult ?? await downloadAndInstall(packageName, connectorsDir, fetch)
 
       const isFirstParty = packageName.startsWith('@spool-lab/')
       if (!isFirstParty && trustStore) {
@@ -402,6 +429,9 @@ app.whenReady().then(async () => {
   spoolDir = join(homedir(), '.spool')
   trustStore = new TrustStore(spoolDir)
 
+  execCapabilityImpl = makeExecCapability()
+  prerequisiteChecker = new PrerequisiteChecker(execCapabilityImpl)
+
   if (isDev) {
     linkDevConnectors(spoolDir, resolve(process.cwd(), '../..'))
   }
@@ -413,8 +443,9 @@ app.whenReady().then(async () => {
       fetch: makeFetchCapability(proxyFetch),
       cookies: makeChromeCookiesCapability(),
       sqlite: makeSqliteCapability(),
-      exec: makeExecCapability(),
+      exec: execCapabilityImpl,
       logFor: (connectorId: string) => makeLogCapabilityFor(connectorId),
+      prerequisitesFor: makePrerequisitesFor(connectorRegistry, prerequisiteChecker),
     },
     registry: connectorRegistry,
     log: {
@@ -470,6 +501,22 @@ app.whenReady().then(async () => {
   })
 
   mainWindow = createWindow()
+
+  mainWindow.on('focus', () => {
+    for (const pkg of connectorRegistry.listPackages()) {
+      const cached = prerequisiteChecker.getCached(pkg.id)
+      if (!cached || cached.some(s => s.status !== 'ok')) {
+        const before = cached
+        prerequisiteChecker.check(pkg).then((after) => {
+          const changed = !before || before.length !== after.length ||
+            before.some((s, i) => s.status !== after[i]?.status)
+          if (changed) {
+            mainWindow?.webContents.send('connector:status-changed', { packageId: pkg.id })
+          }
+        }).catch(() => undefined)
+      }
+    }
+  })
 
   // Auto-updater (only runs in packaged builds)
   setupAutoUpdater(() => mainWindow)
@@ -565,8 +612,9 @@ async function reloadConnectors(): Promise<void> {
       fetch: makeFetchCapability(proxyFetch),
       cookies: makeChromeCookiesCapability(),
       sqlite: makeSqliteCapability(),
-      exec: makeExecCapability(),
+      exec: execCapabilityImpl,
       logFor: (id: string) => makeLogCapabilityFor(id),
+      prerequisitesFor: makePrerequisitesFor(connectorRegistry, prerequisiteChecker),
     },
     registry: connectorRegistry,
     log: {
@@ -583,6 +631,33 @@ async function runConnectorUpdateCheck(): Promise<{ updates: Map<string, UpdateI
   if (installed.length === 0) return { updates: new Map(), installed }
   updateCache = await checkForUpdates(installed, fetch)
   return { updates: updateCache, installed }
+}
+
+function pkgIdForConnector(connectorId: string): string | undefined {
+  for (const pkg of connectorRegistry.listPackages()) {
+    if (pkg.connectors.some(c => c.id === connectorId)) return pkg.id
+  }
+  return undefined
+}
+
+type ResolvedCli =
+  | { ok: true; pkg: ReturnType<ConnectorRegistry['getPackage']> & {}; command: string }
+  | { ok: false; reason: 'package-not-found' | 'not-cli-prereq' | 'no-command-for-platform' | 'requires-manual' }
+
+function stepsDiffer(a: import('@spool/core').SetupStep[] | undefined, b: import('@spool/core').SetupStep[]): boolean {
+  if (!a || a.length !== b.length) return true
+  return a.some((s, i) => s.status !== b[i]?.status)
+}
+
+function resolveCliPrereq(packageId: string, prereqId: string): ResolvedCli {
+  const pkg = connectorRegistry.getPackage(packageId)
+  if (!pkg) return { ok: false, reason: 'package-not-found' }
+  const p = (pkg.prerequisites ?? []).find(x => x.id === prereqId)
+  if (!p || p.install.kind !== 'cli') return { ok: false, reason: 'not-cli-prereq' }
+  const command = p.install.command[process.platform as 'darwin' | 'linux' | 'win32']
+  if (!command) return { ok: false, reason: 'no-command-for-platform' }
+  if (p.install.requiresManual || /\bsudo\b/.test(command)) return { ok: false, reason: 'requires-manual' }
+  return { ok: true, pkg, command }
 }
 
 // ── IPC Handlers ──────────────────────────────────────────────────────────────
@@ -751,12 +826,35 @@ ipcMain.handle('connector:list', (): ConnectorStatus[] => {
   const installed = getInstalledConnectorPackages()
   const versionMap = new Map(installed.map(p => [p.connectorId, p.currentVersion]))
   const pkgNameMap = new Map(installed.map(p => [p.connectorId, p.packageName]))
-  return syncScheduler.getStatus().connectors.map(c => ({
-    ...c,
-    bundled: bundledConnectorIds.has(c.id),
-    version: versionMap.get(c.id) ?? '0.0.0',
-    packageName: pkgNameMap.get(c.id) ?? '',
-  }))
+  const connIdToPackageId = new Map<string, string>()
+  for (const pkg of connectorRegistry.listPackages()) {
+    for (const c of pkg.connectors) {
+      connIdToPackageId.set(c.id, pkg.id)
+    }
+  }
+  const result = syncScheduler.getStatus().connectors.map(c => {
+    const pkgId = connIdToPackageId.get(c.id)
+    const cached = pkgId ? prerequisiteChecker?.getCached(pkgId) : undefined
+    const status: ConnectorStatus = {
+      ...c,
+      bundled: bundledConnectorIds.has(c.id),
+      version: versionMap.get(c.id) ?? '0.0.0',
+      packageName: pkgNameMap.get(c.id) ?? '',
+    }
+    if (pkgId !== undefined) status.packageId = pkgId
+    if (cached !== undefined) status.setup = cached
+    return status
+  })
+  // Kick off background prereq checks for packages not yet cached so the
+  // Setup card appears on first load without needing a focus event.
+  for (const pkg of connectorRegistry.listPackages()) {
+    if (pkg.prerequisites && pkg.prerequisites.length > 0 && !prerequisiteChecker.getCached(pkg.id)) {
+      prerequisiteChecker.check(pkg).then(() => {
+        mainWindow?.webContents.send('connector:status-changed', { packageId: pkg.id })
+      }).catch(() => undefined)
+    }
+  }
+  return result
 })
 
 ipcMain.handle('connector:check-auth', async (_e, { id }: { id: string }): Promise<AuthStatus> => {
@@ -793,6 +891,9 @@ ipcMain.handle('connector:uninstall', (_e, { id }: { id: string }) => {
   const packageName = pkg.packageName
   const siblings = allInstalled.filter(p => p.packageName === packageName)
 
+  // Resolve registry package id before removing from registry
+  const registryPkgId = pkgIdForConnector(id)
+
   // Registry + scheduler first: prevents the scheduler tick from re-queuing
   // syncs, and lets in-flight syncs wind down via the cancel signal.
   for (const sib of siblings) {
@@ -812,6 +913,8 @@ ipcMain.handle('connector:uninstall', (_e, { id }: { id: string }) => {
       () => db.prepare('DELETE FROM captures WHERE platform = ?').run(sib.platform),
     )
   }
+
+  if (registryPkgId) prerequisiteChecker.invalidate(registryPkgId)
 
   const removedIds = siblings.map(s => s.connectorId)
   mainWindow?.webContents.send('connector:event', {
@@ -869,9 +972,97 @@ ipcMain.handle('connector:get-capture-count', (_e, { connectorId }: { connectorI
 })
 
 ipcMain.handle('connector:fetch-registry', async () => {
-  return fetchRegistry({ fetchFn: (input, init) => net.fetch(input as any, init), cacheDir: spoolDir })
+  // Dev-mode override: read registry.json from the workspace so local edits
+  // show up without pushing to GitHub main. Set SPOOL_REGISTRY_URL to a file://
+  // URL, absolute path, or HTTP URL to override explicitly.
+  const override = process.env.SPOOL_REGISTRY_URL
+    ?? (!app.isPackaged ? join(process.cwd(), '../landing/public/registry.json') : undefined)
+  return fetchRegistry({
+    fetchFn: (input, init) => net.fetch(input as any, init),
+    cacheDir: spoolDir,
+    ...(override !== undefined && { url: override }),
+  })
 })
 
 ipcMain.handle('connector:install', async (_e, { packageName }: { packageName: string }) => {
   return installConnectorPackage(packageName)
+})
+
+ipcMain.handle('connector:recheck-prerequisites', async (_e, { packageId }: { packageId: string }) => {
+  const pkg = connectorRegistry.getPackage(packageId)
+  if (!pkg) return { ok: false, error: 'PACKAGE_NOT_FOUND' }
+  const before = prerequisiteChecker.getCached(packageId)
+  prerequisiteChecker.invalidate(packageId)
+  const setup = await prerequisiteChecker.check(pkg)
+  if (stepsDiffer(before, setup)) {
+    mainWindow?.webContents.send('connector:status-changed', { packageId })
+  }
+  return { ok: true, setup }
+})
+
+type InstallResult =
+  | { ok: true; installId: string; exitCode: number }
+  | { ok: false; reason: 'requires-manual' }
+  | { ok: false; reason: 'package-not-found' }
+  | { ok: false; reason: 'not-cli-prereq' }
+  | { ok: false; reason: 'no-command-for-platform' }
+  | { ok: false; reason: 'install-failed'; exitCode: number; errorMessage: string }
+
+ipcMain.handle('connector:install-cli', async (_e, { packageId, prereqId, installId: providedInstallId }: { packageId: string; prereqId: string; installId?: string }) => {
+  const resolved = resolveCliPrereq(packageId, prereqId)
+  if (!resolved.ok) return { ok: false, reason: resolved.reason } satisfies InstallResult
+
+  const { pkg, command } = resolved
+  const installId = providedInstallId ?? `${packageId}::${prereqId}::${Date.now()}`
+  const isWin = process.platform === 'win32'
+  const shellBin = isWin ? (process.env['ComSpec'] || 'cmd.exe') : (process.env['SHELL'] || '/bin/bash')
+  const args = isWin ? ['/c', command] : ['-lc', command]
+
+  // SECURITY: runs with user's shell/env; trust anchor is registry.json allowlist.
+  return new Promise<InstallResult>((resolvePromise) => {
+    const child = spawn(shellBin, args, { env: process.env })
+    runningInstalls.set(installId, child)
+    const timer = setTimeout(() => killChildWithEscalation(child), 120_000)
+    let stderrTail = ''
+    child.stdout?.on('data', () => { /* discard */ })
+    child.stderr?.on('data', (d: Buffer) => { stderrTail = (stderrTail + d.toString()).slice(-4096) })
+    child.on('exit', async (code) => {
+      clearTimeout(timer)
+      runningInstalls.delete(installId)
+      const ok = code === 0
+      if (ok) {
+        const before = prerequisiteChecker.getCached(packageId)
+        prerequisiteChecker.invalidate(packageId)
+        const after = await prerequisiteChecker.check(pkg).catch(() => undefined)
+        if (after && stepsDiffer(before, after)) {
+          mainWindow?.webContents.send('connector:status-changed', { packageId })
+        }
+        resolvePromise({ ok: true, installId, exitCode: code ?? 0 })
+      } else {
+        const errorMessage = stderrTail.trim().split('\n').slice(-3).join('\n')
+        resolvePromise({ ok: false, reason: 'install-failed', exitCode: code ?? -1, errorMessage })
+      }
+    })
+  })
+})
+
+ipcMain.handle('connector:install-cli-cancel', async (_e, { installId }: { installId: string }) => {
+  const child = runningInstalls.get(installId)
+  if (child) {
+    killChildWithEscalation(child)
+    return { ok: true }
+  }
+  return { ok: false, error: 'NOT_FOUND' }
+})
+
+ipcMain.handle('connector:copy-install-command', async (_e, { packageId, prereqId }: { packageId: string; prereqId: string }) => {
+  const resolved = resolveCliPrereq(packageId, prereqId)
+  if (!resolved.ok) return { ok: false, reason: resolved.reason }
+  clipboard.writeText(resolved.command)
+  return { ok: true, command: resolved.command }
+})
+
+ipcMain.handle('connector:open-external', async (_e, { url }: { url: string }) => {
+  await shell.openExternal(url)
+  return { ok: true }
 })

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -170,6 +170,27 @@ const api = {
 
     install: (packageName: string): Promise<{ ok: boolean; error?: string }> =>
       ipcRenderer.invoke('connector:install', { packageName }),
+
+    recheckPrerequisites: (packageId: string) =>
+      ipcRenderer.invoke('connector:recheck-prerequisites', { packageId }),
+
+    installCli: (packageId: string, prereqId: string, installId?: string) =>
+      ipcRenderer.invoke('connector:install-cli', { packageId, prereqId, installId }),
+
+    cancelInstallCli: (installId: string) =>
+      ipcRenderer.invoke('connector:install-cli-cancel', { installId }),
+
+    copyInstallCommand: (packageId: string, prereqId: string) =>
+      ipcRenderer.invoke('connector:copy-install-command', { packageId, prereqId }),
+
+    openExternal: (url: string) =>
+      ipcRenderer.invoke('connector:open-external', { url }),
+
+    onStatusChanged: (cb: (e: { packageId: string }) => void) => {
+      const handler = (_e: unknown, payload: { packageId: string }) => cb(payload)
+      ipcRenderer.on('connector:status-changed', handler)
+      return () => ipcRenderer.removeListener('connector:status-changed', handler)
+    },
   },
 
   // Auto-update

--- a/packages/app/src/renderer/components/ManualInstallModal.tsx
+++ b/packages/app/src/renderer/components/ManualInstallModal.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react'
+import type { ManualInstall } from '@spool/core'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  manual: ManualInstall
+  prereqName: string
+  onCheck?: () => Promise<void> | void
+}
+
+export function ManualInstallModal({ open, onClose, manual, prereqName, onCheck }: Props) {
+  const [checking, setChecking] = useState(false)
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  const openDownload = () => window.spool?.connectors?.openExternal(manual.downloadUrl)
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center" onClick={onClose}>
+      <div
+        className="bg-warm-bg dark:bg-dark-bg rounded-lg border border-warm-border dark:border-dark-border p-5 w-[480px] max-w-[92vw]"
+        onClick={e => e.stopPropagation()}
+      >
+        <h2 className="text-sm font-medium text-warm-text dark:text-dark-text mb-1">Install {prereqName}</h2>
+        <p className="text-xs text-warm-muted dark:text-dark-muted mb-3">
+          This extension isn&apos;t on the Chrome Web Store yet. Manual install takes about two minutes.
+        </p>
+        <div className="mb-3 flex gap-2">
+          <button onClick={openDownload} className="text-[11px] text-accent dark:text-accent-dark hover:underline">
+            Download extension
+          </button>
+          <button
+            onClick={() => navigator.clipboard.writeText('chrome://extensions')}
+            className="text-[11px] text-accent dark:text-accent-dark hover:underline"
+          >
+            Copy chrome://extensions URL
+          </button>
+        </div>
+        <ol className="text-xs text-warm-text dark:text-dark-text space-y-2 mb-3 list-decimal pl-5">
+          {manual.steps.map((stepText: string, i: number) => (
+            <li key={i}>{stepText}</li>
+          ))}
+        </ol>
+        <p className="text-[10px] text-warm-faint dark:text-dark-faint mb-3">
+          Keep the folder in place — moving or deleting it will break the extension.
+        </p>
+        <div className="flex justify-end gap-2">
+          <button onClick={onClose} className="text-xs text-warm-muted dark:text-dark-muted px-3 py-1.5 rounded">
+            Close
+          </button>
+          {onCheck && (
+            <button
+              onClick={async () => {
+                setChecking(true)
+                try { await onCheck() } finally { setChecking(false) }
+              }}
+              disabled={checking}
+              className="text-xs text-white px-3 py-1.5 rounded bg-accent disabled:opacity-50"
+            >
+              {checking ? 'Checking…' : 'Check now'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/renderer/components/PackageSetupCard.tsx
+++ b/packages/app/src/renderer/components/PackageSetupCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Check, X, AlertTriangle, Circle, Terminal, Puzzle, KeyRound, Loader2 } from 'lucide-react'
+import { Check, X, AlertTriangle, Circle, Terminal, Puzzle, KeyRound, Loader2, ChevronDown, ChevronRight } from 'lucide-react'
 import type { SetupStep } from '@spool/core'
 import { ManualInstallModal } from './ManualInstallModal.js'
 
@@ -8,6 +8,12 @@ interface Props {
   packageLabel: string
   steps: SetupStep[]
   onChanged: () => void
+  /**
+   * When true, render even if all prerequisites are OK; default collapsed
+   * behind a summary row that the user can click to expand. Used in the
+   * connector detail page so users can inspect prereq state any time.
+   */
+  alwaysShow?: boolean
 }
 
 function StatusIcon({ status }: { status: SetupStep['status'] }) {
@@ -86,7 +92,7 @@ function StepRow({ packageId, step, onChanged }: { packageId: string; step: Setu
         )
       }
       return (
-        <button onClick={runCliInstall} className="text-[11px] px-2 py-0.5 rounded bg-accent text-white hover:opacity-90">
+        <button onClick={runCliInstall} className="text-[11px] font-medium px-2 py-0.5 rounded border border-accent/30 text-accent dark:text-accent-dark hover:bg-accent/10 dark:hover:bg-accent-dark/10">
           {step.status === 'outdated' ? 'Upgrade' : 'Install'}
         </button>
       )
@@ -95,14 +101,14 @@ function StepRow({ packageId, step, onChanged }: { packageId: string; step: Setu
     if (install.kind === 'browser-extension') {
       if (install.webstoreUrl) {
         return (
-          <button onClick={() => window.spool?.connectors?.openExternal(install.webstoreUrl!)} className="text-[11px] px-2 py-0.5 rounded bg-accent text-white hover:opacity-90">
+          <button onClick={() => window.spool?.connectors?.openExternal(install.webstoreUrl!)} className="text-[11px] font-medium px-2 py-0.5 rounded border border-accent/30 text-accent dark:text-accent-dark hover:bg-accent/10 dark:hover:bg-accent-dark/10">
             Install from Chrome Store
           </button>
         )
       }
       if (install.manual) {
         return (
-          <button onClick={() => setManualOpen(true)} className="text-[11px] px-2 py-0.5 rounded bg-accent text-white hover:opacity-90">
+          <button onClick={() => setManualOpen(true)} className="text-[11px] font-medium px-2 py-0.5 rounded border border-accent/30 text-accent dark:text-accent-dark hover:bg-accent/10 dark:hover:bg-accent-dark/10">
             Install extension
           </button>
         )
@@ -111,7 +117,7 @@ function StepRow({ packageId, step, onChanged }: { packageId: string; step: Setu
 
     if (install.kind === 'site-session') {
       return (
-        <button onClick={() => window.spool?.connectors?.openExternal(install.openUrl)} className="text-[11px] px-2 py-0.5 rounded bg-accent text-white hover:opacity-90">
+        <button onClick={() => window.spool?.connectors?.openExternal(install.openUrl)} className="text-[11px] font-medium px-2 py-0.5 rounded border border-accent/30 text-accent dark:text-accent-dark hover:bg-accent/10 dark:hover:bg-accent-dark/10">
           Open site
         </button>
       )
@@ -120,8 +126,8 @@ function StepRow({ packageId, step, onChanged }: { packageId: string; step: Setu
   }
 
   return (
-    <div className="flex items-start gap-2 py-1">
-      <span className="mt-0.5"><StatusIcon status={step.status} /></span>
+    <div className="flex items-center gap-2 py-1 min-h-[24px]">
+      <StatusIcon status={step.status} />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5">
           <KindIcon kind={step.kind} />
@@ -134,7 +140,7 @@ function StepRow({ packageId, step, onChanged }: { packageId: string; step: Setu
           <div className="text-[10px] text-warm-faint dark:text-dark-faint mt-0.5">{step.hint}</div>
         )}
       </div>
-      {renderAction()}
+      <div className="flex-shrink-0">{renderAction()}</div>
       {install?.kind === 'browser-extension' && install.manual && (
         <ManualInstallModal
           open={manualOpen}
@@ -151,22 +157,57 @@ function StepRow({ packageId, step, onChanged }: { packageId: string; step: Setu
   )
 }
 
-export function PackageSetupCard({ packageId, packageLabel, steps, onChanged }: Props) {
+export function PackageSetupCard({ packageId, packageLabel: _packageLabel, steps, onChanged, alwaysShow }: Props) {
   const okCount = steps.filter(s => s.status === 'ok').length
   const allOk = okCount === steps.length
 
-  // When everything is set up, get out of the user's way entirely.
+  // Default: when everything is set up, get out of the user's way entirely.
   // The card reappears automatically if any step regresses (focus recheck).
-  if (allOk) return null
+  // alwaysShow=true keeps the card visible (collapsed) so users can inspect.
+  const [expanded, setExpanded] = useState(!allOk)
+  if (allOk && !alwaysShow) return null
 
   const recheck = async () => {
     await window.spool?.connectors?.recheckPrerequisites(packageId)
   }
 
+  // Collapsed summary for the "all ok + alwaysShow" case
+  if (allOk && alwaysShow && !expanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        className="w-full px-3 py-2 bg-warm-panel dark:bg-dark-panel rounded-[6px] border border-warm-border dark:border-dark-border flex items-center justify-between text-left hover:border-warm-border-focus dark:hover:border-dark-border-focus transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          <ChevronRight className="w-3 h-3 text-warm-faint dark:text-dark-faint" />
+          <span className="text-[11px] font-medium text-warm-text dark:text-dark-text">Prerequisites</span>
+        </div>
+        <span className="text-[10px] text-warm-muted dark:text-dark-muted flex items-center gap-1">
+          <Check className="w-3 h-3 text-green-500" />
+          {steps.length} of {steps.length} ready
+        </span>
+      </button>
+    )
+  }
+
   return (
     <div className="px-3 py-2 bg-warm-panel dark:bg-dark-panel rounded-[6px] border border-warm-border dark:border-dark-border">
       <div className="flex items-center justify-between mb-1.5">
-        <span className="text-[11px] font-medium text-warm-text dark:text-dark-text">Setup</span>
+        {alwaysShow ? (
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            className="flex items-center gap-1.5 text-[11px] font-medium text-warm-text dark:text-dark-text hover:text-warm-muted dark:hover:text-dark-muted"
+            disabled={!allOk}
+            title={allOk ? 'Collapse' : undefined}
+          >
+            {allOk && <ChevronDown className="w-3 h-3 text-warm-faint dark:text-dark-faint" />}
+            <span>Prerequisites</span>
+          </button>
+        ) : (
+          <span className="text-[11px] font-medium text-warm-text dark:text-dark-text">Setup</span>
+        )}
         <div className="flex items-center gap-2 text-[10px] text-warm-muted dark:text-dark-muted">
           <span>{okCount} of {steps.length} ✓</span>
           <button onClick={recheck} className="hover:text-warm-text dark:hover:text-dark-text">Re-check</button>

--- a/packages/app/src/renderer/components/PackageSetupCard.tsx
+++ b/packages/app/src/renderer/components/PackageSetupCard.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react'
+import { Check, X, AlertTriangle, Circle, Terminal, Puzzle, KeyRound, Loader2 } from 'lucide-react'
+import type { SetupStep } from '@spool/core'
+import { ManualInstallModal } from './ManualInstallModal.js'
+
+interface Props {
+  packageId: string
+  packageLabel: string
+  steps: SetupStep[]
+  onChanged: () => void
+}
+
+function StatusIcon({ status }: { status: SetupStep['status'] }) {
+  if (status === 'ok') return <Check className="w-3.5 h-3.5 text-green-500" />
+  if (status === 'missing') return <X className="w-3.5 h-3.5 text-red-400" />
+  if (status === 'outdated') return <AlertTriangle className="w-3.5 h-3.5 text-amber-500" />
+  if (status === 'error') return <AlertTriangle className="w-3.5 h-3.5 text-amber-500" />
+  return <Circle className="w-3.5 h-3.5 text-warm-faint dark:text-dark-faint" />
+}
+
+function KindIcon({ kind }: { kind: SetupStep['kind'] }) {
+  if (kind === 'cli') return <Terminal className="w-3 h-3" />
+  if (kind === 'browser-extension') return <Puzzle className="w-3 h-3" />
+  return <KeyRound className="w-3 h-3" />
+}
+
+type InstallOutcome = { kind: 'error'; message: string } | { kind: 'requires-manual' } | null
+
+function StepRow({ packageId, step, onChanged }: { packageId: string; step: SetupStep; onChanged: () => void }) {
+  const [installId, setInstallId] = useState<string | null>(null)
+  const installing = installId !== null
+  const [outcome, setOutcome] = useState<InstallOutcome>(null)
+  const [manualOpen, setManualOpen] = useState(false)
+
+  const runCliInstall = async () => {
+    const cid = `${packageId}::${step.id}::${Date.now()}`
+    setInstallId(cid)
+    setOutcome(null)
+    const r = await window.spool?.connectors?.installCli(packageId, step.id, cid)
+    setInstallId(null)
+    if (!r) return
+    if (r.ok) {
+      onChanged()
+      return
+    }
+    if (r.reason === 'requires-manual') {
+      setOutcome({ kind: 'requires-manual' })
+    } else if (r.reason === 'install-failed') {
+      setOutcome({ kind: 'error', message: `Install failed (exit ${r.exitCode})` })
+    } else {
+      setOutcome({ kind: 'error', message: r.reason })
+    }
+  }
+
+  const copyCommand = async () => {
+    await window.spool?.connectors?.copyInstallCommand(packageId, step.id)
+  }
+
+  const cancelInstall = async () => {
+    if (installId) await window.spool?.connectors?.cancelInstallCli(installId)
+  }
+
+  const needsAction = step.status === 'missing' || step.status === 'outdated' || step.status === 'error'
+  const install = step.install
+
+  const renderAction = () => {
+    if (!needsAction || !install) return null
+
+    if (install.kind === 'cli') {
+      if (installing) {
+        return (
+          <div className="flex items-center gap-2 text-[11px] text-warm-muted dark:text-dark-muted">
+            <Loader2 className="w-3 h-3 animate-spin" />
+            <span>Installing…</span>
+            <button onClick={cancelInstall} className="text-[11px] text-warm-faint hover:text-warm-text dark:hover:text-dark-text">Cancel</button>
+          </div>
+        )
+      }
+      if (outcome) {
+        return (
+          <div className="flex items-center gap-2">
+            {outcome.kind === 'error' && <span className="text-[11px] text-red-400">{outcome.message}</span>}
+            <button onClick={runCliInstall} className="text-[11px] text-accent dark:text-accent-dark hover:underline">Retry</button>
+            <button onClick={copyCommand} className="text-[11px] text-warm-muted dark:text-dark-muted hover:underline">Run manually</button>
+          </div>
+        )
+      }
+      return (
+        <button onClick={runCliInstall} className="text-[11px] px-2 py-0.5 rounded bg-accent text-white hover:opacity-90">
+          {step.status === 'outdated' ? 'Upgrade' : 'Install'}
+        </button>
+      )
+    }
+
+    if (install.kind === 'browser-extension') {
+      if (install.webstoreUrl) {
+        return (
+          <button onClick={() => window.spool?.connectors?.openExternal(install.webstoreUrl!)} className="text-[11px] px-2 py-0.5 rounded bg-accent text-white hover:opacity-90">
+            Install from Chrome Store
+          </button>
+        )
+      }
+      if (install.manual) {
+        return (
+          <button onClick={() => setManualOpen(true)} className="text-[11px] px-2 py-0.5 rounded bg-accent text-white hover:opacity-90">
+            Install extension
+          </button>
+        )
+      }
+    }
+
+    if (install.kind === 'site-session') {
+      return (
+        <button onClick={() => window.spool?.connectors?.openExternal(install.openUrl)} className="text-[11px] px-2 py-0.5 rounded bg-accent text-white hover:opacity-90">
+          Open site
+        </button>
+      )
+    }
+    return null
+  }
+
+  return (
+    <div className="flex items-start gap-2 py-1">
+      <span className="mt-0.5"><StatusIcon status={step.status} /></span>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5">
+          <KindIcon kind={step.kind} />
+          <span className={`text-[11px] ${step.status === 'pending' ? 'text-warm-faint dark:text-dark-faint' : 'text-warm-text dark:text-dark-text'}`}>
+            {step.label}
+            {step.detectedVersion && step.status === 'ok' && <span className="ml-1 text-warm-faint dark:text-dark-faint">{step.detectedVersion}</span>}
+          </span>
+        </div>
+        {step.hint && step.status !== 'ok' && (
+          <div className="text-[10px] text-warm-faint dark:text-dark-faint mt-0.5">{step.hint}</div>
+        )}
+      </div>
+      {renderAction()}
+      {install?.kind === 'browser-extension' && install.manual && (
+        <ManualInstallModal
+          open={manualOpen}
+          onClose={() => setManualOpen(false)}
+          manual={install.manual}
+          prereqName={step.label}
+          onCheck={async () => {
+            await window.spool?.connectors?.recheckPrerequisites(packageId)
+            setManualOpen(false)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+export function PackageSetupCard({ packageId, packageLabel, steps, onChanged }: Props) {
+  const okCount = steps.filter(s => s.status === 'ok').length
+  const allOk = okCount === steps.length
+
+  // When everything is set up, get out of the user's way entirely.
+  // The card reappears automatically if any step regresses (focus recheck).
+  if (allOk) return null
+
+  const recheck = async () => {
+    await window.spool?.connectors?.recheckPrerequisites(packageId)
+  }
+
+  return (
+    <div className="px-3 py-2 bg-warm-panel dark:bg-dark-panel rounded-[6px] border border-warm-border dark:border-dark-border">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-[11px] font-medium text-warm-text dark:text-dark-text">Setup</span>
+        <div className="flex items-center gap-2 text-[10px] text-warm-muted dark:text-dark-muted">
+          <span>{okCount} of {steps.length} ✓</span>
+          <button onClick={recheck} className="hover:text-warm-text dark:hover:text-dark-text">Re-check</button>
+        </div>
+      </div>
+      <div className="space-y-0.5">
+        {steps.map(s => <StepRow key={s.id} packageId={packageId} step={s} onChanged={onChanged} />)}
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/renderer/components/SettingsPanel.tsx
+++ b/packages/app/src/renderer/components/SettingsPanel.tsx
@@ -538,7 +538,10 @@ function ConnectorsTab({ claudeCount, codexCount, geminiCount }: { claudeCount: 
           </div>
         </div>
 
-        {/* Setup card (package-level prerequisites) */}
+        {/* Setup card (package-level prerequisites) — alwaysShow on the
+            detail page so users can inspect prereq state any time, not only
+            when something is wrong. Defaults to a collapsed summary row when
+            everything is OK. */}
         {(() => {
           const setup = pkgConnectors.find(c => c.setup && c.setup.length > 0)?.setup
           if (!setup) return null
@@ -549,6 +552,7 @@ function ConnectorsTab({ claudeCount, codexCount, geminiCount }: { claudeCount: 
               packageLabel={pkgLabel}
               steps={setup}
               onChanged={loadConnectors}
+              alwaysShow
             />
           )
         })()}

--- a/packages/app/src/renderer/components/SettingsPanel.tsx
+++ b/packages/app/src/renderer/components/SettingsPanel.tsx
@@ -5,19 +5,12 @@ import { DEFAULT_SEARCH_SORT_ORDER, SEARCH_SORT_OPTIONS, type SearchSortOrder } 
 import type { ThemeEditorStateV1 } from '../theme/editorTypes.js'
 import ThemeEditorSection from './ThemeEditorSection.js'
 import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
+import { commonLabel } from '../lib/common-label.js'
+import { PackageSetupCard } from './PackageSetupCard.js'
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
 type SettingsTab = 'general' | 'appearance' | 'connectors' | 'agent'
-
-// Derive a shared label for a multi-connector package from its sub-connector labels.
-// e.g. ["GitHub Stars", "GitHub Notifications"] → "GitHub"
-function commonLabel(labels: string[]): string {
-  if (labels.length <= 1) return labels[0] ?? ''
-  const words = labels[0]!.split(' ')
-  const shared = words.filter(w => labels.every(l => l.includes(w)))
-  return shared.length > 0 ? shared.join(' ') : words[0]!
-}
 
 // Strip the common package prefix from a sub-label when the parent context is already visible.
 // e.g. stripLabelPrefix("GitHub Stars", "GitHub") → "Stars"
@@ -389,6 +382,13 @@ function ConnectorsTab({ claudeCount, codexCount, geminiCount }: { claudeCount: 
     return off
   }, [loadConnectors])
 
+  // Refresh when prerequisites status changes (e.g. background check completes)
+  useEffect(() => {
+    if (!window.spool?.connectors?.onStatusChanged) return
+    const unsub = window.spool.connectors.onStatusChanged(() => loadConnectors())
+    return () => { unsub() }
+  }, [loadConnectors])
+
   useEffect(() => {
     if (!window.spool?.connectors?.fetchRegistry) return
     setRegistryLoading(true)
@@ -464,7 +464,7 @@ function ConnectorsTab({ claudeCount, codexCount, geminiCount }: { claudeCount: 
 
   // Package-level detail: find all connectors for selected package
   const pkgConnectors = selectedPkg
-    ? connectors.filter(c => (c.packageName || c.id) === selectedPkg)
+    ? connectors.filter(c => (c.packageId ?? (c.packageName || c.id)) === selectedPkg)
     : []
 
   // ── Detail view (drill-down) — package level ──
@@ -537,6 +537,21 @@ function ConnectorsTab({ claudeCount, codexCount, geminiCount }: { claudeCount: 
             )}
           </div>
         </div>
+
+        {/* Setup card (package-level prerequisites) */}
+        {(() => {
+          const setup = pkgConnectors.find(c => c.setup && c.setup.length > 0)?.setup
+          if (!setup) return null
+          const packageId = first.packageId ?? selectedPkg
+          return (
+            <PackageSetupCard
+              packageId={packageId}
+              packageLabel={pkgLabel}
+              steps={setup}
+              onChanged={loadConnectors}
+            />
+          )
+        })()}
 
         {/* Per-connector cards */}
         {pkgConnectors.map(c => {
@@ -670,7 +685,7 @@ function ConnectorsTab({ claudeCount, codexCount, geminiCount }: { claudeCount: 
           // Group installed connectors by package
           const groupMap = new Map<string, { key: string; label: string; color: string; items: typeof connectors }>()
           for (const c of connectors) {
-            const key = c.packageName || c.id
+            const key = c.packageId ?? (c.packageName || c.id)
             const existing = groupMap.get(key)
             if (existing) { existing.items.push(c); continue }
             groupMap.set(key, { key, label: c.label, color: c.color, items: [c] })

--- a/packages/app/src/renderer/components/SourcesPanel.tsx
+++ b/packages/app/src/renderer/components/SourcesPanel.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import type { ConnectorStatus } from '@spool/core'
+import { PackageSetupCard } from './PackageSetupCard.js'
+import { commonLabel } from '../lib/common-label.js'
 
 interface Props {
   onClose: () => void
@@ -83,6 +85,12 @@ export default function SourcesPanel({ onClose, claudeCount, codexCount, geminiC
     return off
   }, [loadConnectors])
 
+  useEffect(() => {
+    if (!window.spool?.connectors?.onStatusChanged) return
+    const unsub = window.spool.connectors.onStatusChanged(() => loadConnectors())
+    return () => { unsub() }
+  }, [loadConnectors])
+
   const handleConnectorSync = async (connectorId: string) => {
     if (!window.spool?.connectors) return
     setSyncingConnector(connectorId)
@@ -131,69 +139,138 @@ export default function SourcesPanel({ onClose, claudeCount, codexCount, geminiC
               <h3 className="text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.04em] uppercase mb-2">
                 Connectors
               </h3>
-              {connectors.map(c => {
-                const isSyncing = syncingConnector === c.id || c.syncing
-                const progress = syncProgress[c.id]
-                return (
-                  <div key={c.id} className="py-2.5 group">
-                    <div className="flex items-center gap-3">
-                      <span
-                        className="w-2 h-2 rounded-full flex-none"
-                        style={{ background: c.enabled ? c.color : '#888' }}
-                      />
-                      <div className="flex-1 min-w-0">
-                        <span className={`text-sm ${c.enabled ? 'text-warm-text dark:text-dark-text' : 'text-warm-muted dark:text-dark-muted'}`}>
-                          {c.label}
-                        </span>
-                        <span className="text-xs text-warm-faint dark:text-dark-muted ml-2">
-                          {!c.enabled
-                            ? 'Not connected'
-                            : isSyncing && progress
-                              ? `page ${progress.page} · ${progress.added} new`
-                              : (connectorCounts[c.id] ?? 0) > 0
-                                ? `${connectorCounts[c.id]} items · ${formatSyncTime(c.state.lastForwardSyncAt)}${!c.state.tailComplete ? ' · syncing history' : ''}`
-                                : c.state.lastErrorCode
-                                  ? c.state.lastErrorMessage ?? 'Error'
-                                  : 'Not synced yet'}
-                        </span>
+              {(() => {
+                // Group connectors by packageId, falling back to c.id for legacy connectors
+                const groups = new Map<string, ConnectorStatus[]>()
+                for (const c of connectors) {
+                  const key = c.packageId ?? c.id
+                  const group = groups.get(key) ?? []
+                  group.push(c)
+                  groups.set(key, group)
+                }
+                return Array.from(groups.entries()).map(([groupKey, groupConnectors]) => {
+                  // Use setup steps from the first connector in the group that has them
+                  const setupSource = groupConnectors.find(c => c.setup && c.setup.length > 0)
+                  const setupSteps = setupSource?.setup
+                  const packageId = setupSource?.packageId ?? groupKey
+                  const setupNotOk = setupSteps && setupSteps.some(s => s.status !== 'ok')
+
+                  // Single connector: render as-is (legacy behavior)
+                  if (groupConnectors.length === 1) {
+                    const c = groupConnectors[0]!
+                    const isSyncing = syncingConnector === c.id || c.syncing
+                    const progress = syncProgress[c.id]
+                    return (
+                      <div key={groupKey} className="mb-2">
+                        {setupSteps && (
+                          <div className="mb-2">
+                            <PackageSetupCard packageId={packageId} packageLabel={c.label} steps={setupSteps} onChanged={loadConnectors} />
+                          </div>
+                        )}
+                        <div className={setupNotOk ? 'opacity-50 pointer-events-none' : ''}>
+                          <div className="py-2.5 group">
+                            <div className="flex items-center gap-3">
+                              <span className="w-2 h-2 rounded-full flex-none" style={{ background: c.enabled ? c.color : '#888' }} />
+                              <div className="flex-1 min-w-0">
+                                <span className={`text-sm ${c.enabled ? 'text-warm-text dark:text-dark-text' : 'text-warm-muted dark:text-dark-muted'}`}>{c.label}</span>
+                                <span className="text-xs text-warm-faint dark:text-dark-muted ml-2">
+                                  {!c.enabled ? 'Not connected'
+                                    : isSyncing && progress ? `page ${progress.page} · ${progress.added} new`
+                                    : (connectorCounts[c.id] ?? 0) > 0 ? `${connectorCounts[c.id]} items · ${formatSyncTime(c.state.lastForwardSyncAt)}${!c.state.tailComplete ? ' · syncing history' : ''}`
+                                    : c.state.lastErrorCode ? c.state.lastErrorMessage ?? 'Error'
+                                    : 'Not synced yet'}
+                                </span>
+                              </div>
+                              {!c.enabled ? (
+                                <button onClick={() => handleEnableConnector(c.id)} className="text-[11px] text-accent dark:text-accent-dark hover:underline">Connect</button>
+                              ) : (
+                                <>
+                                  {!isSyncing && c.state.lastErrorCode?.startsWith('AUTH_') && (
+                                    <span className="text-[10px] text-amber-500 font-medium">needs login</span>
+                                  )}
+                                  <button onClick={() => handleConnectorSync(c.id)} disabled={isSyncing} className="text-[11px] text-accent dark:text-accent-dark hover:underline disabled:opacity-50 opacity-0 group-hover:opacity-100 transition-opacity">
+                                    {isSyncing ? 'Syncing...' : 'Sync'}
+                                  </button>
+                                </>
+                              )}
+                            </div>
+                            {isSyncing && progress && (
+                              <div className="ml-5 mt-1 flex items-center gap-2">
+                                <div className="h-1 w-3 rounded-full bg-accent dark:bg-accent-dark animate-pulse" />
+                                <span className="text-[10px] text-warm-faint dark:text-dark-muted">{progress.phase === 'forward' ? 'Fetching new items' : 'Backfilling history'}...</span>
+                              </div>
+                            )}
+                          </div>
+                        </div>
                       </div>
-                      {!c.enabled ? (
-                        <button
-                          onClick={() => handleEnableConnector(c.id)}
-                          className="text-[11px] text-accent dark:text-accent-dark hover:underline"
-                        >
-                          Connect
-                        </button>
-                      ) : (
-                        <>
-                          {!isSyncing && c.state.lastErrorCode?.startsWith('AUTH_') && (
-                            <span className="text-[10px] text-amber-500 font-medium">needs login</span>
-                          )}
-                          <button
-                            onClick={() => handleConnectorSync(c.id)}
-                            disabled={isSyncing}
-                            className="text-[11px] text-accent dark:text-accent-dark hover:underline disabled:opacity-50 opacity-0 group-hover:opacity-100 transition-opacity"
-                          >
-                            {isSyncing ? 'Syncing...' : 'Sync'}
-                          </button>
-                        </>
+                    )
+                  }
+
+                  // Multi-connector package: render as ONE aggregated row
+                  const pkgLabel = commonLabel(groupConnectors.map(c => c.label))
+                  const pkgColor = groupConnectors[0]!.color
+                  const enabledCount = groupConnectors.filter(c => c.enabled).length
+                  const allEnabled = enabledCount === groupConnectors.length
+                  const noneEnabled = enabledCount === 0
+                  const isSyncingGroup = groupConnectors.some(c => syncingConnector === c.id || c.syncing)
+                  const totalItems = groupConnectors.reduce((sum, c) => sum + (connectorCounts[c.id] ?? 0), 0)
+                  const syncTimes = groupConnectors.map(c => c.state.lastForwardSyncAt).filter(Boolean) as string[]
+                  const earliestSync = syncTimes.length > 0 ? syncTimes.reduce((a, b) => (a < b ? a : b)) : null
+
+                  const handleGroupConnect = () =>
+                    Promise.all(groupConnectors.filter(c => !c.enabled).map(c => handleEnableConnector(c.id).catch(() => undefined)))
+
+                  const handleGroupSync = () =>
+                    Promise.all(groupConnectors.map(c => handleConnectorSync(c.id).catch(() => undefined)))
+
+                  let statusText: string
+                  if (setupNotOk) {
+                    statusText = 'Not set up'
+                  } else if (!allEnabled && noneEnabled) {
+                    statusText = 'Not connected'
+                  } else if (!allEnabled) {
+                    statusText = `${enabledCount}/${groupConnectors.length} enabled`
+                  } else if (isSyncingGroup) {
+                    statusText = 'Syncing...'
+                  } else if (totalItems > 0) {
+                    statusText = `${totalItems} items · ${formatSyncTime(earliestSync)}`
+                  } else {
+                    statusText = 'Not synced yet'
+                  }
+
+                  return (
+                    <div key={groupKey} className="mb-2">
+                      {setupSteps && (
+                        <div className="mb-2">
+                          <PackageSetupCard packageId={packageId} packageLabel={pkgLabel} steps={setupSteps} onChanged={loadConnectors} />
+                        </div>
                       )}
-                    </div>
-                    {isSyncing && progress && (
-                      <div className="ml-5 mt-1 flex items-center gap-2">
-                        <div className="h-1 w-3 rounded-full bg-accent dark:bg-accent-dark animate-pulse" />
-                        <span className="text-[10px] text-warm-faint dark:text-dark-muted">
-                          {progress.phase === 'forward' ? 'Fetching new items' : 'Backfilling history'}...
-                        </span>
+                      <div className={setupNotOk ? 'opacity-50 pointer-events-none' : ''}>
+                        <div className="py-2.5 group">
+                          <div className="flex items-center gap-3">
+                            <span className="w-2 h-2 rounded-full flex-none" style={{ background: allEnabled ? pkgColor : '#888' }} />
+                            <div className="flex-1 min-w-0">
+                              <span className={`text-sm ${allEnabled ? 'text-warm-text dark:text-dark-text' : 'text-warm-muted dark:text-dark-muted'}`}>{pkgLabel}</span>
+                              <span className="text-xs text-warm-faint dark:text-dark-muted ml-2">{statusText}</span>
+                            </div>
+                            {noneEnabled ? (
+                              <button onClick={handleGroupConnect} className="text-[11px] text-accent dark:text-accent-dark hover:underline">Connect</button>
+                            ) : (
+                              <button onClick={handleGroupSync} disabled={isSyncingGroup} className="text-[11px] text-accent dark:text-accent-dark hover:underline disabled:opacity-50 opacity-0 group-hover:opacity-100 transition-opacity">
+                                {isSyncingGroup ? 'Syncing...' : 'Sync'}
+                              </button>
+                            )}
+                          </div>
+                        </div>
                       </div>
-                    )}
-                  </div>
-                )
-              })}
-              {connectors.some(c => c.state.lastErrorCode) && (
+                    </div>
+                  )
+                })
+              })()}
+              {connectors.some(c => c.state.lastErrorCode && !c.setup) && (
                 <div className="mt-2 px-3 py-2 bg-amber-500/10 border border-amber-500/20 rounded-[6px]">
                   <p className="text-xs text-amber-600 dark:text-amber-400">
-                    {connectors.find(c => c.state.lastErrorCode)?.state.lastErrorMessage}
+                    {connectors.find(c => c.state.lastErrorCode && !c.setup)?.state.lastErrorMessage}
                   </p>
                 </div>
               )}

--- a/packages/app/src/renderer/lib/common-label.ts
+++ b/packages/app/src/renderer/lib/common-label.ts
@@ -1,0 +1,13 @@
+export function commonLabel(labels: string[]): string {
+  if (labels.length === 0) return ''
+  if (labels.length === 1) return labels[0]!
+  // Find longest common prefix of words
+  const words = labels.map(l => l.split(/\s+/))
+  let common: string[] = []
+  for (let i = 0; i < words[0]!.length; i++) {
+    const w = words[0]![i]!
+    if (words.every(arr => arr[i] === w)) common.push(w)
+    else break
+  }
+  return common.length > 0 ? common.join(' ').trim() : labels[0]!
+}

--- a/packages/connector-sdk/src/capabilities.ts
+++ b/packages/connector-sdk/src/capabilities.ts
@@ -113,6 +113,17 @@ export interface ExecResult {
 
 export interface ExecCapability {
   run(bin: string, args: string[], opts?: { timeout?: number }): Promise<ExecResult>
+  // TODO: timeout contract is undefined — callers currently sniff the error
+  // message string for "timeout". A future version should throw a recognizable
+  // error: either an AbortError (err.name === 'AbortError') or attach a
+  // structured flag ({ timedOut: true }) so callers can reliably distinguish
+  // timeout from ENOENT/EACCES without message parsing.
+}
+
+// ── Prerequisites ─────────────────────────────────────────────────────────────
+
+export interface PrerequisitesCapability {
+  check(): Promise<import('./connector.js').SetupStep[]>
 }
 
 // ── Bundle ──────────────────────────────────────────────────────────────────
@@ -128,6 +139,7 @@ export interface ConnectorCapabilities {
   log: LogCapability
   sqlite: SqliteCapability
   exec: ExecCapability
+  prerequisites?: PrerequisitesCapability
 }
 
 // ── Manifest allowed values ────────────────────────────────────────────────
@@ -143,6 +155,7 @@ export const KNOWN_CAPABILITIES_V1 = [
   'log',
   'sqlite',
   'exec',
+  'prerequisites',
 ] as const
 
 export type KnownCapabilityV1 = typeof KNOWN_CAPABILITIES_V1[number]

--- a/packages/connector-sdk/src/connector.ts
+++ b/packages/connector-sdk/src/connector.ts
@@ -1,6 +1,72 @@
 import type { SyncErrorCode } from './errors.js'
 import type { CapturedItem } from './captured-item.js'
 
+// ── Prerequisites ─────────────────────────────────────────────────────────────
+
+export type PrerequisiteKind = 'cli' | 'browser-extension' | 'site-session'
+
+export interface Prerequisite {
+  id: string
+  name: string
+  kind: PrerequisiteKind
+  requires?: string[]
+  detect: Detect
+  install: Install
+  minVersion?: string
+  docsUrl?: string
+}
+
+export interface Detect {
+  type: 'exec'
+  command: string
+  args: string[]
+  versionRegex?: string
+  matchStdout?: string
+  timeoutMs?: number
+}
+
+export type Install =
+  | {
+      kind: 'cli'
+      command: Partial<Record<'darwin' | 'linux' | 'win32', string>>
+      requiresManual?: boolean
+    }
+  | {
+      kind: 'browser-extension'
+      webstoreUrl?: string
+      manual?: ManualInstall
+    }
+  | {
+      kind: 'site-session'
+      openUrl: string
+    }
+
+/**
+ * Steps for manual extension install. By convention:
+ * - steps[0]: download step (rendered with a "Download" button wired to downloadUrl)
+ * - steps[1]: unzip step (user action, no button)
+ * - steps[2]: open chrome://extensions step (rendered with an "Open" button)
+ * - steps[3+]: any additional user actions
+ */
+export interface ManualInstall {
+  downloadUrl: string
+  steps: string[]
+}
+
+export type SetupStatus = 'ok' | 'missing' | 'outdated' | 'error' | 'pending'
+
+export interface SetupStep {
+  id: string
+  label: string
+  kind: PrerequisiteKind
+  status: SetupStatus
+  hint?: string
+  detectedVersion?: string
+  minVersion?: string
+  install?: Install
+  docsUrl?: string
+}
+
 // ── Auth ─────────────────────────────────────────────────────────────────────
 
 export interface AuthStatus {
@@ -9,6 +75,7 @@ export interface AuthStatus {
   message?: string
   /** Actionable guidance for the user. */
   hint?: string
+  setup?: SetupStep[]
 }
 
 // ── Page result ──────────────────────────────────────────────────────────────
@@ -39,6 +106,21 @@ export interface FetchContext {
    * Optional until Task 5 wires the engine to always provide it.
    */
   signal?: AbortSignal
+}
+
+// ── checkAuthViaPrerequisites helper ─────────────────────────────────────────
+
+import type { ConnectorCapabilities } from './capabilities.js'
+
+export async function checkAuthViaPrerequisites(caps: ConnectorCapabilities): Promise<AuthStatus> {
+  if (!caps.prerequisites) {
+    return {
+      ok: false,
+      message: 'Prerequisites capability not wired',
+    }
+  }
+  const setup = await caps.prerequisites.check()
+  return { ok: setup.every(s => s.status === 'ok'), setup }
 }
 
 // ── Connector interface ──────────────────────────────────────────────────────

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -1,5 +1,18 @@
 // Public plugin contract types
-export type { Connector, AuthStatus, PageResult, FetchContext } from './connector.js'
+export type {
+  Connector,
+  AuthStatus,
+  PageResult,
+  FetchContext,
+  Prerequisite,
+  PrerequisiteKind,
+  Detect,
+  Install,
+  ManualInstall,
+  SetupStep,
+  SetupStatus,
+} from './connector.js'
+export { checkAuthViaPrerequisites } from './connector.js'
 export type { CapturedItem } from './captured-item.js'
 export type { SyncState } from './sync-state.js'
 
@@ -22,6 +35,7 @@ export type {
   KnownCapabilityV1,
   ExecCapability,
   ExecResult,
+  PrerequisitesCapability,
 } from './capabilities.js'
 export { KNOWN_CAPABILITIES_V1 } from './capabilities.js'
 

--- a/packages/connectors/xiaohongshu/README.md
+++ b/packages/connectors/xiaohongshu/README.md
@@ -12,6 +12,4 @@ Spool will guide you through installing each when you enable the connector.
 
 ## Sub-connectors
 
-- `xiaohongshu-feed` — home feed (ephemeral)
 - `xiaohongshu-notes` — your published notes (persistent)
-- `xiaohongshu-notifications` — messages/likes/comments (ephemeral)

--- a/packages/connectors/xiaohongshu/README.md
+++ b/packages/connectors/xiaohongshu/README.md
@@ -1,0 +1,17 @@
+# @spool-lab/connector-xiaohongshu
+
+Xiaohongshu (小红书) connector for Spool.
+
+## Prerequisites
+
+- [OpenCLI](https://github.com/jackwener/opencli) >= 0.3.0
+- OpenCLI Browser Bridge (Chrome extension)
+- Logged into xiaohongshu.com in Chrome
+
+Spool will guide you through installing each when you enable the connector.
+
+## Sub-connectors
+
+- `xiaohongshu-feed` — home feed (ephemeral)
+- `xiaohongshu-notes` — your published notes (persistent)
+- `xiaohongshu-notifications` — messages/likes/comments (ephemeral)

--- a/packages/connectors/xiaohongshu/package.json
+++ b/packages/connectors/xiaohongshu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spool-lab/connector-xiaohongshu",
   "version": "0.1.0",
-  "description": "Xiaohongshu (小红书) feed, notes, and notifications via opencli",
+  "description": "Xiaohongshu (小红书) creator notes via opencli",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -89,28 +89,10 @@
     ],
     "connectors": [
       {
-        "id": "xiaohongshu-feed",
-        "platform": "xiaohongshu",
-        "label": "Xiaohongshu Feed",
-        "description": "Your Xiaohongshu home feed",
-        "color": "#FF2442",
-        "ephemeral": true,
-        "capabilities": ["exec", "log", "prerequisites"]
-      },
-      {
         "id": "xiaohongshu-notes",
         "platform": "xiaohongshu",
         "label": "Xiaohongshu Notes",
         "description": "Notes you have published",
-        "color": "#FF2442",
-        "ephemeral": false,
-        "capabilities": ["exec", "log", "prerequisites"]
-      },
-      {
-        "id": "xiaohongshu-notifications",
-        "platform": "xiaohongshu",
-        "label": "Xiaohongshu Notifications",
-        "description": "Messages, likes, and comments",
         "color": "#FF2442",
         "ephemeral": false,
         "capabilities": ["exec", "log", "prerequisites"]

--- a/packages/connectors/xiaohongshu/package.json
+++ b/packages/connectors/xiaohongshu/package.json
@@ -1,0 +1,120 @@
+{
+  "name": "@spool-lab/connector-xiaohongshu",
+  "version": "0.1.0",
+  "description": "Xiaohongshu (小红书) feed, notes, and notifications via opencli",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "@spool/connector-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@spool/connector-sdk": "workspace:*",
+    "@types/node": "^22.15.3",
+    "typescript": "^5.4.0",
+    "vitest": "^3.2.4"
+  },
+  "spool": {
+    "type": "connector",
+    "prerequisites": [
+      {
+        "id": "opencli",
+        "name": "OpenCLI",
+        "kind": "cli",
+        "detect": {
+          "type": "exec",
+          "command": "opencli",
+          "args": ["--version"],
+          "versionRegex": "v?(\\d+\\.\\d+\\.\\d+)",
+          "timeoutMs": 5000
+        },
+        "minVersion": "0.3.0",
+        "install": {
+          "kind": "cli",
+          "command": {
+            "darwin": "npm i -g @jackwener/opencli",
+            "linux": "npm i -g @jackwener/opencli",
+            "win32": "npm i -g @jackwener/opencli"
+          }
+        },
+        "docsUrl": "https://github.com/jackwener/opencli"
+      },
+      {
+        "id": "opencli-extension",
+        "name": "Browser Bridge",
+        "kind": "browser-extension",
+        "requires": ["opencli"],
+        "detect": {
+          "type": "exec",
+          "command": "opencli",
+          "args": ["doctor"],
+          "matchStdout": "\\[OK\\].*Extension",
+          "timeoutMs": 10000
+        },
+        "install": {
+          "kind": "browser-extension",
+          "manual": {
+            "downloadUrl": "https://github.com/jackwener/opencli/releases/latest",
+            "steps": [
+              "Download and unzip the extension",
+              "Paste chrome://extensions into Chrome's address bar",
+              "Enable Developer mode (top-right toggle)",
+              "Click 'Load unpacked' and choose the unzipped folder",
+              "Keep the folder in place — moving or deleting it will break the extension"
+            ]
+          }
+        }
+      },
+      {
+        "id": "xhs-login",
+        "name": "Logged into Xiaohongshu",
+        "kind": "site-session",
+        "requires": ["opencli-extension"],
+        "detect": {
+          "type": "exec",
+          "command": "opencli",
+          "args": ["doctor"],
+          "matchStdout": "\\[OK\\].*Connectivity",
+          "timeoutMs": 10000
+        },
+        "install": {
+          "kind": "site-session",
+          "openUrl": "https://www.xiaohongshu.com"
+        }
+      }
+    ],
+    "connectors": [
+      {
+        "id": "xiaohongshu-feed",
+        "platform": "xiaohongshu",
+        "label": "Xiaohongshu Feed",
+        "description": "Your Xiaohongshu home feed",
+        "color": "#FF2442",
+        "ephemeral": true,
+        "capabilities": ["exec", "log", "prerequisites"]
+      },
+      {
+        "id": "xiaohongshu-notes",
+        "platform": "xiaohongshu",
+        "label": "Xiaohongshu Notes",
+        "description": "Notes you have published",
+        "color": "#FF2442",
+        "ephemeral": false,
+        "capabilities": ["exec", "log", "prerequisites"]
+      },
+      {
+        "id": "xiaohongshu-notifications",
+        "platform": "xiaohongshu",
+        "label": "Xiaohongshu Notifications",
+        "description": "Messages, likes, and comments",
+        "color": "#FF2442",
+        "ephemeral": false,
+        "capabilities": ["exec", "log", "prerequisites"]
+      }
+    ]
+  }
+}

--- a/packages/connectors/xiaohongshu/package.json
+++ b/packages/connectors/xiaohongshu/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": ["dist", "README.md"],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run"

--- a/packages/connectors/xiaohongshu/src/index.test.ts
+++ b/packages/connectors/xiaohongshu/src/index.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest'
+import { XhsFeedConnector, XhsNotesConnector, XhsNotificationsConnector } from './index.js'
+import type { ConnectorCapabilities } from '@spool/connector-sdk'
+
+function mockCaps(runImpl: (cmd: string, args: string[]) => Promise<{ exitCode: number; stdout: string; stderr: string }>): ConnectorCapabilities {
+  return {
+    exec: { run: vi.fn().mockImplementation(runImpl) },
+  } as unknown as ConnectorCapabilities
+}
+
+function jsonLines(items: Array<Record<string, unknown>>): string {
+  return items.map(i => JSON.stringify(i)).join('\n')
+}
+
+function mkItem(id: string) {
+  return { id, title: `note ${id}`, url: `https://xhs.test/${id}`, ts: Date.now() }
+}
+
+describe('XhsFeedConnector.fetchPage', () => {
+  it('first call with no cursor invokes opencli without --cursor', async () => {
+    const caps = mockCaps(async () => ({ exitCode: 0, stdout: jsonLines(Array.from({ length: 5 }, (_, i) => mkItem(`a${i}`))), stderr: '' }))
+    const c = new XhsFeedConnector(caps)
+    const r = await c.fetchPage({ cursor: null, sinceItemId: null, phase: 'forward' } as any)
+    expect(r.items).toHaveLength(5)
+    expect(r.nextCursor).toBeNull()   // fewer than limit → no more
+    expect(caps.exec!.run).toHaveBeenCalledWith('opencli', expect.not.arrayContaining(['--cursor']), expect.anything())
+  })
+
+  it('returns page cursor when limit reached under max', async () => {
+    const items = Array.from({ length: 20 }, (_, i) => mkItem(`b${i}`))
+    const caps = mockCaps(async () => ({ exitCode: 0, stdout: jsonLines(items), stderr: '' }))
+    const c = new XhsFeedConnector(caps)
+    const r = await c.fetchPage({ cursor: null, sinceItemId: null, phase: 'forward' } as any)
+    expect(r.nextCursor).toBe('2')
+  })
+
+  it('terminates at MAX_PAGES for feed (3)', async () => {
+    const items = Array.from({ length: 20 }, (_, i) => mkItem(`c${i}`))
+    const caps = mockCaps(async () => ({ exitCode: 0, stdout: jsonLines(items), stderr: '' }))
+    const c = new XhsFeedConnector(caps)
+    // Simulate 3 consecutive calls — at page 3, should return nextCursor: null
+    const r1 = await c.fetchPage({ cursor: null, sinceItemId: null, phase: 'forward' } as any)
+    expect(r1.nextCursor).toBe('2')
+    const r2 = await c.fetchPage({ cursor: '2', sinceItemId: null, phase: 'forward' } as any)
+    expect(r2.nextCursor).toBe('3')
+    const r3 = await c.fetchPage({ cursor: '3', sinceItemId: null, phase: 'forward' } as any)
+    expect(r3.nextCursor).toBeNull()
+  })
+
+  it('even if opencli returns infinite same-cursor data, loop terminates by MAX_PAGES', async () => {
+    // Simulate sync-engine's loop: call fetchPage repeatedly until nextCursor is null
+    const items = Array.from({ length: 20 }, (_, i) => mkItem(`d${i}`))
+    const runMock = vi.fn().mockResolvedValue({ exitCode: 0, stdout: jsonLines(items), stderr: '' })
+    const caps = { exec: { run: runMock } } as unknown as ConnectorCapabilities
+    const c = new XhsFeedConnector(caps)
+
+    let cursor: string | null = null
+    let pages = 0
+    while (pages < 100) {
+      const r = await c.fetchPage({ cursor, sinceItemId: null, phase: 'forward' } as any)
+      pages++
+      if (!r.nextCursor) break
+      cursor = r.nextCursor
+    }
+    expect(pages).toBeLessThanOrEqual(3)   // MAX_PAGES.feed
+  })
+
+  it('passes --cursor to opencli when ctx.cursor is set', async () => {
+    const caps = mockCaps(async () => ({ exitCode: 0, stdout: jsonLines([mkItem('x')]), stderr: '' }))
+    const c = new XhsFeedConnector(caps)
+    await c.fetchPage({ cursor: '2', sinceItemId: null, phase: 'forward' } as any)
+    expect(caps.exec!.run).toHaveBeenCalledWith(
+      'opencli',
+      expect.arrayContaining(['--cursor', '2']),
+      expect.anything(),
+    )
+  })
+
+  it('throws SyncError when opencli exits non-zero', async () => {
+    const caps = mockCaps(async () => ({ exitCode: 1, stdout: '', stderr: 'connection failed' }))
+    const c = new XhsFeedConnector(caps)
+    await expect(c.fetchPage({ cursor: null, sinceItemId: null, phase: 'forward' } as any)).rejects.toThrow(/connection failed/)
+  })
+})
+
+describe('XhsNotesConnector MAX_PAGES cap', () => {
+  it('caps at 20 pages even with infinite data', async () => {
+    const items = Array.from({ length: 20 }, (_, i) => mkItem(`n${i}`))
+    const caps = mockCaps(async () => ({ exitCode: 0, stdout: jsonLines(items), stderr: '' }))
+    const c = new XhsNotesConnector(caps)
+
+    let cursor: string | null = null
+    let pages = 0
+    while (pages < 1000) {
+      const r = await c.fetchPage({ cursor, sinceItemId: null, phase: 'forward' } as any)
+      pages++
+      if (!r.nextCursor) break
+      cursor = r.nextCursor
+    }
+    expect(pages).toBeLessThanOrEqual(20)
+  })
+})
+
+describe('XhsNotificationsConnector', () => {
+  it('is persistent (not ephemeral)', () => {
+    const caps = { exec: { run: vi.fn() } } as unknown as ConnectorCapabilities
+    const c = new XhsNotificationsConnector(caps)
+    expect(c.ephemeral).toBe(false)
+  })
+
+  it('caps at 20 pages', async () => {
+    const items = Array.from({ length: 20 }, (_, i) => mkItem(`m${i}`))
+    const caps = mockCaps(async () => ({ exitCode: 0, stdout: jsonLines(items), stderr: '' }))
+    const c = new XhsNotificationsConnector(caps)
+
+    let cursor: string | null = null
+    let pages = 0
+    while (pages < 1000) {
+      const r = await c.fetchPage({ cursor, sinceItemId: null, phase: 'forward' } as any)
+      pages++
+      if (!r.nextCursor) break
+      cursor = r.nextCursor
+    }
+    expect(pages).toBeLessThanOrEqual(20)
+  })
+})

--- a/packages/connectors/xiaohongshu/src/index.test.ts
+++ b/packages/connectors/xiaohongshu/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { XhsFeedConnector, XhsNotesConnector, XhsNotificationsConnector } from './index.js'
+import { XhsNotesConnector } from './index.js'
 import type { ConnectorCapabilities } from '@spool/connector-sdk'
 
 function mockCaps(runImpl: (cmd: string, args: string[]) => Promise<{ exitCode: number; stdout: string; stderr: string }>): ConnectorCapabilities {
@@ -16,111 +16,48 @@ function mkItem(id: string) {
   return { id, title: `note ${id}`, url: `https://xhs.test/${id}`, ts: Date.now() }
 }
 
-describe('XhsFeedConnector.fetchPage', () => {
-  it('first call with no cursor invokes opencli without --cursor', async () => {
+describe('XhsNotesConnector.fetchPage', () => {
+  it('single-shot fetch returns items with no nextCursor', async () => {
     const caps = mockCaps(async () => ({ exitCode: 0, stdout: jsonLines(Array.from({ length: 5 }, (_, i) => mkItem(`a${i}`))), stderr: '' }))
-    const c = new XhsFeedConnector(caps)
+    const c = new XhsNotesConnector(caps)
     const r = await c.fetchPage({ cursor: null, sinceItemId: null, phase: 'forward' } as any)
     expect(r.items).toHaveLength(5)
-    expect(r.nextCursor).toBeNull()   // fewer than limit → no more
-    expect(caps.exec!.run).toHaveBeenCalledWith('opencli', expect.not.arrayContaining(['--cursor']), expect.anything())
+    expect(r.nextCursor).toBeNull()
   })
 
-  it('returns page cursor when limit reached under max', async () => {
+  it('never passes --cursor / --page / --offset to opencli (unsupported flags)', async () => {
+    const caps = mockCaps(async () => ({ exitCode: 0, stdout: jsonLines([mkItem('x')]), stderr: '' }))
+    const c = new XhsNotesConnector(caps)
+    await c.fetchPage({ cursor: '2', sinceItemId: null, phase: 'forward' } as any)
+    const callArgs = (caps.exec!.run as any).mock.calls[0]![1] as string[]
+    expect(callArgs).not.toContain('--cursor')
+    expect(callArgs).not.toContain('--page')
+    expect(callArgs).not.toContain('--offset')
+  })
+
+  it('returns nextCursor null even when items reach limit (opencli has no pagination)', async () => {
     const items = Array.from({ length: 20 }, (_, i) => mkItem(`b${i}`))
     const caps = mockCaps(async () => ({ exitCode: 0, stdout: jsonLines(items), stderr: '' }))
-    const c = new XhsFeedConnector(caps)
+    const c = new XhsNotesConnector(caps)
     const r = await c.fetchPage({ cursor: null, sinceItemId: null, phase: 'forward' } as any)
-    expect(r.nextCursor).toBe('2')
-  })
-
-  it('terminates at MAX_PAGES for feed (3)', async () => {
-    const items = Array.from({ length: 20 }, (_, i) => mkItem(`c${i}`))
-    const caps = mockCaps(async () => ({ exitCode: 0, stdout: jsonLines(items), stderr: '' }))
-    const c = new XhsFeedConnector(caps)
-    // Simulate 3 consecutive calls — at page 3, should return nextCursor: null
-    const r1 = await c.fetchPage({ cursor: null, sinceItemId: null, phase: 'forward' } as any)
-    expect(r1.nextCursor).toBe('2')
-    const r2 = await c.fetchPage({ cursor: '2', sinceItemId: null, phase: 'forward' } as any)
-    expect(r2.nextCursor).toBe('3')
-    const r3 = await c.fetchPage({ cursor: '3', sinceItemId: null, phase: 'forward' } as any)
-    expect(r3.nextCursor).toBeNull()
-  })
-
-  it('even if opencli returns infinite same-cursor data, loop terminates by MAX_PAGES', async () => {
-    // Simulate sync-engine's loop: call fetchPage repeatedly until nextCursor is null
-    const items = Array.from({ length: 20 }, (_, i) => mkItem(`d${i}`))
-    const runMock = vi.fn().mockResolvedValue({ exitCode: 0, stdout: jsonLines(items), stderr: '' })
-    const caps = { exec: { run: runMock } } as unknown as ConnectorCapabilities
-    const c = new XhsFeedConnector(caps)
-
-    let cursor: string | null = null
-    let pages = 0
-    while (pages < 100) {
-      const r = await c.fetchPage({ cursor, sinceItemId: null, phase: 'forward' } as any)
-      pages++
-      if (!r.nextCursor) break
-      cursor = r.nextCursor
-    }
-    expect(pages).toBeLessThanOrEqual(3)   // MAX_PAGES.feed
-  })
-
-  it('passes --cursor to opencli when ctx.cursor is set', async () => {
-    const caps = mockCaps(async () => ({ exitCode: 0, stdout: jsonLines([mkItem('x')]), stderr: '' }))
-    const c = new XhsFeedConnector(caps)
-    await c.fetchPage({ cursor: '2', sinceItemId: null, phase: 'forward' } as any)
-    expect(caps.exec!.run).toHaveBeenCalledWith(
-      'opencli',
-      expect.arrayContaining(['--cursor', '2']),
-      expect.anything(),
-    )
+    expect(r.nextCursor).toBeNull()
   })
 
   it('throws SyncError when opencli exits non-zero', async () => {
     const caps = mockCaps(async () => ({ exitCode: 1, stdout: '', stderr: 'connection failed' }))
-    const c = new XhsFeedConnector(caps)
+    const c = new XhsNotesConnector(caps)
     await expect(c.fetchPage({ cursor: null, sinceItemId: null, phase: 'forward' } as any)).rejects.toThrow(/connection failed/)
   })
-})
 
-describe('XhsNotesConnector MAX_PAGES cap', () => {
-  it('caps at 20 pages even with infinite data', async () => {
-    const items = Array.from({ length: 20 }, (_, i) => mkItem(`n${i}`))
-    const caps = mockCaps(async () => ({ exitCode: 0, stdout: jsonLines(items), stderr: '' }))
+  it('treats opencli "no X found" exit as empty result, not error', async () => {
+    const caps = mockCaps(async () => ({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'No notes found. Are you logged into creator.xiaohongshu.com?',
+    }))
     const c = new XhsNotesConnector(caps)
-
-    let cursor: string | null = null
-    let pages = 0
-    while (pages < 1000) {
-      const r = await c.fetchPage({ cursor, sinceItemId: null, phase: 'forward' } as any)
-      pages++
-      if (!r.nextCursor) break
-      cursor = r.nextCursor
-    }
-    expect(pages).toBeLessThanOrEqual(20)
-  })
-})
-
-describe('XhsNotificationsConnector', () => {
-  it('is persistent (not ephemeral)', () => {
-    const caps = { exec: { run: vi.fn() } } as unknown as ConnectorCapabilities
-    const c = new XhsNotificationsConnector(caps)
-    expect(c.ephemeral).toBe(false)
-  })
-
-  it('caps at 20 pages', async () => {
-    const items = Array.from({ length: 20 }, (_, i) => mkItem(`m${i}`))
-    const caps = mockCaps(async () => ({ exitCode: 0, stdout: jsonLines(items), stderr: '' }))
-    const c = new XhsNotificationsConnector(caps)
-
-    let cursor: string | null = null
-    let pages = 0
-    while (pages < 1000) {
-      const r = await c.fetchPage({ cursor, sinceItemId: null, phase: 'forward' } as any)
-      pages++
-      if (!r.nextCursor) break
-      cursor = r.nextCursor
-    }
-    expect(pages).toBeLessThanOrEqual(20)
+    const r = await c.fetchPage({ cursor: null, sinceItemId: null, phase: 'forward' } as any)
+    expect(r.items).toEqual([])
+    expect(r.nextCursor).toBeNull()
   })
 })

--- a/packages/connectors/xiaohongshu/src/index.ts
+++ b/packages/connectors/xiaohongshu/src/index.ts
@@ -7,12 +7,10 @@ import type {
 } from '@spool/connector-sdk'
 import { checkAuthViaPrerequisites, SyncError, SyncErrorCode, parseCliJsonOutput } from '@spool/connector-sdk'
 
-const MAX_PAGES: Record<string, number> = {
-  feed: 3,
-  notes: 20,
-  notifications: 20,
-}
-const PAGE_LIMIT = 20
+// opencli xiaohongshu subcommands return a single snapshot of the current
+// top-N items and don't accept any cursor/page/offset flag. We always do a
+// single-shot fetch with --limit.
+const PAGE_LIMIT = 100
 
 abstract class XhsBaseConnector implements Connector {
   abstract readonly id: string
@@ -30,37 +28,24 @@ abstract class XhsBaseConnector implements Connector {
     return checkAuthViaPrerequisites(this.caps)
   }
 
-  async fetchPage(ctx: FetchContext): Promise<PageResult> {
-    const pageNum = ctx.cursor ? Math.max(1, parseInt(ctx.cursor, 10)) : 1
-    const maxPages = MAX_PAGES[this.subcommand] ?? 5
-
+  async fetchPage(_ctx: FetchContext): Promise<PageResult> {
     const args = ['xiaohongshu', this.subcommand, '-f', 'json', '--limit', String(PAGE_LIMIT)]
-    // opencli may not support --cursor yet; the page cap above is our safety net.
-    if (ctx.cursor) args.push('--cursor', ctx.cursor)
-
     const result = await this.caps.exec.run('opencli', args, { timeout: 30_000 })
     if (result.exitCode !== 0) {
+      // opencli treats "no rows" as an error; recognize that pattern as an
+      // empty result so an account with zero items shows "0 items" instead
+      // of red error state.
+      if (/no\s+\w+\s+found/i.test(result.stderr)) {
+        return { items: [], nextCursor: null }
+      }
       throw new SyncError(
         SyncErrorCode.API_UNEXPECTED_STATUS,
         `opencli ${this.subcommand} failed (exit ${result.exitCode}): ${result.stderr.slice(0, 200)}`,
       )
     }
     const items = parseCliJsonOutput(result.stdout, 'xiaohongshu', 'post')
-
-    const hasMore = items.length >= PAGE_LIMIT && pageNum < maxPages
-    return {
-      items,
-      nextCursor: hasMore ? String(pageNum + 1) : null,
-    }
+    return { items, nextCursor: null }
   }
-}
-
-export class XhsFeedConnector extends XhsBaseConnector {
-  readonly id = 'xiaohongshu-feed'
-  readonly label = 'Xiaohongshu Feed'
-  readonly description = 'Your Xiaohongshu home feed'
-  readonly ephemeral = true
-  readonly subcommand = 'feed'
 }
 
 export class XhsNotesConnector extends XhsBaseConnector {
@@ -68,15 +53,14 @@ export class XhsNotesConnector extends XhsBaseConnector {
   readonly label = 'Xiaohongshu Notes'
   readonly description = 'Notes you have published'
   readonly ephemeral = false
-  readonly subcommand = 'notes'
+  readonly subcommand = 'creator-notes'
 }
 
-export class XhsNotificationsConnector extends XhsBaseConnector {
-  readonly id = 'xiaohongshu-notifications'
-  readonly label = 'Xiaohongshu Notifications'
-  readonly description = 'Messages, likes, and comments'
-  readonly ephemeral = false
-  readonly subcommand = 'notifications'
-}
+// Feed and Notifications sub-connectors intentionally omitted for now:
+// - feed: opencli reads from page Pinia store without scrolling, so item
+//   count fluctuates with whatever the store happens to hold (~20 items).
+// - notifications: opencli currently emits only `{rank: N}` placeholders
+//   without stable IDs/content, plus session detach issues.
+// Both will return when upstream behavior stabilizes.
 
-export const connectors = [XhsFeedConnector, XhsNotesConnector, XhsNotificationsConnector]
+export const connectors = [XhsNotesConnector]

--- a/packages/connectors/xiaohongshu/src/index.ts
+++ b/packages/connectors/xiaohongshu/src/index.ts
@@ -1,0 +1,82 @@
+import type {
+  Connector,
+  ConnectorCapabilities,
+  AuthStatus,
+  PageResult,
+  FetchContext,
+} from '@spool/connector-sdk'
+import { checkAuthViaPrerequisites, SyncError, SyncErrorCode, parseCliJsonOutput } from '@spool/connector-sdk'
+
+const MAX_PAGES: Record<string, number> = {
+  feed: 3,
+  notes: 20,
+  notifications: 20,
+}
+const PAGE_LIMIT = 20
+
+abstract class XhsBaseConnector implements Connector {
+  abstract readonly id: string
+  abstract readonly label: string
+  abstract readonly description: string
+  abstract readonly ephemeral: boolean
+  abstract readonly subcommand: string
+
+  readonly platform = 'xiaohongshu'
+  readonly color = '#FF2442'
+
+  constructor(protected readonly caps: ConnectorCapabilities) {}
+
+  async checkAuth(): Promise<AuthStatus> {
+    return checkAuthViaPrerequisites(this.caps)
+  }
+
+  async fetchPage(ctx: FetchContext): Promise<PageResult> {
+    const pageNum = ctx.cursor ? Math.max(1, parseInt(ctx.cursor, 10)) : 1
+    const maxPages = MAX_PAGES[this.subcommand] ?? 5
+
+    const args = ['xiaohongshu', this.subcommand, '-f', 'json', '--limit', String(PAGE_LIMIT)]
+    // opencli may not support --cursor yet; the page cap above is our safety net.
+    if (ctx.cursor) args.push('--cursor', ctx.cursor)
+
+    const result = await this.caps.exec.run('opencli', args, { timeout: 30_000 })
+    if (result.exitCode !== 0) {
+      throw new SyncError(
+        SyncErrorCode.API_UNEXPECTED_STATUS,
+        `opencli ${this.subcommand} failed (exit ${result.exitCode}): ${result.stderr.slice(0, 200)}`,
+      )
+    }
+    const items = parseCliJsonOutput(result.stdout, 'xiaohongshu', 'post')
+
+    const hasMore = items.length >= PAGE_LIMIT && pageNum < maxPages
+    return {
+      items,
+      nextCursor: hasMore ? String(pageNum + 1) : null,
+    }
+  }
+}
+
+export class XhsFeedConnector extends XhsBaseConnector {
+  readonly id = 'xiaohongshu-feed'
+  readonly label = 'Xiaohongshu Feed'
+  readonly description = 'Your Xiaohongshu home feed'
+  readonly ephemeral = true
+  readonly subcommand = 'feed'
+}
+
+export class XhsNotesConnector extends XhsBaseConnector {
+  readonly id = 'xiaohongshu-notes'
+  readonly label = 'Xiaohongshu Notes'
+  readonly description = 'Notes you have published'
+  readonly ephemeral = false
+  readonly subcommand = 'notes'
+}
+
+export class XhsNotificationsConnector extends XhsBaseConnector {
+  readonly id = 'xiaohongshu-notifications'
+  readonly label = 'Xiaohongshu Notifications'
+  readonly description = 'Messages, likes, and comments'
+  readonly ephemeral = false
+  readonly subcommand = 'notifications'
+}
+
+export const connectors = [XhsFeedConnector, XhsNotesConnector, XhsNotificationsConnector]

--- a/packages/connectors/xiaohongshu/tsconfig.json
+++ b/packages/connectors/xiaohongshu/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "lib": ["es2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/connectors/xiaohongshu/tsconfig.json
+++ b/packages/connectors/xiaohongshu/tsconfig.json
@@ -17,5 +17,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
 }

--- a/packages/core/src/connectors/capabilities/exec-impl.test.ts
+++ b/packages/core/src/connectors/capabilities/exec-impl.test.ts
@@ -28,9 +28,23 @@ describe('makeExecCapability', () => {
     ).rejects.toThrow()
   })
 
-  it('rejects when binary not found', async () => {
-    await expect(
-      exec.run('nonexistent-binary-xyz', []),
-    ).rejects.toThrow()
+  it('returns exit 127 when binary not found (login shell semantics)', async () => {
+    const result = await exec.run('nonexistent-binary-xyz', [])
+    expect(result.exitCode).toBe(127)
+    expect(result.stderr).toMatch(/not found|no such/i)
+  })
+
+  it('runs through a login shell so subprocesses inherit user env (e.g. proxy vars)', async () => {
+    // Sanity check: the spawned process can see at least one inherited env var
+    // that login shells typically set. HOME is reliable across macOS/Linux.
+    const result = await exec.run('printenv', ['HOME'])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.trim()).toBeTruthy()
+  })
+
+  it('quotes args safely (no shell injection)', async () => {
+    const result = await exec.run('echo', ['hello world', `it's a $(date) test`])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.trim()).toBe(`hello world it's a $(date) test`)
   })
 })

--- a/packages/core/src/connectors/capabilities/exec-impl.ts
+++ b/packages/core/src/connectors/capabilities/exec-impl.ts
@@ -31,28 +31,71 @@ function buildEnrichedPath(): string {
   return [...extras, base].join(':')
 }
 
+/** POSIX single-quote escaping: wraps in '...' and escapes embedded single quotes. */
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
 let enrichedPath: string | null = null
 
 export function makeExecCapability(): ExecCapability {
   if (!enrichedPath) enrichedPath = buildEnrichedPath()
+  const isWin = process.platform === 'win32'
 
   return {
     run(bin: string, args: string[], opts?: { timeout?: number }): Promise<ExecResult> {
       const timeout = opts?.timeout ?? DEFAULT_TIMEOUT
 
       return new Promise((resolve, reject) => {
-        const proc = spawn(bin, args, {
-          stdio: ['pipe', 'pipe', 'pipe'],
-          env: { ...process.env, PATH: enrichedPath! },
-        })
+        // GUI-launched apps on macOS don't inherit the user's shell env (no
+        // proxy vars, no nvm PATH, etc.) — running through a login shell
+        // sources .zprofile / .bash_profile so subprocesses get a realistic
+        // env. zsh additionally needs -i to source .zshrc where most users
+        // keep proxy/PATH tweaks; bash -i emits "cannot set terminal process
+        // group" warnings in non-TTY contexts (eg. CI) so we stick to plain
+        // -lc for bash and rely on .bash_profile to source .bashrc as is
+        // standard. On Windows there is no equivalent concept, spawn direct.
+        const shellPath = process.env['SHELL'] || '/bin/zsh'
+        const useInteractive = /\bzsh$/.test(shellPath)
+        const proc = isWin
+          ? spawn(bin, args, {
+              stdio: ['pipe', 'pipe', 'pipe'],
+              env: { ...process.env, PATH: enrichedPath! },
+            })
+          : spawn(
+              shellPath,
+              [useInteractive ? '-ilc' : '-lc', [bin, ...args].map(shellQuote).join(' ')],
+              {
+                stdio: ['pipe', 'pipe', 'pipe'],
+                env: { ...process.env, PATH: enrichedPath! },
+                // Run in own process group so timeout kills the inner command
+                // too, not just the shell wrapper.
+                detached: true,
+              },
+            )
 
         let stdout = ''
         let stderr = ''
         let timedOut = false
 
+        const killGroup = () => {
+          if (!isWin && proc.pid) {
+            // Kill the whole process group so the shell wrapper AND the
+            // inner command both terminate. Without this, killing only the
+            // shell leaves the inner command orphaned and stdio pipes open.
+            try { process.kill(-proc.pid, 'SIGKILL') } catch { proc.kill('SIGKILL') }
+          } else {
+            proc.kill()
+          }
+        }
+
         const timer = setTimeout(() => {
           timedOut = true
-          proc.kill()
+          killGroup()
+          // Resolve immediately rather than waiting for stdio drain — the
+          // 'close' handler may not fire promptly when the process group is
+          // killed because orphaned descendants can keep pipes open.
+          reject(new Error(`Process timed out after ${timeout}ms`))
         }, timeout)
 
         proc.stdout.on('data', (d: Buffer) => { stdout += d.toString() })
@@ -60,16 +103,14 @@ export function makeExecCapability(): ExecCapability {
 
         proc.on('close', () => {
           clearTimeout(timer)
-          if (timedOut) {
-            reject(new Error(`Process timed out after ${timeout}ms`))
-          } else {
+          if (!timedOut) {
             resolve({ stdout, stderr, exitCode: proc.exitCode ?? 1 })
           }
         })
 
         proc.on('error', (err) => {
           clearTimeout(timer)
-          reject(err)
+          if (!timedOut) reject(err)
         })
       })
     },

--- a/packages/core/src/connectors/loader.test.ts
+++ b/packages/core/src/connectors/loader.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { validatePrerequisites } from './loader.js'
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -375,5 +376,35 @@ describe('loadConnectors', () => {
     const connector = registry.list()[0]
     await expect(connector.fetchPage({ cursor: null, sinceItemId: null, phase: 'forward', signal: new AbortController().signal }))
       .rejects.toThrow(/not declared/)
+  })
+})
+
+describe('validatePrerequisites', () => {
+  const validBase = {
+    id: 'req1',
+    name: 'Req One',
+    kind: 'exec' as const,
+    detect: { type: 'exec' as const, command: 'req1', args: ['--version'] },
+    install: { kind: 'exec' as const, url: 'https://example.com' },
+  }
+
+  it('accepts a valid prerequisite', () => {
+    expect(validatePrerequisites([validBase], 'pkg')).toHaveLength(1)
+  })
+
+  it('throws on duplicate prerequisite id', () => {
+    expect(() => validatePrerequisites([validBase, validBase], 'pkg'))
+      .toThrow('Prerequisite req1 in pkg: duplicate id')
+  })
+
+  it('throws on missing required fields', () => {
+    expect(() => validatePrerequisites([{ id: 'x' }], 'pkg'))
+      .toThrow(/missing required fields/)
+  })
+
+  it('throws on install.kind mismatch', () => {
+    const bad = { ...validBase, install: { ...validBase.install, kind: 'browser-extension' as any } }
+    expect(() => validatePrerequisites([bad], 'pkg'))
+      .toThrow(/install\.kind/)
   })
 })

--- a/packages/core/src/connectors/loader.test.ts
+++ b/packages/core/src/connectors/loader.test.ts
@@ -101,6 +101,49 @@ describe('loadConnectors', () => {
     expect(registry.list().length).toBe(1)
   })
 
+  it('manifest metadata wins over class field declarations', async () => {
+    const registry = new ConnectorRegistry()
+    writePkg(
+      join(connectorsDir, 'node_modules'),
+      '@spool-lab/connector-drift',
+      {
+        spool: {
+          type: 'connector',
+          id: 'drift',
+          platform: 'drift',
+          label: 'Manifest Label',
+          description: 'manifest description',
+          color: '#abcdef',
+          ephemeral: true,
+          capabilities: ['log'],
+        },
+      },
+      `export default class DriftConn {
+        id = 'drift'; platform = 'drift'; label = 'Stale Class Label';
+        description = 'class description'; color = '#000000'; ephemeral = false;
+        constructor(caps) { this.caps = caps }
+        async checkAuth() { return { ok: true } }
+        async fetchPage() { return { items: [], nextCursor: null } }
+      }`,
+    )
+
+    const report = await loadConnectors({
+      bundledConnectorsDir: bundledDir,
+      connectorsDir,
+      capabilityImpls: fakeCapabilityImpls(),
+      registry,
+      log: silentLogger(),
+      trustStore: makeTrustStore(),
+    })
+
+    expect(report.loadResults.find(r => r.name === '@spool-lab/connector-drift')?.status)
+      .toBe('loaded')
+    const loaded = registry.list()[0]!
+    expect(loaded.label).toBe('Manifest Label')
+    expect(loaded.color).toBe('#abcdef')
+    expect(loaded.ephemeral).toBe(true)
+  })
+
   it('skips packages without spool.type === "connector"', async () => {
     const registry = new ConnectorRegistry()
     writePkg(

--- a/packages/core/src/connectors/loader.ts
+++ b/packages/core/src/connectors/loader.ts
@@ -325,7 +325,7 @@ async function loadOneConnector(
     }
 
     const instance: Connector = new ConnectorClass(caps)
-    validateMetadataConsistency(pkg, instance)
+    applyManifestMetadata(instance, pkg, deps.log)
 
     deps.registry.register(instance)
     const connectorPkg: import('./types.js').ConnectorPackage = {
@@ -405,17 +405,37 @@ function makeUndeclaredError(name: string, accessor: string): SyncError {
   )
 }
 
-function validateMetadataConsistency(pkg: PkgInfo, instance: Connector): void {
+/**
+ * Manifest is the single source of truth for connector metadata.
+ *
+ * Any `readonly id/platform/label/description/color/ephemeral` declared on the
+ * connector class is treated as a default and overwritten with the manifest
+ * value so that runtime behavior always matches what the package declared.
+ *
+ * If the class field disagrees with the manifest, we log a warning so authors
+ * can clean it up — but loading proceeds, since silently dropping a connector
+ * because two redundant declarations drifted is worse than the inconsistency.
+ */
+function applyManifestMetadata(instance: Connector, pkg: PkgInfo, log: LoadDeps['log']): void {
   const fields: Array<keyof typeof pkg.manifest & keyof Connector> = [
     'id', 'platform', 'label', 'description', 'color', 'ephemeral',
   ]
   for (const field of fields) {
-    if (instance[field] !== pkg.manifest[field]) {
-      throw new Error(
-        `metadata mismatch for ${pkg.name}: ` +
-        `instance.${field}=${JSON.stringify(instance[field])} ` +
-        `but manifest.${field}=${JSON.stringify(pkg.manifest[field])}`,
-      )
+    const classValue = (instance as any)[field]
+    const manifestValue = pkg.manifest[field]
+    if (classValue !== undefined && classValue !== manifestValue) {
+      log.warn('connector class field disagrees with manifest; manifest wins', {
+        package: pkg.name,
+        field,
+        classValue,
+        manifestValue,
+      })
     }
+    Object.defineProperty(instance, field, {
+      value: manifestValue,
+      writable: false,
+      configurable: true,
+      enumerable: true,
+    })
   }
 }

--- a/packages/core/src/connectors/loader.ts
+++ b/packages/core/src/connectors/loader.ts
@@ -8,6 +8,8 @@ import type {
   ExecCapability,
   FetchCapability,
   LogCapability,
+  Prerequisite,
+  PrerequisitesCapability,
   SqliteCapability,
 } from '@spool/connector-sdk'
 import { SyncError, SyncErrorCode, KNOWN_CAPABILITIES_V1 } from '@spool/connector-sdk'
@@ -15,12 +17,48 @@ import type { ConnectorRegistry } from './registry.js'
 import { extractBundledConnectorsIfNeeded, type BundleLogger, type BundleReport } from './bundle-extract.js'
 import { TrustStore } from './trust-store.js'
 
+export function validatePrerequisites(prereqs: unknown[], packageName: string): Prerequisite[] {
+  const result: Prerequisite[] = []
+  const seen = new Set<string>()
+  for (const raw of prereqs) {
+    const p = raw as Prerequisite
+    if (!p.id || !p.name || !p.kind || !p.detect || !p.install) {
+      throw new Error(`Invalid prerequisite in ${packageName}: missing required fields`)
+    }
+    if (p.install.kind !== p.kind) {
+      throw new Error(`Prerequisite ${p.id} in ${packageName}: install.kind "${p.install.kind}" must match kind "${p.kind}"`)
+    }
+    if (p.kind === 'browser-extension') {
+      const inst = p.install as { webstoreUrl?: string; manual?: unknown }
+      if (!inst.webstoreUrl && !inst.manual) {
+        throw new Error(`Prerequisite ${p.id} in ${packageName}: browser-extension requires webstoreUrl or manual`)
+      }
+    }
+    if (p.minVersion && !(p.detect.type === 'exec' && p.detect.versionRegex)) {
+      throw new Error(`Prerequisite ${p.id} in ${packageName}: minVersion requires detect.versionRegex`)
+    }
+    if (seen.has(p.id)) {
+      throw new Error(`Prerequisite ${p.id} in ${packageName}: duplicate id`)
+    }
+    for (const req of p.requires ?? []) {
+      if (!seen.has(req)) {
+        throw new Error(`Prerequisite ${p.id} in ${packageName}: requires "${req}" must appear earlier in array`)
+      }
+    }
+    seen.add(p.id)
+    result.push(p)
+  }
+  return result
+}
+
 export interface CapabilityImpls {
   fetch: FetchCapability
   cookies: CookiesCapability
   sqlite: SqliteCapability
   exec: ExecCapability
   logFor(connectorId: string): LogCapability
+  /** Returns the prerequisites capability for the given package id, or undefined if not supported. */
+  prerequisitesFor?: (packageId: string) => PrerequisitesCapability
 }
 
 export interface LoaderLogger extends BundleLogger {
@@ -61,6 +99,7 @@ interface PkgInfo {
   }
   main: string
   multi: boolean
+  prerequisites: Prerequisite[]
 }
 
 const KNOWN_CAPS_SET = new Set<string>(KNOWN_CAPABILITIES_V1)
@@ -147,6 +186,18 @@ function tryReadConnectorManifest(
 
   if (json?.spool?.type !== 'connector') return []
 
+  const packageName = String(json.name)
+  let prerequisites: Prerequisite[]
+  try {
+    prerequisites = validatePrerequisites(
+      Array.isArray(json.spool.prerequisites) ? json.spool.prerequisites : [],
+      packageName,
+    )
+  } catch (err) {
+    log.error('invalid prerequisites in package', { package: packageName, error: String(err) })
+    return []
+  }
+
   // Multi-connector package: spool.connectors is an array
   if (Array.isArray(json.spool.connectors)) {
     const results: PkgInfo[] = []
@@ -155,7 +206,7 @@ function tryReadConnectorManifest(
       const unknown = declared.filter(c => !KNOWN_CAPS_SET.has(c))
       if (unknown.length > 0) {
         log.error('unknown capability in spool.connectors entry', {
-          package: json.name,
+          package: packageName,
           connectorId: entry.id,
           unknown,
           error: `Unknown capability "${unknown[0]}" — known v1 values: ${[...KNOWN_CAPS_SET].join(', ')}`,
@@ -164,7 +215,7 @@ function tryReadConnectorManifest(
       }
       results.push({
         dir: pkgDir,
-        name: String(json.name),
+        name: packageName,
         version: String(json.version ?? '0.0.0'),
         manifest: {
           id: String(entry.id ?? ''),
@@ -177,6 +228,7 @@ function tryReadConnectorManifest(
         },
         main: String(json.main ?? 'dist/index.js'),
         multi: true,
+        prerequisites,
       })
     }
     return results
@@ -190,7 +242,7 @@ function tryReadConnectorManifest(
   const unknown = declared.filter(c => !KNOWN_CAPS_SET.has(c))
   if (unknown.length > 0) {
     log.error('unknown capability in spool.capabilities', {
-      package: json.name,
+      package: packageName,
       unknown,
       error: `Unknown capability "${unknown[0]}" — known v1 values: ${[...KNOWN_CAPS_SET].join(', ')}`,
     })
@@ -199,7 +251,7 @@ function tryReadConnectorManifest(
 
   return [{
     dir: pkgDir,
-    name: String(json.name),
+    name: packageName,
     version: String(json.version ?? '0.0.0'),
     manifest: {
       id: String(json.spool.id ?? ''),
@@ -212,6 +264,7 @@ function tryReadConnectorManifest(
     },
     main: String(json.main ?? 'dist/index.js'),
     multi: false,
+    prerequisites,
   }]
 }
 
@@ -239,7 +292,7 @@ async function loadOneConnector(
       importedModules.set(entryPath, mod)
     }
 
-    const caps = buildCapabilities(pkg.manifest.capabilities, pkg.manifest.id, deps.capabilityImpls)
+    const caps = buildCapabilities(pkg.manifest.capabilities, pkg.manifest.id, pkg.name, deps.capabilityImpls)
     let ConnectorClass: any
 
     if (pkg.multi) {
@@ -275,6 +328,16 @@ async function loadOneConnector(
     validateMetadataConsistency(pkg, instance)
 
     deps.registry.register(instance)
+    const connectorPkg: import('./types.js').ConnectorPackage = {
+      id: pkg.name,
+      packageName: pkg.name,
+      rootDir: pkg.dir,
+      connectors: [instance],
+    }
+    if (pkg.prerequisites.length > 0) {
+      connectorPkg.prerequisites = pkg.prerequisites
+    }
+    deps.registry.registerPackage(connectorPkg)
     deps.log.info('loaded connector', { name: pkg.name, id: pkg.manifest.id, version: pkg.version })
     return { status: 'loaded', name: pkg.name, version: pkg.version }
   } catch (err) {
@@ -291,9 +354,10 @@ async function loadOneConnector(
 function buildCapabilities(
   declared: string[],
   connectorId: string,
+  packageId: string,
   impls: CapabilityImpls,
 ): ConnectorCapabilities {
-  return {
+  const caps: ConnectorCapabilities = {
     fetch: declared.includes('fetch')
       ? impls.fetch
       : (undefinedCapability('fetch') as FetchCapability),
@@ -310,6 +374,10 @@ function buildCapabilities(
       ? impls.exec
       : (undefinedCapability('exec') as ExecCapability),
   }
+  if (declared.includes('prerequisites') && impls.prerequisitesFor) {
+    caps.prerequisites = impls.prerequisitesFor(packageId)
+  }
+  return caps
 }
 
 function undefinedCapability(name: string): unknown {

--- a/packages/core/src/connectors/prerequisites.test.ts
+++ b/packages/core/src/connectors/prerequisites.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi } from 'vitest'
+import { PrerequisiteChecker } from './prerequisites.js'
+import { validatePrerequisites } from './loader.js'
+import type { Prerequisite } from '@spool/connector-sdk'
+import type { ConnectorPackage } from './types.js'
+
+function mkPkg(id: string, prerequisites: Prerequisite[]): ConnectorPackage {
+  return {
+    id,
+    packageName: id,
+    rootDir: '/fake',
+    connectors: [],
+    prerequisites,
+  } as unknown as ConnectorPackage
+}
+
+describe('PrerequisiteChecker', () => {
+  it('marks exec-detect as ok when command succeeds', async () => {
+    const exec = { run: vi.fn().mockResolvedValue({ exitCode: 0, stdout: 'v1.0.0\n', stderr: '' }) }
+    const checker = new PrerequisiteChecker(exec as any)
+    const pkg = mkPkg('p1', [
+      {
+        id: 'tool',
+        name: 'Tool',
+        kind: 'cli',
+        detect: { type: 'exec', command: 'tool', args: ['--version'] },
+        install: { kind: 'cli', command: { darwin: 'brew install tool' } },
+      },
+    ])
+    const steps = await checker.check(pkg)
+    expect(steps).toHaveLength(1)
+    expect(steps[0].status).toBe('ok')
+  })
+
+  it('marks missing when exec throws ENOENT', async () => {
+    const exec = { run: vi.fn().mockRejectedValue(new Error('ENOENT')) }
+    const checker = new PrerequisiteChecker(exec as any)
+    const pkg = mkPkg('p1', [
+      {
+        id: 'tool',
+        name: 'Tool',
+        kind: 'cli',
+        detect: { type: 'exec', command: 'missing', args: [] },
+        install: { kind: 'cli', command: { darwin: 'brew install tool' } },
+      },
+    ])
+    const steps = await checker.check(pkg)
+    expect(steps[0].status).toBe('missing')
+  })
+
+  it('marks outdated when version is below minVersion', async () => {
+    const exec = { run: vi.fn().mockResolvedValue({ exitCode: 0, stdout: 'v0.2.1\n', stderr: '' }) }
+    const checker = new PrerequisiteChecker(exec as any)
+    const pkg = mkPkg('p1', [
+      {
+        id: 'tool',
+        name: 'Tool',
+        kind: 'cli',
+        detect: { type: 'exec', command: 'tool', args: ['--version'], versionRegex: 'v?(\\d+\\.\\d+\\.\\d+)' },
+        minVersion: '0.3.0',
+        install: { kind: 'cli', command: { darwin: 'brew install tool' } },
+      },
+    ])
+    const steps = await checker.check(pkg)
+    expect(steps[0].status).toBe('outdated')
+    expect(steps[0].detectedVersion).toBe('0.2.1')
+    expect(steps[0].minVersion).toBe('0.3.0')
+  })
+
+  it('marks pending when upstream requires is not ok', async () => {
+    const exec = { run: vi.fn().mockRejectedValue(new Error('ENOENT')) }
+    const checker = new PrerequisiteChecker(exec as any)
+    const pkg = mkPkg('p1', [
+      {
+        id: 'upstream',
+        name: 'Upstream',
+        kind: 'cli',
+        detect: { type: 'exec', command: 'upstream', args: [] },
+        install: { kind: 'cli', command: { darwin: 'install upstream' } },
+      },
+      {
+        id: 'downstream',
+        name: 'Downstream',
+        kind: 'browser-extension',
+        requires: ['upstream'],
+        detect: { type: 'exec', command: 'check', args: [] },
+        install: { kind: 'browser-extension', manual: { downloadUrl: 'https://x', steps: ['a'] } },
+      },
+    ])
+    const steps = await checker.check(pkg)
+    expect(steps[0].status).toBe('missing')
+    expect(steps[1].status).toBe('pending')
+    expect(exec.run).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses matchStdout over version when both present', async () => {
+    const exec = { run: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '[OK] Extension connected v0.1.0', stderr: '' }) }
+    const checker = new PrerequisiteChecker(exec as any)
+    const pkg = mkPkg('p1', [
+      {
+        id: 'ext',
+        name: 'Ext',
+        kind: 'browser-extension',
+        detect: {
+          type: 'exec',
+          command: 'tool',
+          args: ['doctor'],
+          matchStdout: '\\[OK\\].*Extension',
+          versionRegex: 'v?(\\d+\\.\\d+\\.\\d+)',
+        },
+        minVersion: '99.0.0',
+        install: { kind: 'browser-extension', manual: { downloadUrl: 'https://x', steps: ['a'] } },
+      },
+    ])
+    const steps = await checker.check(pkg)
+    expect(steps[0].status).toBe('ok')
+  })
+
+  it('marks error when detected version is not parseable as semver', async () => {
+    const exec = { run: vi.fn().mockResolvedValue({ exitCode: 0, stdout: 'garbage-version', stderr: '' }) }
+    const checker = new PrerequisiteChecker(exec as any)
+    const pkg = mkPkg('p1', [
+      {
+        id: 'tool',
+        name: 'Tool',
+        kind: 'cli',
+        detect: { type: 'exec', command: 'tool', args: ['--version'], versionRegex: '(.+)' },
+        minVersion: '0.3.0',
+        install: { kind: 'cli', command: { darwin: 'install' } },
+      },
+    ])
+    const steps = await checker.check(pkg)
+    expect(steps[0].status).toBe('error')
+    expect(steps[0].hint).toMatch(/parse/i)
+  })
+
+  it('dedupes concurrent check calls for the same package', async () => {
+    const exec = {
+      run: vi.fn().mockImplementation(() => new Promise(resolve => setTimeout(() => resolve({ exitCode: 0, stdout: 'v1.0.0', stderr: '' }), 10))),
+    }
+    const checker = new PrerequisiteChecker(exec as any)
+    const pkg = mkPkg('p1', [
+      {
+        id: 'tool',
+        name: 'Tool',
+        kind: 'cli',
+        detect: { type: 'exec', command: 'tool', args: ['--version'] },
+        install: { kind: 'cli', command: { darwin: 'install' } },
+      },
+    ])
+    await Promise.all([checker.check(pkg), checker.check(pkg), checker.check(pkg)])
+    expect(exec.run).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('validatePrerequisites', () => {
+  it('rejects install.kind mismatch', () => {
+    expect(() => validatePrerequisites(
+      [{ id: 'a', name: 'A', kind: 'cli', detect: { type: 'exec', command: 'a', args: [] }, install: { kind: 'browser-extension' } }],
+      'p',
+    )).toThrow(/must match kind/)
+  })
+
+  it('rejects browser-extension without webstoreUrl or manual', () => {
+    expect(() => validatePrerequisites(
+      [{ id: 'a', name: 'A', kind: 'browser-extension', detect: { type: 'exec', command: 'a', args: [] }, install: { kind: 'browser-extension' } }],
+      'p',
+    )).toThrow(/webstoreUrl or manual/)
+  })
+
+  it('rejects forward-referencing requires', () => {
+    expect(() => validatePrerequisites(
+      [
+        { id: 'a', name: 'A', kind: 'cli', requires: ['b'], detect: { type: 'exec', command: 'a', args: [] }, install: { kind: 'cli', command: {} } },
+        { id: 'b', name: 'B', kind: 'cli', detect: { type: 'exec', command: 'b', args: [] }, install: { kind: 'cli', command: {} } },
+      ],
+      'p',
+    )).toThrow(/must appear earlier/)
+  })
+
+  it('accepts valid prerequisites', () => {
+    const r = validatePrerequisites(
+      [
+        { id: 'a', name: 'A', kind: 'cli', detect: { type: 'exec', command: 'a', args: [] }, install: { kind: 'cli', command: {} } },
+        { id: 'b', name: 'B', kind: 'browser-extension', requires: ['a'], detect: { type: 'exec', command: 'b', args: [] }, install: { kind: 'browser-extension', webstoreUrl: 'https://x' } },
+      ],
+      'p',
+    )
+    expect(r).toHaveLength(2)
+  })
+})

--- a/packages/core/src/connectors/prerequisites.ts
+++ b/packages/core/src/connectors/prerequisites.ts
@@ -1,0 +1,106 @@
+import type { Prerequisite, SetupStep, SetupStatus, ExecCapability } from '@spool/connector-sdk'
+import type { ConnectorPackage } from './types.js'
+import { valid, gte } from 'semver'
+
+function baseStep(p: Prerequisite, status: SetupStatus, extras: Partial<SetupStep> = {}): SetupStep {
+  const step: SetupStep = {
+    id: p.id,
+    label: p.name,
+    kind: p.kind,
+    status,
+    install: p.install,
+    ...extras,
+  }
+  if (p.docsUrl !== undefined) step.docsUrl = p.docsUrl
+  if (p.minVersion !== undefined && step.minVersion === undefined) step.minVersion = p.minVersion
+  return step
+}
+
+export class PrerequisiteChecker {
+  private cache = new Map<string, SetupStep[]>()
+  private inFlight = new Map<string, Promise<SetupStep[]>>()
+
+  constructor(private exec: ExecCapability) {}
+
+  getCached(packageId: string): SetupStep[] | undefined {
+    return this.cache.get(packageId)
+  }
+
+  invalidate(packageId: string): void {
+    this.cache.delete(packageId)
+  }
+
+  async check(pkg: ConnectorPackage): Promise<SetupStep[]> {
+    const existing = this.inFlight.get(pkg.id)
+    if (existing) return existing
+    const promise = this.runCheck(pkg).finally(() => this.inFlight.delete(pkg.id))
+    this.inFlight.set(pkg.id, promise)
+    return promise
+  }
+
+  private async runCheck(pkg: ConnectorPackage): Promise<SetupStep[]> {
+    const prereqs = pkg.prerequisites ?? []
+    const steps: SetupStep[] = []
+    const okIds = new Set<string>()
+
+    for (const p of prereqs) {
+      const unmet = (p.requires ?? []).filter(id => !okIds.has(id))
+      if (unmet.length > 0) {
+        steps.push(baseStep(p, 'pending'))
+        continue
+      }
+      const step = await this.detectOne(p)
+      steps.push(step)
+      if (step.status === 'ok') okIds.add(p.id)
+    }
+
+    this.cache.set(pkg.id, steps)
+    return steps
+  }
+
+  private async detectOne(p: Prerequisite): Promise<SetupStep> {
+    if (p.detect.type !== 'exec') {
+      return baseStep(p, 'error', { hint: `Unknown detect type: ${(p.detect as any).type}` })
+    }
+    const timeout = p.detect.timeoutMs ?? 5000
+    let result: { exitCode: number; stdout: string; stderr: string }
+    try {
+      result = await this.exec.run(p.detect.command, p.detect.args, { timeout })
+    } catch (e) {
+      const msg = (e as Error).message ?? ''
+      // TODO: fragile substring sniff — the ExecCapability contract does not
+      // define a recognizable timeout signal (no err.code, err.name, or
+      // { timedOut } flag). See packages/connector-sdk/src/capabilities.ts
+      // near ExecCapability for a proposed fix.
+      if (/timeout/i.test(msg)) return baseStep(p, 'error', { hint: 'Detection timed out' })
+      return baseStep(p, 'missing')
+    }
+
+    if (p.detect.matchStdout) {
+      const re = new RegExp(p.detect.matchStdout)
+      return re.test(result.stdout + result.stderr)
+        ? baseStep(p, 'ok')
+        : baseStep(p, 'missing')
+    }
+
+    if (p.detect.versionRegex && p.minVersion) {
+      const vm = new RegExp(p.detect.versionRegex).exec(result.stdout)
+      if (!vm || !vm[1]) {
+        return baseStep(p, 'error', { hint: 'Could not parse version' })
+      }
+      const detectedVersion = vm[1]
+      if (!valid(detectedVersion)) {
+        return baseStep(p, 'error', { hint: 'Could not parse detected version' })
+      }
+      if (gte(detectedVersion, p.minVersion)) {
+        return baseStep(p, 'ok', { detectedVersion })
+      }
+      return baseStep(p, 'outdated', {
+        detectedVersion,
+        hint: `Detected ${detectedVersion}, requires ≥ ${p.minVersion}`,
+      })
+    }
+
+    return result.exitCode === 0 ? baseStep(p, 'ok') : baseStep(p, 'missing')
+  }
+}

--- a/packages/core/src/connectors/registry-fetch.ts
+++ b/packages/core/src/connectors/registry-fetch.ts
@@ -1,7 +1,8 @@
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const REGISTRY_URL =
+const DEFAULT_REGISTRY_URL =
   'https://raw.githubusercontent.com/spool-lab/spool/main/packages/landing/public/registry.json'
 const CACHE_FILE = 'registry-cache.json'
 const TIMEOUT_MS = 3_000
@@ -23,14 +24,35 @@ export interface RegistryConnector {
 interface FetchRegistryOpts {
   fetchFn?: typeof fetch
   cacheDir: string
+  /** Override source. HTTP(S) URL, file:// URL, or absolute filesystem path. */
+  url?: string
+}
+
+function isFileSource(url: string): boolean {
+  return url.startsWith('file://') || url.startsWith('/')
+}
+
+function readLocalRegistry(url: string): RegistryConnector[] {
+  const path = url.startsWith('file://') ? fileURLToPath(url) : url
+  const raw = readFileSync(path, 'utf-8')
+  const data = JSON.parse(raw) as { connectors?: RegistryConnector[] }
+  return data.connectors ?? []
 }
 
 export async function fetchRegistry(opts: FetchRegistryOpts): Promise<RegistryConnector[]> {
-  const { fetchFn = globalThis.fetch, cacheDir } = opts
+  const { fetchFn = globalThis.fetch, cacheDir, url = DEFAULT_REGISTRY_URL } = opts
   const cachePath = join(cacheDir, CACHE_FILE)
 
+  if (isFileSource(url)) {
+    try {
+      return readLocalRegistry(url)
+    } catch {
+      return readCachedRegistry(cachePath)
+    }
+  }
+
   try {
-    const res = await fetchFn(REGISTRY_URL, { signal: AbortSignal.timeout(TIMEOUT_MS) })
+    const res = await fetchFn(url, { signal: AbortSignal.timeout(TIMEOUT_MS) })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     const data = (await res.json()) as { connectors?: RegistryConnector[] }
     const connectors: RegistryConnector[] = data.connectors ?? []

--- a/packages/core/src/connectors/registry.test.ts
+++ b/packages/core/src/connectors/registry.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { ConnectorRegistry } from './registry.js'
+import type { ConnectorPackage } from './types.js'
+
+function mkConnector(id: string) {
+  return { id, platform: 'p', label: id, description: '', color: '#000', ephemeral: false } as any
+}
+
+function mkPkg(id: string, connectorIds: string[]): ConnectorPackage {
+  return {
+    id,
+    packageName: id,
+    rootDir: '/tmp',
+    connectors: connectorIds.map(mkConnector),
+  } as any
+}
+
+describe('ConnectorRegistry.registerPackage', () => {
+  it('merges connectors when the same package id registers multiple times', () => {
+    const r = new ConnectorRegistry()
+    r.registerPackage(mkPkg('p1', ['a']))
+    r.registerPackage(mkPkg('p1', ['b']))
+    const merged = r.getPackage('p1')
+    expect(merged?.connectors.map(c => c.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('does not duplicate connectors with the same id', () => {
+    const r = new ConnectorRegistry()
+    r.registerPackage(mkPkg('p1', ['a']))
+    r.registerPackage(mkPkg('p1', ['a']))
+    expect(r.getPackage('p1')?.connectors.map(c => c.id)).toEqual(['a'])
+  })
+
+  it('keeps later package fields (e.g. prerequisites) on merge', () => {
+    const r = new ConnectorRegistry()
+    r.registerPackage(mkPkg('p1', ['a']))
+    const p2 = { ...mkPkg('p1', ['b']), prerequisites: [{ id: 'req1' }] } as any
+    r.registerPackage(p2)
+    expect(r.getPackage('p1')?.prerequisites).toEqual([{ id: 'req1' }])
+  })
+
+  it('accumulates three sub-connectors from a multi-connector package', () => {
+    const r = new ConnectorRegistry()
+    for (const id of ['x', 'y', 'z']) {
+      r.registerPackage(mkPkg('multi', [id]))
+    }
+    expect(r.getPackage('multi')?.connectors.map(c => c.id).sort()).toEqual(['x', 'y', 'z'])
+  })
+})

--- a/packages/core/src/connectors/registry.ts
+++ b/packages/core/src/connectors/registry.ts
@@ -1,4 +1,4 @@
-import type { Connector } from './types.js'
+import type { Connector, ConnectorPackage } from './types.js'
 
 /**
  * In-memory registry of available connectors.
@@ -8,9 +8,34 @@ import type { Connector } from './types.js'
  */
 export class ConnectorRegistry {
   private connectors = new Map<string, Connector>()
+  private packages = new Map<string, ConnectorPackage>()
 
   register(connector: Connector): void {
     this.connectors.set(connector.id, connector)
+  }
+
+  registerPackage(pkg: ConnectorPackage): void {
+    const existing = this.packages.get(pkg.id)
+    if (existing) {
+      // Multi-connector packages register once per sub-connector — merge the connectors list
+      const mergedConnectors = [...existing.connectors]
+      for (const c of pkg.connectors) {
+        if (!mergedConnectors.some(e => e.id === c.id)) {
+          mergedConnectors.push(c)
+        }
+      }
+      this.packages.set(pkg.id, { ...pkg, connectors: mergedConnectors })
+    } else {
+      this.packages.set(pkg.id, pkg)
+    }
+  }
+
+  getPackage(id: string): ConnectorPackage | undefined {
+    return this.packages.get(id)
+  }
+
+  listPackages(): ConnectorPackage[] {
+    return Array.from(this.packages.values())
   }
 
   get(id: string): Connector {
@@ -29,6 +54,7 @@ export class ConnectorRegistry {
 
   clear(): void {
     this.connectors.clear()
+    this.packages.clear()
   }
 
   list(): Connector[] {

--- a/packages/core/src/connectors/sync-engine.ts
+++ b/packages/core/src/connectors/sync-engine.ts
@@ -367,6 +367,7 @@ export class SyncEngine {
     const db = this.db
     const delayMs = opts.delayMs ?? DEFAULT_SCHEDULE.pageDelayMs
     const maxMinutes = opts.maxMinutes ?? 0
+    const maxPages = opts.maxPages ?? 100
     const stalePageLimit = opts.stalePageLimit ?? 3
     const checkpointEvery = 25
     const deadline = maxMinutes > 0 ? startedAt + maxMinutes * 60_000 : Number.POSITIVE_INFINITY
@@ -395,6 +396,9 @@ export class SyncEngine {
         const now = yield* Clock.currentTimeMillis
         if (now >= deadline) {
           return { added, pages, stopReason: 'timeout' }
+        }
+        if (pages >= maxPages) {
+          return { added, pages, stopReason: 'max_pages' }
         }
         if (yield* Deferred.isDone(cancel)) {
           return { added, pages, stopReason: 'cancelled' }
@@ -667,6 +671,7 @@ export class SyncEngine {
     const db = this.db
     const delayMs = opts.delayMs ?? DEFAULT_SCHEDULE.pageDelayMs
     const maxMinutes = opts.maxMinutes ?? 0
+    const maxPages = opts.maxPages ?? 100
     const sourceId = getSourceId(db)
     const deadline = maxMinutes > 0 ? startedAt + maxMinutes * 60_000 : Number.POSITIVE_INFINITY
 
@@ -685,6 +690,10 @@ export class SyncEngine {
         const now = yield* Clock.currentTimeMillis
         if (now >= deadline) {
           stopReason = 'timeout'
+          break
+        }
+        if (totalPages >= maxPages) {
+          stopReason = 'max_pages'
           break
         }
         if (yield* Deferred.isDone(cancel)) {

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -84,6 +84,8 @@ export interface SyncOptions {
   maxMinutes?: number
   /** Consecutive pages with 0 new items before stopping forward sync. Default: 3. */
   stalePageLimit?: number
+  /** Hard cap on total pages fetched per sync run. Default: 100. */
+  maxPages?: number
   /** AbortSignal for cancellation. */
   signal?: AbortSignal
   /**
@@ -148,6 +150,14 @@ export interface SyncJob {
   queuedAt: number
 }
 
+export interface ConnectorPackage {
+  id: string
+  packageName: string
+  rootDir: string
+  connectors: Connector[]
+  prerequisites?: import('@spool/connector-sdk').Prerequisite[]
+}
+
 export interface ConnectorStatus {
   id: string
   label: string
@@ -159,6 +169,8 @@ export interface ConnectorStatus {
   bundled: boolean
   version: string
   packageName: string
+  packageId?: string
+  setup?: import('@spool/connector-sdk').SetupStep[]
   state: SyncState
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,3 +51,18 @@ export {
   makeSqliteCapability,
   makeExecCapability,
 } from './connectors/capabilities/index.js'
+export { PrerequisiteChecker } from './connectors/prerequisites.js'
+export type { ConnectorPackage } from './connectors/types.js'
+
+// ── SDK re-exports (so app doesn't need a direct connector-sdk dep) ─────────
+export type {
+  Prerequisite,
+  PrerequisiteKind,
+  Detect,
+  Install,
+  ManualInstall,
+  SetupStep,
+  SetupStatus,
+  PrerequisitesCapability,
+} from '@spool/connector-sdk'
+export { checkAuthViaPrerequisites } from '@spool/connector-sdk'

--- a/packages/landing/public/registry.json
+++ b/packages/landing/public/registry.json
@@ -66,19 +66,6 @@
     },
     {
       "name": "@spool-lab/connector-xiaohongshu",
-      "id": "xiaohongshu-feed",
-      "platform": "xiaohongshu",
-      "label": "Xiaohongshu Feed",
-      "description": "Your Xiaohongshu home feed",
-      "color": "#FF2442",
-      "author": "spool-lab",
-      "category": "social",
-      "firstParty": true,
-      "npm": "https://www.npmjs.com/package/@spool-lab/connector-xiaohongshu",
-      "packageDescription": "Your Xiaohongshu feed, the notes you've published, and your notifications."
-    },
-    {
-      "name": "@spool-lab/connector-xiaohongshu",
       "id": "xiaohongshu-notes",
       "platform": "xiaohongshu",
       "label": "Xiaohongshu Notes",
@@ -87,21 +74,7 @@
       "author": "spool-lab",
       "category": "social",
       "firstParty": true,
-      "npm": "https://www.npmjs.com/package/@spool-lab/connector-xiaohongshu",
-      "packageDescription": "Your Xiaohongshu feed, the notes you've published, and your notifications."
-    },
-    {
-      "name": "@spool-lab/connector-xiaohongshu",
-      "id": "xiaohongshu-notifications",
-      "platform": "xiaohongshu",
-      "label": "Xiaohongshu Notifications",
-      "description": "Messages, likes, and comments",
-      "color": "#FF2442",
-      "author": "spool-lab",
-      "category": "social",
-      "firstParty": true,
-      "npm": "https://www.npmjs.com/package/@spool-lab/connector-xiaohongshu",
-      "packageDescription": "Your Xiaohongshu feed, the notes you've published, and your notifications."
+      "npm": "https://www.npmjs.com/package/@spool-lab/connector-xiaohongshu"
     }
   ]
 }

--- a/packages/landing/public/registry.json
+++ b/packages/landing/public/registry.json
@@ -61,6 +61,42 @@
       "category": "dev",
       "firstParty": true,
       "npm": "https://www.npmjs.com/package/@spool-lab/connector-github"
+    },
+    {
+      "name": "@spool-lab/connector-xiaohongshu",
+      "id": "xiaohongshu-feed",
+      "platform": "xiaohongshu",
+      "label": "Xiaohongshu Feed",
+      "description": "Your Xiaohongshu home feed",
+      "color": "#FF2442",
+      "author": "spool-lab",
+      "category": "social",
+      "firstParty": true,
+      "npm": "https://www.npmjs.com/package/@spool-lab/connector-xiaohongshu"
+    },
+    {
+      "name": "@spool-lab/connector-xiaohongshu",
+      "id": "xiaohongshu-notes",
+      "platform": "xiaohongshu",
+      "label": "Xiaohongshu Notes",
+      "description": "Notes you have published",
+      "color": "#FF2442",
+      "author": "spool-lab",
+      "category": "social",
+      "firstParty": true,
+      "npm": "https://www.npmjs.com/package/@spool-lab/connector-xiaohongshu"
+    },
+    {
+      "name": "@spool-lab/connector-xiaohongshu",
+      "id": "xiaohongshu-notifications",
+      "platform": "xiaohongshu",
+      "label": "Xiaohongshu Notifications",
+      "description": "Messages, likes, and comments",
+      "color": "#FF2442",
+      "author": "spool-lab",
+      "category": "social",
+      "firstParty": true,
+      "npm": "https://www.npmjs.com/package/@spool-lab/connector-xiaohongshu"
     }
   ]
 }

--- a/packages/landing/public/registry.json
+++ b/packages/landing/public/registry.json
@@ -48,7 +48,8 @@
       "author": "spool-lab",
       "category": "dev",
       "firstParty": true,
-      "npm": "https://www.npmjs.com/package/@spool-lab/connector-github"
+      "npm": "https://www.npmjs.com/package/@spool-lab/connector-github",
+      "packageDescription": "What you star and the notifications GitHub sends you."
     },
     {
       "name": "@spool-lab/connector-github",
@@ -60,7 +61,8 @@
       "author": "spool-lab",
       "category": "dev",
       "firstParty": true,
-      "npm": "https://www.npmjs.com/package/@spool-lab/connector-github"
+      "npm": "https://www.npmjs.com/package/@spool-lab/connector-github",
+      "packageDescription": "What you star and the notifications GitHub sends you."
     },
     {
       "name": "@spool-lab/connector-xiaohongshu",
@@ -72,7 +74,8 @@
       "author": "spool-lab",
       "category": "social",
       "firstParty": true,
-      "npm": "https://www.npmjs.com/package/@spool-lab/connector-xiaohongshu"
+      "npm": "https://www.npmjs.com/package/@spool-lab/connector-xiaohongshu",
+      "packageDescription": "Your Xiaohongshu feed, the notes you've published, and your notifications."
     },
     {
       "name": "@spool-lab/connector-xiaohongshu",
@@ -84,7 +87,8 @@
       "author": "spool-lab",
       "category": "social",
       "firstParty": true,
-      "npm": "https://www.npmjs.com/package/@spool-lab/connector-xiaohongshu"
+      "npm": "https://www.npmjs.com/package/@spool-lab/connector-xiaohongshu",
+      "packageDescription": "Your Xiaohongshu feed, the notes you've published, and your notifications."
     },
     {
       "name": "@spool-lab/connector-xiaohongshu",
@@ -96,7 +100,8 @@
       "author": "spool-lab",
       "category": "social",
       "firstParty": true,
-      "npm": "https://www.npmjs.com/package/@spool-lab/connector-xiaohongshu"
+      "npm": "https://www.npmjs.com/package/@spool-lab/connector-xiaohongshu",
+      "packageDescription": "Your Xiaohongshu feed, the notes you've published, and your notifications."
     }
   ]
 }

--- a/packages/landing/src/pages/connectors/index.astro
+++ b/packages/landing/src/pages/connectors/index.astro
@@ -2,7 +2,6 @@
 import registry from '../../../public/registry.json'
 const connectors = registry.connectors
 
-// Group multi-connector packages by npm name
 interface SubConnector { label: string; description: string }
 interface GroupedPackage {
   name: string
@@ -12,13 +11,15 @@ interface GroupedPackage {
   bundled: boolean
   firstParty: boolean
   description: string
+  packageDescription?: string
   subs: SubConnector[]
 }
 const packageMap = new Map<string, GroupedPackage>()
-for (const c of connectors) {
+for (const c of connectors as Array<typeof connectors[number] & { packageDescription?: string }>) {
   const existing = packageMap.get(c.name)
   if (existing) {
     existing.subs.push({ label: c.label, description: c.description })
+    if (c.packageDescription && !existing.packageDescription) existing.packageDescription = c.packageDescription
   } else {
     packageMap.set(c.name, {
       name: c.name,
@@ -28,6 +29,7 @@ for (const c of connectors) {
       bundled: !!c.bundled,
       firstParty: c.firstParty,
       description: c.description,
+      packageDescription: c.packageDescription,
       subs: [{ label: c.label, description: c.description }],
     })
   }
@@ -40,6 +42,15 @@ for (const pkg of packageMap.values()) {
   }
 }
 const packages = [...packageMap.values()]
+
+const subNamesOf = (pkg: GroupedPackage): string[] => {
+  if (pkg.subs.length <= 1) return []
+  const prefix = pkg.label.trim()
+  return pkg.subs.map(s => {
+    const cleaned = s.label.replace(new RegExp(`^${prefix}\\s*`, 'i'), '').trim()
+    return cleaned || s.label
+  })
+}
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -117,27 +128,10 @@ const packages = [...packageMap.values()]
       align-items: center;
       gap: 16px;
     }
-
-    nav a {
-      color: var(--muted);
-      text-decoration: none;
-      font-size: 14px;
-      font-weight: 500;
-      transition: color 0.15s;
-    }
-
+    nav a { color: var(--muted); text-decoration: none; font-size: 14px; font-weight: 500; transition: color 0.15s; }
     nav a:hover { color: var(--text); }
-
-    nav a.home {
-      color: var(--text);
-      font-weight: 600;
-    }
-
-    nav .sep {
-      color: var(--faint);
-      font-size: 14px;
-      user-select: none;
-    }
+    nav a.home { color: var(--text); font-weight: 600; }
+    nav .sep { color: var(--faint); font-size: 14px; user-select: none; }
 
     main {
       max-width: 860px;
@@ -160,139 +154,185 @@ const packages = [...packageMap.values()]
 
     .grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+      grid-template-columns: repeat(2, 1fr);
       grid-auto-rows: 1fr;
-      gap: 16px;
+      gap: 12px;
+    }
+    @media (max-width: 640px) {
+      .grid { grid-template-columns: 1fr; }
     }
 
     .card {
       background: var(--surface);
       border: 1px solid var(--border);
       border-radius: 10px;
-      padding: 20px;
+      padding: 16px;
       display: flex;
       flex-direction: column;
-      gap: 12px;
-      height: 100%;
+      gap: 10px;
     }
 
-    .card-header {
+    .card-head {
       display: flex;
       align-items: center;
-      gap: 12px;
+      gap: 11px;
     }
 
-    .color-dot {
-      width: 12px;
-      height: 12px;
-      border-radius: 50%;
+    .icon {
+      width: 34px;
+      height: 34px;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      font-weight: 600;
+      font-size: 14px;
+      letter-spacing: -0.02em;
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
       flex-shrink: 0;
     }
 
-    .card-title {
-      font-size: 15px;
+    .head-text { min-width: 0; }
+
+    .title {
+      font-size: 14px;
       font-weight: 600;
-      flex: 1;
+      letter-spacing: -0.01em;
+      line-height: 1.2;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
-    .badge {
+    .author {
       font-size: 11px;
-      font-weight: 500;
-      padding: 2px 7px;
-      border-radius: 4px;
-      background: var(--accent-subtle);
-      color: var(--accent);
+      color: var(--faint);
+      margin-top: 2px;
     }
 
-    .badge.category {
-      background: var(--surface2);
+    .desc {
+      font-size: 12.5px;
       color: var(--muted);
+      line-height: 1.45;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      min-height: calc(12.5px * 1.45 * 2);
     }
 
-    .card-desc {
-      font-size: 13px;
-      color: var(--muted);
-      line-height: 1.5;
-    }
-
-    .card-footer {
+    .footer {
       display: flex;
-      align-items: center;
       justify-content: space-between;
-      gap: 12px;
+      align-items: center;
+      gap: 10px;
       margin-top: auto;
     }
 
-    .cli-hint {
-      font-family: 'Geist Mono', monospace;
+    .meta {
+      font-size: 11.5px;
+      color: var(--muted);
+      display: inline-flex;
+      align-items: center;
+    }
+    .meta .category { text-transform: capitalize; }
+    .meta .sep { color: var(--faint); margin: 0 6px; }
+    .source-count {
+      position: relative;
+      cursor: default;
+    }
+    .source-count[data-sources]:hover::after {
+      content: attr(data-sources);
+      position: absolute;
+      left: 50%;
+      bottom: calc(100% + 8px);
+      transform: translateX(-50%);
+      background: var(--text);
+      color: var(--bg);
       font-size: 11px;
-      color: var(--faint);
+      font-weight: 500;
+      line-height: 1.4;
+      padding: 6px 10px;
+      border-radius: 6px;
+      white-space: nowrap;
+      pointer-events: none;
+      z-index: 10;
+      box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+    }
+    .source-count[data-sources]:hover::before {
+      content: "";
+      position: absolute;
+      left: 50%;
+      bottom: calc(100% + 3px);
+      transform: translateX(-50%);
+      border: 4px solid transparent;
+      border-top-color: var(--text);
+      pointer-events: none;
+      z-index: 10;
+    }
+
+    .actions {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-shrink: 0;
     }
 
     .install-btn {
       display: inline-block;
-      padding: 6px 14px;
+      padding: 5px 12px;
       border-radius: 6px;
       background: var(--accent);
       color: #fff;
-      font-size: 13px;
+      font-size: 12px;
       font-weight: 500;
       text-decoration: none;
       transition: opacity 0.15s;
       white-space: nowrap;
-      flex-shrink: 0;
     }
+    .install-btn:hover { opacity: 0.88; }
 
-    .install-btn:hover { opacity: 0.85; }
-
-    .included-label {
+    .copy-btn {
+      height: 28px;
+      padding: 0 10px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: transparent;
+      color: var(--muted);
+      cursor: pointer;
       display: inline-flex;
       align-items: center;
       gap: 5px;
-      padding: 6px 14px;
+      font-family: inherit;
+      font-size: 12px;
+      font-weight: 500;
+      transition: border-color 0.15s, color 0.15s, background 0.15s;
+    }
+    .copy-btn:hover { border-color: var(--border2); color: var(--text); background: var(--bg); }
+    .copy-btn svg { width: 12px; height: 12px; display: block; }
+    .copy-btn .icon-check { display: none; }
+    .copy-btn.copied { color: var(--accent); border-color: var(--accent); }
+    .copy-btn.copied .icon-copy { display: none; }
+    .copy-btn.copied .icon-check { display: block; }
+    .copy-btn .label-default { display: inline; }
+    .copy-btn .label-done { display: none; }
+    .copy-btn.copied .label-default { display: none; }
+    .copy-btn.copied .label-done { display: inline; }
+
+    .built-in {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 5px 10px;
       border-radius: 6px;
       background: var(--surface2);
       color: var(--muted);
-      font-size: 13px;
-      font-weight: 500;
-      white-space: nowrap;
-      flex-shrink: 0;
-    }
-
-    .included-label .check {
-      color: #4ADE80;
-      font-size: 14px;
-      line-height: 1;
-    }
-
-    .badge.bundled {
-      background: var(--surface2);
-      color: var(--muted);
-    }
-
-    .card-subs {
-      display: flex;
-      flex-direction: column;
-      gap: 3px;
-    }
-
-    .card-sub {
-      display: flex;
-      align-items: baseline;
-      gap: 6px;
       font-size: 12px;
-      line-height: 1.3;
-    }
-
-    .sub-label {
       font-weight: 500;
-      color: var(--text);
       white-space: nowrap;
     }
-
-    .sub-desc {
-      color: var(--muted);
-    }
+    .built-in .check { color: #4ADE80; font-size: 12px; line-height: 1; }
   </style>
 </head>
 <body>
@@ -307,47 +347,73 @@ const packages = [...packageMap.values()]
     <p class="subtitle">Install connectors to index your data sources into Spool.</p>
 
     <div class="grid">
-      {packages.map(pkg => (
-        <div class="card">
-          <div class="card-header">
-            <span class="color-dot" style={`background: ${pkg.color}`}></span>
-            <span class="card-title">{pkg.label}</span>
-            <span class="badge category">{pkg.category}</span>
-            {pkg.bundled
-              ? <span class="badge bundled">built-in</span>
-              : pkg.firstParty && <span class="badge">official</span>}
-          </div>
-          {pkg.subs.length > 1 ? (
-            <div class="card-subs">
-              {pkg.subs.map(sub => {
-                const stripped = sub.label.startsWith(pkg.label + ' ') ? sub.label.slice(pkg.label.length + 1) : sub.label
-                return (
-                  <div class="card-sub">
-                    <span class="sub-label">{stripped}</span>
-                    <span class="sub-desc">{sub.description}</span>
-                  </div>
-                )
-              })}
+      {packages.map(pkg => {
+        const initial = pkg.label.replace(/^[^A-Za-z0-9\u4e00-\u9fa5]+/, '').charAt(0).toUpperCase() || '·'
+        const sourceCount = pkg.subs.length
+        const desc = sourceCount > 1 ? (pkg.packageDescription ?? pkg.description) : pkg.description
+        const cliCmd = `spool connector install ${pkg.name}`
+        const subNames = subNamesOf(pkg)
+        return (
+          <div class="card">
+            <div class="card-head">
+              <span class="icon" style={`background: ${pkg.color}`}>{initial}</span>
+              <div class="head-text">
+                <div class="title">{pkg.label}</div>
+                <div class="author">Spool Lab</div>
+              </div>
             </div>
-          ) : (
-            <p class="card-desc">{pkg.description}</p>
-          )}
-          <div class="card-footer">
-            {pkg.bundled ? (
-              <>
-                <span class="cli-hint">Included with Spool</span>
-                <span class="included-label"><span class="check">&#10003;</span> Included</span>
-              </>
-            ) : (
-              <>
-                <span class="cli-hint">spool connector install {pkg.name}</span>
-                <a href={`spool://connector/install/${pkg.name}`} class="install-btn">Install</a>
-              </>
-            )}
+            <p class="desc">{desc}</p>
+            <div class="footer">
+              <span class="meta">
+                <span class="category">{pkg.category}</span>
+                <span class="sep">·</span>
+                <span class="source-count" data-sources={subNames.length ? subNames.join(' · ') : undefined}>
+                  {sourceCount} {sourceCount === 1 ? 'source' : 'sources'}
+                </span>
+              </span>
+              <span class="actions">
+                {pkg.bundled ? (
+                  <span class="built-in"><span class="check">&#10003;</span> Built-in</span>
+                ) : (
+                  <>
+                    <button class="copy-btn" type="button" data-cmd={cliCmd} aria-label="Copy install command">
+                      <svg class="icon-copy" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <rect x="5" y="5" width="8" height="8" rx="1.5"/>
+                        <path d="M3 11V4a1 1 0 0 1 1-1h7"/>
+                      </svg>
+                      <svg class="icon-check" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <path d="M3.5 8.5l3 3 6-6.5"/>
+                      </svg>
+                      <span class="label-default">Copy CLI</span>
+                      <span class="label-done">Copied</span>
+                    </button>
+                    <a href={`spool://connector/install/${pkg.name}`} class="install-btn">Install</a>
+                  </>
+                )}
+              </span>
+            </div>
           </div>
-        </div>
-      ))}
+        )
+      })}
     </div>
   </main>
+
+  <script is:inline>
+    document.querySelectorAll('.copy-btn').forEach((btn) => {
+      btn.addEventListener('click', async (e) => {
+        e.preventDefault()
+        const cmd = btn.getAttribute('data-cmd') || ''
+        try {
+          await navigator.clipboard.writeText(cmd)
+          btn.classList.add('copied')
+          btn.setAttribute('title', 'Copied!')
+          setTimeout(() => {
+            btn.classList.remove('copied')
+            btn.setAttribute('title', 'Copy install command')
+          }, 1400)
+        } catch {}
+      })
+    })
+  </script>
 </body>
 </html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       file-uri-to-path:
         specifier: ^2.0.0
         version: 2.0.0
+      lucide-react:
+        specifier: ^1.8.0
+        version: 1.8.0(react@19.2.5)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -207,14 +210,17 @@ importers:
   packages/connectors/xiaohongshu:
     devDependencies:
       '@spool/connector-sdk':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../../connector-sdk
       '@types/node':
         specifier: ^22.15.3
         version: 22.19.17
       typescript:
-        specifier: ^5.7.3
+        specifier: ^5.4.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
 
   packages/core:
     dependencies:
@@ -3096,6 +3102,11 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  lucide-react@1.8.0:
+    resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -7770,6 +7781,10 @@ snapshots:
       yallist: 4.0.0
 
   lru-cache@7.18.3: {}
+
+  lucide-react@1.8.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   magic-string@0.30.21:
     dependencies:


### PR DESCRIPTION
## Summary

Adds a **package-level prerequisites** declaration to the Spool connector plugin system, with the Xiaohongshu (XHS) connector as the first real consumer.

A connector package can now declare external dependencies (CLI tools, browser extensions, site logins) in its `package.json`. The app detects them at runtime, renders a Setup checklist in the UI, offers one-click primary actions (supervised install, open Chrome Store, open login page), and re-checks automatically when the window regains focus or the user clicks Install.

**Status: draft.** XHS package isn't on npm yet; tested locally via the dev-mode workspace symlink path.

## Design

**Two concepts, two names:**
- `prerequisites` (manifest, static): what the package needs
- `setup` (runtime, dynamic): current per-step status

**Three prerequisite kinds**, schema open for future ones:

| kind | detection | install action |
|---|---|---|
| `cli` | `exec --version` + optional `minVersion` (semver) | supervised install via user's login shell, 120s + SIGKILL escalation, cancel; copy-to-clipboard fallback |
| `browser-extension` | `exec doctor` + `matchStdout` regex | Chrome Web Store URL, or manual-install modal with Download + Copy URL buttons |
| `site-session` | `exec doctor` + connectivity regex | open login URL in default browser |

**Dependency ordering** via `requires: ["otherId"]` — downstream marked `pending` if upstream isn't ok, skipping its detect call.

**Detection in main process** (`PrerequisiteChecker`) using the existing `exec` capability. In-memory cache, in-flight dedup prevents redundant spawns on rapid focus events. **No DB migration** — prerequisite state is purely runtime.

**Auto-recheck triggers:** window focus (always, even when previously all-ok — extensions / CLIs / login sessions can degrade silently outside the app), post-install success, manual Re-check. Diff-before-broadcast prevents spurious renders when nothing changed.

**Default `checkAuth`:** SDK helper `checkAuthViaPrerequisites(caps)` that connectors can call when their auth is fully covered by prerequisites. XHS uses this — zero custom `checkAuth` logic in the connector code.

**UI:** one Setup card per package. SourcesPanel hides it when everything is ok (overview stays quiet); the connector detail view in SettingsPanel keeps it visible in collapsed form so users can inspect prereq state any time. The card pre-populates with `status='pending'` rows from the manifest the moment the package is opened, then per-step status flips when the actual check completes — no flash of empty state.

**IPC error shapes** are discriminated unions everywhere (`{ok: true, ...} | {ok: false, reason: '...'}`), no string sentinels.

## Manifest is the single source of truth

The loader used to require the connector class fields (id, label, ephemeral, ...) to exactly match the package manifest, throwing if they drifted. That made multi-connector packages fragile: tweak `class.ephemeral` without updating `package.json` and the entire sub-connector silently fails to load while its siblings still appear, looking like a UI bug rather than a metadata bug. The loader now uses `defineProperty` to overwrite class fields with manifest values after instantiation — manifest wins, drift only logs a warning.

## Exec capability inherits user shell env

GUI-launched apps on macOS don't inherit shell env (no `http_proxy`, no nvm-managed PATH, etc.), which surfaced as the GitHub connector hanging on `gh api` calls (TCP read reset) for users behind a proxy. The exec capability now wraps spawn in the user's shell so rc files get sourced:
- zsh: `-ilc` (sources .zprofile + .zshrc)
- bash: `-lc` (sources .bash_profile, which standardly chains to .bashrc; -i avoided because bash emits TTY warnings in CI)

Subprocesses spawn detached so timeouts can SIGKILL the whole process group rather than orphaning the inner command.

## XHS Connector

Currently ships **one sub-connector**: `xiaohongshu-notes` (creator notes, persistent, single-shot fetch). The package keeps its multi-connector array structure so feed and notifications can return cleanly when their upstream issues resolve:

- `xiaohongshu-feed` — opencli reads the page Pinia store snapshot without scrolling, so item count fluctuates (~20) regardless of `--limit`
- `xiaohongshu-notifications` — opencli returns only `[{rank: N}]` placeholders without real content fields

Notes uses opencli's `creator-notes` subcommand (single-shot, `--limit 100`, no pagination since opencli has no cursor flag). Empty results (which opencli reports as exit 1 "No notes found") are treated as a successful empty page rather than a sync error.

## Safety against infinite crawl

**Two layers:**

1. **Connector-level**: `nextCursor: null` always for opencli-backed connectors (no pagination supported upstream)
2. **Sync-engine `maxPages` option**: new optional field on `SyncOptions` (default 100). Both ephemeral and persistent sync loops check the cap and exit with `stopReason: 'max_pages'`. Defense in depth for any connector

## Dev-mode conveniences

Three non-production-affecting paths added for local testing:

- **Local registry**: in `!app.isPackaged`, `connector:fetch-registry` reads `packages/landing/public/registry.json` from the workspace. `SPOOL_REGISTRY_URL` env var overrides explicitly. Production still fetches from `raw.githubusercontent.com`
- **Workspace install**: in dev, the Install button symlinks the package from `packages/connectors/<dir>` if present; otherwise falls through to npm. Lets us test unpublished connectors via the real Install UX
- **XHS is NOT bundled**: registered as a regular installable package. Tested via the dev-mode symlink path until published

## Tests

- `packages/core/src/connectors/prerequisites.test.ts` — PrerequisiteChecker detect paths and `validatePrerequisites` manifest validator
- `packages/core/src/connectors/registry.test.ts` — multi-connector package merge in ConnectorRegistry
- `packages/core/src/connectors/loader.test.ts` — manifest-as-truth (drift between class field and manifest is logged but doesn't fail loading)
- `packages/core/src/connectors/capabilities/exec-impl.test.ts` — login-shell semantics, arg quoting, missing-binary returns exit 127, timeout kills process group
- `packages/connectors/xiaohongshu/src/index.test.ts` — single-shot fetch, never passes unsupported flags, treats opencli "no X found" exit as empty result, surfaces real errors

Total: 140 core tests + 5 XHS tests pass. CI green.

## Files of note

- `packages/connector-sdk/src/connector.ts` — SDK types (`Prerequisite`, `Detect`, `Install`, `ManualInstall`, `SetupStep`, `AuthStatus.setup`), `checkAuthViaPrerequisites` helper
- `packages/core/src/connectors/prerequisites.ts` — `PrerequisiteChecker` (semver, in-flight dedup, dependency-aware ordering)
- `packages/core/src/connectors/loader.ts` — manifest as single source of truth via `applyManifestMetadata`
- `packages/core/src/connectors/capabilities/exec-impl.ts` — login-shell wrap with shell-specific flag (zsh `-ilc`, bash `-lc`), detached process group for clean kill
- `packages/core/src/connectors/registry.ts` — `registerPackage` merges on same id (for multi-connector packages)
- `packages/core/src/connectors/sync-engine.ts` — `maxPages` safety cap in both loops
- `packages/app/src/main/index.ts` — 6 IPC handlers, supervised install (SIGKILL escalation, login-shell, 120s timeout, cancel), focus-driven recheck (always, with diff-before-broadcast), pending-steps seeding so the prereq card renders before the first check completes
- `packages/app/src/renderer/components/PackageSetupCard.tsx` — status icons, per-kind primary actions, inline install progress, hide-when-all-ok by default, `alwaysShow` mode for connector detail (collapsed pill that expands on click), ghost-style accent install button
- `packages/app/src/renderer/components/ManualInstallModal.tsx` — data-driven step list, Download / Copy URL / Check now actions
- `packages/connectors/xiaohongshu/` — package with `xiaohongshu-notes` sub-connector + prereqs

## Test plan

- [x] Core: 140 tests passing across PrerequisiteChecker, validatePrerequisites, registry, loader (manifest truth), exec-impl (login shell), sync-engine
- [x] XHS connector: 5 tests covering single-shot fetch, unsupported-flag avoidance, empty-state handling, error propagation
- [x] App tsc --noEmit clean
- [x] CI green (unit + e2e mac + e2e linux)
- [x] Manual: fresh install → prereq card visible immediately with pending rows → check completes within ~1s and rows flip to ✓/✗ → Install OpenCLI triggers supervised shell → extension manual-install modal → login flow → card collapses to pill on detail view when all ok, expandable on click → focus event triggers recheck → removing extension flips card back to ✗
- [x] Manual: GitHub connector sync works through user's `.zshrc` proxy via the new login-shell wrap (verified: no more `read tcp` reset)
- [x] Regression: HN, Twitter Bookmarks, Typeless render and sync unchanged (no prerequisites declared)

## Known caveats

- XHS package not yet published to npm. Registry URL points to a package that cannot be `npm install`ed outside this workspace. Before merging, either publish the package or gate the registry entry behind a flag
- XHS feed and notifications sub-connectors are intentionally absent — see the `refactor(connector-xiaohongshu): scope to notes-only` commit for rationale and re-add path

## Follow-ups

- Prod-style smoke test before releases (npm pack → install into fresh app) — dev/prod install paths diverge enough that pure dev testing has missed regressions before
- Re-add `xiaohongshu-feed` once opencli supports scroll-before-snapshot, and `xiaohongshu-notifications` once its JSON output includes real content fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)
