### PR TITLE
chore: rename @spool/connector-sdk to @spool-lab/connector-sdk

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,10 +17,10 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter @spool/connector-sdk build
+      - run: pnpm --filter @spool-lab/connector-sdk build
       - run: pnpm --filter @spool/core build
       - run: pnpm --filter @spool/core test
-      - run: pnpm --filter @spool/connector-sdk test
+      - run: pnpm --filter @spool-lab/connector-sdk test
       - run: pnpm --filter @spool/cli build
       - run: pnpm --filter @spool/cli test
 
@@ -45,7 +45,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build SDK
-        run: pnpm --filter @spool/connector-sdk build
+        run: pnpm --filter @spool-lab/connector-sdk build
 
       - name: Build core
         run: pnpm --filter @spool/core build

--- a/docs/connector-sync-architecture.md
+++ b/docs/connector-sync-architecture.md
@@ -812,7 +812,7 @@ Package it as `@your-scope/connector-my-platform-bookmarks` (or any npm name) wi
   "main": "dist/index.js",
   "keywords": ["spool-connector"],
   "peerDependencies": {
-    "@spool/connector-sdk": "^1.0.0"
+    "@spool-lab/connector-sdk": "^1.0.0"
   },
   "spool": {
     "type": "connector",

--- a/packages/app/src/main/dev-connectors.test.ts
+++ b/packages/app/src/main/dev-connectors.test.ts
@@ -134,7 +134,7 @@ ${pluginList}
 
     // packages/connector-sdk
     mkdirSync(join(dir, 'packages', 'connector-sdk'), { recursive: true })
-    writeFileSync(join(dir, 'packages', 'connector-sdk', 'package.json'), '{"name":"@spool/connector-sdk"}')
+    writeFileSync(join(dir, 'packages', 'connector-sdk', 'package.json'), '{"name":"@spool-lab/connector-sdk"}')
 
     // packages/connectors/<name>
     for (const c of connectors) {
@@ -178,7 +178,7 @@ ${pluginList}
 
     linkDevConnectors(spoolDir, workspace)
 
-    const sdkLink = join(spoolDir, 'connectors', 'node_modules', '@spool', 'connector-sdk')
+    const sdkLink = join(spoolDir, 'connectors', 'node_modules', '@spool-lab', 'connector-sdk')
     expect(lstatSync(sdkLink).isSymbolicLink()).toBe(true)
     expect(readlinkSync(sdkLink)).toBe(join(workspace, 'packages', 'connector-sdk'))
   })

--- a/packages/app/src/main/dev-connectors.ts
+++ b/packages/app/src/main/dev-connectors.ts
@@ -65,7 +65,7 @@ export function linkDevConnectors(spoolDir: string, workspaceRoot: string): void
   const nodeModules = join(spoolDir, 'connectors', 'node_modules')
 
   const sdkSource = join(workspaceRoot, 'packages', 'connector-sdk')
-  const sdkScopeDir = join(nodeModules, '@spool')
+  const sdkScopeDir = join(nodeModules, '@spool-lab')
   mkdirSync(sdkScopeDir, { recursive: true })
   ensureSymlink(sdkSource, join(sdkScopeDir, 'connector-sdk'))
 

--- a/packages/connector-sdk/README.md
+++ b/packages/connector-sdk/README.md
@@ -1,4 +1,4 @@
-# @spool/connector-sdk
+# @spool-lab/connector-sdk
 
 Public plugin contract for Spool connectors. A Spool connector is an npm package whose `package.json` declares `spool.type: "connector"` and whose default export is a class implementing the `Connector` interface exported from this package.
 

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@spool/connector-sdk",
+  "name": "@spool-lab/connector-sdk",
   "version": "0.1.0",
   "description": "Public plugin contract for Spool connectors.",
   "type": "module",

--- a/packages/connectors/github/package.json
+++ b/packages/connectors/github/package.json
@@ -1,22 +1,27 @@
 {
   "name": "@spool-lab/connector-github",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "GitHub Stars and Notifications for Spool",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": ["dist"],
-  "keywords": ["spool-connector", "github"],
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "spool-connector",
+    "github"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
     "prepack": "pnpm run build"
   },
   "peerDependencies": {
-    "@spool/connector-sdk": "workspace:^"
+    "@spool-lab/connector-sdk": "workspace:^"
   },
   "devDependencies": {
-    "@spool/connector-sdk": "workspace:^",
+    "@spool-lab/connector-sdk": "workspace:^",
     "@types/node": "^22.15.3",
     "typescript": "^5.7.3"
   },
