### PR TITLE
fix: use directory watching instead of globs for chokidar v4 compatibility

### DIFF
--- a/packages/core/src/sync/watcher.ts
+++ b/packages/core/src/sync/watcher.ts
@@ -1,11 +1,17 @@
 import chokidar, { type FSWatcher } from 'chokidar'
 import type { Syncer } from './syncer.js'
 import type { SessionSource } from '../types.js'
-import { detectSessionSource, getSessionRoots, getSessionWatchPatterns } from './source-paths.js'
+import { detectSessionSource, getSessionRoots } from './source-paths.js'
 // No native module dependencies — uses node:sqlite via @spool/core
 
 export type WatcherEvent = 'new-sessions'
 export type WatcherEventCallback = (event: WatcherEvent, data: { count: number }) => void
+
+/** Check if a file path is a session file we care about */
+function isSessionFile(filePath: string): boolean {
+  return filePath.endsWith('.jsonl')
+    || (filePath.endsWith('.json') && /(?:^|[/\\])session-[^/\\]*\.json$/.test(filePath))
+}
 
 export class SpoolWatcher {
   private watcher: FSWatcher | null = null
@@ -26,15 +32,18 @@ export class SpoolWatcher {
       codex: getSessionRoots('codex'),
       gemini: getSessionRoots('gemini'),
     }
-    const patterns = [
-      ...getSessionWatchPatterns('claude', this.sourceRoots.claude),
-      ...getSessionWatchPatterns('codex', this.sourceRoots.codex),
-      ...getSessionWatchPatterns('gemini', this.sourceRoots.gemini),
+    // chokidar v4 removed glob support — watch directories directly
+    // and use `ignored` to filter for session files only
+    const dirs = [
+      ...this.sourceRoots.claude,
+      ...this.sourceRoots.codex,
+      ...this.sourceRoots.gemini,
     ]
 
-    this.watcher = chokidar.watch(patterns, {
+    this.watcher = chokidar.watch(dirs, {
       persistent: true,
       ignoreInitial: true, // initial sync is done by Syncer.syncAll()
+      ignored: (path, stats) => stats?.isFile() === true && !isSessionFile(path),
       awaitWriteFinish: {
         stabilityThreshold: 2000,
         pollInterval: 200,


### PR DESCRIPTION
## Summary

- **`spool sync --watch` silently stops detecting new/changed sessions** because chokidar v4 [removed glob support](https://github.com/paulmillr/chokidar/blob/main/README.md#upgrading). The watcher passes patterns like `/path/**/*.jsonl` which v4 accepts without error but never matches any filesystem events.
- Switch to watching root directories directly with an `ignored` callback that filters for session files (`.jsonl` and `session-*.json`), following chokidar v4's recommended migration path.

## Root cause

```typescript
// BEFORE (broken): chokidar v4 ignores glob patterns silently
chokidar.watch(['/path/**/*.jsonl'], { ... })

// AFTER (fixed): watch directories, filter via ignored callback
chokidar.watch(['/path'], {
  ignored: (path, stats) => stats?.isFile() === true && !isSessionFile(path),
  ...
})
```

## Evidence

### Before fix (glob pattern → 0 events):
```
=== OLD (glob) ===
Pattern: /Users/didi/.claude/projects/**/*.jsonl
--- Writing test file ---
--- Done ---
// No ADD or CHANGE events detected
```

### After fix (directory + ignored → events detected):
```
=== NEW (dir+ignored) ===
Dir: /Users/didi/.claude/projects
--- Writing test file ---
NEW ADD: -Users-didi/test-compare-1776168876960.jsonl
NEW CHANGE: -Users-didi/172dd025-62fa-4f54-930e-02f3905e45a5.jsonl
--- Done ---
```

### Integration test results:
```
=== Test 1: New .jsonl file ===
  syncFile: test-session-1.jsonl claude  ✅
=== Test 2: Append to existing .jsonl ===
  syncFile: test-session-1.jsonl claude  ✅
=== Test 3: Non-.jsonl file (should be ignored) ===
  (no syncFile call)                     ✅
=== Test 4: Second .jsonl file ===
  syncFile: test-session-2.jsonl claude  ✅

✓ .jsonl files detected: PASS (3)
✓ .txt files ignored: PASS
```

### Gemini session file filtering also verified:
```
✓ session-*.json detected: PASS
✓ config.json ignored: PASS
```

## Test plan

- [x] Existing unit tests pass (`pnpm test --filter @spool/core` → 17 files, 118 passed)
- [x] New `.jsonl` file creation triggers `syncFile`
- [x] Appending to existing `.jsonl` triggers `syncFile`
- [x] Non-session files (`.txt`, `.json`) are correctly ignored
- [x] Gemini `session-*.json` files are correctly detected
- [x] Build succeeds (`pnpm run build --filter @spool/core`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)