### PR TITLE
fix(cli): drop twitter-bookmarks default from connector-sync

### DIFF
--- a/packages/cli/src/commands/connector-sync.ts
+++ b/packages/cli/src/commands/connector-sync.ts
@@ -19,10 +19,10 @@ import type { SyncState } from '@spool/core'
 
 export const connectorSyncCommand = new Command('connector-sync')
   .description('Sync a connector until fully complete')
-  .argument('[connector-id]', 'Connector ID (default: twitter-bookmarks)', 'twitter-bookmarks')
+  .argument('[connector-id]', 'Connector ID (omit to list available)')
   .option('--reset', 'Delete all data for this connector and sync from scratch')
   .option('--delay <ms>', 'Delay between page requests in ms', '600')
-  .action(async (connectorId: string, opts: { reset?: boolean; delay?: string }) => {
+  .action(async (connectorId: string | undefined, opts: { reset?: boolean; delay?: string }) => {
     const db = getDB()
     const registry = new ConnectorRegistry()
     const spoolDir = join(homedir(), '.spool')
@@ -42,9 +42,22 @@ export const connectorSyncCommand = new Command('connector-sync')
       trustStore: new TrustStore(spoolDir),
     })
 
+    const available = registry.list().map(c => c.id)
+
+    if (!connectorId) {
+      if (available.length === 0) {
+        console.error('No connectors installed.')
+        process.exit(1)
+      }
+      console.log('Available connectors:')
+      for (const id of available) console.log(`  ${id}`)
+      console.log('\nUsage: spool connector-sync <connector-id>')
+      process.exit(0)
+    }
+
     if (!registry.has(connectorId)) {
       console.error(`Unknown connector: ${connectorId}`)
-      console.error(`Available: ${registry.list().map(c => c.id).join(', ')}`)
+      console.error(`Available: ${available.join(', ')}`)
       process.exit(1)
     }
 

--- a/packages/cli/src/commands/connector-sync.ts
+++ b/packages/cli/src/commands/connector-sync.ts
@@ -1,6 +1,9 @@
 import { Command } from 'commander'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 import {
   getDB,
   ConnectorRegistry,


### PR DESCRIPTION
## Summary
- `spool connector-sync` no longer defaults `connector-id` to `twitter-bookmarks` — stale since multi-connector packages landed (#70). Running with no args now lists installed connectors and prints usage (exit 0)
- Also fix a pre-existing ESM bug: `__dirname` was referenced directly but the package is `"type": "module"`, so the subcommand crashed on invocation. Derived from `import.meta.url`

## Test plan
- [x] `pnpm --filter @spool/cli build` passes
- [x] `spool connector-sync` with no args lists 8 connectors, exits 0
- [x] `spool connector-sync bogus-id` errors with available list
- [x] Valid-id path unchanged from pre-fix behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)