### PR TITLE
feat: add star/bookmark for sessions and captures

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -7,6 +7,7 @@ import { Worker } from 'node:worker_threads'
 import {
   getDB, Syncer, SpoolWatcher,
   searchFragments, searchAll, searchSessionPreview, searchCaptures, listRecentSessions, getSessionWithMessages, getStatus,
+  starItem, unstarItem, listStarredItems, getStarredUuidsByType,
   ConnectorRegistry, SyncScheduler,
   loadSyncState, saveSyncState,
   loadConnectors, makeFetchCapability, makeChromeCookiesCapability, makeLogCapabilityFor, makeSqliteCapability, makeExecCapability,
@@ -637,16 +638,16 @@ function resolveCliPrereq(packageId: string, prereqId: string): ResolvedCli {
 
 // ── IPC Handlers ──────────────────────────────────────────────────────────────
 
-ipcMain.handle('spool:search', (_e, { query, limit = 10, source }: { query: string; limit?: number; source?: string }) => {
-  const cacheKey = `${source ?? 'all'}|${limit}|${query}`
+ipcMain.handle('spool:search', (_e, { query, limit = 10, source, onlyStarred }: { query: string; limit?: number; source?: string; onlyStarred?: boolean }) => {
+  const cacheKey = `${source ?? 'all'}|${limit}|${onlyStarred ? 'starred' : 'full'}|${query}`
   if (!isSyncActive) {
     const cached = searchCache.get(cacheKey)
     if (cached) return cached
   }
 
   const results = source === 'claude' || source === 'codex' || source === 'gemini'
-    ? searchFragments(db, query, { limit, source })
-    : searchAll(db, query, { limit })
+    ? searchFragments(db, query, { limit, source, ...(onlyStarred ? { onlyStarred: true } : {}) })
+    : searchAll(db, query, { limit, ...(onlyStarred ? { onlyStarred: true } : {}) })
 
   if (!isSyncActive) {
     searchCache.set(cacheKey, results)
@@ -693,6 +694,26 @@ ipcMain.handle('spool:get-session', (_e, { sessionUuid }: { sessionUuid: string 
 
 ipcMain.handle('spool:get-status', () => {
   return getStatus(db)
+})
+
+ipcMain.handle('spool:star-item', (_e, { kind, uuid }: { kind: 'session' | 'capture'; uuid: string }) => {
+  starItem(db, kind, uuid)
+  searchCache.clear()
+  return { ok: true }
+})
+
+ipcMain.handle('spool:unstar-item', (_e, { kind, uuid }: { kind: 'session' | 'capture'; uuid: string }) => {
+  unstarItem(db, kind, uuid)
+  searchCache.clear()
+  return { ok: true }
+})
+
+ipcMain.handle('spool:list-starred-items', (_e, { limit = 200 }: { limit?: number } = {}) => {
+  return listStarredItems(db, limit)
+})
+
+ipcMain.handle('spool:get-starred-uuids', () => {
+  return getStarredUuidsByType(db)
 })
 
 ipcMain.handle('spool:get-runtime-info', () => {

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -16,7 +16,7 @@ import {
   PrerequisiteChecker,
 } from '@spool-lab/core'
 import type { UpdateInfo } from '@spool-lab/core'
-import type { AuthStatus, ConnectorStatus, FragmentResult, SchedulerEvent, SearchResult, SessionSource } from '@spool-lab/core'
+import type { AuthStatus, ConnectorStatus, FragmentResult, SchedulerEvent, SearchResult, SessionSource, StarKind } from '@spool-lab/core'
 import { setupTray } from './tray.js'
 import { AcpManager } from './acp.js'
 import { setupAutoUpdater, downloadUpdate, quitAndInstall } from './updater.js'
@@ -696,13 +696,13 @@ ipcMain.handle('spool:get-status', () => {
   return getStatus(db)
 })
 
-ipcMain.handle('spool:star-item', (_e, { kind, uuid }: { kind: 'session' | 'capture'; uuid: string }) => {
+ipcMain.handle('spool:star-item', (_e, { kind, uuid }: { kind: StarKind; uuid: string }) => {
   starItem(db, kind, uuid)
   searchCache.clear()
   return { ok: true }
 })
 
-ipcMain.handle('spool:unstar-item', (_e, { kind, uuid }: { kind: 'session' | 'capture'; uuid: string }) => {
+ipcMain.handle('spool:unstar-item', (_e, { kind, uuid }: { kind: StarKind; uuid: string }) => {
   unstarItem(db, kind, uuid)
   searchCache.clear()
   return { ok: true }

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import type { FragmentResult, Session, Message, StatusInfo, SyncResult, SearchResult, ConnectorStatus, AuthStatus, SchedulerStatus, RegistryConnector } from '@spool-lab/core'
+import type { FragmentResult, Session, Message, StatusInfo, SyncResult, SearchResult, StarKind, StarredItem, ConnectorStatus, AuthStatus, SchedulerStatus, RegistryConnector } from '@spool-lab/core'
 import type { SearchSortOrder } from '../shared/searchSort.js'
 import type { ThemeEditorStateV1 } from '../renderer/theme/editorTypes.js'
 
@@ -41,8 +41,8 @@ export interface AgentsConfig {
 export type SpoolAPI = typeof api
 
 const api = {
-  search: (query: string, limit?: number, source?: string): Promise<SearchResult[]> =>
-    ipcRenderer.invoke('spool:search', { query, limit, source }),
+  search: (query: string, limit?: number, source?: string, onlyStarred?: boolean): Promise<SearchResult[]> =>
+    ipcRenderer.invoke('spool:search', { query, limit, source, onlyStarred }),
 
   searchPreview: (query: string, limit?: number, source?: string): Promise<SearchResult[]> =>
     ipcRenderer.invoke('spool:search-preview', { query, limit, source }),
@@ -55,6 +55,18 @@ const api = {
 
   getStatus: (): Promise<StatusInfo> =>
     ipcRenderer.invoke('spool:get-status'),
+
+  starItem: (kind: StarKind, uuid: string): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('spool:star-item', { kind, uuid }),
+
+  unstarItem: (kind: StarKind, uuid: string): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke('spool:unstar-item', { kind, uuid }),
+
+  listStarredItems: (limit?: number): Promise<StarredItem[]> =>
+    ipcRenderer.invoke('spool:list-starred-items', { limit }),
+
+  getStarredUuids: (): Promise<{ session: string[]; capture: string[] }> =>
+    ipcRenderer.invoke('spool:get-starred-uuids'),
 
   getRuntimeInfo: (): Promise<{ isDev: boolean; appPath: string; appName: string }> =>
     ipcRenderer.invoke('spool:get-runtime-info'),

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState, useCallback, useRef, startTransition, useDeferredValue } from 'react'
-import type { FragmentResult, SearchResult, StatusInfo } from '@spool-lab/core'
+import type { FragmentResult, StarKind, StarredItem, SearchResult, StatusInfo } from '@spool-lab/core'
 import SearchBar, { type SearchMode } from './components/SearchBar.js'
 import FragmentResults from './components/FragmentResults.js'
 import HomeView from './components/HomeView.js'
 import SessionDetail from './components/SessionDetail.js'
+import StarredItems from './components/StarredItems.js'
+import StarredEntryButton from './components/StarredEntryButton.js'
 import StatusBar from './components/StatusBar.js'
 import AiAnswerCard from './components/AiAnswerCard.js'
 import SettingsPanel from './components/SettingsPanel.js'
@@ -13,7 +15,7 @@ import { defaultThemeEditorState, type ThemeEditorStateV1 } from './theme/editor
 import { applyEditorTheme } from './theme/applyEditorTheme.js'
 import { loadThemeEditorState, saveThemeEditorState } from './theme/persist.js'
 
-type View = 'search' | 'session'
+type View = 'search' | 'session' | 'starred'
 type SettingsTab = 'general' | 'appearance' | 'connectors' | 'agent'
 
 interface AgentInfo {
@@ -72,7 +74,104 @@ export default function App() {
   const deferredResults = useDeferredValue(results)
   const [lastCompletedPreviewQuery, setLastCompletedPreviewQuery] = useState('')
 
+  const [starredSessions, setStarredSessions] = useState<Set<string>>(new Set())
+  const [starredCaptures, setStarredCaptures] = useState<Set<string>>(new Set())
+  const [starredItems, setStarredItems] = useState<StarredItem[]>([])
+  const [starredScopedResults, setStarredScopedResults] = useState<SearchResult[]>([])
+  const [isStarredSearching, setIsStarredSearching] = useState(false)
+  const starredSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const starredSearchSeq = useRef(0)
+  const totalStarred = starredSessions.size + starredCaptures.size
+
   const isHomeMode = homeMode && view === 'search' && !selectedSession
+
+  const refreshStarredUuids = useCallback(async () => {
+    if (!window.spool?.getStarredUuids) return
+    try {
+      const uuids = await window.spool.getStarredUuids()
+      setStarredSessions(prev => setsEqual(prev, uuids.session) ? prev : new Set(uuids.session))
+      setStarredCaptures(prev => setsEqual(prev, uuids.capture) ? prev : new Set(uuids.capture))
+    } catch (err) { console.error(err) }
+  }, [])
+
+  const refreshStarredItems = useCallback(async () => {
+    if (!window.spool?.listStarredItems) return
+    try {
+      const items = await window.spool.listStarredItems()
+      setStarredItems(items)
+    } catch (err) { console.error(err) }
+  }, [])
+
+  useEffect(() => { refreshStarredUuids() }, [refreshStarredUuids])
+  useEffect(() => {
+    if (view === 'starred') refreshStarredItems()
+  }, [view, refreshStarredItems])
+
+  const handleToggleStar = useCallback((kind: StarKind, uuid: string, next: boolean) => {
+    const setState = kind === 'session' ? setStarredSessions : setStarredCaptures
+    setState(prev => {
+      const updated = new Set(prev)
+      if (next) updated.add(uuid)
+      else updated.delete(uuid)
+      return updated
+    })
+    if (!next) {
+      setStarredItems(prev => prev.filter(it =>
+        !(it.kind === kind && (it.kind === 'session' ? it.session.sessionUuid : it.capture.captureUuid) === uuid),
+      ))
+    }
+
+    const request = next
+      ? window.spool.starItem(kind, uuid)
+      : window.spool.unstarItem(kind, uuid)
+
+    request.catch(err => {
+      console.error(err)
+      setState(prev => {
+        const reverted = new Set(prev)
+        if (next) reverted.delete(uuid)
+        else reverted.add(uuid)
+        return reverted
+      })
+      refreshStarredUuids()
+      if (view === 'starred') refreshStarredItems()
+    })
+  }, [refreshStarredUuids, refreshStarredItems, view])
+
+  const handleToggleStarredView = useCallback(() => {
+    if (starredSearchTimer.current) clearTimeout(starredSearchTimer.current)
+    starredSearchSeq.current++
+    setQuery('')
+    setSelectedSession(null)
+    setTargetMessageId(null)
+    setStarredScopedResults([])
+    setIsStarredSearching(false)
+    if (view === 'starred') {
+      setView('search')
+      setHomeMode(true)
+    } else {
+      setView('starred')
+      setHomeMode(false)
+    }
+  }, [view])
+
+  const runStarredScopedSearch = useCallback(async (q: string) => {
+    const needle = q.trim()
+    if (!needle || !window.spool) {
+      setStarredScopedResults([])
+      setIsStarredSearching(false)
+      return
+    }
+    const requestId = ++starredSearchSeq.current
+    setIsStarredSearching(true)
+    try {
+      const res = await window.spool.search(needle, 50, undefined, true)
+      if (requestId !== starredSearchSeq.current) return
+      startTransition(() => { setStarredScopedResults(res) })
+    } finally {
+      if (requestId === starredSearchSeq.current) setIsStarredSearching(false)
+    }
+  }, [])
 
   useEffect(() => {
     loadThemeEditorState()
@@ -129,6 +228,7 @@ export default function App() {
       if (searchTimer.current) clearTimeout(searchTimer.current)
       if (toastTimer.current) clearTimeout(toastTimer.current)
       if (syncRefreshTimer.current) clearTimeout(syncRefreshTimer.current)
+      if (starredSearchTimer.current) clearTimeout(starredSearchTimer.current)
     }
   }, [])
 
@@ -278,7 +378,15 @@ export default function App() {
   const handleQueryChange = useCallback((q: string) => {
     setQuery(q)
     if (!q.trim()) setHomeMode(true)
-    if (searchMode === 'fast') {
+    if (view === 'starred') {
+      if (starredSearchTimer.current) clearTimeout(starredSearchTimer.current)
+      if (!q.trim()) {
+        setStarredScopedResults([])
+        setIsStarredSearching(false)
+      } else {
+        starredSearchTimer.current = setTimeout(() => runStarredScopedSearch(q), 120)
+      }
+    } else if (searchMode === 'fast') {
       if (searchTimer.current) clearTimeout(searchTimer.current)
       searchTimer.current = setTimeout(() => doSearch(q), 120)
       void doPreviewSearch(q)
@@ -288,7 +396,7 @@ export default function App() {
       setAiError(null)
       aiAnswerRef.current = ''
     }
-  }, [doPreviewSearch, doSearch, searchMode, aiAnswer, aiError])
+  }, [doPreviewSearch, doSearch, searchMode, aiAnswer, aiError, view, runStarredScopedSearch])
 
   const handleSubmit = useCallback(() => {
     if (!query.trim()) return
@@ -341,6 +449,10 @@ export default function App() {
     setView('search'); setSelectedSession(null); setTargetMessageId(null)
   }, [])
 
+  const handleBackToHome = useCallback(() => {
+    setView('search'); setSelectedSession(null); setTargetMessageId(null); setHomeMode(true); setQuery('')
+  }, [])
+
   const handleConnectClick = useCallback(() => {
     setSettingsTab('connectors')
     setShowSettings(true)
@@ -364,24 +476,33 @@ export default function App() {
     <div className="relative flex flex-col h-screen bg-warm-bg dark:bg-dark-bg text-warm-text dark:text-dark-text">
       <div className="flex flex-col flex-1 min-h-0">
         {isHomeMode ? (
-          <HomeView
-            query={query}
-            onChange={handleQueryChange}
-            onSubmit={handleSubmit}
-            onSelectSuggestion={handleSelectSuggestion}
-            suggestions={previewSuggestions}
-            isSearching={isSearching}
-            hasSettledQuery={lastCompletedPreviewQuery === query}
-            isDev={Boolean(runtimeInfo?.isDev)}
-            claudeCount={status?.claudeSessions ?? null}
-            codexCount={status?.codexSessions ?? null}
-            geminiCount={status?.geminiSessions ?? null}
-            captureSources={captureSources}
-            platformColors={platformColors}
-            mode={searchMode}
-            {...(hasAgents ? { onModeChange: handleModeChange } : {})}
-            onConnectClick={handleConnectClick}
-          />
+          <>
+            <div className="flex justify-end items-center h-10 px-3 flex-none">
+              <StarredEntryButton
+                count={totalStarred}
+                active={false}
+                onClick={handleToggleStarredView}
+              />
+            </div>
+            <HomeView
+              query={query}
+              onChange={handleQueryChange}
+              onSubmit={handleSubmit}
+              onSelectSuggestion={handleSelectSuggestion}
+              suggestions={previewSuggestions}
+              isSearching={isSearching}
+              hasSettledQuery={lastCompletedPreviewQuery === query}
+              isDev={Boolean(runtimeInfo?.isDev)}
+              claudeCount={status?.claudeSessions ?? null}
+              codexCount={status?.codexSessions ?? null}
+              geminiCount={status?.geminiSessions ?? null}
+              captureSources={captureSources}
+              platformColors={platformColors}
+              mode={searchMode}
+              {...(hasAgents ? { onModeChange: handleModeChange } : {})}
+              onConnectClick={handleConnectClick}
+            />
+          </>
         ) : (
           <>
             <div className="flex items-center gap-3 px-4 h-10 flex-none mt-2">
@@ -392,11 +513,12 @@ export default function App() {
                 query={query}
                 onChange={handleQueryChange}
                 onSubmit={handleSubmit}
-                {...(view === 'session' ? { onBack: handleBack } : {})}
+                {...(view === 'session' ? { onBack: handleBack } : view === 'starred' ? { onBack: handleBackToHome } : {})}
                 isSearching={isSearching}
                 variant="compact"
                 mode={searchMode}
                 {...(hasAgents ? { onModeChange: handleModeChange } : {})}
+                {...(view === 'starred' ? { placeholder: 'Filter starred…', scoped: true } : {})}
               />
               {searchMode === 'ai' && availableAgents.length > 0 && (
                 <AgentSelector
@@ -405,11 +527,36 @@ export default function App() {
                   onSelect={setAiAgent}
                 />
               )}
+              <StarredEntryButton
+                count={totalStarred}
+                active={view === 'starred'}
+                onClick={handleToggleStarredView}
+              />
             </div>
 
             <div className="flex-1 min-h-0 overflow-hidden">
               {view === 'session' && selectedSession ? (
-                <SessionDetail sessionUuid={selectedSession} targetMessageId={targetMessageId} onCopySessionId={handleCopySessionId} />
+                <SessionDetail
+                  sessionUuid={selectedSession}
+                  targetMessageId={targetMessageId}
+                  onCopySessionId={handleCopySessionId}
+                  isStarred={starredSessions.has(selectedSession)}
+                  onToggleStar={handleToggleStar}
+                />
+              ) : view === 'starred' ? (
+                <StarredItems
+                  items={starredItems}
+                  filterQuery={query}
+                  scopedResults={starredScopedResults}
+                  isScopedSearching={isStarredSearching}
+                  starredSessions={starredSessions}
+                  starredCaptures={starredCaptures}
+                  platformColors={platformColors}
+                  defaultSortOrder={defaultSearchSort}
+                  onOpenSession={handleOpenSession}
+                  onToggleStar={handleToggleStar}
+                  onCopySessionId={handleCopySessionId}
+                />
               ) : (
                 <div className="h-full flex flex-col overflow-hidden">
                   {searchMode === 'ai' && (aiAnswer || aiStreaming || aiError) && (
@@ -444,6 +591,9 @@ export default function App() {
                         defaultSortOrder={defaultSearchSort}
                         onCopySessionId={handleCopySessionId}
                         platformColors={platformColors}
+                        starredSessions={starredSessions}
+                        starredCaptures={starredCaptures}
+                        onToggleStar={handleToggleStar}
                       />
                     </div>
                   )}
@@ -549,4 +699,10 @@ function AgentSelector({ agents, activeAgent, onSelect }: {
       )}
     </div>
   )
+}
+
+function setsEqual(a: Set<string>, b: string[]): boolean {
+  if (a.size !== b.length) return false
+  for (const v of b) if (!a.has(v)) return false
+  return true
 }

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -85,21 +85,21 @@ export default function App() {
 
   const isHomeMode = homeMode && view === 'search' && !selectedSession
 
-  const refreshStarredUuids = useCallback(async () => {
+  const refreshStarredUuids = useCallback(() => {
     if (!window.spool?.getStarredUuids) return
-    try {
-      const uuids = await window.spool.getStarredUuids()
-      setStarredSessions(prev => setsEqual(prev, uuids.session) ? prev : new Set(uuids.session))
-      setStarredCaptures(prev => setsEqual(prev, uuids.capture) ? prev : new Set(uuids.capture))
-    } catch (err) { console.error(err) }
+    window.spool.getStarredUuids()
+      .then(uuids => {
+        setStarredSessions(prev => setsEqual(prev, uuids.session) ? prev : new Set(uuids.session))
+        setStarredCaptures(prev => setsEqual(prev, uuids.capture) ? prev : new Set(uuids.capture))
+      })
+      .catch(console.error)
   }, [])
 
-  const refreshStarredItems = useCallback(async () => {
+  const refreshStarredItems = useCallback(() => {
     if (!window.spool?.listStarredItems) return
-    try {
-      const items = await window.spool.listStarredItems()
-      setStarredItems(items)
-    } catch (err) { console.error(err) }
+    window.spool.listStarredItems()
+      .then(setStarredItems)
+      .catch(console.error)
   }, [])
 
   useEffect(() => { refreshStarredUuids() }, [refreshStarredUuids])
@@ -109,16 +109,16 @@ export default function App() {
 
   const handleToggleStar = useCallback((kind: StarKind, uuid: string, next: boolean) => {
     const setState = kind === 'session' ? setStarredSessions : setStarredCaptures
-    setState(prev => {
-      const updated = new Set(prev)
-      if (next) updated.add(uuid)
-      else updated.delete(uuid)
-      return updated
-    })
+    const withUuid = (uuids: Set<string>) => {
+      const out = new Set(uuids)
+      if (next) out.add(uuid)
+      else out.delete(uuid)
+      return out
+    }
+
+    setState(withUuid)
     if (!next) {
-      setStarredItems(prev => prev.filter(it =>
-        !(it.kind === kind && (it.kind === 'session' ? it.session.sessionUuid : it.capture.captureUuid) === uuid),
-      ))
+      setStarredItems(prev => prev.filter(it => !isSameStarredItem(it, kind, uuid)))
     }
 
     const request = next
@@ -446,11 +446,17 @@ export default function App() {
   }, [])
 
   const handleBack = useCallback(() => {
-    setView('search'); setSelectedSession(null); setTargetMessageId(null)
+    setView('search')
+    setSelectedSession(null)
+    setTargetMessageId(null)
   }, [])
 
   const handleBackToHome = useCallback(() => {
-    setView('search'); setSelectedSession(null); setTargetMessageId(null); setHomeMode(true); setQuery('')
+    setView('search')
+    setSelectedSession(null)
+    setTargetMessageId(null)
+    setHomeMode(true)
+    setQuery('')
   }, [])
 
   const handleConnectClick = useCallback(() => {
@@ -474,10 +480,10 @@ export default function App() {
 
   return (
     <div className="relative flex flex-col h-screen bg-warm-bg dark:bg-dark-bg text-warm-text dark:text-dark-text">
-      <div className="flex flex-col flex-1 min-h-0">
+      <div className="flex flex-col flex-1 min-h-0 relative">
         {isHomeMode ? (
           <>
-            <div className="flex justify-end items-center h-10 px-3 flex-none">
+            <div className="absolute top-3 right-3 z-20">
               <StarredEntryButton
                 count={totalStarred}
                 active={false}
@@ -705,4 +711,10 @@ function setsEqual(a: Set<string>, b: string[]): boolean {
   if (a.size !== b.length) return false
   for (const v of b) if (!a.has(v)) return false
   return true
+}
+
+function isSameStarredItem(item: StarredItem, kind: StarKind, uuid: string): boolean {
+  if (item.kind !== kind) return false
+  const itemUuid = item.kind === 'session' ? item.session.sessionUuid : item.capture.captureUuid
+  return itemUuid === uuid
 }

--- a/packages/app/src/renderer/components/Badges.tsx
+++ b/packages/app/src/renderer/components/Badges.tsx
@@ -1,0 +1,25 @@
+import { getSessionSourceColor, getSessionSourceShortLabel } from '../../shared/sessionSources.js'
+
+export function SourceBadge({ source }: { source: string }) {
+  return (
+    <span
+      data-testid="source-badge"
+      data-source={source}
+      className="text-[10px] font-semibold font-mono px-1.5 py-0.5 rounded text-white"
+      style={{ background: getSessionSourceColor(source) }}
+    >
+      {getSessionSourceShortLabel(source)}
+    </span>
+  )
+}
+
+export function PlatformBadge({ platform, color }: { platform: string; color: string }) {
+  return (
+    <span
+      className="text-[10px] font-semibold font-mono px-1.5 py-0.5 rounded text-white"
+      style={{ background: color }}
+    >
+      {platform}
+    </span>
+  )
+}

--- a/packages/app/src/renderer/components/FragmentResults.tsx
+++ b/packages/app/src/renderer/components/FragmentResults.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useState } from 'react'
-import type { FragmentResult, CaptureResult, SearchResult } from '@spool-lab/core'
+import { Star } from 'lucide-react'
+import type { FragmentResult, CaptureResult, SearchResult, StarKind } from '@spool-lab/core'
 import ContinueActions from './ContinueActions.js'
+import StarButton from './StarButton.js'
+import { SourceBadge, PlatformBadge } from './Badges.js'
 import { SEARCH_SORT_OPTIONS, type SearchSortOrder } from '../../shared/searchSort.js'
-import { getSessionSourceColor, getSessionSourceLabel, getSessionSourceShortLabel } from '../../shared/sessionSources.js'
+import { getSessionSourceLabel } from '../../shared/sessionSources.js'
+import { formatRelativeDate } from '../../shared/formatDate.js'
 
 type Props = {
   results: SearchResult[]
@@ -11,15 +15,26 @@ type Props = {
   defaultSortOrder: SearchSortOrder
   onCopySessionId: (source: FragmentResult['source']) => void
   platformColors: Record<string, string>
+  starredSessions: Set<string>
+  starredCaptures: Set<string>
+  onToggleStar: (kind: StarKind, uuid: string, next: boolean) => void
 }
 
-export default function FragmentResults({ results, query, onOpenSession, defaultSortOrder, onCopySessionId, platformColors }: Props) {
+export default function FragmentResults({ results, query, onOpenSession, defaultSortOrder, onCopySessionId, platformColors, starredSessions, starredCaptures, onToggleStar }: Props) {
   const [activeFilter, setActiveFilter] = useState('all')
   const [sortOrder, setSortOrder] = useState<SearchSortOrder>(defaultSortOrder)
+
+  const isResultStarred = (r: SearchResult): boolean =>
+    r.kind === 'fragment' ? starredSessions.has(r.sessionUuid) : starredCaptures.has(r.captureUuid)
 
   useEffect(() => {
     setSortOrder(defaultSortOrder)
   }, [defaultSortOrder])
+
+  useEffect(() => {
+    if (activeFilter === 'starred' && !results.some(isResultStarred)) setActiveFilter('all')
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeFilter, results, starredSessions, starredCaptures])
 
   if (results.length === 0) {
     return (
@@ -41,28 +56,34 @@ export default function FragmentResults({ results, query, onOpenSession, default
   const sourceKeys = [...new Set(results.map(r =>
     r.kind === 'fragment' ? r.source : r.platform
   ))]
+  const starredInResults = results.some(isResultStarred)
   const filtered = activeFilter === 'all'
     ? results
-    : results.filter(r =>
-        r.kind === 'fragment' ? r.source === activeFilter : r.platform === activeFilter
-      )
+    : activeFilter === 'starred'
+      ? results.filter(isResultStarred)
+      : results.filter(r =>
+          r.kind === 'fragment' ? r.source === activeFilter : r.platform === activeFilter
+        )
   const sortedResults = sortResults(filtered, sortOrder)
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
       <div className="flex items-center gap-3 border-b border-warm-border dark:border-dark-border px-4 min-h-11 flex-none">
         <div className="flex gap-0 min-w-0 flex-1 overflow-x-auto overflow-y-hidden scrollbar-none">
-          {(['all', ...sourceKeys] as string[]).map(src => (
+          {(['all', ...(starredInResults ? ['starred'] : []), ...sourceKeys] as string[]).map(src => (
             <button
               key={src}
               onClick={() => setActiveFilter(src)}
-              className={`px-3 py-2 text-xs font-medium border-b-2 -mb-px transition-colors whitespace-nowrap ${
+              className={`px-3 py-2 text-xs font-medium border-b-2 -mb-px transition-colors whitespace-nowrap flex items-center gap-1 ${
                 activeFilter === src
                   ? 'border-accent text-warm-text dark:text-dark-text'
                   : 'border-transparent text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text'
               }`}
             >
-              {src === 'all' ? 'All' : formatSourceFilterLabel(src)}
+              {src === 'starred' && (
+                <Star size={11} strokeWidth={2} fill="currentColor" className="text-accent dark:text-accent-dark flex-none" />
+              )}
+              {src === 'all' ? 'All' : src === 'starred' ? 'Starred' : formatSourceFilterLabel(src)}
             </button>
           ))}
         </div>
@@ -95,8 +116,21 @@ export default function FragmentResults({ results, query, onOpenSession, default
         <div className="divide-y divide-warm-border dark:divide-dark-border">
           {sortedResults.map((result, i) =>
             result.kind === 'capture'
-              ? <CaptureRow key={`cap-${result.captureId}`} result={result} platformColors={platformColors} />
-              : <FragmentRow key={`frag-${result.sessionUuid}-${i}`} result={result} onOpenSession={onOpenSession} onCopySessionId={onCopySessionId} />
+              ? <CaptureRow
+                  key={`cap-${result.captureId}`}
+                  result={result}
+                  platformColors={platformColors}
+                  isStarred={starredCaptures.has(result.captureUuid)}
+                  onToggleStar={onToggleStar}
+                />
+              : <FragmentRow
+                  key={`frag-${result.sessionUuid}-${i}`}
+                  result={result}
+                  onOpenSession={onOpenSession}
+                  onCopySessionId={onCopySessionId}
+                  isStarred={starredSessions.has(result.sessionUuid)}
+                  onToggleStar={onToggleStar}
+                />
           )}
         </div>
       </div>
@@ -115,17 +149,25 @@ function FragmentRow({
   result,
   onOpenSession,
   onCopySessionId,
+  isStarred,
+  onToggleStar,
 }: {
   result: FragmentResult & { kind: 'fragment' }
   onOpenSession: (uuid: string, messageId?: number) => void
   onCopySessionId: (source: FragmentResult['source']) => void
+  isStarred: boolean
+  onToggleStar: (kind: StarKind, uuid: string, next: boolean) => void
 }) {
   const snippet = result.snippet.replace(/<mark>/g, '<strong>').replace(/<\/mark>/g, '</strong>')
   const date = formatDate(result.startedAt)
   const project = result.project.split('/').pop() ?? result.project
 
   return (
-    <div data-testid="fragment-row" className="px-4 py-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors">
+    <div
+      data-testid="fragment-row"
+      data-starred={isStarred ? '1' : '0'}
+      className="px-4 py-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors"
+    >
       <div
         className="cursor-pointer"
         onClick={() => onOpenSession(result.sessionUuid, result.messageId)}
@@ -137,6 +179,13 @@ function FragmentRow({
             {result.profileLabel && <span> · {result.profileLabel}</span>}
             {result.matchCount > 1 && <span data-testid="match-count"> · {result.matchCount} matches</span>}
           </span>
+          <StarButton
+            kind="session"
+            uuid={result.sessionUuid}
+            isStarred={isStarred}
+            onToggle={onToggleStar}
+            testId="fragment-star"
+          />
           <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
         </div>
 
@@ -156,9 +205,11 @@ function FragmentRow({
   )
 }
 
-function CaptureRow({ result, platformColors }: {
+function CaptureRow({ result, platformColors, isStarred, onToggleStar }: {
   result: CaptureResult & { kind: 'capture' }
   platformColors: Record<string, string>
+  isStarred: boolean
+  onToggleStar: (kind: StarKind, uuid: string, next: boolean) => void
 }) {
   const snippet = result.snippet.replace(/<mark>/g, '<strong>').replace(/<\/mark>/g, '</strong>')
   const date = formatDate(result.capturedAt)
@@ -168,6 +219,8 @@ function CaptureRow({ result, platformColors }: {
       href={result.url}
       target="_blank"
       rel="noopener noreferrer"
+      data-testid="capture-row"
+      data-starred={isStarred ? '1' : '0'}
       className="block px-4 py-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors"
     >
       <div className="flex items-center gap-2 mb-1.5">
@@ -175,6 +228,14 @@ function CaptureRow({ result, platformColors }: {
         <span className="text-xs text-warm-muted dark:text-dark-muted truncate flex-1">
           {result.author ? `You saved this · ${result.author}` : 'You saved this'}
         </span>
+        <StarButton
+          kind="capture"
+          uuid={result.captureUuid}
+          isStarred={isStarred}
+          onToggle={onToggleStar}
+          insideAnchor
+          testId="capture-star"
+        />
         <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
       </div>
 
@@ -190,43 +251,7 @@ function CaptureRow({ result, platformColors }: {
   )
 }
 
-function PlatformBadge({ platform, color }: { platform: string; color: string }) {
-  return (
-    <span
-      className="text-[10px] font-semibold font-mono px-1.5 py-0.5 rounded text-white"
-      style={{ background: color }}
-    >
-      {platform}
-    </span>
-  )
-}
-
-function SourceBadge({ source }: { source: string }) {
-  return (
-    <span
-      data-testid="source-badge"
-      data-source={source}
-      className="text-[10px] font-semibold font-mono px-1.5 py-0.5 rounded text-white"
-      style={{ background: getSessionSourceColor(source) }}
-    >
-      {getSessionSourceShortLabel(source)}
-    </span>
-  )
-}
-
-function formatDate(iso: string): string {
-  try {
-    const d = new Date(iso)
-    const now = new Date()
-    const diffDays = Math.floor((now.getTime() - d.getTime()) / 86400000)
-    if (diffDays === 0) return 'today'
-    if (diffDays === 1) return 'yesterday'
-    if (diffDays < 7) return `${diffDays}d ago`
-    return d.toLocaleDateString()
-  } catch {
-    return iso.slice(0, 10)
-  }
-}
+const formatDate = formatRelativeDate
 
 function sortResults(results: SearchResult[], sortOrder: SearchSortOrder): SearchResult[] {
   if (sortOrder === 'relevance') return results

--- a/packages/app/src/renderer/components/FragmentResults.tsx
+++ b/packages/app/src/renderer/components/FragmentResults.tsx
@@ -159,7 +159,7 @@ function FragmentRow({
   onToggleStar: (kind: StarKind, uuid: string, next: boolean) => void
 }) {
   const snippet = result.snippet.replace(/<mark>/g, '<strong>').replace(/<\/mark>/g, '</strong>')
-  const date = formatDate(result.startedAt)
+  const date = formatRelativeDate(result.startedAt)
   const project = result.project.split('/').pop() ?? result.project
 
   return (
@@ -212,7 +212,7 @@ function CaptureRow({ result, platformColors, isStarred, onToggleStar }: {
   onToggleStar: (kind: StarKind, uuid: string, next: boolean) => void
 }) {
   const snippet = result.snippet.replace(/<mark>/g, '<strong>').replace(/<\/mark>/g, '</strong>')
-  const date = formatDate(result.capturedAt)
+  const date = formatRelativeDate(result.capturedAt)
 
   return (
     <a
@@ -251,7 +251,6 @@ function CaptureRow({ result, platformColors, isStarred, onToggleStar }: {
   )
 }
 
-const formatDate = formatRelativeDate
 
 function sortResults(results: SearchResult[], sortOrder: SearchSortOrder): SearchResult[] {
   if (sortOrder === 'relevance') return results

--- a/packages/app/src/renderer/components/FragmentResults.tsx
+++ b/packages/app/src/renderer/components/FragmentResults.tsx
@@ -179,6 +179,7 @@ function FragmentRow({
             {result.profileLabel && <span> · {result.profileLabel}</span>}
             {result.matchCount > 1 && <span data-testid="match-count"> · {result.matchCount} matches</span>}
           </span>
+          <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
           <StarButton
             kind="session"
             uuid={result.sessionUuid}
@@ -186,7 +187,6 @@ function FragmentRow({
             onToggle={onToggleStar}
             testId="fragment-star"
           />
-          <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
         </div>
 
         <p
@@ -228,6 +228,7 @@ function CaptureRow({ result, platformColors, isStarred, onToggleStar }: {
         <span className="text-xs text-warm-muted dark:text-dark-muted truncate flex-1">
           {result.author ? `You saved this · ${result.author}` : 'You saved this'}
         </span>
+        <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
         <StarButton
           kind="capture"
           uuid={result.captureUuid}
@@ -236,7 +237,6 @@ function CaptureRow({ result, platformColors, isStarred, onToggleStar }: {
           insideAnchor
           testId="capture-star"
         />
-        <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
       </div>
 
       <p

--- a/packages/app/src/renderer/components/SearchBar.tsx
+++ b/packages/app/src/renderer/components/SearchBar.tsx
@@ -12,9 +12,11 @@ interface Props {
   variant?: ('home' | 'compact') | undefined
   mode?: SearchMode | undefined
   onModeChange?: ((mode: SearchMode) => void) | undefined
+  placeholder?: string | undefined
+  scoped?: boolean | undefined
 }
 
-export default function SearchBar({ query, onChange, onBack, onSubmit, isSearching, variant = 'compact', mode = 'fast', onModeChange }: Props) {
+export default function SearchBar({ query, onChange, onBack, onSubmit, isSearching, variant = 'compact', mode = 'fast', onModeChange, placeholder, scoped = false }: Props) {
   const inputRef = useRef<HTMLInputElement>(null)
   const [showBusyIndicator, setShowBusyIndicator] = useState(false)
 
@@ -76,11 +78,15 @@ export default function SearchBar({ query, onChange, onBack, onSubmit, isSearchi
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.nativeEvent.isComposing) onSubmit?.()
           }}
-          placeholder="Search my thinking…"
+          placeholder={placeholder ?? 'Search my thinking…'}
           className={[
             'w-full rounded-full outline-none',
-            'bg-warm-surface dark:bg-dark-surface',
-            'border border-warm-border dark:border-dark-border',
+            scoped
+              ? 'bg-accent/5 dark:bg-accent-dark/5'
+              : 'bg-warm-surface dark:bg-dark-surface',
+            scoped
+              ? 'border border-accent/30 dark:border-accent-dark/30'
+              : 'border border-warm-border dark:border-dark-border',
             'placeholder:text-warm-faint dark:placeholder:text-dark-muted',
             'text-warm-text dark:text-dark-text',
             'focus:ring-0',

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -213,7 +213,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
           </p>
         </div>
 
-        <div className="flex items-end gap-1.5 flex-none self-end">
+        <div className="flex items-center gap-1.5 flex-none self-end">
           <StarButton
             kind="session"
             uuid={sessionUuid}

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -1,15 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { Session, Message } from '@spool-lab/core'
+import type { Session, Message, StarKind } from '@spool-lab/core'
 import MessageBubble, { type FindRange } from './MessageBubble.js'
 import SessionFindBar from './SessionFindBar.js'
+import StarButton from './StarButton.js'
 
 type Props = {
   sessionUuid: string
   targetMessageId?: number | null
   onCopySessionId: (source: Session['source']) => void
+  isStarred: boolean
+  onToggleStar: (kind: StarKind, uuid: string, next: boolean) => void
 }
 
-export default function SessionDetail({ sessionUuid, targetMessageId, onCopySessionId }: Props) {
+export default function SessionDetail({ sessionUuid, targetMessageId, onCopySessionId, isStarred, onToggleStar }: Props) {
   const [session, setSession] = useState<Session | null>(null)
   const [messages, setMessages] = useState<Message[]>([])
   const [loading, setLoading] = useState(true)
@@ -210,17 +213,27 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
           </p>
         </div>
 
-        <button
-          onClick={handleCopySessionId}
-          title="Copy session ID for CLI resume"
-          className="flex items-center gap-1.5 self-end text-xs text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 rounded px-2.5 py-1 transition-colors flex-none"
-        >
-          <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
-            <rect x="4.5" y="4.5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.2"/>
-            <path d="M8.5 4.5V3C8.5 2.17 7.83 1.5 7 1.5H3C2.17 1.5 1.5 2.17 1.5 3V7C1.5 7.83 2.17 8.5 3 8.5H4.5" stroke="currentColor" strokeWidth="1.2"/>
-          </svg>
-          Copy Session ID
-        </button>
+        <div className="flex items-end gap-1.5 flex-none self-end">
+          <StarButton
+            kind="session"
+            uuid={sessionUuid}
+            isStarred={isStarred}
+            onToggle={onToggleStar}
+            size="md"
+            testId="session-star"
+          />
+          <button
+            onClick={handleCopySessionId}
+            title="Copy session ID for CLI resume"
+            className="flex items-center gap-1.5 text-xs text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 rounded px-2.5 py-1 transition-colors"
+          >
+            <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+              <rect x="4.5" y="4.5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.2"/>
+              <path d="M8.5 4.5V3C8.5 2.17 7.83 1.5 7 1.5H3C2.17 1.5 1.5 2.17 1.5 3V7C1.5 7.83 2.17 8.5 3 8.5H4.5" stroke="currentColor" strokeWidth="1.2"/>
+            </svg>
+            Copy Session ID
+          </button>
+        </div>
       </div>
 
       <SessionFindBar

--- a/packages/app/src/renderer/components/StarButton.tsx
+++ b/packages/app/src/renderer/components/StarButton.tsx
@@ -23,8 +23,8 @@ export default function StarButton({
   insideAnchor = false,
   testId,
 }: Props) {
-  const iconSize = size === 'md' ? 15 : 12
-  const box = size === 'md' ? 'h-[26px] w-[26px]' : 'w-5 h-5'
+  const iconSize = size === 'md' ? 15 : 13
+  const box = size === 'md' ? 'h-6 w-6' : 'w-5 h-5'
   const label = kind === 'capture' ? 'capture' : 'session'
 
   return (
@@ -41,6 +41,7 @@ export default function StarButton({
       data-starred={isStarred ? '1' : '0'}
       className={[
         'flex-none flex items-center justify-center rounded transition-colors',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40',
         box,
         isStarred
           ? 'text-accent dark:text-accent-dark hover:opacity-70'

--- a/packages/app/src/renderer/components/StarButton.tsx
+++ b/packages/app/src/renderer/components/StarButton.tsx
@@ -8,11 +8,9 @@ type Props = {
   uuid: string
   isStarred: boolean
   onToggle: (kind: StarKind, uuid: string, next: boolean) => void
-  /** sm = 12px icon (inline in rows), md = 15px (detail header / unstar shortcut). */
   size?: Size
   /** Set when the button is rendered inside an `<a>` — prevents the anchor from navigating. */
   insideAnchor?: boolean
-  /** Testid to attach. */
   testId?: string
 }
 

--- a/packages/app/src/renderer/components/StarButton.tsx
+++ b/packages/app/src/renderer/components/StarButton.tsx
@@ -1,0 +1,59 @@
+import { Star } from 'lucide-react'
+import type { StarKind } from '@spool-lab/core'
+
+type Size = 'sm' | 'md'
+
+type Props = {
+  kind: StarKind
+  uuid: string
+  isStarred: boolean
+  onToggle: (kind: StarKind, uuid: string, next: boolean) => void
+  /** sm = 12px icon (inline in rows), md = 15px (detail header / unstar shortcut). */
+  size?: Size
+  /** Set when the button is rendered inside an `<a>` — prevents the anchor from navigating. */
+  insideAnchor?: boolean
+  /** Testid to attach. */
+  testId?: string
+}
+
+export default function StarButton({
+  kind,
+  uuid,
+  isStarred,
+  onToggle,
+  size = 'sm',
+  insideAnchor = false,
+  testId,
+}: Props) {
+  const iconSize = size === 'md' ? 15 : 12
+  const box = size === 'md' ? 'h-[26px] w-[26px]' : 'w-5 h-5'
+  const label = kind === 'capture' ? 'capture' : 'session'
+
+  return (
+    <button
+      onClick={(e) => {
+        if (insideAnchor) e.preventDefault()
+        e.stopPropagation()
+        onToggle(kind, uuid, !isStarred)
+      }}
+      title={isStarred ? 'Unstar' : 'Star for quick access'}
+      aria-label={isStarred ? `Unstar ${label}` : `Star ${label}`}
+      aria-pressed={isStarred}
+      {...(testId ? { 'data-testid': testId } : {})}
+      data-starred={isStarred ? '1' : '0'}
+      className={[
+        'flex-none flex items-center justify-center rounded transition-colors',
+        box,
+        isStarred
+          ? 'text-accent dark:text-accent-dark hover:opacity-70'
+          : 'text-warm-faint dark:text-dark-muted hover:text-accent dark:hover:text-accent-dark',
+      ].join(' ')}
+    >
+      <Star
+        size={iconSize}
+        strokeWidth={1.8}
+        {...(isStarred ? { fill: 'currentColor' } : {})}
+      />
+    </button>
+  )
+}

--- a/packages/app/src/renderer/components/StarredEntryButton.tsx
+++ b/packages/app/src/renderer/components/StarredEntryButton.tsx
@@ -8,6 +8,7 @@ type Props = {
 
 export default function StarredEntryButton({ count, active, onClick }: Props) {
   const hasCount = count > 0
+  const highlighted = active || hasCount
   return (
     <button
       onClick={onClick}
@@ -26,7 +27,8 @@ export default function StarredEntryButton({ count, active, onClick }: Props) {
       <Star
         size={13}
         strokeWidth={1.8}
-        {...(active || hasCount ? { fill: 'currentColor', className: 'text-accent dark:text-accent-dark flex-none' } : { className: 'flex-none' })}
+        fill={highlighted ? 'currentColor' : 'none'}
+        className={highlighted ? 'flex-none text-accent dark:text-accent-dark' : 'flex-none'}
       />
       {hasCount && <span className="text-[11px] font-medium tabular-nums leading-none">{count}</span>}
     </button>

--- a/packages/app/src/renderer/components/StarredEntryButton.tsx
+++ b/packages/app/src/renderer/components/StarredEntryButton.tsx
@@ -1,0 +1,34 @@
+import { Star } from 'lucide-react'
+
+type Props = {
+  count: number
+  active: boolean
+  onClick: () => void
+}
+
+export default function StarredEntryButton({ count, active, onClick }: Props) {
+  const hasCount = count > 0
+  return (
+    <button
+      onClick={onClick}
+      title={active ? 'Back to search' : `Starred (${count})`}
+      aria-label={active ? 'Return to search' : 'View starred sessions'}
+      aria-pressed={active}
+      data-testid="starred-entry"
+      className={[
+        'flex items-center gap-1 h-7 rounded-full transition-colors flex-none select-none',
+        hasCount ? 'px-2.5' : 'px-1.5',
+        active
+          ? 'bg-accent/10 dark:bg-accent-dark/10 text-accent dark:text-accent-dark'
+          : 'text-warm-muted dark:text-dark-muted hover:text-accent dark:hover:text-accent-dark hover:bg-warm-surface dark:hover:bg-dark-surface',
+      ].join(' ')}
+    >
+      <Star
+        size={13}
+        strokeWidth={1.8}
+        {...(active || hasCount ? { fill: 'currentColor', className: 'text-accent dark:text-accent-dark flex-none' } : { className: 'flex-none' })}
+      />
+      {hasCount && <span className="text-[11px] font-medium tabular-nums leading-none">{count}</span>}
+    </button>
+  )
+}

--- a/packages/app/src/renderer/components/StarredEntryButton.tsx
+++ b/packages/app/src/renderer/components/StarredEntryButton.tsx
@@ -30,7 +30,7 @@ export default function StarredEntryButton({ count, active, onClick }: Props) {
         fill={highlighted ? 'currentColor' : 'none'}
         className={highlighted ? 'flex-none text-accent dark:text-accent-dark' : 'flex-none'}
       />
-      {hasCount && <span className="text-[11px] font-medium tabular-nums leading-none">{count}</span>}
+      {hasCount && <span className="text-[11px] font-medium tabular-nums leading-none translate-y-[0.5px]">{count}</span>}
     </button>
   )
 }

--- a/packages/app/src/renderer/components/StarredItems.tsx
+++ b/packages/app/src/renderer/components/StarredItems.tsx
@@ -1,0 +1,240 @@
+import { Star } from 'lucide-react'
+import type { FragmentResult, Session, Capture, StarKind, StarredItem, SearchResult } from '@spool-lab/core'
+import FragmentResults from './FragmentResults.js'
+import StarButton from './StarButton.js'
+import { SourceBadge, PlatformBadge } from './Badges.js'
+import { DEFAULT_SEARCH_SORT_ORDER, type SearchSortOrder } from '../../shared/searchSort.js'
+import { formatRelativeDate } from '../../shared/formatDate.js'
+
+type Props = {
+  items: StarredItem[]
+  filterQuery: string
+  scopedResults: SearchResult[]
+  isScopedSearching: boolean
+  starredSessions: Set<string>
+  starredCaptures: Set<string>
+  platformColors: Record<string, string>
+  defaultSortOrder: SearchSortOrder
+  onOpenSession: (uuid: string, messageId?: number) => void
+  onToggleStar: (kind: StarKind, uuid: string, next: boolean) => void
+  onCopySessionId: (source: FragmentResult['source']) => void
+}
+
+export default function StarredItems({
+  items,
+  filterQuery,
+  scopedResults,
+  isScopedSearching,
+  starredSessions,
+  starredCaptures,
+  platformColors,
+  defaultSortOrder = DEFAULT_SEARCH_SORT_ORDER,
+  onOpenSession,
+  onToggleStar,
+  onCopySessionId,
+}: Props) {
+  const needle = filterQuery.trim()
+
+  if (items.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-warm-faint dark:text-dark-muted gap-2 pb-12">
+        <Star size={28} strokeWidth={1.4} className="opacity-40" />
+        <p className="text-sm text-warm-muted dark:text-dark-muted">You haven&apos;t starred anything yet.</p>
+        <p className="text-xs opacity-80">Star sessions or captures to save them here.</p>
+      </div>
+    )
+  }
+
+  // Non-empty query → scoped FTS across starred items.
+  if (needle) {
+    if (isScopedSearching && scopedResults.length === 0) {
+      return (
+        <div className="flex flex-col items-center justify-center h-full text-warm-faint dark:text-dark-muted gap-2 pb-12">
+          <span className="w-1.5 h-1.5 rounded-full bg-accent dark:bg-accent-dark animate-pulse" />
+          <p className="text-sm text-warm-muted dark:text-dark-muted">Searching your starred items…</p>
+        </div>
+      )
+    }
+    if (scopedResults.length === 0) {
+      return (
+        <div className="flex flex-col h-full">
+          <StarredHeader total={items.length} matched={0} filterQuery={needle} />
+          <div className="flex flex-col items-center justify-center flex-1 text-warm-faint dark:text-dark-muted gap-2 pb-12">
+            <p className="text-sm text-warm-muted dark:text-dark-muted">No starred item matches &ldquo;{needle}&rdquo;.</p>
+            <p className="text-[11px] opacity-80">Press <kbd className="font-mono bg-warm-surface dark:bg-dark-surface px-1.5 py-0.5 rounded border border-warm-border dark:border-dark-border">Enter</kbd> to search everywhere instead.</p>
+          </div>
+        </div>
+      )
+    }
+    return (
+      <div className="flex flex-col h-full">
+        <StarredHeader total={items.length} matched={scopedResults.length} filterQuery={needle} />
+        <div className="flex-1 min-h-0">
+          <FragmentResults
+            results={scopedResults}
+            query={needle}
+            onOpenSession={onOpenSession}
+            defaultSortOrder={defaultSortOrder}
+            onCopySessionId={onCopySessionId}
+            platformColors={platformColors}
+            starredSessions={starredSessions}
+            starredCaptures={starredCaptures}
+            onToggleStar={onToggleStar}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  // Empty query → mixed list of starred items ordered by starred_at DESC
+  // (already sorted server-side). Keep session and capture rows visually
+  // distinct but co-ordered chronologically.
+  return (
+    <div className="h-full flex flex-col overflow-hidden">
+      <StarredHeader total={items.length} />
+      <div className="flex-1 overflow-y-auto">
+        <div className="divide-y divide-warm-border dark:divide-dark-border">
+          {items.map(item => (
+            item.kind === 'session'
+              ? <StarredSessionRow
+                  key={`s-${item.session.sessionUuid}`}
+                  session={item.session}
+                  onOpen={onOpenSession}
+                  onToggleStar={onToggleStar}
+                />
+              : <StarredCaptureRow
+                  key={`c-${item.capture.captureUuid}`}
+                  capture={item.capture}
+                  platformColors={platformColors}
+                  onToggleStar={onToggleStar}
+                />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function StarredHeader({
+  total,
+  matched,
+  filterQuery,
+}: {
+  total: number
+  matched?: number
+  filterQuery?: string
+}) {
+  const scoped = filterQuery && matched !== undefined
+  return (
+    <div className="flex items-center gap-2 border-b border-warm-border dark:border-dark-border px-4 min-h-11 flex-none">
+      <Star size={14} strokeWidth={1.8} fill="currentColor" className="text-accent dark:text-accent-dark flex-none" />
+      <span className="text-xs font-medium text-warm-text dark:text-dark-text">Starred</span>
+      <span className="text-xs text-warm-faint dark:text-dark-muted tabular-nums">
+        {scoped ? `${matched} of ${total}` : total}
+      </span>
+      {scoped && (
+        <span className="text-[11px] text-warm-faint dark:text-dark-muted italic ml-2 truncate">
+          matching &ldquo;{filterQuery}&rdquo;
+        </span>
+      )}
+    </div>
+  )
+}
+
+function StarredSessionRow({
+  session,
+  onOpen,
+  onToggleStar,
+}: {
+  session: Session
+  onOpen: (uuid: string) => void
+  onToggleStar: (kind: StarKind, uuid: string, next: boolean) => void
+}) {
+  const date = formatDate(session.startedAt)
+
+  return (
+    <div
+      data-testid="starred-row"
+      data-kind="session"
+      className="px-4 py-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors flex items-start gap-3"
+    >
+      <button
+        onClick={() => onOpen(session.sessionUuid)}
+        className="flex-1 min-w-0 text-left cursor-pointer"
+      >
+        <div className="flex items-center gap-2 mb-1">
+          <SourceBadge source={session.source} />
+          <span className="text-xs text-warm-muted dark:text-dark-muted truncate flex-1">
+            You starred this · {session.projectDisplayName}
+          </span>
+          <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
+        </div>
+        <p className="text-sm text-warm-text dark:text-dark-text truncate">
+          {session.title ?? '(no title)'}
+        </p>
+        <p className="text-xs text-warm-faint dark:text-dark-muted mt-0.5">
+          {session.messageCount} messages
+          {session.model && ` · ${session.model}`}
+        </p>
+      </button>
+
+      <StarButton
+        kind="session"
+        uuid={session.sessionUuid}
+        isStarred={true}
+        onToggle={onToggleStar}
+        size="md"
+      />
+    </div>
+  )
+}
+
+function StarredCaptureRow({
+  capture,
+  platformColors,
+  onToggleStar,
+}: {
+  capture: Capture
+  platformColors: Record<string, string>
+  onToggleStar: (kind: StarKind, uuid: string, next: boolean) => void
+}) {
+  const date = formatDate(capture.capturedAt)
+
+  return (
+    <a
+      href={capture.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      data-testid="starred-row"
+      data-kind="capture"
+      className="flex items-start gap-3 px-4 py-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors"
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1">
+          <PlatformBadge platform={capture.platform} color={platformColors[capture.platform] ?? '#C85A00'} />
+          <span className="text-xs text-warm-muted dark:text-dark-muted truncate flex-1">
+            You starred this{capture.author ? ` · ${capture.author}` : ''}
+          </span>
+          <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
+        </div>
+        <p className="text-sm text-warm-text dark:text-dark-text truncate">
+          {capture.title || capture.url}
+        </p>
+        <p className="text-xs text-warm-faint dark:text-dark-muted mt-0.5 truncate">
+          {capture.url}
+        </p>
+      </div>
+
+      <StarButton
+        kind="capture"
+        uuid={capture.captureUuid}
+        isStarred={true}
+        onToggle={onToggleStar}
+        size="md"
+        insideAnchor
+      />
+    </a>
+  )
+}
+
+const formatDate = formatRelativeDate

--- a/packages/app/src/renderer/components/StarredItems.tsx
+++ b/packages/app/src/renderer/components/StarredItems.tsx
@@ -127,13 +127,13 @@ function StarredHeader({
   const scoped = filterQuery && matched !== undefined
   return (
     <div className="flex items-center gap-2 border-b border-warm-border dark:border-dark-border px-4 min-h-11 flex-none">
-      <Star size={14} strokeWidth={1.8} fill="currentColor" className="text-accent dark:text-accent-dark flex-none" />
-      <span className="text-xs font-medium text-warm-text dark:text-dark-text">Starred</span>
-      <span className="text-xs text-warm-faint dark:text-dark-muted tabular-nums">
+      <Star size={13} strokeWidth={1.8} fill="currentColor" className="text-accent dark:text-accent-dark flex-none" />
+      <span className="text-xs font-medium text-warm-text dark:text-dark-text leading-none">Starred</span>
+      <span className="text-xs text-warm-faint dark:text-dark-muted tabular-nums leading-none">
         {scoped ? `${matched} of ${total}` : total}
       </span>
       {scoped && (
-        <span className="text-[11px] text-warm-faint dark:text-dark-muted italic ml-2 truncate">
+        <span className="text-[11px] text-warm-faint dark:text-dark-muted italic ml-2 truncate leading-none">
           matching &ldquo;{filterQuery}&rdquo;
         </span>
       )}
@@ -151,40 +151,39 @@ function StarredSessionRow({
   onToggleStar: (kind: StarKind, uuid: string, next: boolean) => void
 }) {
   const date = formatRelativeDate(session.startedAt)
+  const handleOpen = () => onOpen(session.sessionUuid)
 
   return (
     <div
+      role="button"
+      tabIndex={0}
+      onClick={handleOpen}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleOpen() } }}
       data-testid="starred-row"
       data-kind="session"
-      className="px-4 py-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors flex items-start gap-3"
+      className="px-4 py-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
     >
-      <button
-        onClick={() => onOpen(session.sessionUuid)}
-        className="flex-1 min-w-0 text-left cursor-pointer"
-      >
-        <div className="flex items-center gap-2 mb-1">
-          <SourceBadge source={session.source} />
-          <span className="text-xs text-warm-muted dark:text-dark-muted truncate flex-1">
-            You starred this · {session.projectDisplayName}
-          </span>
-          <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
-        </div>
-        <p className="text-sm text-warm-text dark:text-dark-text truncate">
-          {session.title ?? '(no title)'}
-        </p>
-        <p className="text-xs text-warm-faint dark:text-dark-muted mt-0.5">
-          {session.messageCount} messages
-          {session.model && ` · ${session.model}`}
-        </p>
-      </button>
-
-      <StarButton
-        kind="session"
-        uuid={session.sessionUuid}
-        isStarred={true}
-        onToggle={onToggleStar}
-        size="md"
-      />
+      <div className="flex items-center gap-2 mb-1">
+        <SourceBadge source={session.source} />
+        <span className="text-xs text-warm-muted dark:text-dark-muted truncate flex-1">
+          You starred this · {session.projectDisplayName}
+        </span>
+        <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
+        <StarButton
+          kind="session"
+          uuid={session.sessionUuid}
+          isStarred={true}
+          onToggle={onToggleStar}
+          size="sm"
+        />
+      </div>
+      <p className="text-sm text-warm-text dark:text-dark-text truncate">
+        {session.title ?? '(no title)'}
+      </p>
+      <p className="text-xs text-warm-faint dark:text-dark-muted mt-0.5">
+        {session.messageCount} messages
+        {session.model && ` · ${session.model}`}
+      </p>
     </div>
   )
 }
@@ -207,32 +206,29 @@ function StarredCaptureRow({
       rel="noopener noreferrer"
       data-testid="starred-row"
       data-kind="capture"
-      className="flex items-start gap-3 px-4 py-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors"
+      className="block px-4 py-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors"
     >
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 mb-1">
-          <PlatformBadge platform={capture.platform} color={platformColors[capture.platform] ?? '#C85A00'} />
-          <span className="text-xs text-warm-muted dark:text-dark-muted truncate flex-1">
-            You starred this{capture.author ? ` · ${capture.author}` : ''}
-          </span>
-          <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
-        </div>
-        <p className="text-sm text-warm-text dark:text-dark-text truncate">
-          {capture.title || capture.url}
-        </p>
-        <p className="text-xs text-warm-faint dark:text-dark-muted mt-0.5 truncate">
-          {capture.url}
-        </p>
+      <div className="flex items-center gap-2 mb-1">
+        <PlatformBadge platform={capture.platform} color={platformColors[capture.platform] ?? '#C85A00'} />
+        <span className="text-xs text-warm-muted dark:text-dark-muted truncate flex-1">
+          You starred this{capture.author ? ` · ${capture.author}` : ''}
+        </span>
+        <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
+        <StarButton
+          kind="capture"
+          uuid={capture.captureUuid}
+          isStarred={true}
+          onToggle={onToggleStar}
+          size="sm"
+          insideAnchor
+        />
       </div>
-
-      <StarButton
-        kind="capture"
-        uuid={capture.captureUuid}
-        isStarred={true}
-        onToggle={onToggleStar}
-        size="md"
-        insideAnchor
-      />
+      <p className="text-sm text-warm-text dark:text-dark-text truncate">
+        {capture.title || capture.url}
+      </p>
+      <p className="text-xs text-warm-faint dark:text-dark-muted mt-0.5 truncate">
+        {capture.url}
+      </p>
     </a>
   )
 }

--- a/packages/app/src/renderer/components/StarredItems.tsx
+++ b/packages/app/src/renderer/components/StarredItems.tsx
@@ -150,7 +150,7 @@ function StarredSessionRow({
   onOpen: (uuid: string) => void
   onToggleStar: (kind: StarKind, uuid: string, next: boolean) => void
 }) {
-  const date = formatDate(session.startedAt)
+  const date = formatRelativeDate(session.startedAt)
 
   return (
     <div
@@ -198,7 +198,7 @@ function StarredCaptureRow({
   platformColors: Record<string, string>
   onToggleStar: (kind: StarKind, uuid: string, next: boolean) => void
 }) {
-  const date = formatDate(capture.capturedAt)
+  const date = formatRelativeDate(capture.capturedAt)
 
   return (
     <a
@@ -237,4 +237,3 @@ function StarredCaptureRow({
   )
 }
 
-const formatDate = formatRelativeDate

--- a/packages/app/src/shared/formatDate.ts
+++ b/packages/app/src/shared/formatDate.ts
@@ -1,0 +1,13 @@
+export function formatRelativeDate(iso: string): string {
+  try {
+    const d = new Date(iso)
+    const now = new Date()
+    const diffDays = Math.floor((now.getTime() - d.getTime()) / 86400000)
+    if (diffDays === 0) return 'today'
+    if (diffDays === 1) return 'yesterday'
+    if (diffDays < 7) return `${diffDays}d ago`
+    return d.toLocaleDateString()
+  } catch {
+    return iso.slice(0, 10)
+  }
+}

--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -191,6 +191,22 @@ function runMigrations(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_capture_connectors_connector
       ON capture_connectors(connector_id);
 
+    -- ── Stars ─────────────────────────────────────────────────────────────
+    -- Unified star table for both sessions and captures. Referent is keyed by
+    -- its natural UUID (session_uuid / capture_uuid), which stays stable
+    -- across re-index. No FK — queries filter orphans at read time via JOIN,
+    -- so transient referent absence (e.g. transcript file removed then
+    -- restored) doesn't destroy the star. CHECK constraint guards against
+    -- typos in item_type.
+    CREATE TABLE IF NOT EXISTS stars (
+      item_type  TEXT NOT NULL CHECK (item_type IN ('session', 'capture')),
+      item_uuid  TEXT NOT NULL,
+      starred_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (item_type, item_uuid)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_stars_starred_at ON stars(starred_at DESC);
+
     CREATE TABLE IF NOT EXISTS connector_sync_state (
       connector_id        TEXT PRIMARY KEY,
       head_cursor         TEXT,
@@ -335,6 +351,25 @@ function runMigrations(db: Database.Database): void {
       db.exec(`DROP INDEX IF EXISTS idx_captures_source`)
     })()
     db.pragma('user_version = 3')
+  }
+
+  if (version < 4) {
+    // v4: unified stars table covering both sessions and captures. An earlier
+    // in-development iteration used a session-only `session_stars` table —
+    // drop it if present before creating the unified table. Since this
+    // version was never released, users skipping past the intermediate state
+    // simply get the final schema.
+    db.exec(`
+      DROP TABLE IF EXISTS session_stars;
+      CREATE TABLE IF NOT EXISTS stars (
+        item_type  TEXT NOT NULL CHECK (item_type IN ('session', 'capture')),
+        item_uuid  TEXT NOT NULL,
+        starred_at TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (item_type, item_uuid)
+      );
+      CREATE INDEX IF NOT EXISTS idx_stars_starred_at ON stars(starred_at DESC);
+    `)
+    db.pragma('user_version = 4')
   }
 
   rebuildFtsTableIfEmpty(db, 'messages', 'messages_fts_trigram')

--- a/packages/core/src/db/queries.ts
+++ b/packages/core/src/db/queries.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import type Database from 'better-sqlite3'
-import type { Session, Message, FragmentResult, StatusInfo, CaptureResult, SearchResult, Source, SearchMatchType, SessionSource } from '../types.js'
+import type { Session, Message, FragmentResult, StatusInfo, CaptureResult, SearchResult, Source, SearchMatchType, SessionSource, StarKind, StarredItem, Capture } from '../types.js'
 import type { CapturedItem } from '../connectors/types.js'
 import { DB_PATH, getDBSize } from './db.js'
 import { buildSearchPlan, canUseSessionSearchFts, getNaturalSearchPhrase, getNaturalSearchTerms, selectFtsTableKind, shouldUseSessionFallback } from './search-query.js'
@@ -160,23 +160,26 @@ export function insertMessages(
   }
 }
 
+const SESSION_SELECT = `
+  SELECT
+    s.id, s.project_id AS projectId, s.source_id AS sourceId,
+    s.session_uuid AS sessionUuid, s.file_path AS filePath,
+    s.title, s.started_at AS startedAt, s.ended_at AS endedAt,
+    s.message_count AS messageCount, s.has_tool_use AS hasToolUse,
+    s.cwd, s.model,
+    src.name AS source,
+    p.display_path AS projectDisplayPath,
+    p.display_name AS projectDisplayName
+  FROM sessions s
+  JOIN sources src ON src.id = s.source_id
+  JOIN projects p ON p.id = s.project_id`
+
 export function listRecentSessions(
   db: Database.Database,
   limit = 50,
 ): Session[] {
   return (db.prepare(`
-    SELECT
-      s.id, s.project_id AS projectId, s.source_id AS sourceId,
-      s.session_uuid AS sessionUuid, s.file_path AS filePath,
-      s.title, s.started_at AS startedAt, s.ended_at AS endedAt,
-      s.message_count AS messageCount, s.has_tool_use AS hasToolUse,
-      s.cwd, s.model,
-      src.name AS source,
-      p.display_path AS projectDisplayPath,
-      p.display_name AS projectDisplayName
-    FROM sessions s
-    JOIN sources src ON src.id = s.source_id
-    JOIN projects p ON p.id = s.project_id
+    ${SESSION_SELECT}
     ORDER BY s.started_at DESC
     LIMIT ?
   `).all(limit) as Array<Record<string, unknown>>).map(rowToSession)
@@ -187,18 +190,7 @@ export function getSessionWithMessages(
   sessionUuid: string,
 ): { session: Session; messages: Message[] } | null {
   const sessionRow = db.prepare(`
-    SELECT
-      s.id, s.project_id AS projectId, s.source_id AS sourceId,
-      s.session_uuid AS sessionUuid, s.file_path AS filePath,
-      s.title, s.started_at AS startedAt, s.ended_at AS endedAt,
-      s.message_count AS messageCount, s.has_tool_use AS hasToolUse,
-      s.cwd, s.model,
-      src.name AS source,
-      p.display_path AS projectDisplayPath,
-      p.display_name AS projectDisplayName
-    FROM sessions s
-    JOIN sources src ON src.id = s.source_id
-    JOIN projects p ON p.id = s.project_id
+    ${SESSION_SELECT}
     WHERE s.session_uuid = ?
   `).get(sessionUuid) as Record<string, unknown> | undefined
 
@@ -233,9 +225,9 @@ export function getSessionWithMessages(
 export function searchFragments(
   db: Database.Database,
   query: string,
-  opts: { limit?: number; source?: SessionSource; since?: string } = {},
+  opts: { limit?: number; source?: SessionSource; since?: string; onlyStarred?: boolean } = {},
 ): FragmentResult[] {
-  const { limit = 10, source, since } = opts
+  const { limit = 10, source, since, onlyStarred } = opts
 
   const rowLimit = Math.max(limit * 10, 50)
   const naturalTerms = getNaturalSearchTerms(query)
@@ -246,6 +238,7 @@ export function searchFragments(
     return searchFragmentSessionFallback(db, naturalTerms, naturalPhrase, rowLimit, 'fts', {
       ...(source ? { source } : {}),
       ...(since ? { since } : {}),
+      ...(onlyStarred ? { onlyStarred } : {}),
     }).slice(0, limit)
   }
 
@@ -254,6 +247,7 @@ export function searchFragments(
       return searchFragmentSessionFallback(db, naturalTerms, naturalPhrase, rowLimit, step.matchType, {
         ...(source ? { source } : {}),
         ...(since ? { since } : {}),
+        ...(onlyStarred ? { onlyStarred } : {}),
       })
     }
 
@@ -261,6 +255,7 @@ export function searchFragments(
     const rows = searchFragmentRows(db, ftsTable, step.query, rowLimit, {
       ...(source ? { source } : {}),
       ...(since ? { since } : {}),
+      ...(onlyStarred ? { onlyStarred } : {}),
     })
     return collapseFragmentRows(rows, step.matchType)
   })
@@ -320,9 +315,9 @@ function searchFragmentRows(
   ftsTable: 'messages_fts' | 'messages_fts_trigram',
   ftsQuery: string,
   limit: number,
-  opts: { source?: SessionSource; since?: string } = {},
+  opts: { source?: SessionSource; since?: string; onlyStarred?: boolean } = {},
 ): Array<Record<string, unknown>> {
-  const { source, since } = opts
+  const { source, since, onlyStarred } = opts
   const conditions: string[] = [`${ftsTable} MATCH ?`, 'm.is_sidechain = 0']
   const params: (string | number)[] = [ftsQuery]
 
@@ -333,6 +328,9 @@ function searchFragmentRows(
   if (since) {
     conditions.push('m.timestamp >= ?')
     params.push(since)
+  }
+  if (onlyStarred) {
+    conditions.push("EXISTS (SELECT 1 FROM stars WHERE stars.item_type = 'session' AND stars.item_uuid = sess.session_uuid)")
   }
   params.push(limit)
 
@@ -503,7 +501,7 @@ function searchFragmentSessionFallback(
   phrase: string,
   limit: number,
   matchType: SearchMatchType,
-  opts: { source?: SessionSource; since?: string } = {},
+  opts: { source?: SessionSource; since?: string; onlyStarred?: boolean } = {},
 ): FragmentResult[] {
   if (terms.length < 1) return []
 
@@ -587,7 +585,7 @@ function searchSessionRowsByTerms(
   phrase: string,
   limit: number,
   matchType: SearchMatchType,
-  opts: { source?: SessionSource; since?: string } = {},
+  opts: { source?: SessionSource; since?: string; onlyStarred?: boolean } = {},
 ): Array<Record<string, unknown>> {
   if (canUseSessionSearchFts(phrase)) {
     return searchSessionRowsByFts(db, terms, phrase, limit, matchType, opts)
@@ -600,9 +598,9 @@ function searchSessionRowsByLike(
   db: Database.Database,
   terms: string[],
   limit: number,
-  opts: { source?: SessionSource; since?: string } = {},
+  opts: { source?: SessionSource; since?: string; onlyStarred?: boolean } = {},
 ): Array<Record<string, unknown>> {
-  const { source, since } = opts
+  const { source, since, onlyStarred } = opts
   const titleScoreParts: string[] = []
   const whereClauses: string[] = []
   const scoreParams: string[] = []
@@ -634,6 +632,9 @@ function searchSessionRowsByLike(
   if (since) {
     conditions.push('sess.started_at >= ?')
     params.push(since)
+  }
+  if (onlyStarred) {
+    conditions.push("EXISTS (SELECT 1 FROM stars WHERE stars.item_type = 'session' AND stars.item_uuid = sess.session_uuid)")
   }
   params.push(limit)
 
@@ -671,9 +672,9 @@ function searchSessionRowsByFts(
   phrase: string,
   limit: number,
   matchType: SearchMatchType,
-  opts: { source?: SessionSource; since?: string } = {},
+  opts: { source?: SessionSource; since?: string; onlyStarred?: boolean } = {},
 ): Array<Record<string, unknown>> {
-  const { source, since } = opts
+  const { source, since, onlyStarred } = opts
   const ftsTable = selectFtsTableKind(phrase) === 'trigram' ? 'session_search_fts_trigram' : 'session_search_fts'
   const ftsQuery = matchType === 'phrase'
     ? `"${phrase.replace(/"/g, '""')}"`
@@ -703,6 +704,9 @@ function searchSessionRowsByFts(
   if (since) {
     conditions.push('sess.started_at >= ?')
     params.push(since)
+  }
+  if (onlyStarred) {
+    conditions.push("EXISTS (SELECT 1 FROM stars WHERE stars.item_type = 'session' AND stars.item_uuid = sess.session_uuid)")
   }
   params.push(limit)
 
@@ -849,6 +853,105 @@ function escapeLike(value: string): string {
     .replace(/_/g, '\\_')
 }
 
+// ── Stars (sessions + captures) ─────────────────────────────────────────────
+
+export function starItem(db: Database.Database, kind: StarKind, uuid: string): void {
+  db.prepare(
+    'INSERT OR IGNORE INTO stars (item_type, item_uuid) VALUES (?, ?)',
+  ).run(kind, uuid)
+}
+
+export function unstarItem(db: Database.Database, kind: StarKind, uuid: string): void {
+  db.prepare('DELETE FROM stars WHERE item_type = ? AND item_uuid = ?').run(kind, uuid)
+}
+
+export function isStarred(db: Database.Database, kind: StarKind, uuid: string): boolean {
+  const row = db
+    .prepare('SELECT 1 AS hit FROM stars WHERE item_type = ? AND item_uuid = ?')
+    .get(kind, uuid) as { hit: number } | undefined
+  return row !== undefined
+}
+
+export function getStarredUuidsByType(
+  db: Database.Database,
+): { session: string[]; capture: string[] } {
+  const rows = db
+    .prepare('SELECT item_type AS kind, item_uuid AS uuid FROM stars')
+    .all() as Array<{ kind: StarKind; uuid: string }>
+  const session: string[] = []
+  const capture: string[] = []
+  for (const r of rows) {
+    if (r.kind === 'session') session.push(r.uuid)
+    else if (r.kind === 'capture') capture.push(r.uuid)
+  }
+  return { session, capture }
+}
+
+export function listStarredItems(db: Database.Database, limit = 200): StarredItem[] {
+  // Orphan-filter at the SQL level so LIMIT counts only live rows; otherwise
+  // a user with 200+ orphaned stars could see an empty page.
+  const rows = db.prepare(`
+    SELECT item_type AS kind, item_uuid AS uuid, starred_at AS starredAt
+    FROM stars
+    WHERE (item_type = 'session' AND EXISTS (SELECT 1 FROM sessions WHERE session_uuid = stars.item_uuid))
+       OR (item_type = 'capture' AND EXISTS (SELECT 1 FROM captures WHERE capture_uuid = stars.item_uuid))
+    ORDER BY starred_at DESC
+    LIMIT ?
+  `).all(limit) as Array<{ kind: StarKind; uuid: string; starredAt: string }>
+
+  if (rows.length === 0) return []
+
+  const sessionUuids = rows.filter(r => r.kind === 'session').map(r => r.uuid)
+  const captureUuids = rows.filter(r => r.kind === 'capture').map(r => r.uuid)
+
+  const sessionMap = new Map<string, Session>()
+  if (sessionUuids.length > 0) {
+    const placeholders = sessionUuids.map(() => '?').join(', ')
+    const sessRows = db.prepare(`
+      ${SESSION_SELECT}
+      WHERE s.session_uuid IN (${placeholders})
+    `).all(...sessionUuids) as Array<Record<string, unknown>>
+    for (const row of sessRows) {
+      const session = rowToSession(row)
+      sessionMap.set(session.sessionUuid, session)
+    }
+  }
+
+  const captureMap = new Map<string, Capture>()
+  if (captureUuids.length > 0) {
+    const placeholders = captureUuids.map(() => '?').join(', ')
+    const capRows = db.prepare(`
+      SELECT
+        id             AS captureId,
+        capture_uuid   AS captureUuid,
+        url,
+        title,
+        author,
+        platform,
+        content_type   AS contentType,
+        thumbnail_url  AS thumbnailUrl,
+        captured_at    AS capturedAt
+      FROM captures
+      WHERE capture_uuid IN (${placeholders})
+    `).all(...captureUuids) as Array<Capture>
+    for (const row of capRows) {
+      captureMap.set(row.captureUuid, row)
+    }
+  }
+
+  const items: StarredItem[] = []
+  for (const r of rows) {
+    if (r.kind === 'session') {
+      const session = sessionMap.get(r.uuid)
+      if (session) items.push({ kind: 'session', starredAt: r.starredAt, session })
+    } else if (r.kind === 'capture') {
+      const capture = captureMap.get(r.uuid)
+      if (capture) items.push({ kind: 'capture', starredAt: r.starredAt, capture })
+    }
+  }
+  return items
+}
+
 export function getStatus(db: Database.Database): StatusInfo {
   const counts = db.prepare(`
     SELECT src.name, COUNT(*) AS cnt
@@ -949,9 +1052,9 @@ export function insertCapture(
 export function searchCaptures(
   db: Database.Database,
   query: string,
-  opts: { limit?: number; platform?: string; since?: string } = {},
+  opts: { limit?: number; platform?: string; since?: string; onlyStarred?: boolean } = {},
 ): CaptureResult[] {
-  const { limit = 10, platform, since } = opts
+  const { limit = 10, platform, since, onlyStarred } = opts
 
   const ftsTable = selectFtsTableKind(query) === 'trigram' ? 'captures_fts_trigram' : 'captures_fts'
   const rowLimit = Math.max(limit * 10, 50)
@@ -959,6 +1062,7 @@ export function searchCaptures(
     const rows = searchCaptureRows(db, ftsTable, step.query, rowLimit, {
       ...(platform ? { platform } : {}),
       ...(since ? { since } : {}),
+      ...(onlyStarred ? { onlyStarred } : {}),
     })
     return mapCaptureRows(rows, step.matchType)
   })
@@ -971,9 +1075,9 @@ function searchCaptureRows(
   ftsTable: 'captures_fts' | 'captures_fts_trigram',
   ftsQuery: string,
   limit: number,
-  opts: { platform?: string; since?: string } = {},
+  opts: { platform?: string; since?: string; onlyStarred?: boolean } = {},
 ): Array<Record<string, unknown>> {
-  const { platform, since } = opts
+  const { platform, since, onlyStarred } = opts
   const conditions: string[] = [`${ftsTable} MATCH ?`]
   const params: (string | number)[] = [ftsQuery]
 
@@ -984,6 +1088,9 @@ function searchCaptureRows(
   if (since) {
     conditions.push('c.captured_at >= ?')
     params.push(since)
+  }
+  if (onlyStarred) {
+    conditions.push("EXISTS (SELECT 1 FROM stars WHERE stars.item_type = 'capture' AND stars.item_uuid = c.capture_uuid)")
   }
   params.push(limit)
 
@@ -1049,19 +1156,21 @@ function mergeCaptureGroups(groups: CaptureResult[][], limit: number): CaptureRe
 export function searchAll(
   db: Database.Database,
   query: string,
-  opts: { limit?: number; source?: Source; since?: string } = {},
+  opts: { limit?: number; source?: Source; since?: string; onlyStarred?: boolean } = {},
 ): SearchResult[] {
-  const { limit = 20, source, since } = opts
+  const { limit = 20, source, since, onlyStarred } = opts
 
-  const fragOpts: { limit: number; source?: SessionSource; since?: string } = { limit }
+  const fragOpts: { limit: number; source?: SessionSource; since?: string; onlyStarred?: boolean } = { limit }
   if (source === 'claude' || source === 'codex' || source === 'gemini') fragOpts.source = source
   if (since) fragOpts.since = since
+  if (onlyStarred) fragOpts.onlyStarred = true
 
   const fragments = searchFragments(db, query, fragOpts)
     .map(f => ({ ...f, kind: 'fragment' as const }))
 
-  const capOpts: { limit: number; since?: string } = { limit }
+  const capOpts: { limit: number; since?: string; onlyStarred?: boolean } = { limit }
   if (since) capOpts.since = since
+  if (onlyStarred) capOpts.onlyStarred = true
 
   const captures = searchCaptures(db, query, capOpts)
     .map(c => ({ ...c, kind: 'capture' as const }))

--- a/packages/core/src/db/stars.test.ts
+++ b/packages/core/src/db/stars.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const tempDirs: string[] = []
+const openDbs: Array<{ close: () => void }> = []
+
+afterEach(() => {
+  while (openDbs.length > 0) openDbs.pop()?.close()
+  vi.unstubAllEnvs()
+  vi.resetModules()
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('stars (unified)', () => {
+  it('star + isStarred + unstar roundtrip for sessions', async () => {
+    const mod = await load()
+    const { db, seedSession } = mod
+    const uuid = 'sess-1'
+    seedSession(uuid, 'Proj', 'Title')
+
+    expect(mod.isStarred(db, 'session', uuid)).toBe(false)
+    mod.starItem(db, 'session', uuid)
+    expect(mod.isStarred(db, 'session', uuid)).toBe(true)
+
+    mod.unstarItem(db, 'session', uuid)
+    expect(mod.isStarred(db, 'session', uuid)).toBe(false)
+  })
+
+  it('star + isStarred + unstar roundtrip for captures', async () => {
+    const mod = await load()
+    const { db, seedCapture } = mod
+    const uuid = 'cap-1'
+    seedCapture(uuid, 'https://x.com/1', 'Tweet', 'twitter')
+
+    expect(mod.isStarred(db, 'capture', uuid)).toBe(false)
+    mod.starItem(db, 'capture', uuid)
+    expect(mod.isStarred(db, 'capture', uuid)).toBe(true)
+
+    mod.unstarItem(db, 'capture', uuid)
+    expect(mod.isStarred(db, 'capture', uuid)).toBe(false)
+  })
+
+  it('session and capture with same uuid string are independent', async () => {
+    const mod = await load()
+    const { db } = mod
+    mod.starItem(db, 'session', 'same-uuid')
+    expect(mod.isStarred(db, 'session', 'same-uuid')).toBe(true)
+    expect(mod.isStarred(db, 'capture', 'same-uuid')).toBe(false)
+    mod.starItem(db, 'capture', 'same-uuid')
+    expect(mod.isStarred(db, 'capture', 'same-uuid')).toBe(true)
+  })
+
+  it('starItem is idempotent and preserves original starred_at', async () => {
+    const mod = await load()
+    const { db, seedSession } = mod
+    seedSession('x', 'P', 'T')
+    mod.starItem(db, 'session', 'x')
+    const first = db.prepare('SELECT starred_at FROM stars WHERE item_type=? AND item_uuid=?').get('session', 'x') as { starred_at: string }
+    mod.starItem(db, 'session', 'x')
+    const second = db.prepare('SELECT starred_at FROM stars WHERE item_type=? AND item_uuid=?').get('session', 'x') as { starred_at: string }
+    expect(second.starred_at).toBe(first.starred_at)
+  })
+
+  it('CHECK constraint rejects unknown item_type', async () => {
+    const mod = await load()
+    const { db } = mod
+    expect(() =>
+      db.prepare('INSERT INTO stars (item_type, item_uuid) VALUES (?, ?)').run('bogus', 'x'),
+    ).toThrow()
+  })
+
+  it('listStarredItems returns mixed sessions + captures by starred_at DESC', async () => {
+    const mod = await load()
+    const { db, seedSession, seedCapture } = mod
+    seedSession('s1', 'P', 'Session one')
+    seedCapture('c1', 'https://u/1', 'Cap one', 'twitter')
+    seedSession('s2', 'P', 'Session two')
+
+    // Explicit timestamps so order is deterministic.
+    db.prepare("INSERT INTO stars (item_type, item_uuid, starred_at) VALUES ('session', 's1', '2026-01-01 00:00:00')").run()
+    db.prepare("INSERT INTO stars (item_type, item_uuid, starred_at) VALUES ('capture', 'c1', '2026-02-01 00:00:00')").run()
+    db.prepare("INSERT INTO stars (item_type, item_uuid, starred_at) VALUES ('session', 's2', '2026-03-01 00:00:00')").run()
+
+    const items = mod.listStarredItems(db)
+    expect(items.map(i => i.kind === 'session' ? i.session.sessionUuid : i.capture.captureUuid))
+      .toEqual(['s2', 'c1', 's1'])
+    expect(items[1]!.kind).toBe('capture')
+  })
+
+  it('listStarredItems filters orphans (starred referent missing)', async () => {
+    const mod = await load()
+    const { db, seedSession } = mod
+    seedSession('alive', 'P', 'A')
+    mod.starItem(db, 'session', 'alive')
+    mod.starItem(db, 'session', 'ghost-session')
+    mod.starItem(db, 'capture', 'ghost-capture')
+
+    const items = mod.listStarredItems(db)
+    expect(items).toHaveLength(1)
+    expect(items[0]!.kind).toBe('session')
+    if (items[0]!.kind === 'session') {
+      expect(items[0]!.session.sessionUuid).toBe('alive')
+    }
+  })
+
+  it('getStarredUuidsByType splits session + capture uuids', async () => {
+    const mod = await load()
+    const { db } = mod
+    mod.starItem(db, 'session', 's1')
+    mod.starItem(db, 'session', 's2')
+    mod.starItem(db, 'capture', 'c1')
+
+    const { session, capture } = mod.getStarredUuidsByType(db)
+    expect(new Set(session)).toEqual(new Set(['s1', 's2']))
+    expect(new Set(capture)).toEqual(new Set(['c1']))
+  })
+
+  it('unstarItem on non-starred uuid is a no-op', async () => {
+    const mod = await load()
+    const { db } = mod
+    expect(() => mod.unstarItem(db, 'session', 'nobody')).not.toThrow()
+    expect(() => mod.unstarItem(db, 'capture', 'nobody')).not.toThrow()
+  })
+
+  it('persists across a fresh getDB()', async () => {
+    const spoolDir = makeTempDir('spool-stars-persist-')
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDir)
+
+    const first = await loadInto(spoolDir)
+    first.seedSession('persist-uuid', 'P', 'T')
+    first.starItem(first.db, 'session', 'persist-uuid')
+    first.db.close()
+    openDbs.length = 0
+
+    vi.resetModules()
+    const second = await loadInto(spoolDir)
+    expect(second.isStarred(second.db, 'session', 'persist-uuid')).toBe(true)
+  })
+})
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+async function load() {
+  const spoolDir = makeTempDir('spool-stars-')
+  vi.stubEnv('SPOOL_DATA_DIR', spoolDir)
+  return loadInto(spoolDir)
+}
+
+async function loadInto(_spoolDir: string) {
+  vi.resetModules()
+  const dbModule = await import('./db.js')
+  const queryModule = await import('./queries.js')
+  const db = dbModule.getDB()
+  openDbs.push(db)
+
+  function seedSession(sessionUuid: string, projectDisplay: string, title: string): void {
+    const sourceId = queryModule.getSourceId(db, 'claude')
+    const projectId = queryModule.getOrCreateProject(
+      db,
+      sourceId,
+      projectDisplay.toLowerCase().replace(/\s+/g, '-'),
+      `/fake/${projectDisplay}`,
+      projectDisplay,
+    )
+    queryModule.upsertSession(db, {
+      projectId,
+      sourceId,
+      sessionUuid,
+      filePath: `/fake/${sessionUuid}.jsonl`,
+      title,
+      startedAt: '2026-01-01T00:00:00Z',
+      endedAt: '2026-01-01T00:10:00Z',
+      messageCount: 2,
+      hasToolUse: false,
+      cwd: '/fake',
+      model: 'claude-opus-4-7',
+      rawFileMtime: '2026-01-01T00:10:00Z',
+    })
+  }
+
+  function seedCapture(captureUuid: string, url: string, title: string, platform: string): void {
+    const connectorSource = db.prepare("SELECT id FROM sources WHERE name='connector'").get() as { id: number }
+    db.prepare(`
+      INSERT INTO captures
+        (source_id, capture_uuid, url, title, content_text, author, platform, platform_id, content_type, thumbnail_url, metadata, captured_at, raw_json)
+      VALUES (?, ?, ?, ?, '', NULL, ?, NULL, 'page', NULL, '{}', '2026-01-01T00:00:00Z', NULL)
+    `).run(connectorSource.id, captureUuid, url, title, platform)
+  }
+
+  return {
+    db,
+    starItem: queryModule.starItem,
+    unstarItem: queryModule.unstarItem,
+    isStarred: queryModule.isStarred,
+    listStarredItems: queryModule.listStarredItems,
+    getStarredUuidsByType: queryModule.getStarredUuidsByType,
+    seedSession,
+    seedCapture,
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -116,3 +116,24 @@ export type { CapturedItem } from './connectors/types.js'
 export type SearchResult =
   | (FragmentResult & { kind: 'fragment' })
   | (CaptureResult & { kind: 'capture' })
+
+// ── Stars ──────────────────────────────────────────────────────────────────
+
+export type StarKind = 'session' | 'capture'
+
+/** Display-shape of a capture row outside of search results. */
+export interface Capture {
+  captureId: number
+  captureUuid: string
+  url: string
+  title: string
+  author: string | null
+  platform: string
+  contentType: string
+  thumbnailUrl: string | null
+  capturedAt: string
+}
+
+export type StarredItem =
+  | { kind: 'session'; starredAt: string; session: Session }
+  | { kind: 'capture'; starredAt: string; capture: Capture }


### PR DESCRIPTION
Closes #72.

## Summary

Adds a **star** primitive that spans both first-party sessions (Claude Code / Codex / Gemini transcripts) and connector-indexed captures (YouTube likes, Twitter bookmarks, GitHub stars, Reddit saves, XHS notes, …). Users mark high-value items in-place from the search result row, from the session detail header, or from the Starred view itself; and they resurface those items via a persistent top-right entry, a scoped filter tab on search results, and a full-text search scoped to starred content.

https://github.com/user-attachments/assets/91c05c8c-b9bf-41ae-bbc0-dbe8dae65fbb

## Design

**Why unified, not parallel tables.** An earlier iteration had `session_stars`; the final schema is a single `stars(item_type, item_uuid, starred_at)` table. Sessions and captures are *product-level* peers in Spool (both appear in the same search results and source-chip row), so treating their stars as peers makes the Starred view a one-liner (`ORDER BY starred_at DESC` across both kinds) instead of a JS-level merge of two lists. Parallel tables made sense for `sessions`/`captures` because those shapes genuinely diverge; a star record is `(referent, time)` and doesn't need to.

**Why no FK.** `deleteSessionByFilePath` drops session rows when transcripts disappear, and captures can vanish when a connector is uninstalled. A cascade delete would destroy stars for items that may come back. The table keeps its rows; all read paths `JOIN` to filter orphans so the UI never surfaces dead references.

**Why not also starrable: messages, projects, anything else.** Out of scope for this PR. `item_type` is constrained via a `CHECK` so future additions are explicit schema changes.

## Features

**Starring an item**
- Session detail header — star button next to *Copy Session ID*.
- Fragment row in search results — always-visible ★ (muted outline when unstarred, filled accent when starred). No hover-reveal: discoverable at first look.
- Capture row in search results — same pattern; `e.preventDefault()` keeps the `<a>` wrapper from navigating.
- Any of these three moments is the most common one to say "I want to keep this."

**Finding starred items**
- **Top-right entry button** — persistent, visible on every view, shows count when non-zero; toggles into the Starred view.
- **Starred view** — mixed chronological list of sessions + captures ordered by `starred_at DESC`. Empty state, filter state, and post-search state all have copy. Clicking a session opens it; clicking a capture opens the URL.
- **Starred tab in global search** — appears in the source-filter row whenever any result in the current query is starred; filters down to them.

**Searching within starred**
- On the Starred view, typing in the search bar runs a scoped FTS (`onlyStarred=true`) across message content of starred sessions *and* text of starred captures. Results render via the existing `FragmentResults` component with snippet highlighting.
- The search bar shifts its placeholder to *Filter starred…* and switches to a subtle accent border so the scope shift is visually signalled.
- Pressing Enter escapes back to global search as a power-user exit.

## Implementation notes

**Core (`packages/core`)**
- Migration `v4` creates `stars` and drops any earlier `session_stars` left over from intermediate dev builds.
- `starItem / unstarItem / isStarred / getStarredUuidsByType / listStarredItems` — the full API in five functions.
- `listStarredItems` orphan-filters in SQL (`WHERE ... AND EXISTS (...)`) so `LIMIT` counts only live rows. Details for sessions and captures are batch-fetched via `IN (...)`, then reassembled in `starred_at` order.
- `searchFragments` and `searchCaptures` gained an `onlyStarred` option that injects an `EXISTS (SELECT 1 FROM stars ...)` predicate into every search path (FTS, FTS-fallback, LIKE-fallback).

**Renderer (`packages/app/src/renderer`)**
- `StarButton` is a single shared component; used five places, no copy-paste.
- `Badges.tsx` hosts the shared `SourceBadge` / `PlatformBadge`.
- `shared/formatDate.ts` has the relative-date helper that was copy-pasted across the codebase.
- App-level starred state splits into `starredSessions: Set<string>`, `starredCaptures: Set<string>` (complete, cheap, refreshed on mount), and `starredItems: StarredItem[]` (up to 200, refreshed only when entering the Starred view). Set updates are identity-preserving when content hasn't changed, so search-result rows don't re-render on unrelated star changes.

**Main (`packages/app/src/main`)**
- Four new IPC handlers: `star-item`, `unstar-item`, `list-starred-items`, `get-starred-uuids`.
- The search cache is keyed on `onlyStarred`, and `star-item / unstar-item` clear it to keep scoped results consistent.

## Test plan

- [x] `pnpm -F @spool-lab/core test` — 166 passing (10 new in `stars.test.ts` including CHECK constraint, cross-type UUID independence, orphan filtering, persistence across DB reopen).
- [x] Core `tsc --noEmit` clean.
- [x] App `tsc -p tsconfig.json --noEmit` clean.
- [x] `pnpm -F @spool/app run build:electron` builds.
- [x] Manual QA: star a session from detail view → appears in Starred view.
- [x] Manual QA: star a capture from search result → appears in Starred view.
- [x] Manual QA: Starred view filter matches content inside starred sessions (full-text, not just titles).
- [x] Manual QA: Starred tab in global search appears only when at least one result is starred; filtering it hides unstarred rows.
- [x] Manual QA: unstar from Starred view removes the row without a round-trip flicker.
- [x] Manual QA: restart the app — starred state persists.

## Notes

- This PR does **not** add a `spool star <uuid>` CLI command; deferred until the UI flow has settled.
- Orphan stars (referent gone but star row remains) are filtered silently. A future "show archived" toggle could surface them; not built yet.