### PR TITLE
chore(connector-sdk): publish to npm

### DIFF
--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spool/connector-sdk",
   "version": "0.1.0",
-  "private": true,
+  "description": "Public plugin contract for Spool connectors.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,11 +15,26 @@
     "dist",
     "README.md"
   ],
+  "keywords": [
+    "spool",
+    "spool-connector",
+    "plugin-sdk"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/spool-lab/spool.git",
+    "directory": "packages/connector-sdk"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest run",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepack": "pnpm run build"
   },
   "devDependencies": {
     "@types/node": "^22.15.3",


### PR DESCRIPTION
## Summary
- Drops `"private": true` from `@spool/connector-sdk` so community connector authors can install the SDK via npm instead of using file paths or tarballs
- Adds `publishConfig.access: public`, `repository`, `license`, `keywords`, `prepack` hook
- No code changes, no runtime behavior change for first-party connectors (they continue to resolve the bundled SDK at `~/.spool/connectors/node_modules/@spool/connector-sdk` at runtime)

## Why now
P2 work on community plugin validation — currently external authors have no clean way to declare a dev-time dependency on the SDK. Publishing unblocks real community plugin development and lets us actually exercise the `spool://connector/install/` trust flow with a non-`@spool-lab/*` plugin.

## Packaging verification
- `pnpm pack` produces a tarball with only `dist/`, `README.md`, and `package.json` (no tests — tsconfig excludes `*.test.ts`)
- `vitest` passes (12/12)

## After merge
- `pnpm --filter @spool/connector-sdk publish --access public` under the spool-lab npm org
- Future SDK bumps follow normal 0.x semver (breaking changes allowed, signal via minor bump)

## Test plan
- [x] `pnpm --filter @spool/connector-sdk build` passes
- [x] `pnpm --filter @spool/connector-sdk test` passes
- [x] `pnpm pack` tarball contents verified (no src, no tests)
- [ ] `pnpm publish --dry-run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)