@@ -30,7 +35,10 @@
         "description": "Repos you recently starred on GitHub",
         "color": "#333333",
         "ephemeral": false,
-        "capabilities": ["exec", "log"]
+        "capabilities": [
+          "exec",
+          "log"
+        ]
       },
       {
         "id": "github-notifications",
@@ -39,7 +47,10 @@
         "description": "Your GitHub notifications",
         "color": "#333333",
         "ephemeral": true,
-        "capabilities": ["exec", "log"]
+        "capabilities": [
+          "exec",
+          "log"
+        ]
       }
     ]
   }

--- a/packages/connectors/github/src/index.ts
+++ b/packages/connectors/github/src/index.ts
@@ -5,8 +5,8 @@ import type {
   PageResult,
   FetchContext,
   CapturedItem,
-} from '@spool/connector-sdk'
-import { SyncError, SyncErrorCode, parseCliJsonOutput } from '@spool/connector-sdk'
+} from '@spool-lab/connector-sdk'
+import { SyncError, SyncErrorCode, parseCliJsonOutput } from '@spool-lab/connector-sdk'
 
 async function checkGhAuth(caps: ConnectorCapabilities): Promise<AuthStatus> {
   try {

--- a/packages/connectors/hackernews-hot/package.json
+++ b/packages/connectors/hackernews-hot/package.json
@@ -1,22 +1,27 @@
 {
   "name": "@spool-lab/connector-hackernews-hot",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Top stories on Hacker News right now for Spool",
-  "keywords": ["spool-connector", "hackernews"],
+  "keywords": [
+    "spool-connector",
+    "hackernews"
+  ],
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "prepack": "pnpm run build",
     "build": "tsc",
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@spool/connector-sdk": "workspace:^"
+    "@spool-lab/connector-sdk": "workspace:^"
   },
   "devDependencies": {
-    "@spool/connector-sdk": "workspace:^",
+    "@spool-lab/connector-sdk": "workspace:^",
     "@types/node": "^22.15.3",
     "typescript": "^5.7.3"
   },
@@ -28,6 +33,9 @@
     "description": "Top stories on Hacker News right now",
     "color": "#FF6600",
     "ephemeral": true,
-    "capabilities": ["fetch", "log"]
+    "capabilities": [
+      "fetch",
+      "log"
+    ]
   }
 }

--- a/packages/connectors/hackernews-hot/src/index.ts
+++ b/packages/connectors/hackernews-hot/src/index.ts
@@ -5,8 +5,8 @@ import type {
   PageResult,
   FetchContext,
   CapturedItem,
-} from '@spool/connector-sdk'
-import { SyncError, SyncErrorCode } from '@spool/connector-sdk'
+} from '@spool-lab/connector-sdk'
+import { SyncError, SyncErrorCode } from '@spool-lab/connector-sdk'
 
 const HN_API = 'https://hacker-news.firebaseio.com/v0'
 const TOP_N = 30

--- a/packages/connectors/reddit/package.json
+++ b/packages/connectors/reddit/package.json
@@ -1,22 +1,27 @@
 {
   "name": "@spool-lab/connector-reddit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Reddit Saved and Upvoted posts for Spool",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": ["dist"],
-  "keywords": ["spool-connector", "reddit"],
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "spool-connector",
+    "reddit"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
     "prepack": "pnpm run build"
   },
   "peerDependencies": {
-    "@spool/connector-sdk": "workspace:^"
+    "@spool-lab/connector-sdk": "workspace:^"
   },
   "devDependencies": {
-    "@spool/connector-sdk": "workspace:^",
+    "@spool-lab/connector-sdk": "workspace:^",
     "@types/node": "^22.15.3",
     "typescript": "^5.7.3"
   },
@@ -30,7 +35,11 @@
         "description": "Posts and comments you saved on Reddit",
         "color": "#FF4500",
         "ephemeral": false,
