### PR TITLE
Fix landing deploy workflow for pnpm workspace

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'packages/landing/**'
+      - '.github/workflows/deploy-landing.yml'
   workflow_dispatch:
 
 jobs:
@@ -30,8 +31,7 @@ jobs:
         run: pnpm --filter @spool/landing build
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy packages/landing/dist --project-name spool-landing
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm --filter @spool/landing deploy


### PR DESCRIPTION
## Summary
- trigger landing deploys when the workflow file itself changes
- run the landing package's own deploy script instead of wrangler-action's root-level install path

## Testing
- pnpm --filter @spool/landing build
- pnpm --filter @spool/landing exec wrangler --version