### PR TITLE
fix(core): rewrite session watcher on fs.watch recursive

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,8 +7,12 @@ on:
 
 jobs:
   unit:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -387,6 +387,9 @@ app.whenReady().then(async () => {
     searchCache.clear()
     mainWindow?.webContents.send('spool:new-sessions', data)
   })
+  watcher.on('error', (_event, data) => {
+    console.error('[watcher]', data.error, data.root ? `(root=${data.root})` : '')
+  })
 
   // ── Connector framework ──────────────────────────────────────────────
   connectorRegistry = new ConnectorRegistry()

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -26,6 +26,9 @@ export const syncCommand = new Command('sync')
       watcher.on('new-sessions', (_event, data) => {
         console.log(`[${new Date().toLocaleTimeString()}] +${data.count} new session(s) indexed`)
       })
+      watcher.on('error', (_event, data) => {
+        console.error(`[${new Date().toLocaleTimeString()}] watcher error:`, data.error, data.root ? `(root=${data.root})` : '')
+      })
       watcher.start()
 
       process.on('SIGINT', () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@spool-lab/connector-sdk": "workspace:^",
     "better-sqlite3": "^11.10.0",
-    "chokidar": "^4.0.3",
     "effect": "^3.21.0",
     "semver": "^7.7.4",
     "tar": "^7.5.13"

--- a/packages/core/src/sync/watcher.test.ts
+++ b/packages/core/src/sync/watcher.test.ts
@@ -55,10 +55,11 @@ async function startWatcher(syncer: Syncer, extra: Partial<ConstructorParameters
   const w = new SpoolWatcher(syncer, { ...FAST, ...extra })
   runningWatchers.push(w)
   w.start()
-  // macOS FSEvents (which backs fs.watch recursive) has a small priming window
-  // after the stream is scheduled on the runloop. Events that happen before it
-  // is hot can be dropped. Give it a moment before tests start writing.
-  await new Promise(r => setTimeout(r, 250))
+  // macOS FSEvents (which backs fs.watch recursive) has a priming window
+  // after the stream is scheduled on the runloop. Events that happen before
+  // it is hot can be dropped. CI runners are slower than local machines, so
+  // give it a generous margin here.
+  await new Promise(r => setTimeout(r, process.platform === 'darwin' ? 500 : 150))
   return w
 }
 

--- a/packages/core/src/sync/watcher.test.ts
+++ b/packages/core/src/sync/watcher.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, appendFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { SpoolWatcher, type WatcherEvent, type WatcherEventData } from './watcher.js'
+import type { Syncer } from './syncer.js'
+import type { SessionSource } from '../types.js'
+
+const FAST = { stabilityMs: 40, pollMs: 15, flushMs: 40 } as const
+
+const tempDirs: string[] = []
+const runningWatchers: SpoolWatcher[] = []
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  while (runningWatchers.length > 0) runningWatchers.pop()?.stop()
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempRoots() {
+  const baseDir = mkdtempSync(join(tmpdir(), 'spool-watcher-'))
+  tempDirs.push(baseDir)
+  const claudeRoot = join(baseDir, 'claude', 'projects')
+  const codexRoot = join(baseDir, 'codex', 'sessions')
+  const geminiRoot = join(baseDir, 'gemini', 'tmp')
+  mkdirSync(join(claudeRoot, 'project-a'), { recursive: true })
+  mkdirSync(join(codexRoot, '2026', '04', '20'), { recursive: true })
+  mkdirSync(join(geminiRoot, 'workspace', 'chats'), { recursive: true })
+  vi.stubEnv('SPOOL_CLAUDE_DIR', claudeRoot)
+  vi.stubEnv('SPOOL_CODEX_DIR', codexRoot)
+  vi.stubEnv('SPOOL_GEMINI_DIR', join(baseDir, 'gemini'))
+  return { baseDir, claudeRoot, codexRoot, geminiRoot }
+}
+
+interface SyncCall { path: string; source: SessionSource }
+
+function makeStubSyncer(opts: { result?: 'added' | 'updated' | 'skipped' | 'error' | ((p: string) => 'added' | 'updated' | 'skipped' | 'error'); throws?: Error } = {}) {
+  const calls: SyncCall[] = []
+  const syncer = {
+    syncFile(path: string, source: SessionSource) {
+      calls.push({ path, source })
+      if (opts.throws) throw opts.throws
+      if (typeof opts.result === 'function') return opts.result(path)
+      return opts.result ?? 'added'
+    },
+  } as unknown as Syncer
+  return { syncer, calls }
+}
+
+async function startWatcher(syncer: Syncer, extra: Partial<ConstructorParameters<typeof SpoolWatcher>[1]> = {}) {
+  const w = new SpoolWatcher(syncer, { ...FAST, ...extra })
+  runningWatchers.push(w)
+  w.start()
+  // macOS FSEvents (which backs fs.watch recursive) has a small priming window
+  // after the stream is scheduled on the runloop. Events that happen before it
+  // is hot can be dropped. Give it a moment before tests start writing.
+  await new Promise(r => setTimeout(r, 250))
+  return w
+}
+
+const waitFor = async (pred: () => boolean, timeoutMs = 2000, stepMs = 10) => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (pred()) return
+    await new Promise(r => setTimeout(r, stepMs))
+  }
+  throw new Error('waitFor: timed out')
+}
+
+describe('SpoolWatcher', () => {
+  test('emits new-sessions and calls syncFile once when a session file is added', async () => {
+    const { claudeRoot } = makeTempRoots()
+    const { syncer, calls } = makeStubSyncer({ result: 'added' })
+    const events: Array<{ event: WatcherEvent; data: WatcherEventData }> = []
+    const w = await startWatcher(syncer)
+    w.on('new-sessions', (event, data) => { events.push({ event, data }) })
+
+    const filePath = join(claudeRoot, 'project-a', 'abc.jsonl')
+    writeFileSync(filePath, '{}\n')
+
+    await waitFor(() => calls.length > 0)
+    await waitFor(() => events.length > 0)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toEqual({ path: filePath, source: 'claude' })
+    expect(events).toHaveLength(1)
+    expect(events[0]?.event).toBe('new-sessions')
+    expect((events[0]?.data as { count: number }).count).toBe(1)
+  })
+
+  test('ignores non-session files', async () => {
+    const { claudeRoot } = makeTempRoots()
+    const { syncer, calls } = makeStubSyncer()
+    await startWatcher(syncer)
+
+    writeFileSync(join(claudeRoot, 'project-a', 'notes.txt'), 'hi')
+    writeFileSync(join(claudeRoot, 'project-a', 'rando.json'), '{}')
+
+    await new Promise(r => setTimeout(r, FAST.stabilityMs * 4))
+    expect(calls).toHaveLength(0)
+  })
+
+  test('debounces rapid writes to the same file — syncFile called once per stable window', async () => {
+    const { claudeRoot } = makeTempRoots()
+    const { syncer, calls } = makeStubSyncer({ result: 'updated' })
+    await startWatcher(syncer)
+
+    const filePath = join(claudeRoot, 'project-a', 'live.jsonl')
+    writeFileSync(filePath, '{"i":0}\n')
+    for (let i = 1; i <= 8; i++) {
+      await new Promise(r => setTimeout(r, 8))
+      appendFileSync(filePath, `{"i":${i}}\n`)
+    }
+
+    await waitFor(() => calls.length >= 1)
+    // Give any trailing events a chance to flush
+    await new Promise(r => setTimeout(r, FAST.stabilityMs * 3))
+
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+    // The main point: we coalesce — not 9 calls, one per write
+    expect(calls.length).toBeLessThan(4)
+    for (const c of calls) expect(c.path).toBe(filePath)
+  })
+
+  test('detects codex and gemini sources', async () => {
+    const { codexRoot, geminiRoot } = makeTempRoots()
+    const { syncer, calls } = makeStubSyncer()
+    await startWatcher(syncer)
+
+    const codexFile = join(codexRoot, '2026', '04', '20', 'rollout.jsonl')
+    const geminiFile = join(geminiRoot, 'workspace', 'chats', 'session-2026-04-20T00-00-deadbeef.json')
+    writeFileSync(codexFile, '{}\n')
+    writeFileSync(geminiFile, '{}')
+
+    await waitFor(() => calls.length >= 2, 3000)
+
+    const sources = new Set(calls.map(c => c.source))
+    expect(sources.has('codex')).toBe(true)
+    expect(sources.has('gemini')).toBe(true)
+  })
+
+  test('coalesces many new-session events into a single count', async () => {
+    const { claudeRoot } = makeTempRoots()
+    const { syncer, calls } = makeStubSyncer({ result: 'added' })
+    const events: Array<WatcherEventData> = []
+    const w = await startWatcher(syncer, { flushMs: 80 })
+    w.on('new-sessions', (_event, data) => { events.push(data) })
+
+    // Write into a directory that already exists at start() time to avoid
+    // racing against FSEvents delivery of the mkdir event on macOS.
+    for (let i = 0; i < 5; i++) {
+      writeFileSync(join(claudeRoot, 'project-a', `s${i}.jsonl`), '{}\n')
+      await new Promise(r => setTimeout(r, 5))
+    }
+
+    await waitFor(() => calls.length >= 5, 5000)
+    await waitFor(() => events.length >= 1, 3000)
+    // Allow flush window to close
+    await new Promise(r => setTimeout(r, 160))
+
+    const totalCount = events.reduce((n, d) => n + ((d as { count: number }).count ?? 0), 0)
+    expect(totalCount).toBe(5)
+    // Expect events to coalesce, not one per file
+    expect(events.length).toBeLessThanOrEqual(2)
+  })
+
+  test('stop() prevents any further syncFile calls and clears timers', async () => {
+    const { claudeRoot } = makeTempRoots()
+    const { syncer, calls } = makeStubSyncer()
+    const w = await startWatcher(syncer)
+
+    w.stop()
+    writeFileSync(join(claudeRoot, 'project-a', 'after-stop.jsonl'), '{}\n')
+    await new Promise(r => setTimeout(r, FAST.stabilityMs * 4))
+    expect(calls).toHaveLength(0)
+  })
+
+  test('does not throw when a session root does not exist', () => {
+    vi.stubEnv('SPOOL_CLAUDE_DIR', join(tmpdir(), 'spool-watcher-nonexistent-' + Date.now()))
+    vi.stubEnv('SPOOL_CODEX_DIR', join(tmpdir(), 'spool-watcher-nonexistent-' + Date.now() + '-b'))
+    vi.stubEnv('SPOOL_GEMINI_DIR', join(tmpdir(), 'spool-watcher-nonexistent-' + Date.now() + '-g'))
+    const { syncer } = makeStubSyncer()
+    const w = new SpoolWatcher(syncer, FAST)
+    runningWatchers.push(w)
+    expect(() => w.start()).not.toThrow()
+  })
+
+  test('captures errors from underlying watchers instead of surfacing as unhandled rejections', async () => {
+    const { claudeRoot } = makeTempRoots()
+    const { syncer } = makeStubSyncer()
+    const fakeWatchers: EventEmitter[] = []
+    const fakeWatch = (path: string) => {
+      const ee = new EventEmitter() as EventEmitter & { close: () => void }
+      ;(ee as unknown as { path: string }).path = path
+      ee.close = () => { /* noop */ }
+      fakeWatchers.push(ee)
+      return ee as unknown as import('node:fs').FSWatcher
+    }
+    const errors: Array<{ root?: string; error: Error }> = []
+    const w = new SpoolWatcher(syncer, { ...FAST, watchFn: fakeWatch })
+    runningWatchers.push(w)
+    w.on('error', (_event, data) => {
+      errors.push({ root: (data as { root?: string }).root, error: (data as { error: Error }).error })
+    })
+    w.start()
+
+    expect(fakeWatchers.length).toBeGreaterThan(0)
+    const err = Object.assign(new Error('EMFILE: too many open files, watch'), { code: 'EMFILE' })
+    fakeWatchers[0]!.emit('error', err)
+
+    await waitFor(() => errors.length > 0)
+    expect(errors[0]?.error.message).toContain('EMFILE')
+    // Ensure other watchers still alive — we can still emit and capture them
+    if (fakeWatchers.length > 1) {
+      fakeWatchers[1]!.emit('error', new Error('second'))
+      await waitFor(() => errors.length >= 2)
+    }
+    // Sanity — no unhandled rejections; process still alive
+    expect(claudeRoot).toBeTruthy()
+  })
+
+  test('reports errors thrown from syncFile via the error event', async () => {
+    const { claudeRoot } = makeTempRoots()
+    const { syncer } = makeStubSyncer({ throws: new Error('parse bomb') })
+    const errors: Error[] = []
+    const w = await startWatcher(syncer)
+    w.on('error', (_event, data) => { errors.push((data as { error: Error }).error) })
+
+    writeFileSync(join(claudeRoot, 'project-a', 'bad.jsonl'), '{}\n')
+
+    await waitFor(() => errors.length > 0, 3000)
+    expect(errors[0]?.message).toBe('parse bomb')
+  })
+})

