### PR TITLE
feat(registry): add @graydawnc/connector-youtube

### DIFF
--- a/packages/landing/public/registry.json
+++ b/packages/landing/public/registry.json
@@ -101,6 +101,18 @@
       "category": "social",
       "firstParty": true,
       "npm": "https://www.npmjs.com/package/@spool-lab/connector-xiaohongshu"
+    },
+    {
+      "name": "@graydawnc/connector-youtube",
+      "id": "youtube-liked",
+      "platform": "youtube",
+      "label": "YouTube Liked Videos",
+      "description": "Videos you've liked on YouTube",
+      "color": "#FF0000",
+      "author": "graydawnc",
+      "category": "media",
+      "firstParty": false,
+      "npm": "https://www.npmjs.com/package/@graydawnc/connector-youtube"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds the first non-`@spool-lab/` entry to the public connector registry — community-authored YouTube Liked Videos connector at `@graydawnc/connector-youtube`.

Marked `firstParty: false` to signal community provenance. The in-app browser already branches on this flag to require TrustStore confirmation before install, so no additional code changes are needed for the trust-prompt path.

End-to-end validated before landing:
- deep link install (`spool://connector/install/...`) → TrustStore prompt → accept
- prerequisites: `yt-dlp` auto-install via brew, YouTube session detection via `--cookies-from-browser chrome`
- first sync: 4 captures written with correct platform, title, url, author, thumbnail, metadata (channel / channelId / duration / viewCount), and source row pointing to the `connector` source (M:N provenance from #85)

## Test plan
- [x] JSON valid (`jq . registry.json`)
- [x] Package published at `@graydawnc/connector-youtube@0.1.1`
- [x] Live install + sync verified on dev box

🤖 Generated with [Claude Code](https://claude.com/claude-code)