-        "capabilities": ["fetch", "cookies:chrome", "log"]
+        "capabilities": [
+          "fetch",
+          "cookies:chrome",
+          "log"
+        ]
       },
       {
         "id": "reddit-upvoted",
@@ -39,7 +48,11 @@
         "description": "Posts you upvoted on Reddit",
         "color": "#FF4500",
         "ephemeral": false,
-        "capabilities": ["fetch", "cookies:chrome", "log"]
+        "capabilities": [
+          "fetch",
+          "cookies:chrome",
+          "log"
+        ]
       }
     ]
   }

--- a/packages/connectors/reddit/src/fetch.ts
+++ b/packages/connectors/reddit/src/fetch.ts
@@ -1,5 +1,5 @@
-import type { FetchCapability, Cookie, CapturedItem } from '@spool/connector-sdk'
-import { SyncError, SyncErrorCode, abortableSleep } from '@spool/connector-sdk'
+import type { FetchCapability, Cookie, CapturedItem } from '@spool-lab/connector-sdk'
+import { SyncError, SyncErrorCode, abortableSleep } from '@spool-lab/connector-sdk'
 
 const USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36'

--- a/packages/connectors/reddit/src/index.ts
+++ b/packages/connectors/reddit/src/index.ts
@@ -4,8 +4,8 @@ import type {
   AuthStatus,
   PageResult,
   FetchContext,
-} from '@spool/connector-sdk'
-import { SyncError, SyncErrorCode } from '@spool/connector-sdk'
+} from '@spool-lab/connector-sdk'
+import { SyncError, SyncErrorCode } from '@spool-lab/connector-sdk'
 import { buildAuth, fetchUsername, fetchListingPage } from './fetch.js'
 
 interface RedditSession {

--- a/packages/connectors/twitter-bookmarks/package.json
+++ b/packages/connectors/twitter-bookmarks/package.json
@@ -17,10 +17,10 @@
     "prepack": "pnpm run build"
   },
   "peerDependencies": {
-    "@spool/connector-sdk": "workspace:^"
+    "@spool-lab/connector-sdk": "workspace:^"
   },
   "devDependencies": {
-    "@spool/connector-sdk": "workspace:^",
+    "@spool-lab/connector-sdk": "workspace:^",
     "@types/node": "^22.15.3",
     "typescript": "^5.7.3"
   },

--- a/packages/connectors/twitter-bookmarks/src/graphql-fetch.ts
+++ b/packages/connectors/twitter-bookmarks/src/graphql-fetch.ts
@@ -1,5 +1,5 @@
-import type { FetchCapability, CapturedItem } from '@spool/connector-sdk'
-import { SyncError, SyncErrorCode, abortableSleep } from '@spool/connector-sdk'
+import type { FetchCapability, CapturedItem } from '@spool-lab/connector-sdk'
+import { SyncError, SyncErrorCode, abortableSleep } from '@spool-lab/connector-sdk'
 
 // ── Constants ───────────────────────────────────────────────────────────────
 

--- a/packages/connectors/twitter-bookmarks/src/index.ts
+++ b/packages/connectors/twitter-bookmarks/src/index.ts
@@ -5,8 +5,8 @@ import type {
   PageResult,
   FetchContext,
   Cookie,
-} from '@spool/connector-sdk'
-import { SyncError, SyncErrorCode } from '@spool/connector-sdk'
+} from '@spool-lab/connector-sdk'
+import { SyncError, SyncErrorCode } from '@spool-lab/connector-sdk'
 import { fetchBookmarkPage } from './graphql-fetch.js'
 
 interface TwitterAuth {

--- a/packages/connectors/typeless/package.json
+++ b/packages/connectors/typeless/package.json
@@ -1,12 +1,18 @@
 {
   "name": "@spool-lab/connector-typeless",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Your voice transcripts from Typeless for Spool",
-  "keywords": ["spool-connector", "typeless", "voice"],
+  "keywords": [
+    "spool-connector",
+    "typeless",
+    "voice"
+  ],
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "prepack": "pnpm run build",
     "build": "tsc",
@@ -14,10 +20,10 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@spool/connector-sdk": "workspace:^"
+    "@spool-lab/connector-sdk": "workspace:^"
   },
   "devDependencies": {
-    "@spool/connector-sdk": "workspace:^",
+    "@spool-lab/connector-sdk": "workspace:^",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.15.3",
     "better-sqlite3": "^11.9.1",
@@ -32,6 +38,9 @@
     "description": "Your voice transcripts from Typeless",
     "color": "#1D1A1A",
     "ephemeral": false,
-    "capabilities": ["sqlite", "log"]
+    "capabilities": [
+      "sqlite",
+      "log"
+    ]
   }
 }