--- a/packages/core/src/sync/watcher.ts
+++ b/packages/core/src/sync/watcher.ts
@@ -1,75 +1,211 @@
-import chokidar, { type FSWatcher } from 'chokidar'
+import { watch as fsWatch, statSync, type FSWatcher } from 'node:fs'
+import { resolve as resolvePath } from 'node:path'
 import type { Syncer } from './syncer.js'
 import type { SessionSource } from '../types.js'
-import { detectSessionSource, getSessionRoots, getSessionWatchPatterns } from './source-paths.js'
-// No native module dependencies — uses node:sqlite via @spool-lab/core
+import { detectSessionSource, getSessionRoots } from './source-paths.js'
 
-export type WatcherEvent = 'new-sessions'
-export type WatcherEventCallback = (event: WatcherEvent, data: { count: number }) => void
+export type WatcherEvent = 'new-sessions' | 'error'
+
+export interface WatcherEventDataMap {
+  'new-sessions': { count: number }
+  'error': { error: Error; root?: string }
+}
+
+export type WatcherEventData = WatcherEventDataMap[WatcherEvent]
+
+export type WatcherEventCallback<E extends WatcherEvent = WatcherEvent> = (
+  event: E,
+  data: WatcherEventDataMap[E],
+) => void
+
+export interface SpoolWatcherOptions {
+  /** Milliseconds of inactivity before considering a file's writes finished. */
+  stabilityMs?: number
+  /** Poll interval while waiting for size/mtime to settle. */
+  pollMs?: number
+  /** Window over which new-session events coalesce into a single emission. */
+  flushMs?: number
+  /** Dependency injection for tests — defaults to node:fs watch. */
+  watchFn?: typeof fsWatch
+}
+
+interface PendingEntry {
+  timer: ReturnType<typeof setTimeout>
+  lastSize: number
+  lastMtimeMs: number
+}
+
+const DEFAULT_STABILITY_MS = 2000
+const DEFAULT_POLL_MS = 200
+const DEFAULT_FLUSH_MS = 500
 
 export class SpoolWatcher {
-  private watcher: FSWatcher | null = null
-  private listeners: WatcherEventCallback[] = []
+  private watchers: FSWatcher[] = []
+  private listeners: Map<WatcherEvent, WatcherEventCallback[]> = new Map()
+  private pending: Map<string, PendingEntry> = new Map()
   private pendingNew = 0
   private flushTimer: ReturnType<typeof setTimeout> | null = null
-  private sourceRoots: Record<SessionSource, string[]> = {
-    claude: [],
-    codex: [],
-    gemini: [],
+  private sourceRoots: Record<SessionSource, string[]> = { claude: [], codex: [], gemini: [] }
+  private stopped = false
+  private readonly stabilityMs: number
+  private readonly pollMs: number
+  private readonly flushMs: number
+  private readonly watchFn: typeof fsWatch
+
+  constructor(private syncer: Syncer, opts: SpoolWatcherOptions = {}) {
+    this.stabilityMs = opts.stabilityMs ?? DEFAULT_STABILITY_MS
+    this.pollMs = opts.pollMs ?? DEFAULT_POLL_MS
+    this.flushMs = opts.flushMs ?? DEFAULT_FLUSH_MS
+    this.watchFn = opts.watchFn ?? fsWatch
   }
 
-  constructor(private syncer: Syncer) {}
-
   start(): void {
+    this.stopped = false
     this.sourceRoots = {
       claude: getSessionRoots('claude'),
       codex: getSessionRoots('codex'),
       gemini: getSessionRoots('gemini'),
     }
-    const patterns = [
-      ...getSessionWatchPatterns('claude', this.sourceRoots.claude),
-      ...getSessionWatchPatterns('codex', this.sourceRoots.codex),
-      ...getSessionWatchPatterns('gemini', this.sourceRoots.gemini),
+    const roots = [
+      ...this.sourceRoots.claude,
+      ...this.sourceRoots.codex,
+      ...this.sourceRoots.gemini,
     ]
-
-    this.watcher = chokidar.watch(patterns, {
-      persistent: true,
-      ignoreInitial: true, // initial sync is done by Syncer.syncAll()
-      awaitWriteFinish: {
-        stabilityThreshold: 2000,
-        pollInterval: 200,
-      },
-    })
-
-    this.watcher
-      .on('add', (path) => this.handleFile(path))
-      .on('change', (path) => this.handleFile(path))
+    for (const root of roots) this.watchRoot(root)
   }
 
   stop(): void {
-    this.watcher?.close()
-    this.watcher = null
-    if (this.flushTimer) clearTimeout(this.flushTimer)
+    this.stopped = true
+    for (const w of this.watchers) {
+      try { w.close() } catch { /* ignore */ }
+    }
+    this.watchers = []
+    for (const entry of this.pending.values()) clearTimeout(entry.timer)
+    this.pending.clear()
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer)
+      this.flushTimer = null
+    }
+    this.pendingNew = 0
   }
 
-  on(event: WatcherEvent, cb: WatcherEventCallback): void {
-    this.listeners.push(cb)
+  on<E extends WatcherEvent>(event: E, cb: WatcherEventCallback<E>): void {
+    const list = this.listeners.get(event) ?? []
+    list.push(cb as WatcherEventCallback)
+    this.listeners.set(event, list)
   }
 
-  private handleFile(filePath: string): void {
-    const source = detectSessionSource(filePath, this.sourceRoots)
-    if (!source) return
-    const result = this.syncer.syncFile(filePath, source)
+  private watchRoot(root: string): void {
+    let w: FSWatcher
+    try {
+      w = this.watchFn(root, { persistent: true, recursive: true })
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code
+      // Missing root is expected (e.g. user hasn't used Gemini CLI) — silently skip.
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+        this.emit('error', { error: err as Error, root })
+      }
+      return
+    }
 
-    if (result === 'added' || result === 'updated') {
-      this.pendingNew++
-      // Debounce: flush all pending new-session events together
-      if (this.flushTimer) clearTimeout(this.flushTimer)
-      this.flushTimer = setTimeout(() => {
-        const count = this.pendingNew
-        this.pendingNew = 0
-        this.listeners.forEach(cb => cb('new-sessions', { count }))
-      }, 500)
+    w.on('change', (_eventType, filename) => {
+      if (this.stopped || !filename) return
+      const abs = resolvePath(root, filename.toString())
+      this.schedulePoll(abs)
+    })
+
+    w.on('error', (err) => {
+      this.emit('error', { error: err as Error, root })
+    })
+
+    this.watchers.push(w)
+  }
+
+  private schedulePoll(filePath: string): void {
+    // Only process files whose final path matches a configured source.
+    // Prefilter here avoids noisy stat() on unrelated dir events.
+    if (!detectSessionSource(filePath, this.sourceRoots)) {
+      // Could still be a future session file in a new subdir — but detectSessionSource
+      // already matches by suffix + root containment, so unrelated hits are rejected here.
+      return
+    }
+
+    const existing = this.pending.get(filePath)
+    if (existing) clearTimeout(existing.timer)
+
+    const entry: PendingEntry = {
+      lastSize: existing?.lastSize ?? -1,
+      lastMtimeMs: existing?.lastMtimeMs ?? -1,
+      timer: setTimeout(() => this.pollStability(filePath), this.stabilityMs),
+    }
+    this.pending.set(filePath, entry)
+  }
+
+  private pollStability(filePath: string): void {
+    if (this.stopped) return
+    const entry = this.pending.get(filePath)
+    if (!entry) return
+
+    let size: number
+    let mtimeMs: number
+    try {
+      const s = statSync(filePath)
+      if (!s.isFile()) {
+        this.pending.delete(filePath)
+        return
+      }
+      size = s.size
+      mtimeMs = s.mtimeMs
+    } catch {
+      // File gone or transient error — drop.
+      this.pending.delete(filePath)
+      return
+    }
+
+    if (size === entry.lastSize && mtimeMs === entry.lastMtimeMs) {
+      this.pending.delete(filePath)
+      this.runSync(filePath)
+      return
+    }
+    entry.lastSize = size
+    entry.lastMtimeMs = mtimeMs
+    entry.timer = setTimeout(() => this.pollStability(filePath), this.pollMs)
+  }
+
+  private runSync(filePath: string): void {
+    // Decouple the sync call from the watcher event path so a slow or throwing
+    // syncFile cannot stall event delivery or create unhandled rejections.
+    queueMicrotask(() => {
+      if (this.stopped) return
+      const source = detectSessionSource(filePath, this.sourceRoots)
+      if (!source) return
+      let result: ReturnType<Syncer['syncFile']>
+      try {
+        result = this.syncer.syncFile(filePath, source)
+      } catch (err) {
+        this.emit('error', { error: err as Error })
+        return
+      }
+      if (result === 'added' || result === 'updated') {
+        this.pendingNew++
+        if (this.flushTimer) clearTimeout(this.flushTimer)
+        this.flushTimer = setTimeout(() => this.flushNew(), this.flushMs)
+      }
+    })
+  }
+
+  private flushNew(): void {
+    this.flushTimer = null
+    const count = this.pendingNew
+    this.pendingNew = 0
+    if (count > 0) this.emit('new-sessions', { count })
+  }
+
+  private emit<E extends WatcherEvent>(event: E, data: WatcherEventDataMap[E]): void {
+    const list = this.listeners.get(event)
+    if (!list) return
+    for (const cb of list) {
+      try { (cb as WatcherEventCallback<E>)(event, data) } catch { /* listener errors shouldn't break the watcher */ }
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,9 +251,6 @@ importers:
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
-      chokidar:
-        specifier: ^4.0.3
-        version: 4.0.3
       effect:
         specifier: ^3.21.0
         version: 3.21.0
@@ -2066,10 +2063,6 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
-  chokidar@4.0.3:
-    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
-    engines: {node: '>= 14.16.0'}
-
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
@@ -3759,10 +3752,6 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
-
-  readdirp@4.1.2:
-    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
-    engines: {node: '>= 14.18.0'}
 
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
@@ -6568,10 +6557,6 @@ snapshots:
 
   check-error@2.1.3: {}
 
-  chokidar@4.0.3:
-    dependencies:
-      readdirp: 4.1.2
-
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
@@ -8762,8 +8747,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-
-  readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
 


### PR DESCRIPTION
Closes #83.

## Summary

- Replaces chokidar with `node:fs` `fs.watch({ recursive: true })` — backed by FSEvents (macOS), `ReadDirectoryChangesW` (Windows), recursive inotify (Linux 20+). **One watcher per root, regardless of subdirectory count.**
- Adds `.on('error', ...)` on every watcher and a new `error` event so EMFILE / ENOSPC are captured and surfaced instead of leaking as unhandled rejections.
- Keeps write-finish stability via a local size+mtime poll (replaces chokidar's `awaitWriteFinish`), so the syncer only runs on quiesced files.
- Isolates `syncFile()` behind `queueMicrotask` + try/catch so a slow/throwing parser can't stall event delivery.
- Drops the direct `chokidar` dependency — the watcher is its only consumer.

## Why this shape

Issue #83 walks through the full history, but the short version:

| PR | Behavior on macOS with ~400 session subdirs |
|---|---|
| Pre-#77 (globs) | Zero events (chokidar v4 silently dropped glob support) |
| #77 (dirs + ignored) | EMFILE spam, unhandled rejections, main-proc stall |
| #82 (revert of #77) | Back to zero events |
| **This PR** | Events fire, 0 FD per subdir, errors are handled |

Chokidar v4/v5 removed `fsevents` entirely, so on macOS it falls back to `fs.watch` per-directory. Node's own `fs.watch` with `recursive: true` goes straight to FSEvents and uses one stream per root — the exact property we need.

## Test plan

- [x] 9 new unit tests in `packages/core/src/sync/watcher.test.ts` cover: event filtering, write-finish debounce, multi-root (claude/codex/gemini), coalesced new-session counts, `stop()` cleanup, missing-root tolerance, underlying-watcher error capture, `syncFile` throw capture.
- [x] Full core suite: 156 passed.
- [x] Local smoke (500 session subdirs, `ulimit -n 256`): FD delta **0**, session file in deep subdir detected, zero error events.
- [x] Reviewer: please verify on a machine with a populated `~/.claude/projects/` that the dev app boots clean (no EMFILE in console) and that creating a new Claude Code session makes it appear in the UI without manual re-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)