### PR TITLE
fix(release): build in CI + catch startup errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,14 @@ pnpm run rebuild:native:electron  # before launching the Electron app or e2e tes
 ## Release
 
 ```bash
-./scripts/release.sh        # bump version, build, create GitHub release
+./scripts/release.sh        # bump version, push tag, dispatch CI release workflow
 ```
+
+Build + signing happen in GitHub Actions (see `.github/workflows/release.yml`) so
+releases are never tied to a local developer certificate. The script blocks
+until CI finishes; artifacts appear on the release page when it returns.
+
+To test a local build without cutting a release, use `pnpm --filter @spool/app build:mac`.
 
 ## Acknowledgements
 

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -521,6 +521,15 @@ app.whenReady().then(async () => {
   }
 
   app.on('activate', showOrCreateWindow)
+}).catch((err) => {
+  // Without this catch, any rejection from the startup sequence becomes an
+  // unhandled promise rejection — Node 20+ terminates the process with SIGTRAP,
+  // producing an opaque EXC_BREAKPOINT crash with only `PromiseRejectCallback`
+  // in the stack. Logging the error here gives users something actionable.
+  console.error('[startup] fatal error during app initialization:', err)
+  if (err instanceof Error && err.stack) console.error(err.stack)
+  dialog.showErrorBox('Spool failed to start', err instanceof Error ? err.message : String(err))
+  app.exit(1)
 })
 
 app.on('window-all-closed', () => {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,127 +1,74 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bumps version, tags, pushes, and dispatches the CI Release workflow.
+# Build + artifact upload happen in GitHub Actions so the release is never
+# signed with a local Apple Development cert (which is tied to specific
+# device UDIDs and would crash for everyone else). See .github/workflows/release.yml.
+
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-# ── Helpers ──
 red()   { printf "\033[31m%s\033[0m\n" "$*"; }
 green() { printf "\033[32m%s\033[0m\n" "$*"; }
 dim()   { printf "\033[90m%s\033[0m\n" "$*"; }
 
-# ── Preflight ──
-command -v gh   >/dev/null || { red "gh CLI not found"; exit 1; }
-command -v pnpm >/dev/null || { red "pnpm not found"; exit 1; }
-command -v jq   >/dev/null || { red "jq not found"; exit 1; }
+command -v gh >/dev/null || { red "gh CLI not found"; exit 1; }
+command -v jq >/dev/null || { red "jq not found"; exit 1; }
 
 if [[ -n "$(git status --porcelain)" ]]; then
   red "Working tree is dirty. Commit or stash first."
   exit 1
 fi
 
-# ── Read current version ──
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" != "main" ]]; then
+  red "Releases must be cut from main (currently on '$BRANCH')."
+  exit 1
+fi
+
 OLD_VERSION=$(jq -r .version package.json)
 dim "Current version: $OLD_VERSION"
 
-# ── Bump patch ──
 IFS='.' read -r major minor patch <<< "$OLD_VERSION"
 patch=$((patch + 1))
 NEW_VERSION="$major.$minor.$patch"
+TAG="v$NEW_VERSION"
 green "Bumping to $NEW_VERSION"
 
-# Update all package.json files
 for f in package.json packages/app/package.json packages/core/package.json packages/cli/package.json packages/landing/package.json; do
   if [[ -f "$f" ]]; then
     jq --arg v "$NEW_VERSION" '.version = $v' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
   fi
 done
 
-# ── Build ──
-green "Building app..."
-pnpm install --frozen-lockfile 2>/dev/null || pnpm install
-cd packages/app
-pnpm run build
-cd "$ROOT"
-
-# ── Find DMG ──
-DMG=$(find packages/app/dist -name "*.dmg" ! -name "*.blockmap" | head -1)
-if [[ -z "$DMG" ]]; then
-  red "No DMG found in packages/app/dist/"
-  exit 1
-fi
-
-DMG_NAME="Spool-${NEW_VERSION}-arm64.dmg"
-FINAL_DMG="packages/app/dist/$DMG_NAME"
-mv "$DMG" "$FINAL_DMG"
-green "DMG: $FINAL_DMG ($(du -h "$FINAL_DMG" | cut -f1))"
-
-# ── Find ZIP + latest-mac.yml (required for auto-update) ──
-ZIP=$(find packages/app/dist -name "*.zip" | head -1)
-ZIP_NAME="Spool-${NEW_VERSION}-arm64-mac.zip"
-FINAL_ZIP="packages/app/dist/$ZIP_NAME"
-if [[ -n "$ZIP" ]]; then
-  mv "$ZIP" "$FINAL_ZIP"
-  green "ZIP: $FINAL_ZIP ($(du -h "$FINAL_ZIP" | cut -f1))"
-else
-  red "Warning: No ZIP found — auto-update won't work for this release"
-fi
-
-YML=$(find packages/app/dist -name "latest-mac.yml" | head -1)
-if [[ -n "$YML" ]]; then
-  green "YML: $YML"
-else
-  red "Warning: No latest-mac.yml found — auto-update won't work for this release"
-fi
-
-# ── Clean junk from dist ──
-find packages/app/dist -maxdepth 1 -mindepth 1 \
-  -not -name "$DMG_NAME" \
-  -not -name "$ZIP_NAME" \
-  -not -name "latest-mac.yml" \
-  -not -name "mac-arm64" \
-  -exec rm -rf {} + 2>/dev/null || true
-
-# ── Generate release notes from commits since last tag ──
-LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-if [[ -n "$LAST_TAG" ]]; then
-  NOTES=$(git log "$LAST_TAG"..HEAD --pretty=format:"- %s" --no-merges)
-else
-  NOTES=$(git log --pretty=format:"- %s" --no-merges -20)
-fi
-
-TAG="v$NEW_VERSION"
-
-# ── Commit, tag, push ──
 git add -A
 git commit -m "release: v$NEW_VERSION"
 git tag -a "$TAG" -m "v$NEW_VERSION"
-git push && git push --tags
+git push origin main
+git push origin "$TAG"
 
-# ── Create GitHub release ──
-green "Creating GitHub release $TAG..."
-NOTES_FILE=$(mktemp)
-cat > "$NOTES_FILE" <<NOTES_EOF
-## What's new
+green "Dispatching Release workflow on $TAG..."
+gh workflow run release.yml --ref "$TAG"
 
-$NOTES
+# `gh workflow run` is fire-and-forget — poll for the run it just queued so we
+# can hand it to `gh run watch` and block until CI finishes. Without this the
+# script would return before artifacts exist, defeating the point of waiting.
+dim "Waiting for workflow run to appear..."
+RUN_ID=""
+for _ in $(seq 1 30); do
+  RUN_ID=$(gh run list --workflow=release.yml --branch "$TAG" --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)
+  [[ -n "$RUN_ID" && "$RUN_ID" != "null" ]] && break
+  sleep 2
+done
 
-## Install
+if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
+  red "Could not locate dispatched run. Check manually:"
+  echo "  https://github.com/spool-lab/spool/actions/workflows/release.yml"
+  exit 1
+fi
 
-\`\`\`bash
-curl -fsSL https://spool.pro/install.sh | bash
-\`\`\`
+green "Watching run $RUN_ID..."
+gh run watch "$RUN_ID" --exit-status
 
-Requires macOS on Apple Silicon (M1+).
-NOTES_EOF
-
-RELEASE_ASSETS="$FINAL_DMG"
-[[ -f "$FINAL_ZIP" ]] && RELEASE_ASSETS="$RELEASE_ASSETS $FINAL_ZIP"
-[[ -n "$YML" && -f "$YML" ]] && RELEASE_ASSETS="$RELEASE_ASSETS $YML"
-
-gh release create "$TAG" $RELEASE_ASSETS \
-  --title "Spool $NEW_VERSION" \
-  --notes-file "$NOTES_FILE"
-
-rm -f "$NOTES_FILE"
-
-green "Done! https://github.com/spool-lab/spool/releases/tag/$TAG"
+green "Done: https://github.com/spool-lab/spool/releases/tag/$TAG"


### PR DESCRIPTION
## Summary

- Fixes #108: 0.3.7 crashes immediately on launch on any Mac not on the maintainer's provisioning profile.
- Root cause: `scripts/release.sh` ran `pnpm run build` locally, and electron-builder auto-discovered an **Apple Development** certificate from Keychain. Dev certs are tied to specific device UDIDs via the embedded provisioning profile — on any other Mac, hardened-runtime codesign enforcement kills the app at startup with `EXC_BREAKPOINT / SIGTRAP` in `CrBrowserMain`.
- The existing `.github/workflows/release.yml` already sets `CSC_IDENTITY_AUTO_DISCOVERY=false`, so moving the build to CI produces a consistent unsigned (ad-hoc) artifact that runs on any machine.

## Changes

- **`scripts/release.sh`**: now bumps version, pushes the tag, dispatches `release.yml` on that tag, then `gh run watch --exit-status` blocks until CI finishes. No more local build / local `gh release create`.
- **`packages/app/src/main/index.ts`**: `.catch()` on `app.whenReady().then(...)` — any startup rejection now logs, shows an error dialog, and exits with code 1 instead of surfacing as an opaque SIGTRAP via Node's unhandled-rejection path. This makes future startup regressions actually diagnosable.
- **`README.md`**: note that local DMG testing uses `pnpm --filter @spool/app build:mac`, release.sh is CI-only now.

## Test plan

- [ ] Run `./scripts/release.sh` on a new throwaway branch commit → expect bump → tag push → workflow dispatch → watch → release appears with CI-built artifacts
- [ ] Download the resulting DMG on a second Mac (different UDID), `xattr -dr com.apple.quarantine /Applications/Spool.app`, launch → expect app opens normally instead of SIGTRAP
- [ ] Optional: temporarily break startup (e.g. `throw` inside `whenReady`) → expect error dialog + non-zero exit instead of silent crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)