### PR TITLE
Remove booking links from landing page

### DIFF
--- a/packages/landing/src/pages/index.astro
+++ b/packages/landing/src/pages/index.astro
@@ -892,12 +892,6 @@
         </a>
       </div>
       <p class="install-label">macOS &middot; Apple Silicon &middot; works with Claude Code, Codex CLI, Gemini CLI, or any ACP agent</p>
-      <p style="margin-top: 16px; font-size: 13px; color: var(--muted);">
-        <a href="https://cal.com/doodlewind/30min" target="_blank" rel="noopener" style="color: var(--accent); text-decoration: none; display: inline-flex; align-items: center; gap: 6px; transition: opacity 80ms;" onmouseenter="this.style.opacity='0.8'" onmouseleave="this.style.opacity='1'">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 10l5-5"/><path d="M20 5v4h-4"/><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M3 10h18"/><path d="M10 4v18"/></svg>
-          Book a 30-min call with the author
-        </a>
-      </p>
     </div>
   </div>
 
@@ -1081,7 +1075,7 @@
 
   <!-- Footer -->
   <footer>
-    <p>Spool by <a href="https://github.com/spool-lab">Spool Lab</a>. <span style="margin: 0 4px;">&middot;</span> <a href="https://cal.com/doodlewind/30min" target="_blank" rel="noopener">Talk to the author</a></p>
+    <p>Spool by <a href="https://github.com/spool-lab">Spool Lab</a>.</p>
   </footer>
 
   <script>


### PR DESCRIPTION
## Summary
- remove the 30-minute booking CTA beneath the hero install section
- remove the footer author contact link

## Testing
- pnpm --filter @spool/landing build