--- a/packages/connectors/typeless/src/db-reader.ts
+++ b/packages/connectors/typeless/src/db-reader.ts
@@ -1,4 +1,4 @@
-import type { SqliteDatabase } from '@spool/connector-sdk'
+import type { SqliteDatabase } from '@spool-lab/connector-sdk'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 

--- a/packages/connectors/typeless/src/index.test.ts
+++ b/packages/connectors/typeless/src/index.test.ts
@@ -3,7 +3,7 @@ import Database from 'better-sqlite3'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import type { ConnectorCapabilities, FetchContext, SqliteCapability, SqliteDatabase, SqliteStatement } from '@spool/connector-sdk'
+import type { ConnectorCapabilities, FetchContext, SqliteCapability, SqliteDatabase, SqliteStatement } from '@spool-lab/connector-sdk'
 import TypelessConnector from './index.js'
 
 // ── Mock capabilities ─────────────────────────────────────────────────────────

--- a/packages/connectors/typeless/src/index.ts
+++ b/packages/connectors/typeless/src/index.ts
@@ -5,8 +5,8 @@ import type {
   PageResult,
   FetchContext,
   CapturedItem,
-} from '@spool/connector-sdk'
-import { SyncError, SyncErrorCode } from '@spool/connector-sdk'
+} from '@spool-lab/connector-sdk'
+import { SyncError, SyncErrorCode } from '@spool-lab/connector-sdk'
 import {
   fetchTranscriptPage,
   DEFAULT_DB_PATH,

--- a/packages/connectors/xiaohongshu/package.json
+++ b/packages/connectors/xiaohongshu/package.json
@@ -1,20 +1,23 @@
 {
   "name": "@spool-lab/connector-xiaohongshu",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Xiaohongshu (小红书) creator notes via opencli",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@spool/connector-sdk": "workspace:*"
+    "@spool-lab/connector-sdk": "workspace:*"
   },
   "devDependencies": {
-    "@spool/connector-sdk": "workspace:*",
+    "@spool-lab/connector-sdk": "workspace:*",
     "@types/node": "^22.15.3",
     "typescript": "^5.4.0",
     "vitest": "^3.2.4"
@@ -29,7 +32,9 @@
         "detect": {
           "type": "exec",
           "command": "opencli",
-          "args": ["--version"],
+          "args": [
+            "--version"
+          ],
           "versionRegex": "v?(\\d+\\.\\d+\\.\\d+)",
           "timeoutMs": 5000
         },
@@ -48,11 +53,15 @@
         "id": "opencli-extension",
         "name": "Browser Bridge",
         "kind": "browser-extension",
-        "requires": ["opencli"],
+        "requires": [
+          "opencli"
+        ],
         "detect": {
           "type": "exec",
           "command": "opencli",
-          "args": ["doctor"],
+          "args": [
+            "doctor"
+          ],
           "matchStdout": "\\[OK\\].*Extension",
           "timeoutMs": 10000
         },
@@ -74,11 +83,15 @@
         "id": "xhs-login",
         "name": "Logged into Xiaohongshu",
         "kind": "site-session",
-        "requires": ["opencli-extension"],
+        "requires": [
+          "opencli-extension"
+        ],
         "detect": {
           "type": "exec",
           "command": "opencli",
-          "args": ["doctor"],
+          "args": [
+            "doctor"
+          ],
           "matchStdout": "\\[OK\\].*Connectivity",
           "timeoutMs": 10000
         },
@@ -96,7 +109,11 @@
         "description": "Notes you have published",
         "color": "#FF2442",
         "ephemeral": false,
-        "capabilities": ["exec", "log", "prerequisites"]
+        "capabilities": [
+          "exec",
+          "log",
+          "prerequisites"
+        ]
       }
     ]
   }

