### PR TITLE
fix(connectors): bundle SDK per connector; structural SyncError check

### DIFF
--- a/packages/app/src/main/dev-connectors.test.ts
+++ b/packages/app/src/main/dev-connectors.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, afterEach } from 'vitest'
 import { mkdtempSync, mkdirSync, writeFileSync, readlinkSync, lstatSync, rmSync, symlinkSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { ensureSymlink, linkDevConnectors } from './dev-connectors.js'
+import { ensureSymlink, linkDevConnectors, pruneBrokenConnectorLinks } from './dev-connectors.js'
 
 function makeTempDir(): string {
   return mkdtempSync(join(tmpdir(), 'dev-connectors-test-'))
@@ -135,5 +135,73 @@ describe('linkDevConnectors', () => {
     linkDevConnectors(spoolDir, workspace)
 
     expect(() => lstatSync(join(spoolDir, 'connectors'))).toThrow()
+  })
+})
+
+// ── pruneBrokenConnectorLinks ────────────────────────────────────────────────
+
+describe('pruneBrokenConnectorLinks', () => {
+  function connectorsNm(spoolDir: string): string {
+    const p = join(spoolDir, 'connectors', 'node_modules')
+    mkdirSync(p, { recursive: true })
+    return p
+  }
+
+  it('removes broken symlinks in scoped dirs', () => {
+    const spoolDir = tmp()
+    const nm = connectorsNm(spoolDir)
+    mkdirSync(join(nm, '@spool-lab'))
+
+    const brokenLink = join(nm, '@spool-lab', 'connector-x')
+    symlinkSync('/nonexistent/path/does-not-exist', brokenLink)
+
+    pruneBrokenConnectorLinks(spoolDir)
+
+    expect(() => lstatSync(brokenLink)).toThrow()
+  })
+
+  it('preserves valid symlinks', () => {
+    const spoolDir = tmp()
+    const target = join(tmp(), 'real-target')
+    mkdirSync(target)
+    const nm = connectorsNm(spoolDir)
+    mkdirSync(join(nm, '@spool-lab'))
+
+    const goodLink = join(nm, '@spool-lab', 'connector-x')
+    symlinkSync(target, goodLink)
+
+    pruneBrokenConnectorLinks(spoolDir)
+
+    expect(lstatSync(goodLink).isSymbolicLink()).toBe(true)
+    expect(readlinkSync(goodLink)).toBe(target)
+  })
+
+  it('preserves regular (npm-installed) directories', () => {
+    const spoolDir = tmp()
+    const nm = connectorsNm(spoolDir)
+    const installedDir = join(nm, '@graydawnc', 'connector-y')
+    mkdirSync(installedDir, { recursive: true })
+    writeFileSync(join(installedDir, 'package.json'), '{"name":"@graydawnc/connector-y"}')
+
+    pruneBrokenConnectorLinks(spoolDir)
+
+    expect(lstatSync(installedDir).isDirectory()).toBe(true)
+  })
+
+  it('handles broken unscoped symlinks at top level', () => {
+    const spoolDir = tmp()
+    const nm = connectorsNm(spoolDir)
+
+    const brokenLink = join(nm, 'connector-z')
+    symlinkSync('/nonexistent/target', brokenLink)
+
+    pruneBrokenConnectorLinks(spoolDir)
+
+    expect(() => lstatSync(brokenLink)).toThrow()
+  })
+
+  it('no-ops when node_modules does not exist', () => {
+    const spoolDir = tmp()
+    expect(() => pruneBrokenConnectorLinks(spoolDir)).not.toThrow()
   })
 })

--- a/packages/app/src/main/dev-connectors.ts
+++ b/packages/app/src/main/dev-connectors.ts
@@ -12,6 +12,42 @@ export function ensureSymlink(target: string, linkPath: string): void {
   symlinkSync(target, linkPath)
 }
 
