### PR TITLE
Use pnpm run for landing deploy script

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -34,4 +34,4 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: pnpm --filter @spool/landing deploy
+        run: pnpm --filter @spool/landing run deploy


### PR DESCRIPTION
## Summary
- call the landing package deploy script via pnpm run so pnpm does not treat deploy as its built-in subcommand

## Testing
- pnpm --filter @spool/landing build