--- a/packages/connectors/xiaohongshu/src/index.test.ts
+++ b/packages/connectors/xiaohongshu/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { XhsNotesConnector } from './index.js'
-import type { ConnectorCapabilities } from '@spool/connector-sdk'
+import type { ConnectorCapabilities } from '@spool-lab/connector-sdk'
 
 function mockCaps(runImpl: (cmd: string, args: string[]) => Promise<{ exitCode: number; stdout: string; stderr: string }>): ConnectorCapabilities {
   return {

--- a/packages/connectors/xiaohongshu/src/index.ts
+++ b/packages/connectors/xiaohongshu/src/index.ts
@@ -4,8 +4,8 @@ import type {
   AuthStatus,
   PageResult,
   FetchContext,
-} from '@spool/connector-sdk'
-import { checkAuthViaPrerequisites, SyncError, SyncErrorCode, parseCliJsonOutput } from '@spool/connector-sdk'
+} from '@spool-lab/connector-sdk'
+import { checkAuthViaPrerequisites, SyncError, SyncErrorCode, parseCliJsonOutput } from '@spool-lab/connector-sdk'
 
 // opencli xiaohongshu subcommands return a single snapshot of the current
 // top-N items and don't accept any cursor/page/offset flag. We always do a

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,13 +14,13 @@
   "scripts": {
     "rebuild:native": "pnpm run rebuild:native:node",
     "rebuild:native:node": "node ../../scripts/rebuild-better-sqlite3-node.mjs",
-    "build": "pnpm --filter @spool/connector-sdk build && tsc",
+    "build": "pnpm --filter @spool-lab/connector-sdk build && tsc",
     "dev": "tsc --watch",
     "test": "pnpm run rebuild:native && vitest run",
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@spool/connector-sdk": "workspace:^",
+    "@spool-lab/connector-sdk": "workspace:^",
     "better-sqlite3": "^11.10.0",
     "chokidar": "^4.0.3",
     "effect": "^3.21.0",

--- a/packages/core/src/connectors/capabilities/cookies-chrome.test.ts
+++ b/packages/core/src/connectors/capabilities/cookies-chrome.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { makeChromeCookiesCapability, getMatchingHostKeys } from './cookies-chrome.js'
-import { SyncError, SyncErrorCode } from '@spool/connector-sdk'
+import { SyncError, SyncErrorCode } from '@spool-lab/connector-sdk'
 
 describe('getMatchingHostKeys', () => {
   it('matches host-only and same-host domain cookies', () => {

--- a/packages/core/src/connectors/capabilities/cookies-chrome.ts
+++ b/packages/core/src/connectors/capabilities/cookies-chrome.ts
@@ -11,8 +11,8 @@ import { existsSync, unlinkSync, copyFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir, platform, homedir } from 'node:os'
 import { pbkdf2Sync, createDecipheriv, randomUUID } from 'node:crypto'
-import type { CookiesCapability, Cookie, CookieQuery } from '@spool/connector-sdk'
-import { SyncError, SyncErrorCode } from '@spool/connector-sdk'
+import type { CookiesCapability, Cookie, CookieQuery } from '@spool-lab/connector-sdk'
+import { SyncError, SyncErrorCode } from '@spool-lab/connector-sdk'
 
 function getMacOSChromeKey(): Buffer {
   const candidates = [

--- a/packages/core/src/connectors/capabilities/exec-impl.ts
+++ b/packages/core/src/connectors/capabilities/exec-impl.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process'
 import { readdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import type { ExecCapability, ExecResult } from '@spool/connector-sdk'
+import type { ExecCapability, ExecResult } from '@spool-lab/connector-sdk'
 
 const DEFAULT_TIMEOUT = 60_000
 

--- a/packages/core/src/connectors/capabilities/fetch-impl.ts
+++ b/packages/core/src/connectors/capabilities/fetch-impl.ts
@@ -1,4 +1,4 @@
-import type { FetchCapability } from '@spool/connector-sdk'
+import type { FetchCapability } from '@spool-lab/connector-sdk'
 
 export function makeFetchCapability(
   fetchFn: typeof globalThis.fetch = globalThis.fetch,

--- a/packages/core/src/connectors/capabilities/log-impl.ts
+++ b/packages/core/src/connectors/capabilities/log-impl.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect'
-import type { LogCapability, LogFields } from '@spool/connector-sdk'
+import type { LogCapability, LogFields } from '@spool-lab/connector-sdk'
 
 export function makeLogCapabilityFor(connectorId: string): LogCapability {
   const baseAttrs: LogFields = { 'connector.id': connectorId }

--- a/packages/core/src/connectors/capabilities/sqlite-impl.ts
+++ b/packages/core/src/connectors/capabilities/sqlite-impl.ts
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3'
-import type { SqliteCapability, SqliteDatabase, SqliteStatement } from '@spool/connector-sdk'
+import type { SqliteCapability, SqliteDatabase, SqliteStatement } from '@spool-lab/connector-sdk'
 
 export function makeSqliteCapability(): SqliteCapability {
   return {

--- a/packages/core/src/connectors/loader.test.ts
+++ b/packages/core/src/connectors/loader.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path'
 import { loadConnectors } from './loader.js'
 import { ConnectorRegistry } from './registry.js'
 import { TrustStore } from './trust-store.js'
-import type { Connector } from '@spool/connector-sdk'
+import type { Connector } from '@spool-lab/connector-sdk'
 
 function writePkg(nodeModulesDir: string, name: string, manifest: object, entrySource: string) {
   const segments = name.startsWith('@') ? name.split('/') : [name]

--- a/packages/core/src/connectors/loader.ts
+++ b/packages/core/src/connectors/loader.ts
@@ -11,8 +11,8 @@ import type {
   Prerequisite,
   PrerequisitesCapability,
   SqliteCapability,
-} from '@spool/connector-sdk'
-import { SyncError, SyncErrorCode, KNOWN_CAPABILITIES_V1 } from '@spool/connector-sdk'
+} from '@spool-lab/connector-sdk'
+import { SyncError, SyncErrorCode, KNOWN_CAPABILITIES_V1 } from '@spool-lab/connector-sdk'
 import type { ConnectorRegistry } from './registry.js'
 import { extractBundledConnectorsIfNeeded, type BundleLogger, type BundleReport } from './bundle-extract.js'
 import { TrustStore } from './trust-store.js'

--- a/packages/core/src/connectors/prerequisites.test.ts
+++ b/packages/core/src/connectors/prerequisites.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { PrerequisiteChecker } from './prerequisites.js'
 import { validatePrerequisites } from './loader.js'
-import type { Prerequisite } from '@spool/connector-sdk'
+import type { Prerequisite } from '@spool-lab/connector-sdk'
 import type { ConnectorPackage } from './types.js'
 
 function mkPkg(id: string, prerequisites: Prerequisite[]): ConnectorPackage {

--- a/packages/core/src/connectors/prerequisites.ts
+++ b/packages/core/src/connectors/prerequisites.ts
@@ -1,4 +1,4 @@
-import type { Prerequisite, SetupStep, SetupStatus, ExecCapability } from '@spool/connector-sdk'
+import type { Prerequisite, SetupStep, SetupStatus, ExecCapability } from '@spool-lab/connector-sdk'
 import type { ConnectorPackage } from './types.js'
 import { valid, gte } from 'semver'
 

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -7,14 +7,14 @@ import type {
   FetchContext,
   CapturedItem,
   SyncState,
-} from '@spool/connector-sdk'
-import { SyncError as SdkSyncError, SyncErrorCode, SYNC_ERROR_HINTS } from '@spool/connector-sdk'
+} from '@spool-lab/connector-sdk'
+import { SyncError as SdkSyncError, SyncErrorCode, SYNC_ERROR_HINTS } from '@spool-lab/connector-sdk'
 
 // ── Re-exports from SDK ────────────────────────────────────────────────────
 export {
   SyncErrorCode,
   SYNC_ERROR_HINTS,
-} from '@spool/connector-sdk'
+} from '@spool-lab/connector-sdk'
 export type {
   Connector,
   AuthStatus,
@@ -22,7 +22,7 @@ export type {
   FetchContext,
   CapturedItem,
   SyncState,
-} from '@spool/connector-sdk'
+} from '@spool-lab/connector-sdk'
 
 // ── Internal Effect-tagged SyncError ──────────────────────────────────────
 const RETRYABLE_CODES = new Set<SyncErrorCode>([
@@ -38,7 +38,7 @@ const RETRYABLE_CODES = new Set<SyncErrorCode>([
 /**
  * Internal Effect-tagged version of SyncError used inside @spool/core for
  * Effect's typed error channel. External callers (connectors) use the plain
- * class exported from @spool/connector-sdk. Translation between the two
+ * class exported from @spool-lab/connector-sdk. Translation between the two
  * happens in SyncError.from().
  */
 export class SyncError extends Data.TaggedError('SyncError')<{
@@ -155,7 +155,7 @@ export interface ConnectorPackage {
   packageName: string
   rootDir: string
   connectors: Connector[]
-  prerequisites?: import('@spool/connector-sdk').Prerequisite[]
+  prerequisites?: import('@spool-lab/connector-sdk').Prerequisite[]
 }
 
 export interface ConnectorStatus {
@@ -170,7 +170,7 @@ export interface ConnectorStatus {
   version: string
   packageName: string
   packageId?: string
-  setup?: import('@spool/connector-sdk').SetupStep[]
+  setup?: import('@spool-lab/connector-sdk').SetupStep[]
   state: SyncState
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,5 +64,5 @@ export type {
   SetupStep,
   SetupStatus,
   PrerequisitesCapability,
-} from '@spool/connector-sdk'
-export { checkAuthViaPrerequisites } from '@spool/connector-sdk'
+} from '@spool-lab/connector-sdk'
+export { checkAuthViaPrerequisites } from '@spool-lab/connector-sdk'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,7 +152,7 @@ importers:
 
   packages/connectors/github:
     devDependencies:
-      '@spool/connector-sdk':
+      '@spool-lab/connector-sdk':
         specifier: workspace:^
         version: link:../../connector-sdk
       '@types/node':
@@ -164,7 +164,7 @@ importers:
 
   packages/connectors/hackernews-hot:
     devDependencies:
-      '@spool/connector-sdk':
+      '@spool-lab/connector-sdk':
         specifier: workspace:^
         version: link:../../connector-sdk
       '@types/node':
@@ -176,7 +176,7 @@ importers:
 
   packages/connectors/reddit:
     devDependencies:
-      '@spool/connector-sdk':
+      '@spool-lab/connector-sdk':
         specifier: workspace:^
         version: link:../../connector-sdk
       '@types/node':
@@ -188,7 +188,7 @@ importers:
 
   packages/connectors/twitter-bookmarks:
     devDependencies:
-      '@spool/connector-sdk':
+      '@spool-lab/connector-sdk':
         specifier: workspace:^
         version: link:../../connector-sdk
       '@types/node':
@@ -200,7 +200,7 @@ importers:
 
   packages/connectors/typeless:
     devDependencies:
-      '@spool/connector-sdk':
+      '@spool-lab/connector-sdk':
         specifier: workspace:^
         version: link:../../connector-sdk
       '@types/better-sqlite3':
@@ -221,7 +221,7 @@ importers:
 
   packages/connectors/xiaohongshu:
     devDependencies:
-      '@spool/connector-sdk':
+      '@spool-lab/connector-sdk':
         specifier: workspace:*
         version: link:../../connector-sdk
       '@types/node':
@@ -236,7 +236,7 @@ importers:
 
   packages/core:
     dependencies:
-      '@spool/connector-sdk':
+      '@spool-lab/connector-sdk':
         specifier: workspace:^
         version: link:../connector-sdk
       better-sqlite3:

--- a/scripts/build-bundled-connectors.sh
+++ b/scripts/build-bundled-connectors.sh
@@ -42,10 +42,10 @@ for plugin in "${FIRST_PARTY_PLUGINS[@]}"; do
   (cd "$pkg_dir" && pnpm pack --pack-destination "$OUT_DIR")
 done
 
-# Also pack the SDK so plugins can resolve @spool/connector-sdk at runtime
-echo "==> Packing @spool/connector-sdk"
-pnpm --filter @spool/connector-sdk build
-sdk_dir="$(pnpm --filter @spool/connector-sdk exec pwd)"
+# Also pack the SDK so plugins can resolve @spool-lab/connector-sdk at runtime
+echo "==> Packing @spool-lab/connector-sdk"
+pnpm --filter @spool-lab/connector-sdk build
+sdk_dir="$(pnpm --filter @spool-lab/connector-sdk exec pwd)"
 (cd "$sdk_dir" && pnpm pack --pack-destination "$OUT_DIR")
 
 echo "==> Bundled connectors ready:"

--- a/scripts/phantom-independence-check.sh
+++ b/scripts/phantom-independence-check.sh
@@ -31,8 +31,8 @@ fi
 echo "==> Building $FULL_NAME"
 (cd "$REPO_ROOT" && pnpm --filter "$FULL_NAME" build)
 
-echo "==> Building @spool/connector-sdk"
-(cd "$REPO_ROOT" && pnpm --filter "@spool/connector-sdk" build)
+echo "==> Building @spool-lab/connector-sdk"
+(cd "$REPO_ROOT" && pnpm --filter "@spool-lab/connector-sdk" build)
 
 # Create a staging temp dir — use a local name to avoid overriding $TMPDIR
 WORK_DIR="$(mktemp -d -t spool-phantom-check-XXXXXX)"
@@ -49,12 +49,11 @@ if [[ -z "$TARBALL" ]]; then
   exit 1
 fi
 
-# Pack the SDK — it is marked private so pnpm pack refuses; use npm pack directly.
-# The SDK has no workspace: deps so npm pack is fine here.
-echo "==> Packing @spool/connector-sdk to $WORK_DIR"
+# Pack the SDK. The SDK has no workspace: deps so npm pack is fine here.
+echo "==> Packing @spool-lab/connector-sdk to $WORK_DIR"
 (cd "$SDK_DIR" && npm pack --pack-destination "$WORK_DIR" 2>/dev/null)
 
-SDK_TARBALL="$(ls "$WORK_DIR"/spool-connector-sdk-*.tgz 2>/dev/null | head -1)"
+SDK_TARBALL="$(ls "$WORK_DIR"/spool-lab-connector-sdk-*.tgz 2>/dev/null | head -1)"
 if [[ -z "$SDK_TARBALL" ]]; then
   echo "SDK tarball not found after pack in $WORK_DIR:" >&2
   ls "$WORK_DIR" >&2
@@ -81,7 +80,7 @@ cat > package.json <<EOF
   "type": "module",
   "dependencies": {
     "$FULL_NAME": "file:plugin.tgz",
-    "@spool/connector-sdk": "file:sdk.tgz"
+    "@spool-lab/connector-sdk": "file:sdk.tgz"
   }
 }
 EOF


### PR DESCRIPTION
## Summary
- `@spool` scope is reserved on npm and not owned by the publishing account; aligning the SDK's scope with `@spool-lab` (where all official connectors already live) unblocks publishing
- Bump versions on already-published `@spool-lab/connector-*` packages so they can be rebuilt with the renamed peerDep

## Why
Follow-up to #88 — publishing the SDK failed with a 404 because `graydawnc` isn't an admin of the `@spool` scope and npm won't let us register it (reserved). Keeping the SDK internal defeats the purpose of #88. `@spool-lab/connector-sdk` matches the scope that already owns all the official connector packages on npm, keeps everything under one org, and matches the GitHub org.

## Changes
- `@spool/connector-sdk` → `@spool-lab/connector-sdk` everywhere (package name, all imports, devDeps/peerDeps, dev-connectors symlink scope path, bundle/phantom scripts, docs, workflow)
- Version bumps on already-published connectors (new source imports require a new tarball):
  - reddit, hackernews-hot, typeless, xiaohongshu: 0.1.0 → 0.1.1
  - github: 0.1.1 → 0.1.2
- Internal workspace packages (`@spool/core`, `@spool/app`, `@spool/cli`, `@spool/landing`) are untouched — they are not published

## Runtime impact
Existing installs of `@spool-lab/connector-*@0.1.0` import from the old SDK path and will break after a user upgrades Spool. The update checker from #66 picks up the bumped versions on next launch and re-installs them with corrected imports.

## Test plan
- [x] `pnpm -r build` (SDK + all connectors + core + cli) clean
- [x] Full test suite passes (151 tests, 1 skipped across core)
- [x] `pnpm --filter @spool/app exec tsc --noEmit` clean
- [ ] CI green
- [ ] After merge: publish `@spool-lab/connector-sdk@0.1.0` to npm
- [ ] After merge: republish 5 bumped connector packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)