### PR TITLE
Revert "fix: use directory watching instead of globs for chokidar v4 compatibility (#77)"

### DIFF
--- a/packages/core/src/sync/watcher.ts
+++ b/packages/core/src/sync/watcher.ts
@@ -1,17 +1,11 @@
 import chokidar, { type FSWatcher } from 'chokidar'
 import type { Syncer } from './syncer.js'
 import type { SessionSource } from '../types.js'
-import { detectSessionSource, getSessionRoots } from './source-paths.js'
+import { detectSessionSource, getSessionRoots, getSessionWatchPatterns } from './source-paths.js'
 // No native module dependencies — uses node:sqlite via @spool/core
 
 export type WatcherEvent = 'new-sessions'
 export type WatcherEventCallback = (event: WatcherEvent, data: { count: number }) => void
-
-/** Check if a file path is a session file we care about */
-function isSessionFile(filePath: string): boolean {
-  return filePath.endsWith('.jsonl')
-    || (filePath.endsWith('.json') && /(?:^|[/\\])session-[^/\\]*\.json$/.test(filePath))
-}
 
 export class SpoolWatcher {
   private watcher: FSWatcher | null = null
@@ -32,18 +26,15 @@ export class SpoolWatcher {
       codex: getSessionRoots('codex'),
       gemini: getSessionRoots('gemini'),
     }
-    // chokidar v4 removed glob support — watch directories directly
-    // and use `ignored` to filter for session files only
-    const dirs = [
-      ...this.sourceRoots.claude,
-      ...this.sourceRoots.codex,
-      ...this.sourceRoots.gemini,
+    const patterns = [
+      ...getSessionWatchPatterns('claude', this.sourceRoots.claude),
+      ...getSessionWatchPatterns('codex', this.sourceRoots.codex),
+      ...getSessionWatchPatterns('gemini', this.sourceRoots.gemini),
     ]
 
-    this.watcher = chokidar.watch(dirs, {
+    this.watcher = chokidar.watch(patterns, {
       persistent: true,
       ignoreInitial: true, // initial sync is done by Syncer.syncAll()
-      ignored: (path, stats) => stats?.isFile() === true && !isSessionFile(path),
       awaitWriteFinish: {
         stabilityThreshold: 2000,
         pollInterval: 200,


### PR DESCRIPTION
Reverts #77.

## Why

PR #77 switched `chokidar.watch(glob)` to `chokidar.watch(dirs)`, which restored event delivery on chokidar v4 but introduced a worse regression on macOS:

- chokidar v4/v5 removed the `fsevents` dependency entirely — on macOS it falls back to `fs.watch`, and each watched directory consumes one FD
- Recursive watching of `~/.claude/projects/` (373 subdirs locally) + `~/.codex/sessions/` (43 subdirs) blows past the macOS per-process soft FD limit (default 256)
- Result: `EMFILE: too many open files, watch` thrown inside `FSWatcher._handle.onchange` repeatedly
- Because `watcher.ts` has no `.on('error', ...)` handler, these surface as unhandled promise rejections that accumulate unboundedly (rejection id 9500+ within minutes)
- Accumulating rejections + synchronous `syncFile()` on each event → main process saturates, cursor shows spinner on hover, RSS grows

Reverting gets us back to the zero-events state (a bug) rather than the cascading-failure state (a worse bug). A proper fix is tracked in a follow-up issue.

## Test plan

- [x] `pnpm build` passes
- [x] Dev app boots without EMFILE spam in console
- [x] Accept: new sessions do not auto-appear in the UI until manual re-sync (pre-existing behavior under the silent-glob bug; tracked in follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)