+function removeIfBrokenSymlink(p: string): boolean {
+  let stat
+  try { stat = lstatSync(p) } catch { return false }
+  if (!stat.isSymbolicLink()) return false
+  if (existsSync(p)) return false
+  rmSync(p, { force: true })
+  return true
+}
+
+/**
+ * Remove broken symlinks under ~/.spool/connectors/node_modules.
+ *
+ * Dev symlinks (from linkDevConnectors) point into a workspace checkout;
+ * deleting the worktree or switching to a branch that no longer carries a
+ * connector leaves the symlink dangling. A dangling link later breaks npm
+ * installs (mkdirSync follows the link and ENOENTs on the missing target).
+ */
+export function pruneBrokenConnectorLinks(spoolDir: string): void {
+  const nodeModules = join(spoolDir, 'connectors', 'node_modules')
+  if (!existsSync(nodeModules)) return
+
+  for (const entry of readdirSync(nodeModules)) {
+    const entryPath = join(nodeModules, entry)
+    if (entry.startsWith('@')) {
+      let children: string[]
+      try { children = readdirSync(entryPath) } catch { continue }
+      for (const child of children) {
+        const p = join(entryPath, child)
+        if (removeIfBrokenSymlink(p)) console.log(`[connectors] pruned broken symlink ${p}`)
+      }
+    } else {
+      if (removeIfBrokenSymlink(entryPath)) console.log(`[connectors] pruned broken symlink ${entryPath}`)
+    }
+  }
+}
+
 /**
  * Try to install a connector package from the workspace by symlinking.
  * Returns the resolved name+version on success, or null if the package

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -21,7 +21,7 @@ import { setupTray } from './tray.js'
 import { AcpManager } from './acp.js'
 import { setupAutoUpdater, downloadUpdate, quitAndInstall } from './updater.js'
 import { openTerminal } from './terminal.js'
-import { linkDevConnectors, installFromWorkspace } from './dev-connectors.js'
+import { linkDevConnectors, installFromWorkspace, pruneBrokenConnectorLinks } from './dev-connectors.js'
 import { getSessionResumeCommand } from '../shared/resumeCommand.js'
 import { resolveResumeWorkingDirectory } from './sessionResume.js'
 import { loadUIPreferences, saveThemeEditor, saveThemeSource } from './uiPreferences.js'
@@ -430,6 +430,8 @@ app.whenReady().then(async () => {
 
   execCapabilityImpl = makeExecCapability()
   prerequisiteChecker = new PrerequisiteChecker(execCapabilityImpl)
+
+  pruneBrokenConnectorLinks(spoolDir)
 
   if (!app.isPackaged) {
     linkDevConnectors(spoolDir, resolve(process.cwd(), '../..'))

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/connector-sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Public plugin contract for Spool connectors.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/connector-sdk/src/errors.ts
+++ b/packages/connector-sdk/src/errors.ts
@@ -85,6 +85,28 @@ const RETRYABLE_CODES = new Set<SyncErrorCode>([
 ])
 
 /**
+ * Structural shape of a SyncError, independent of class identity. Used by
+ * {@link isSyncError} so a SyncError thrown from a differently-loaded copy of
+ * this SDK (e.g. one bundled inside a connector tarball) still gets recognized.
+ */
+export interface SyncErrorShape {
+  readonly _tag: 'SyncError'
+  readonly code: SyncErrorCode
+  readonly message: string
+  readonly cause?: unknown
+}
+
+/**
+ * Structural check for SyncError that survives module duplication. Matches on
+ * the `_tag` field rather than class identity, so it works across copies of
+ * this SDK loaded from different paths (host vs. bundled-in-connector).
+ */
+export function isSyncError(e: unknown): e is SyncErrorShape {
+  return typeof e === 'object' && e !== null
+    && (e as { _tag?: unknown })._tag === 'SyncError'
+}
+
+/**
  * Error thrown by connectors and the sync engine. Tagged with a machine-readable
  * SyncErrorCode so the framework and UI can classify and respond.
  *
@@ -105,6 +127,7 @@ export class SyncError extends Error {
 
   static from(e: unknown): SyncError {
     if (e instanceof SyncError) return e
+    if (isSyncError(e)) return new SyncError(e.code, e.message, e.cause)
     return new SyncError(
       SyncErrorCode.CONNECTOR_ERROR,
       e instanceof Error ? e.message : String(e),

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -17,7 +17,7 @@ export type { CapturedItem } from './captured-item.js'
 export type { SyncState } from './sync-state.js'
 
 // Error types
-export { SyncError, SyncErrorCode, SYNC_ERROR_HINTS } from './errors.js'
+export { SyncError, SyncErrorCode, SYNC_ERROR_HINTS, isSyncError } from './errors.js'
 
 // Capabilities
 export type {

--- a/packages/connectors/github/package.json
+++ b/packages/connectors/github/package.json
@@ -1,27 +1,29 @@
 {
   "name": "@spool-lab/connector-github",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "GitHub Stars and Notifications for Spool",
+  "keywords": [
+    "spool-connector",
+    "github"
+  ],
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
-  "keywords": [
-    "spool-connector",
-    "github"
-  ],
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
     "prepack": "pnpm run build"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@spool-lab/connector-sdk": "workspace:^"
   },
+  "bundledDependencies": [
+    "@spool-lab/connector-sdk"
+  ],
   "devDependencies": {
-    "@spool-lab/connector-sdk": "workspace:^",
     "@types/node": "^22.15.3",
     "typescript": "^5.7.3"
   },

--- a/packages/connectors/hackernews-hot/package.json
+++ b/packages/connectors/hackernews-hot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/connector-hackernews-hot",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Top stories on Hacker News right now for Spool",
   "keywords": [
     "spool-connector",
@@ -17,11 +17,13 @@
     "build": "tsc",
     "clean": "rm -rf dist"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@spool-lab/connector-sdk": "workspace:^"
   },
+  "bundledDependencies": [
+    "@spool-lab/connector-sdk"
+  ],
   "devDependencies": {
-    "@spool-lab/connector-sdk": "workspace:^",
     "@types/node": "^22.15.3",
     "typescript": "^5.7.3"
   },

--- a/packages/connectors/reddit/package.json
+++ b/packages/connectors/reddit/package.json
@@ -1,27 +1,29 @@
 {
   "name": "@spool-lab/connector-reddit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Reddit Saved and Upvoted posts for Spool",
+  "keywords": [
+    "spool-connector",
+    "reddit"
+  ],
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
-  "keywords": [
-    "spool-connector",
-    "reddit"
-  ],
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
     "prepack": "pnpm run build"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@spool-lab/connector-sdk": "workspace:^"
   },
+  "bundledDependencies": [
+    "@spool-lab/connector-sdk"
+  ],
   "devDependencies": {
-    "@spool-lab/connector-sdk": "workspace:^",
     "@types/node": "^22.15.3",
     "typescript": "^5.7.3"
   },

--- a/packages/connectors/twitter-bookmarks/package.json
+++ b/packages/connectors/twitter-bookmarks/package.json
@@ -1,26 +1,28 @@
 {
   "name": "@spool-lab/connector-twitter-bookmarks",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Your saved tweets on X (Twitter Bookmarks) for Spool",
+  "keywords": [
+    "spool-connector"
+  ],
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
-  "keywords": [
-    "spool-connector"
-  ],
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
     "prepack": "pnpm run build"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@spool-lab/connector-sdk": "workspace:^"
   },
+  "bundledDependencies": [
+    "@spool-lab/connector-sdk"
+  ],
   "devDependencies": {
-    "@spool-lab/connector-sdk": "workspace:^",
     "@types/node": "^22.15.3",
     "typescript": "^5.7.3"
   },
@@ -32,6 +34,10 @@
     "description": "Your saved tweets on X",
     "color": "#1DA1F2",
     "ephemeral": false,
-    "capabilities": ["fetch", "cookies:chrome", "log"]
+    "capabilities": [
+      "fetch",
+      "cookies:chrome",
+      "log"
+    ]
   }
 }

--- a/packages/connectors/typeless/package.json
+++ b/packages/connectors/typeless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/connector-typeless",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Your voice transcripts from Typeless for Spool",
   "keywords": [
     "spool-connector",
@@ -19,11 +19,13 @@
     "clean": "rm -rf dist",
     "test": "vitest run"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@spool-lab/connector-sdk": "workspace:^"
   },
+  "bundledDependencies": [
+    "@spool-lab/connector-sdk"
+  ],
   "devDependencies": {
-    "@spool-lab/connector-sdk": "workspace:^",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.15.3",
     "better-sqlite3": "^11.9.1",

--- a/packages/connectors/xiaohongshu/package.json
+++ b/packages/connectors/xiaohongshu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/connector-xiaohongshu",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Xiaohongshu (小红书) creator notes via opencli",
   "type": "module",
   "main": "dist/index.js",
@@ -13,11 +13,13 @@
     "build": "tsc -p tsconfig.json",
     "test": "vitest run"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@spool-lab/connector-sdk": "workspace:*"
   },
+  "bundledDependencies": [
+    "@spool-lab/connector-sdk"
+  ],
   "devDependencies": {
-    "@spool-lab/connector-sdk": "workspace:*",
     "@types/node": "^22.15.3",
     "typescript": "^5.4.0",
     "vitest": "^3.2.4"

--- a/packages/core/src/connectors/npm-install.test.ts
+++ b/packages/core/src/connectors/npm-install.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect, vi } from 'vitest'
-import { registryUrl, checkForUpdates } from './npm-install.js'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, symlinkSync, rmSync, existsSync, lstatSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import * as tar from 'tar'
+import { registryUrl, checkForUpdates, downloadAndInstall } from './npm-install.js'
 
 describe('registryUrl', () => {
   it('builds correct URL for scoped package', () => {
@@ -81,5 +85,74 @@ describe('checkForUpdates', () => {
     expect(result.size).toBe(1)
     expect(result.get('@spool-lab/a')).toEqual({ current: '0.1.0', latest: '0.3.0' })
     expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('downloadAndInstall', () => {
+  const tempDirs: string[] = []
+  afterEach(() => {
+    for (const d of tempDirs) rmSync(d, { recursive: true, force: true })
+    tempDirs.length = 0
+  })
+  function tmp(): string {
+    const d = mkdtempSync(join(tmpdir(), 'npm-install-test-'))
+    tempDirs.push(d)
+    return d
+  }
+
+  async function buildTarball(sourceDir: string, outPath: string): Promise<void> {
+    // npm packs with contents under a top-level "package/" dir that tar.extract strips.
+    const stage = mkdtempSync(join(tmpdir(), 'npm-pack-stage-'))
+    tempDirs.push(stage)
+    const pkgDir = join(stage, 'package')
+    mkdirSync(pkgDir)
+    for (const name of ['package.json', 'index.js']) {
+      const src = join(sourceDir, name)
+      if (existsSync(src)) writeFileSync(join(pkgDir, name), readFileSync(src))
+    }
+    await tar.create({ gzip: true, file: outPath, cwd: stage }, ['package'])
+  }
+
+  function mockFetch(registryJson: object, tarballBytes: Buffer): typeof fetch {
+    return vi.fn(async (url: string) => {
+      if (String(url).endsWith('.tgz')) {
+        return new Response(tarballBytes, { status: 200 })
+      }
+      return new Response(JSON.stringify(registryJson), { status: 200 })
+    }) as unknown as typeof fetch
+  }
+
+  it('replaces a broken symlink at installPath', async () => {
+    const src = tmp()
+    writeFileSync(join(src, 'package.json'), JSON.stringify({
+      name: '@spool-lab/connector-foo',
+      version: '0.1.0',
+      spool: { type: 'connector' },
+    }))
+    writeFileSync(join(src, 'index.js'), 'module.exports = {}\n')
+    const tarballPath = join(tmp(), 'pkg.tgz')
+    await buildTarball(src, tarballPath)
+
+    const connectorsDir = tmp()
+    const scopeDir = join(connectorsDir, 'node_modules', '@spool-lab')
+    mkdirSync(scopeDir, { recursive: true })
+    const installPath = join(scopeDir, 'connector-foo')
+    // Simulate a broken dev symlink left over from a removed worktree.
+    symlinkSync('/nonexistent/worktree/packages/connectors/foo', installPath)
+
+    const fetchFn = mockFetch({
+      name: '@spool-lab/connector-foo',
+      version: '0.1.0',
+      dist: { tarball: 'https://registry.npmjs.org/@spool-lab/connector-foo/-/connector-foo-0.1.0.tgz' },
+      spool: { type: 'connector' },
+    }, readFileSync(tarballPath))
+
+    const result = await downloadAndInstall('@spool-lab/connector-foo', connectorsDir, fetchFn)
+
+    expect(result.name).toBe('@spool-lab/connector-foo')
+    expect(result.version).toBe('0.1.0')
+    expect(lstatSync(installPath).isDirectory()).toBe(true)
+    expect(existsSync(join(installPath, 'package.json'))).toBe(true)
+    expect(existsSync(join(installPath, 'index.js'))).toBe(true)
   })
 })

--- a/packages/core/src/connectors/npm-install.ts
+++ b/packages/core/src/connectors/npm-install.ts
@@ -78,6 +78,9 @@ export async function downloadAndInstall(
   // Extract to node_modules
   const nameSegments = info.name.startsWith('@') ? info.name.split('/') : [info.name]
   const installPath = join(connectorsDir, 'node_modules', ...nameSegments)
+  // Clear any stale entry first: a broken dev symlink (from a removed
+  // worktree) would cause mkdirSync to ENOENT by following the dangling link.
+  rmSync(installPath, { recursive: true, force: true })
   mkdirSync(installPath, { recursive: true })
   await tar.extract({ file: tmpPath, cwd: installPath, strip: 1 })
 

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -8,7 +8,7 @@ import type {
   CapturedItem,
   SyncState,
 } from '@spool-lab/connector-sdk'
-import { SyncError as SdkSyncError, SyncErrorCode, SYNC_ERROR_HINTS } from '@spool-lab/connector-sdk'
+import { SyncErrorCode, SYNC_ERROR_HINTS, isSyncError } from '@spool-lab/connector-sdk'
 
 // ── Re-exports from SDK ────────────────────────────────────────────────────
 export {
@@ -52,7 +52,7 @@ export class SyncError extends Data.TaggedError('SyncError')<{
 
   static from(e: unknown): SyncError {
     if (e instanceof SyncError) return e
-    if (e instanceof SdkSyncError) {
+    if (isSyncError(e)) {
       return new SyncError(e.code, e.message, e.cause)
     }
     return new SyncError(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,10 +160,11 @@ importers:
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
   packages/connectors/github:
-    devDependencies:
+    dependencies:
       '@spool-lab/connector-sdk':
         specifier: workspace:^
         version: link:../../connector-sdk
+    devDependencies:
       '@types/node':
         specifier: ^22.15.3
         version: 22.19.17
@@ -172,10 +173,11 @@ importers:
         version: 5.9.3
 
   packages/connectors/hackernews-hot:
-    devDependencies:
+    dependencies:
       '@spool-lab/connector-sdk':
         specifier: workspace:^
         version: link:../../connector-sdk
+    devDependencies:
       '@types/node':
         specifier: ^22.15.3
         version: 22.19.17
@@ -184,10 +186,11 @@ importers:
         version: 5.9.3
 
   packages/connectors/reddit:
-    devDependencies:
+    dependencies:
       '@spool-lab/connector-sdk':
         specifier: workspace:^
         version: link:../../connector-sdk
+    devDependencies:
       '@types/node':
         specifier: ^22.15.3
         version: 22.19.17
@@ -196,10 +199,11 @@ importers:
         version: 5.9.3
 
   packages/connectors/twitter-bookmarks:
-    devDependencies:
+    dependencies:
       '@spool-lab/connector-sdk':
         specifier: workspace:^
         version: link:../../connector-sdk
+    devDependencies:
       '@types/node':
         specifier: ^22.15.3
         version: 22.19.17
@@ -208,10 +212,11 @@ importers:
         version: 5.9.3
 
   packages/connectors/typeless:
-    devDependencies:
+    dependencies:
       '@spool-lab/connector-sdk':
         specifier: workspace:^
         version: link:../../connector-sdk
+    devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -229,10 +234,11 @@ importers:
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
   packages/connectors/xiaohongshu:
-    devDependencies:
+    dependencies:
       '@spool-lab/connector-sdk':
         specifier: workspace:*
         version: link:../../connector-sdk
+    devDependencies:
       '@types/node':
         specifier: ^22.15.3
         version: 22.19.17
@@ -1360,6 +1366,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}

--- a/scripts/pack-connector.sh
+++ b/scripts/pack-connector.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Pack a connector into a publish-ready tarball with @spool-lab/connector-sdk
+# bundled inside it (bundledDependencies). Uses `pnpm deploy` to materialize
+# deps into a hoisted node_modules, then `npm pack` to produce the tarball.
+#
+# `pnpm pack` alone errors with ERR_PNPM_BUNDLED_DEPENDENCIES_WITHOUT_HOISTED
+# because the workspace uses isolated node-linker.
+#
+# Usage:
+#   scripts/pack-connector.sh <plugin-name> [out-dir]
+# e.g.
+#   scripts/pack-connector.sh twitter-bookmarks /tmp/out
+#
+set -euo pipefail
+
+PLUGIN="${1:-}"
+OUT_DIR="${2:-$(mktemp -d -t spool-pack-XXXXXX)}"
+if [[ -z "$PLUGIN" ]]; then
+  echo "usage: $0 <plugin-name> [out-dir]" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FULL_NAME="@spool-lab/connector-$PLUGIN"
+
+if [[ ! -d "$REPO_ROOT/packages/connectors/$PLUGIN" ]]; then
+  echo "plugin dir not found: packages/connectors/$PLUGIN" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT_DIR"
+STAGE="$(mktemp -d -t spool-pack-stage-XXXXXX)"
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "==> Building $FULL_NAME and SDK"
+pnpm --filter "$FULL_NAME" --filter "@spool-lab/connector-sdk" build
+
+echo "==> Deploying $FULL_NAME to $STAGE (hoisted, prod-only)"
+pnpm --filter "$FULL_NAME" deploy --prod --config.node-linker=hoisted "$STAGE"
+
+echo "==> Packing tarball into $OUT_DIR"
+# --ignore-scripts: the staged dir doesn't have the workspace scaffolding that
+# prepack's `pnpm run build` expects. Build already ran above.
+(cd "$STAGE" && npm pack --ignore-scripts --pack-destination "$OUT_DIR" >/dev/null)
+
+TARBALL="$(ls "$OUT_DIR"/spool-lab-connector-"$PLUGIN"-*.tgz 2>/dev/null | head -1)"
+if [[ -z "$TARBALL" ]]; then
+  echo "tarball not found in $OUT_DIR:" >&2
+  ls "$OUT_DIR" >&2
+  exit 1
+fi
+
+# Sanity: confirm SDK was bundled
+if ! tar -tzf "$TARBALL" | grep -q "package/node_modules/@spool-lab/connector-sdk/package.json"; then
+  echo "SDK was not bundled into $TARBALL — bundledDependencies not honored?" >&2
+  exit 1
+fi
+
+echo "==> $TARBALL"

--- a/scripts/phantom-independence-check.sh
+++ b/scripts/phantom-independence-check.sh
@@ -19,7 +19,6 @@ fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PLUGIN_DIR="$REPO_ROOT/packages/connectors/$PLUGIN"
-SDK_DIR="$REPO_ROOT/packages/connector-sdk"
 FULL_NAME="@spool-lab/connector-$PLUGIN"
 
 if [[ ! -d "$PLUGIN_DIR" ]]; then
@@ -27,20 +26,13 @@ if [[ ! -d "$PLUGIN_DIR" ]]; then
   exit 2
 fi
 
-# Build fresh
-echo "==> Building $FULL_NAME"
-(cd "$REPO_ROOT" && pnpm --filter "$FULL_NAME" build)
-
-echo "==> Building @spool-lab/connector-sdk"
-(cd "$REPO_ROOT" && pnpm --filter "@spool-lab/connector-sdk" build)
-
-# Create a staging temp dir — use a local name to avoid overriding $TMPDIR
 WORK_DIR="$(mktemp -d -t spool-phantom-check-XXXXXX)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
-# Pack the plugin with pnpm — pnpm rewrites workspace: protocol refs to real semver
-echo "==> Packing $FULL_NAME to $WORK_DIR"
-(cd "$PLUGIN_DIR" && pnpm pack --pack-destination "$WORK_DIR")
+# Pack via the shared script — produces a tarball with SDK bundled inside
+# (bundledDependencies). SDK does NOT need to be separately installed.
+echo "==> Packing $FULL_NAME (SDK bundled inside)"
+bash "$REPO_ROOT/scripts/pack-connector.sh" "$PLUGIN" "$WORK_DIR"
 
 TARBALL="$(ls "$WORK_DIR"/spool-lab-connector-"$PLUGIN"-*.tgz 2>/dev/null | head -1)"
 if [[ -z "$TARBALL" ]]; then
@@ -49,29 +41,12 @@ if [[ -z "$TARBALL" ]]; then
   exit 1
 fi
 
-# Pack the SDK. The SDK has no workspace: deps so npm pack is fine here.
-echo "==> Packing @spool-lab/connector-sdk to $WORK_DIR"
-(cd "$SDK_DIR" && npm pack --pack-destination "$WORK_DIR" 2>/dev/null)
-
-SDK_TARBALL="$(ls "$WORK_DIR"/spool-lab-connector-sdk-*.tgz 2>/dev/null | head -1)"
-if [[ -z "$SDK_TARBALL" ]]; then
-  echo "SDK tarball not found after pack in $WORK_DIR:" >&2
-  ls "$WORK_DIR" >&2
-  exit 1
-fi
-
-# Copy tarballs into the install dir so file: references are relative basenames
-# (avoids npm path-handling quirks with absolute paths on some platforms)
 INSTALL_DIR="$WORK_DIR/install-test"
 mkdir -p "$INSTALL_DIR"
-cp "$TARBALL"     "$INSTALL_DIR/plugin.tgz"
-cp "$SDK_TARBALL" "$INSTALL_DIR/sdk.tgz"
+cp "$TARBALL" "$INSTALL_DIR/plugin.tgz"
 
 cd "$INSTALL_DIR"
 
-# Minimal package.json: explicit dep on both the plugin tarball and the SDK.
-# The SDK is a peerDependency of the plugin so npm won't auto-install it;
-# we list it here so it is present in the isolated node_modules.
 cat > package.json <<EOF
 {
   "name": "phantom-test",
@@ -79,8 +54,7 @@ cat > package.json <<EOF
   "private": true,
   "type": "module",
   "dependencies": {
-    "$FULL_NAME": "file:plugin.tgz",
-    "@spool-lab/connector-sdk": "file:sdk.tgz"
+    "$FULL_NAME": "file:plugin.tgz"
   }
 }
 EOF


### PR DESCRIPTION
## Summary

Fixes the regression where the app UI shows "Installing…" → silently reverts to "Install".

## Root cause

1. **PR #97** (remove bundled connector system) removed the mechanism that shipped `@spool-lab/connector-sdk` into `~/.spool/connectors/node_modules/` at app startup. After that, packaged builds had no SDK on disk for user-installed connectors to import. A stale dev symlink on my machine masked this for a while; deleting a dev worktree exposed it.
2. `packages/core/src/connectors/types.ts` did `e instanceof SdkSyncError` — a **class-identity check across the plugin boundary**. This is a well-known anti-pattern (VS Code / Obsidian don't do it): any duplicated SDK copy (a connector bundling its own) breaks the check, and `SyncError`-typed connector errors get misclassified as generic `CONNECTOR_ERROR` instead of e.g. `AUTH_SESSION_EXPIRED` / `API_RATE_LIMITED`.

## Fix

Contract across the plugin boundary is now **types + `_tag` discriminant**, not class identity.

- SDK exports `isSyncError` structural guard (`_tag === 'SyncError'`). `SyncError.from()` uses `instanceof` first (fast, same-copy case), falls back to `isSyncError` (cross-copy case).
- `core/types.ts` swaps its `instanceof SdkSyncError` for `isSyncError`.
- Each connector now has `"@spool-lab/connector-sdk"` as a regular `dependencies` entry plus `"bundledDependencies": ["@spool-lab/connector-sdk"]`. `pnpm pack` bundles the SDK files into `tarball/package/node_modules/@spool-lab/connector-sdk/`, so `tar.extract({ strip: 1 })` already places it where Node's module resolver finds it. **No host-side SDK provisioning.**
- `rmSync` before `mkdirSync` in `downloadAndInstall`, and `pruneBrokenConnectorLinks` at startup, remain as independent hygiene — they handle stale dev symlinks from deleted worktrees (which was the original ENOENT symptom surface).

## Packaging

- `scripts/pack-connector.sh` (new) produces publish-ready tarballs. `pnpm pack` alone errors with `ERR_PNPM_BUNDLED_DEPENDENCIES_WITHOUT_HOISTED` under the workspace's isolated node-linker, so we `pnpm deploy --prod --config.node-linker=hoisted` into a hoisted snapshot and `npm pack --ignore-scripts` that.
- `scripts/phantom-independence-check.sh` rewritten to use the new packer; no longer installs SDK separately (it's bundled).

## Already published to npm

- `@spool-lab/connector-sdk@0.1.2`
- `@spool-lab/connector-github@0.1.3`
- `@spool-lab/connector-hackernews-hot@0.1.2`
- `@spool-lab/connector-reddit@0.1.2`
- `@spool-lab/connector-twitter-bookmarks@0.1.1`
- `@spool-lab/connector-typeless@0.1.2`
- `@spool-lab/connector-xiaohongshu@0.1.2`

## Test plan

- [x] SDK vitest: 12/12
- [x] core vitest: 167/168 (1 pre-existing skip)
- [x] app `dev-connectors` vitest: 12/12
- [x] `tsc --noEmit` clean for sdk / core / app
- [x] `scripts/phantom-independence-check.sh twitter-bookmarks` PASSES (tarball independently installable + `require`-able)
- [x] End-to-end: rebuilt packaged Spool.app, extracted local twitter-bookmarks@0.1.1 tarball into `~/.spool/connectors/node_modules/`, launched — loader registered the connector **without** any `@spool-lab/connector-sdk` present at the top level of `~/.spool/connectors/node_modules/`
- [x] CI: unit + e2e on Ubuntu + macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)