### PR TITLE
feat(cli): show resume command in search results

### DIFF
--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -62,7 +62,7 @@ function printResult(r: FragmentResult, n: number, total: number): void {
 function buildResumeCommand(r: FragmentResult): string | null {
   switch (r.source) {
     case 'claude':
-      return `claude -r ${r.sessionUuid}` + (r.cwd ? ` -p ${r.cwd}` : '')
+      return `claude -r ${r.sessionUuid}`
     case 'codex':
       return `codex resume ${r.sessionUuid}`
     default:

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -48,12 +48,26 @@ function printResult(r: FragmentResult, n: number, total: number): void {
   console.log(`Session: "${r.sessionTitle}"`)
   console.log(`Date:    ${formatDate(r.startedAt)}`)
   console.log(`UUID:    ${r.sessionUuid}`)
+
+  const resumeCmd = buildResumeCommand(r)
+  if (resumeCmd) console.log(`Resume:  ${resumeCmd}`)
+
   console.log(``)
-  // Strip mark tags and wrap text
   const snippet = r.snippet
     .replace(/<mark>/g, '\x1b[1m\x1b[33m')
     .replace(/<\/mark>/g, '\x1b[0m')
   console.log(`  ${snippet}`)
+}
+
+function buildResumeCommand(r: FragmentResult): string | null {
+  switch (r.source) {
+    case 'claude':
+      return `claude -r ${r.sessionUuid}` + (r.cwd ? ` -p ${r.cwd}` : '')
+    case 'codex':
+      return `codex resume ${r.sessionUuid}`
+    default:
+      return null
+  }
 }
 
 function formatDate(iso: string): string {


### PR DESCRIPTION
## Summary
- Search results now include a `Resume:` line with a copyable command to resume the session
- Claude: `claude -r <uuid>`
- Codex: `codex resume <uuid>`
- Gemini: not shown (no resume support)

## Test plan
- [x] 32 CLI tests pass
- [x] Manual test: `spool search 'dark fantasy'` shows Resume line
- [x] Verified `claude -r <uuid>` resumes the correct session

🤖 Generated with [Claude Code](https://claude.com/claude-code)