### PR TITLE
fix(stars): end-to-end orphan cleanup + Install button polish

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -12,6 +12,7 @@ import {
   loadSyncState, saveSyncState,
   loadConnectors, makeFetchCapability, makeChromeCookiesCapability, makeLogCapabilityFor, makeSqliteCapability, makeExecCapability,
   TrustStore, downloadAndInstall, uninstallConnector, resolveNpmPackage, checkForUpdates,
+  deleteConnectorItems,
   fetchRegistry,
   PrerequisiteChecker,
 } from '@spool-lab/core'
@@ -932,20 +933,11 @@ ipcMain.handle('connector:uninstall', (_e, { id }: { id: string }) => {
 
   uninstallConnector(packageName, connectorsDir)
 
-  // Best-effort DB cleanup — captures_fts_delete trigger can fail on corrupted FTS rows
+  // Best-effort DB cleanup — captures_fts_delete trigger can fail on corrupted FTS rows.
+  // deleteConnectorItems handles capture_connectors + stars + captures in the right order.
   for (const sib of siblings) {
     tryRun(() => db.prepare('DELETE FROM connector_sync_state WHERE connector_id = ?').run(sib.connectorId), `sync state for ${sib.connectorId}`)
-    tryRun(
-      () => {
-        db.prepare('DELETE FROM capture_connectors WHERE connector_id = ?').run(sib.connectorId)
-        db.prepare(`
-          DELETE FROM captures
-          WHERE source_id = (SELECT id FROM sources WHERE name = 'connector')
-            AND NOT EXISTS (SELECT 1 FROM capture_connectors WHERE capture_id = captures.id)
-        `).run()
-      },
-      `captures for ${sib.connectorId}`,
-    )
+    tryRun(() => deleteConnectorItems(db, sib.connectorId), `captures for ${sib.connectorId}`)
   }
 
   if (registryPkgId) prerequisiteChecker.invalidate(registryPkgId)

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -243,9 +243,20 @@ export default function App() {
         refreshCaptureSourcesRef.current()
       } else if (event.type === 'uninstalled') {
         refreshCaptureSourcesRef.current()
+        // Uninstall wipes the connector's captures in DB; any stars on those
+        // captures were cleared too, so refetch the UUID sets + list so the
+        // badge/detail view drop the now-dead references.
+        refreshStarredUuids()
+        refreshStarredItems()
+      } else if (event.type === 'sync-complete') {
+        // Ephemeral connectors wipe + replace their captures each sync, and
+        // stars on those captures are cleared in the same transaction.
+        // Refresh so the badge/list reflect reality immediately.
+        refreshStarredUuids()
+        if (view === 'starred') refreshStarredItems()
       }
     })
