### PR TITLE
chore: add root `pnpm spool` shortcut for CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "turbo lint",
     "clean": "turbo clean",
     "check:phantom-independence": "scripts/phantom-independence-check.sh",
-    "dev:install:mac": "scripts/dev-install-mac.sh"
+    "dev:install:mac": "scripts/dev-install-mac.sh",
+    "spool": "node packages/cli/bin/spool.js"
   },
   "devDependencies": {
     "turbo": "^2.9.6",


### PR DESCRIPTION
## Summary
- Add `"spool": "node packages/cli/bin/spool.js"` script to root `package.json`
- Enables `pnpm spool <command>` as a convenient shortcut during development

## Test plan
- [x] `pnpm spool --version` outputs `0.3.3`
- [x] `pnpm spool status` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)