### PR TITLE
fix(prereq): accept zero-padded CalVer + align Setup card icons

### DIFF
--- a/packages/app/src/renderer/components/PackageSetupCard.tsx
+++ b/packages/app/src/renderer/components/PackageSetupCard.tsx
@@ -126,8 +126,10 @@ function StepRow({ packageId, step, onChanged }: { packageId: string; step: Setu
   }
 
   return (
-    <div className="flex items-center gap-2 py-1 min-h-[24px]">
-      <StatusIcon status={step.status} />
+    <div className="flex items-start gap-2 py-1 min-h-[24px]">
+      <span className="flex items-center h-[18px]">
+        <StatusIcon status={step.status} />
+      </span>
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5">
           <KindIcon kind={step.kind} />
@@ -140,7 +142,7 @@ function StepRow({ packageId, step, onChanged }: { packageId: string; step: Setu
           <div className="text-[10px] text-warm-faint dark:text-dark-faint mt-0.5">{step.hint}</div>
         )}
       </div>
-      <div className="flex-shrink-0">{renderAction()}</div>
+      <div className="flex-shrink-0 flex items-center h-[18px]">{renderAction()}</div>
       {install?.kind === 'browser-extension' && install.manual && (
         <ManualInstallModal
           open={manualOpen}

--- a/packages/core/src/connectors/prerequisites.test.ts
+++ b/packages/core/src/connectors/prerequisites.test.ts
@@ -48,6 +48,42 @@ describe('PrerequisiteChecker', () => {
     expect(steps[0].status).toBe('missing')
   })
 
+  it('accepts zero-padded CalVer (e.g. yt-dlp 2026.03.17) by stripping leading zeros', async () => {
+    const exec = { run: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '2026.03.17\n', stderr: '' }) }
+    const checker = new PrerequisiteChecker(exec as any)
+    const pkg = mkPkg('p1', [
+      {
+        id: 'yt-dlp',
+        name: 'yt-dlp',
+        kind: 'cli',
+        detect: { type: 'exec', command: 'yt-dlp', args: ['--version'], versionRegex: '(\\d{4}\\.\\d{2}\\.\\d{2})' },
+        minVersion: '2024.01.01',
+        install: { kind: 'cli', command: { darwin: 'brew install yt-dlp' } },
+      },
+    ])
+    const steps = await checker.check(pkg)
+    expect(steps[0].status).toBe('ok')
+    expect(steps[0].detectedVersion).toBe('2026.03.17')
+  })
+
+  it('correctly compares zero-padded CalVer across years/months', async () => {
+    const exec = { run: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '2024.02.05\n', stderr: '' }) }
+    const checker = new PrerequisiteChecker(exec as any)
+    const pkg = mkPkg('p1', [
+      {
+        id: 'yt-dlp',
+        name: 'yt-dlp',
+        kind: 'cli',
+        detect: { type: 'exec', command: 'yt-dlp', args: ['--version'], versionRegex: '(\\d{4}\\.\\d{2}\\.\\d{2})' },
+        minVersion: '2024.03.01',
+        install: { kind: 'cli', command: { darwin: 'brew install yt-dlp' } },
+      },
+    ])
+    const steps = await checker.check(pkg)
+    expect(steps[0].status).toBe('outdated')
+    expect(steps[0].detectedVersion).toBe('2024.02.05')
+  })
+
   it('marks outdated when version is below minVersion', async () => {
     const exec = { run: vi.fn().mockResolvedValue({ exitCode: 0, stdout: 'v0.2.1\n', stderr: '' }) }
     const checker = new PrerequisiteChecker(exec as any)

--- a/packages/core/src/connectors/prerequisites.ts
+++ b/packages/core/src/connectors/prerequisites.ts
@@ -89,10 +89,15 @@ export class PrerequisiteChecker {
         return baseStep(p, 'error', { hint: 'Could not parse version' })
       }
       const detectedVersion = vm[1]
-      if (!valid(detectedVersion)) {
+      // Normalize for semver: strip leading zeros from numeric segments so
+      // zero-padded CalVer (yt-dlp, Ubuntu, Postgres) like `2026.03.17`
+      // validates as `2026.3.17`. Ordering is preserved.
+      const normalizedDetected = stripLeadingZeros(detectedVersion)
+      const normalizedMin = stripLeadingZeros(p.minVersion)
+      if (!valid(normalizedDetected)) {
         return baseStep(p, 'error', { hint: 'Could not parse detected version' })
       }
-      if (gte(detectedVersion, p.minVersion)) {
+      if (gte(normalizedDetected, normalizedMin)) {
         return baseStep(p, 'ok', { detectedVersion })
       }
       return baseStep(p, 'outdated', {
@@ -103,4 +108,8 @@ export class PrerequisiteChecker {
 
     return result.exitCode === 0 ? baseStep(p, 'ok') : baseStep(p, 'missing')
   }
+}
+
+function stripLeadingZeros(version: string): string {
+  return version.replace(/(^|\.)0+(\d)/g, '$1$2')
 }


### PR DESCRIPTION
## Summary
Two fixes surfaced while onboarding a YouTube connector (yt-dlp).

### 1. Zero-padded CalVer broke prereq detection
`prerequisites.ts` handed the detected version string straight to `semver.valid()`. yt-dlp uses CalVer like `2026.03.17` — semver disallows leading zeros in numeric segments, so even though the regex matched, the checker returned "Could not parse detected version" and the prereq sat in an error state forever. Same trap would bite any CalVer-padded dep (Ubuntu, Postgres, many Python packages).

Fix: strip leading zeros from numeric segments before `valid()` / `gte()`. Ordering is preserved, existing semver-shaped inputs unchanged.

### 2. Setup card status icon drifted below the label row
The prereq row used `items-center`. When a prereq had a hint below the label (error/outdated cases), the status icon centered against the full two-line height and visually floated down between the label and the hint. Same for the right-side action button.

Fix: `items-start` on the row + fixed-height wrappers around the icon / action so they sit at the first-line center.

## Test plan
- [x] Added two unit tests for zero-padded CalVer (accept `2026.03.17`, still mark `2024.02.05` as outdated vs `2024.03.01`)
- [x] Full prereq test suite passes (13 tests)
- [x] Manual end-to-end: fresh install of `@graydawnc/connector-youtube` on dev box → yt-dlp detection now resolves to ok with `2026.03.17` displayed
- [x] Status icon + action button visually aligned to label-line center in the rebuilt app

🤖 Generated with [Claude Code](https://claude.com/claude-code)