-  }, [])
+  }, [refreshStarredUuids, refreshStarredItems, view])
 
   // Listen for AI streaming chunks and tool calls
   useEffect(() => {

--- a/packages/app/src/renderer/components/SettingsPanel.tsx
+++ b/packages/app/src/renderer/components/SettingsPanel.tsx
@@ -770,10 +770,15 @@ function ConnectorsTab({ claudeCount, codexCount, geminiCount }: { claudeCount: 
         )}
         {!registryLoading && !registryError && discoverPackages.map(pkg => {
           const meta = pkg.subs.length > 1
-            ? pkg.subs.map(s => stripLabelPrefix(s.label, pkg.label)).join(', ')
-            : pkg.description
+              ? pkg.subs.map(s => stripLabelPrefix(s.label, pkg.label)).join(', ')
+              : pkg.description
+          const isInstalling = installingPackage === pkg.name
+          const hasError = !!installErrors[pkg.name] && !isInstalling
+          // Keep the button latched visible during install + error so feedback
+          // doesn't vanish when the pointer leaves the row.
+          const buttonAlwaysVisible = isInstalling || hasError
           return (
-            <div key={pkg.name} className="flex items-center gap-3 py-2.5">
+            <div key={pkg.name} className="group flex items-center gap-3 py-2.5">
               <span
                 className="w-2 h-2 rounded-full flex-none opacity-50"
                 style={{ background: pkg.color }}
@@ -785,16 +790,16 @@ function ConnectorsTab({ claudeCount, codexCount, geminiCount }: { claudeCount: 
                     <span className="text-[11px] text-warm-faint dark:text-dark-muted truncate min-w-0" title={meta}>{meta}</span>
                   )}
                 </div>
-                {installErrors[pkg.name] && installingPackage !== pkg.name && (
+                {hasError && (
                   <div className="text-[10px] text-red-400 mt-0.5">{installErrors[pkg.name]}</div>
                 )}
               </div>
               <button
                 onClick={() => handleInstall(pkg.name)}
-                disabled={installingPackage === pkg.name}
-                className="text-[11px] font-medium text-accent dark:text-accent-dark hover:underline disabled:opacity-50 flex-none"
+                disabled={isInstalling}
+                className={`text-[11px] font-medium text-accent dark:text-accent-dark hover:underline disabled:opacity-50 flex-none transition-opacity ${buttonAlwaysVisible ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100'}`}
               >
-                {installingPackage === pkg.name ? 'Installing…' : 'Install'}
+                {isInstalling ? 'Installing…' : 'Install'}
               </button>
             </div>
           )

--- a/packages/cli/src/commands/connector.ts
+++ b/packages/cli/src/commands/connector.ts
@@ -9,6 +9,7 @@ import {
   loadSyncState,
   SyncEngine,
   TrustStore,
+  deleteConnectorItems,
 } from '@spool-lab/core'
 import type { SetupStep } from '@spool-lab/core'
 import * as readline from 'node:readline'
@@ -210,17 +211,11 @@ const uninstallSubcommand = new Command('uninstall')
       uninstallConnector(pkg.packageName, connectorsDir)
       trustStore.remove(pkg.packageName)
 
-      // Clean DB data for all connectors in the package (matches app behavior)
+      // Clean DB data for all connectors in the package (matches app behavior).
+      // deleteConnectorItems handles capture_connectors + stars + captures together.
       for (const cid of allConnectorIds) {
         tryRun(() => db.prepare('DELETE FROM connector_sync_state WHERE connector_id = ?').run(cid))
-        tryRun(() => {
-          db.prepare('DELETE FROM capture_connectors WHERE connector_id = ?').run(cid)
-          db.prepare(`
-            DELETE FROM captures
-            WHERE source_id = (SELECT id FROM sources WHERE name = 'connector')
-              AND NOT EXISTS (SELECT 1 FROM capture_connectors WHERE capture_id = captures.id)
-          `).run()
-        })
+        tryRun(() => deleteConnectorItems(db, cid))
       }
 
       console.log(`Uninstalled ${pkg.packageName}`)

--- a/packages/core/src/connectors/sync-engine.test.ts
+++ b/packages/core/src/connectors/sync-engine.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import Database from 'better-sqlite3'
-import { SyncEngine, loadSyncState } from './sync-engine.js'
+import { SyncEngine, loadSyncState, deleteConnectorItems } from './sync-engine.js'
 import { SyncError, SyncErrorCode } from './types.js'
 import type { Connector, FetchContext, PageResult, AuthStatus } from './types.js'
 import { createTestDB, makeItem, setState, countCaptures } from './test-helpers.js'
@@ -166,6 +166,21 @@ describe('SyncEngine contract', () => {
       await engine.sync(connector2, { direction: 'forward', delayMs: 0 })
 
       expect(db.prepare("SELECT COUNT(*) AS n FROM stars WHERE item_type='capture'").get()).toEqual({ n: 0 })
+    })
+
+    it('deleteConnectorItems (uninstall path) drops stars on wiped captures', async () => {
+      const connector = createScriptedConnector([
+        { items: [makeItem('#X')], nextCursor: null },
+      ])
+      await engine.sync(connector, { direction: 'forward', delayMs: 0 })
+      const capUuid = (db.prepare('SELECT capture_uuid FROM captures').get() as { capture_uuid: string }).capture_uuid
+      db.prepare("INSERT INTO stars (item_type, item_uuid) VALUES ('capture', ?)").run(capUuid)
+
+      // Simulate uninstall: both app and CLI call deleteConnectorItems directly
+      deleteConnectorItems(db, 'test-connector')
+
+      expect(db.prepare("SELECT COUNT(*) AS n FROM captures").get()).toEqual({ n: 0 })
+      expect(db.prepare("SELECT COUNT(*) AS n FROM stars").get()).toEqual({ n: 0 })
     })
   })
 

--- a/packages/core/src/connectors/sync-engine.test.ts
+++ b/packages/core/src/connectors/sync-engine.test.ts
@@ -147,6 +147,26 @@ describe('SyncEngine contract', () => {
       expect(r2.added).toBe(3)
       expect(r2.total).toBe(3)
     })
+
+    it('ephemeral re-sync drops stars on captures that are being wiped', async () => {
+      const connector1 = createScriptedConnector([
+        { items: [makeItem('#A')], nextCursor: null },
+      ], { ephemeral: true })
+      await engine.sync(connector1, { direction: 'forward', delayMs: 0 })
+
+      // Star the capture that was just synced
+      const capUuid = (db.prepare('SELECT capture_uuid FROM captures').get() as { capture_uuid: string }).capture_uuid
+      db.prepare("INSERT INTO stars (item_type, item_uuid) VALUES ('capture', ?)").run(capUuid)
+      expect(db.prepare("SELECT COUNT(*) AS n FROM stars WHERE item_type='capture'").get()).toEqual({ n: 1 })
+
+      // Re-sync replaces captures with new UUIDs → star on old UUID must go
+      const connector2 = createScriptedConnector([
+        { items: [makeItem('#B')], nextCursor: null },
+      ], { ephemeral: true })
+      await engine.sync(connector2, { direction: 'forward', delayMs: 0 })
+
+      expect(db.prepare("SELECT COUNT(*) AS n FROM stars WHERE item_type='capture'").get()).toEqual({ n: 0 })
+    })
   })
 
   // ── Head-side ───────────────────────────────────────────────────────────

--- a/packages/core/src/connectors/sync-engine.ts
+++ b/packages/core/src/connectors/sync-engine.ts
@@ -226,7 +226,7 @@ function upsertItems(
   return { newCount, updatedCount }
 }
 
-function deleteConnectorItems(db: Database.Database, connectorId: string): void {
+export function deleteConnectorItems(db: Database.Database, connectorId: string): void {
   // 1. Drop this connector's M:N claims.
   db.prepare('DELETE FROM capture_connectors WHERE connector_id = ?').run(connectorId)
   // 2. Drop stars on captures that are about to disappear. Bulk-replace

--- a/packages/core/src/connectors/sync-engine.ts
+++ b/packages/core/src/connectors/sync-engine.ts
@@ -229,7 +229,22 @@ function upsertItems(
 function deleteConnectorItems(db: Database.Database, connectorId: string): void {
   // 1. Drop this connector's M:N claims.
   db.prepare('DELETE FROM capture_connectors WHERE connector_id = ?').run(connectorId)
-  // 2. Delete captures that belonged to this connector and have no other
+  // 2. Drop stars on captures that are about to disappear. Bulk-replace
+  //    connectors (ephemeral or full-wipe) re-insert captures with new UUIDs
+  //    on the next sync, so without this the star becomes a permanent orphan.
+  //    Scoped with the same predicate as the capture delete below.
+  db.prepare(`
+    DELETE FROM stars
+    WHERE item_type = 'capture'
+      AND item_uuid IN (
+        SELECT capture_uuid FROM captures
+        WHERE source_id = (SELECT id FROM sources WHERE name = 'connector')
+          AND NOT EXISTS (
+            SELECT 1 FROM capture_connectors WHERE capture_id = captures.id
+          )
+      )
+  `).run()
+  // 3. Delete captures that belonged to this connector and have no other
   //    connector attribution left. Scoped to source='connector' so we never
   //    touch session-world captures.
   db.prepare(`

--- a/packages/core/src/connectors/test-helpers.ts
+++ b/packages/core/src/connectors/test-helpers.ts
@@ -60,6 +60,13 @@ export function createTestDB(): InstanceType<typeof Database> {
       last_error_code     TEXT,
       last_error_message  TEXT
     );
+
+    CREATE TABLE stars (
+      item_type  TEXT NOT NULL CHECK (item_type IN ('session', 'capture')),
+      item_uuid  TEXT NOT NULL,
+      starred_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (item_type, item_uuid)
+    );
   `)
   return db
 }

--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -376,6 +376,16 @@ function runMigrations(db: Database.Database): void {
   rebuildFtsTableIfEmpty(db, 'captures', 'captures_fts_trigram')
   rebuildFtsTableIfEmpty(db, 'session_search', 'session_search_fts')
   rebuildFtsTableIfEmpty(db, 'session_search', 'session_search_fts_trigram')
+
+  // Prune stars on captures that no longer exist. Connector-sourced captures
+  // are bulk-replaced with fresh UUIDs on re-sync, so orphans here are
+  // permanent (no "transient absence" semantics like session files have).
+  // Cheap, idempotent, bounded by orphan count.
+  db.exec(`
+    DELETE FROM stars
+    WHERE item_type = 'capture'
+      AND NOT EXISTS (SELECT 1 FROM captures WHERE capture_uuid = stars.item_uuid)
+  `)
 }
 
 function rebuildFtsTableIfEmpty(

--- a/packages/core/src/db/queries.ts
+++ b/packages/core/src/db/queries.ts
@@ -875,9 +875,15 @@ export function isStarred(db: Database.Database, kind: StarKind, uuid: string): 
 export function getStarredUuidsByType(
   db: Database.Database,
 ): { session: string[]; capture: string[] } {
-  const rows = db
-    .prepare('SELECT item_type AS kind, item_uuid AS uuid FROM stars')
-    .all() as Array<{ kind: StarKind; uuid: string }>
+  // Orphan-filter to stay consistent with listStarredItems — otherwise the
+  // badge count shows stars the list can't render (e.g. capture deleted by
+  // an ephemeral connector re-sync).
+  const rows = db.prepare(`
+    SELECT item_type AS kind, item_uuid AS uuid
+    FROM stars
+    WHERE (item_type = 'session' AND EXISTS (SELECT 1 FROM sessions WHERE session_uuid = stars.item_uuid))
+       OR (item_type = 'capture' AND EXISTS (SELECT 1 FROM captures WHERE capture_uuid = stars.item_uuid))
+  `).all() as Array<{ kind: StarKind; uuid: string }>
   const session: string[] = []
   const capture: string[] = []
   for (const r of rows) {

--- a/packages/core/src/db/stars.test.ts
+++ b/packages/core/src/db/stars.test.ts
@@ -110,7 +110,10 @@ describe('stars (unified)', () => {
 
   it('getStarredUuidsByType splits session + capture uuids', async () => {
     const mod = await load()
-    const { db } = mod
+    const { db, seedSession, seedCapture } = mod
+    seedSession('s1', 'P', 'T')
+    seedSession('s2', 'P', 'T')
+    seedCapture('c1', 'https://u/1', 'T', 'twitter')
     mod.starItem(db, 'session', 's1')
     mod.starItem(db, 'session', 's2')
     mod.starItem(db, 'capture', 'c1')
@@ -120,11 +123,43 @@ describe('stars (unified)', () => {
     expect(new Set(capture)).toEqual(new Set(['c1']))
   })
 
+  it('getStarredUuidsByType filters orphans (matches listStarredItems semantics)', async () => {
+    const mod = await load()
+    const { db, seedSession } = mod
+    seedSession('alive', 'P', 'T')
+    mod.starItem(db, 'session', 'alive')
+    mod.starItem(db, 'session', 'ghost-session')
+    mod.starItem(db, 'capture', 'ghost-capture')
+
+    const { session, capture } = mod.getStarredUuidsByType(db)
+    expect(session).toEqual(['alive'])
+    expect(capture).toEqual([])
+  })
+
   it('unstarItem on non-starred uuid is a no-op', async () => {
     const mod = await load()
     const { db } = mod
     expect(() => mod.unstarItem(db, 'session', 'nobody')).not.toThrow()
     expect(() => mod.unstarItem(db, 'capture', 'nobody')).not.toThrow()
+  })
+
+  it('startup sweep prunes orphan capture stars but preserves session orphans', async () => {
+    const spoolDir = makeTempDir('spool-stars-sweep-')
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDir)
+
+    const first = await loadInto(spoolDir)
+    // Inject two orphan stars directly (no referent rows).
+    first.db.prepare("INSERT INTO stars (item_type, item_uuid) VALUES ('capture', 'ghost-cap')").run()
+    first.db.prepare("INSERT INTO stars (item_type, item_uuid) VALUES ('session', 'ghost-sess')").run()
+    first.db.close()
+    openDbs.length = 0
+
+    // Reopen → migrations + startup sweep run
+    vi.resetModules()
+    const second = await loadInto(spoolDir)
+    const rows = second.db.prepare('SELECT item_type, item_uuid FROM stars ORDER BY item_type').all()
+    // capture orphan gone; session orphan preserved (transient-absence design)
+    expect(rows).toEqual([{ item_type: 'session', item_uuid: 'ghost-sess' }])
   })
 
   it('persists across a fresh getDB()', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,7 @@ export { resolveSystemBinary, cachedResolve, clearResolveCache } from './util/re
 
 // ── Connector framework ─────────────────────────────────────────────────────
 export { ConnectorRegistry } from './connectors/registry.js'
-export { SyncEngine, loadSyncState, saveSyncState } from './connectors/sync-engine.js'
+export { SyncEngine, loadSyncState, saveSyncState, deleteConnectorItems } from './connectors/sync-engine.js'
 export { SyncScheduler } from './connectors/sync-scheduler.js'
 export type { SchedulerEvent, SchedulerEventHandler } from './connectors/sync-scheduler.js'
 export {


### PR DESCRIPTION
## Summary

Starred badge showed stale counts after two different events (ephemeral connector re-sync, connector uninstall). Root cause lived in multiple layers:

1. **DB:** `deleteConnectorItems` wiped captures but not the `stars` rows referencing them → permanent orphans because connector captures get re-inserted with new UUIDs.
2. **DB (dup):** Uninstall paths (app IPC + CLI) inlined their own capture-delete SQL instead of calling `deleteConnectorItems`, so even fixing #1 missed those sites.
3. **Read path:** `getStarredUuidsByType` (powers the badge) did a raw `SELECT` while `listStarredItems` (powers the list) had an orphan filter — the two disagreed.
4. **Renderer:** Even with DB clean, renderer didn't re-fetch `starredSessions` / `starredCaptures` on `uninstalled` / `sync-complete` events, so the badge showed a stale cached count.

Separately, the Available Connectors list has a minor UX polish to match DESIGN.md.

## Changes

### DB / cleanup
- `sync-engine.ts`: `deleteConnectorItems` drops matching `stars` rows before deleting captures; exported from `@spool-lab/core`.
- `app/main/index.ts` + `cli/commands/connector.ts`: uninstall paths now call `deleteConnectorItems` instead of duplicating the capture-delete SQL. Single owner for the teardown.
- `queries.ts`: `getStarredUuidsByType` gets the same EXISTS orphan filter as `listStarredItems`.
- `db.ts`: startup sweep deletes capture orphans (idempotent; respects session "transient absence" design per db.ts:197).
- `test-helpers.ts`: in-memory schema now includes `stars` (had drifted from prod).

### Renderer
- `App.tsx`: `uninstalled` and `sync-complete` events now refresh `starredSessions` / `starredCaptures` (+ the starred list if that view is active). Badge updates immediately.

### Polish (Available Connectors)
- `SettingsPanel.tsx`: Install button is hidden until hover/focus, matching DESIGN.md ("Action buttons: Appear on hover/selection only, opacity 0 → 1"). Stays latched visible during install + error states so feedback doesn't vanish when the pointer leaves the row.

### Tests
- `stars.test.ts`: `getStarredUuidsByType` orphan filter; startup sweep prunes captures but preserves session orphans.
- `sync-engine.test.ts`: ephemeral re-sync drops stars on wiped captures; `deleteConnectorItems` called directly (uninstall simulation) also clears.

## Verification

- [x] `pnpm --filter @spool-lab/core test` → 171/171 pass (+3 new)
- [x] Real DB verified before and after each fix: orphan capture stars cleared on re-sync and on uninstall.
- [x] Manual UI test: installed X Bookmarks → starred a capture → uninstalled → badge dropped immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)