### PR TITLE
feat(cli): add proxy support via https_proxy/http_proxy

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,8 @@
   },
   "dependencies": {
     "@spool-lab/core": "workspace:^",
-    "commander": "^13.1.0"
+    "commander": "^13.1.0",
+    "undici": "^6.23.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/cli/src/commands/connector-shared.ts
+++ b/packages/cli/src/commands/connector-shared.ts
@@ -1,5 +1,6 @@
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { ProxyAgent, type Dispatcher } from 'undici'
 import {
   getDB,
   ConnectorRegistry,
@@ -9,6 +10,26 @@ import {
 } from '@spool-lab/core'
 import type { PrerequisitesCapability } from '@spool-lab/core'
 import type Database from 'better-sqlite3'
+
+function getProxyUrl(): string | undefined {
+  return process.env['https_proxy'] || process.env['HTTPS_PROXY']
+    || process.env['http_proxy'] || process.env['HTTP_PROXY']
+    || undefined
+}
+
+let _proxyDispatcher: Dispatcher | undefined
+function getProxyDispatcher(): Dispatcher | undefined {
+  const url = getProxyUrl()
+  if (!url) return undefined
+  if (!_proxyDispatcher) _proxyDispatcher = new ProxyAgent(url)
+  return _proxyDispatcher
+}
+
+export function proxyFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+  const dispatcher = getProxyDispatcher()
+  if (!dispatcher) return globalThis.fetch(input, init)
+  return globalThis.fetch(input, { ...init, dispatcher } as unknown as RequestInit)
+}
 
 export interface BootstrapResult {
   db: Database.Database
@@ -35,7 +56,7 @@ export async function bootstrap(opts?: { readonly?: boolean }): Promise<Bootstra
   const report = await loadConnectors({
     connectorsDir,
     capabilityImpls: {
-      fetch: makeFetchCapability(),
+      fetch: makeFetchCapability(proxyFetch),
       cookies: makeChromeCookiesCapability(),
       sqlite: makeSqliteCapability(),
       exec: execImpl,

--- a/packages/cli/src/commands/connector-shared.ts
+++ b/packages/cli/src/commands/connector-shared.ts
@@ -12,9 +12,30 @@ import type { PrerequisitesCapability } from '@spool-lab/core'
 import type Database from 'better-sqlite3'
 
 function getProxyUrl(): string | undefined {
-  return process.env['https_proxy'] || process.env['HTTPS_PROXY']
+  const fromEnv = process.env['https_proxy'] || process.env['HTTPS_PROXY']
     || process.env['http_proxy'] || process.env['HTTP_PROXY']
-    || undefined
+  if (fromEnv) return fromEnv
+
+  if (process.platform === 'darwin') {
+    try {
+      const { execFileSync } = require('node:child_process') as typeof import('node:child_process')
+      const out = execFileSync('scutil', ['--proxy'], { encoding: 'utf8', timeout: 3000 })
+      const httpsEnabled = /HTTPSEnable\s*:\s*1/.test(out)
+      if (httpsEnabled) {
+        const host = out.match(/HTTPSProxy\s*:\s*(\S+)/)?.[1]
+        const port = out.match(/HTTPSPort\s*:\s*(\d+)/)?.[1]
+        if (host && port) return `http://${host}:${port}`
+      }
+      const httpEnabled = /HTTPEnable\s*:\s*1/.test(out)
+      if (httpEnabled) {
+        const host = out.match(/HTTPProxy\s*:\s*(\S+)/)?.[1]
+        const port = out.match(/HTTPPort\s*:\s*(\d+)/)?.[1]
+        if (host && port) return `http://${host}:${port}`
+      }
+    } catch {}
+  }
+
+  return undefined
 }
 
 let _proxyDispatcher: Dispatcher | undefined

--- a/packages/cli/src/commands/connector.ts
+++ b/packages/cli/src/commands/connector.ts
@@ -12,7 +12,7 @@ import {
 } from '@spool-lab/core'
 import type { SetupStep } from '@spool-lab/core'
 import * as readline from 'node:readline'
-import { bootstrap } from './connector-shared.js'
+import { bootstrap, proxyFetch } from './connector-shared.js'
 
 // ── list ───────────────────────────────────────────────────────────────────
 
@@ -143,7 +143,7 @@ const installSubcommand = new Command('install')
 
     console.log(`Installing ${packageName}...`)
     try {
-      const result = await downloadAndInstall(packageName, connectorsDir, fetch)
+      const result = await downloadAndInstall(packageName, connectorsDir, proxyFetch)
 
       if (!isFirstParty) {
         const trustStore = new TrustStore(spoolDir)
@@ -367,7 +367,7 @@ const updateSubcommand = new Command('update')
     }
 
     console.log('Checking for updates...')
-    const updates = await checkForUpdates(toCheck, fetch)
+    const updates = await checkForUpdates(toCheck, proxyFetch)
 
     if (updates.size === 0) {
       console.log('All connectors are up to date.')
@@ -391,7 +391,7 @@ const updateSubcommand = new Command('update')
     for (const [name, info] of updates) {
       process.stdout.write(`Updating ${name}...`)
       try {
-        await downloadAndInstall(name, connectorsDir, fetch)
+        await downloadAndInstall(name, connectorsDir, proxyFetch)
         console.log(` ${info.current} → ${info.latest}`)
       } catch (err) {
         console.log(` FAILED: ${err instanceof Error ? err.message : String(err)}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       commander:
         specifier: ^13.1.0
         version: 13.1.0
+      undici:
+        specifier: ^6.23.0
+        version: 6.25.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -4230,6 +4233,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
 
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
@@ -9384,6 +9391,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
+
+  undici@6.25.0: {}
 
   undici@7.24.4: {}
 


### PR DESCRIPTION
## Summary
- CLI now automatically detects and uses proxy settings for all network requests
- Detection priority: `https_proxy`/`http_proxy` env vars → macOS system proxy (`scutil --proxy`) → direct
- Uses `undici@6` ProxyAgent (compatible with Node.js 22 built-in undici)
- Applies to: connector sync, connector install, connector update

No user configuration needed — just works on macOS with system proxy enabled.

## Test plan
- [x] 32 CLI tests pass
- [x] `spool connector sync twitter-bookmarks` succeeds with macOS system proxy (19 items synced)
- [x] Direct fetch (no proxy) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)