### PR TITLE
chore: remove leftover connector mentions from docs + drop unused spool:// scheme

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -25,14 +25,6 @@ if (customUserDataDir) {
 // macOS menu bar shows the first menu's label as the app name
 app.setName(isDevMode ? 'Spool DEV' : 'Spool')
 
-if (process.defaultApp) {
-  if (process.argv.length >= 2) {
-    app.setAsDefaultProtocolClient('spool', process.execPath, [process.argv[1]!])
-  }
-} else {
-  app.setAsDefaultProtocolClient('spool')
-}
-
 const uiPreferences = loadUIPreferences()
 nativeTheme.themeSource = uiPreferences.themeSource
 let focusExistingWindow = () => {}

--- a/packages/landing/pages/blog/hello-spool.md
+++ b/packages/landing/pages/blog/hello-spool.md
@@ -18,9 +18,9 @@ You can't grep through JSONL files and get useful results. You can't ask your ag
 
 ## How Spool works
 
-Spool watches your session directories in real time. Every conversation becomes searchable the moment it's written — no manual export, no copy-paste.
+Spool watches your session directories in real time. Every conversation becomes searchable the moment it's written — no manual export, no copy-paste. All local, all on your machine.
 
-It also indexes data from installable connector plugins: your GitHub stars, Twitter bookmarks, Reddit saves, and more. All local, all on your machine.
+For platform data — GitHub stars, Twitter bookmarks, Reddit saves — see [Spool Daemon](/daemon/), our sibling app focused on capture sync.
 
 ## What's next: agent-native search
 

--- a/packages/landing/pages/docs/guides/agent-integration.md
+++ b/packages/landing/pages/docs/guides/agent-integration.md
@@ -7,7 +7,7 @@ description: Use Spool as a search backend for your AI coding agents.
 Agent integration is under active development. The `/spool` skill and standalone CLI are not yet functional — stay tuned.
 :::
 
-Spool is designed to work with AI coding agents. Once the integration is ready, your agent will be able to search your personal data — past sessions, bookmarks, stars — without leaving your workflow. Session indexing already supports Claude Code, Codex CLI, and Gemini CLI.
+Spool is designed to work with AI coding agents. Once the integration is ready, your agent will be able to search your past sessions without leaving your workflow. Session indexing already supports Claude Code, Codex CLI, and Gemini CLI.
 
 ## Planned: Claude Code skill
 
@@ -28,6 +28,6 @@ A standalone `spool` CLI is also under development, which will allow any agent o
 ## How it will work
 
 1. Your agent sends a search query to Spool
-2. Spool searches the local SQLite index (Claude sessions, Codex sessions, Gemini sessions, connector data)
+2. Spool searches the local SQLite index (Claude sessions, Codex sessions, Gemini sessions)
 3. Matching fragments are returned with source metadata
 4. Your agent incorporates the context into its response

--- a/packages/landing/pages/docs/guides/data-sources.md
+++ b/packages/landing/pages/docs/guides/data-sources.md
@@ -1,13 +1,11 @@
 ---
 title: Data Sources
-description: Platforms and data types that Spool can index.
+description: AI agent session sources that Spool indexes.
 ---
 
-Spool indexes data from two main sources: **agent sessions** (watched automatically) and **platform data** (pulled via connector plugins).
+Spool indexes your AI agent sessions automatically. Each source is watched in real time — new sessions become searchable the moment they're written, no manual export needed.
 
-## Agent sessions (automatic)
-
-Spool watches these directories in real time:
+## Agent sessions
 
 | Agent | Path |
 |-------|------|
@@ -17,29 +15,6 @@ Spool watches these directories in real time:
 | Codex CLI (profiles) | `~/.codex-profiles/*/sessions/` |
 | Gemini CLI | `~/.gemini/tmp/*/chats/` |
 
-New sessions become searchable the moment they're written. No manual export needed.
+## Platform data (Twitter, GitHub, Reddit, etc.)
 
-## Platform data (via connector plugins)
-
-Connector plugins pull your bookmarks, stars, and saves from various platforms to your machine. Spool indexes everything they capture.
-
-### Supported connectors
-
-- **Code**: GitHub Stars, GitLab Stars, Bitbucket
-- **Social**: Twitter/X Bookmarks, Reddit Saved, Hacker News Favorites
-- **Video**: YouTube Likes, Bilibili Favorites
-- **Reading**: Substack, Medium Bookmarks, Pocket, Instapaper
-- **Professional**: LinkedIn Saved, Slack Bookmarks
-- **Notes**: Notion, Obsidian, Apple Notes
-
-### Syncing data
-
-```bash
-# Install a connector
-spool connectors install twitter-bookmarks
-
-# Sync all installed connectors
-spool connectors sync
-```
-
-Spool indexes new data from connectors as it arrives.
+Connector-based platform sync (bookmarks, stars, saves) lives in **[Spool Daemon](/daemon/)**, a sibling app. Daemon's captures show up alongside Spool sessions in the same search box when both apps are installed.

--- a/packages/landing/pages/docs/quick-start.md
+++ b/packages/landing/pages/docs/quick-start.md
@@ -3,7 +3,7 @@ title: Quick Start
 description: Get up and running with Spool in under 5 minutes.
 ---
 
-After [installing Spool](/docs/installation), you can start searching your data right away.
+After [installing Spool](/docs/installation), you can start searching your sessions right away.
 
 ## 1. Launch Spool
 
@@ -11,15 +11,18 @@ Open Spool from your Applications folder. It starts indexing your Claude Code, C
 
 ## 2. Search from the app
 
-Use the search bar to find anything across your indexed data — past agent sessions, bookmarks, starred repos, and more.
+Use the search bar to find anything across your indexed sessions. Try a keyword from a recent conversation — it's there the moment the session file is written.
 
-## 3. Install connector plugins
+## 3. Search from your terminal
 
-Install connector plugins to pull bookmarks, stars, and saves from your favorite platforms:
+The bundled CLI runs the same search engine:
 
 ```bash
-spool connectors install twitter-bookmarks
-spool connectors sync
+spool search "auth middleware"
+spool list -n 10
+spool show <uuid>
 ```
 
-Spool indexes everything your connectors capture.
+## What about platform data (Twitter, GitHub, Reddit, …)?
+
+Bookmarks, stars, and saves live in **[Spool Daemon](/daemon/)** — a sibling app focused on capture sync. Once you install Daemon, its captures appear alongside Spool sessions in the same search box.

--- a/packages/landing/pages/docs/reference/configuration.md
+++ b/packages/landing/pages/docs/reference/configuration.md
@@ -11,7 +11,7 @@ Spool stores its data in `~/.spool/`.
 |------|---------|
 | `~/.spool/spool.db` | Local search index (SQLite) |
 | `~/.spool/agents.json` | Agent and SDK configuration |
-| `~/.spool/connectors/` | Connector plugin sync data |
+| `~/.spool/ui.json` | UI preferences (theme, etc.) |
 
 ## Watched directories
 


### PR DESCRIPTION
Final sweep before v0.4.0 — stale references the per-feature M5 PRs (#112–#117) didn't catch.

## Changes

| File | What | Why |
|---|---|---|
| `packages/app/src/main/index.ts` | Drop `spool://` custom-protocol registration | URL handler was removed in #113; registration without a handler is silently broken UX |
| `packages/landing/pages/docs/guides/data-sources.md` | Rewrite "Platform data" section as a forward to Spool Daemon | Doc currently tells users to run `spool connectors install …`, which exits 1 on the shipped CLI |
| `packages/landing/pages/docs/quick-start.md` | Drop step 3 ("Install connector plugins") | Same — references commands that no longer exist |
| `packages/landing/pages/docs/reference/configuration.md` | Drop `~/.spool/connectors/` row; add `ui.json` row | Connector dir is no longer part of Spool's data model |
| `packages/landing/pages/docs/guides/agent-integration.md` | Drop "bookmarks, stars" + "connector data" mentions | Planned-feature list described removed surface |
| `packages/landing/pages/blog/hello-spool.md` | Rewrite connector-plugin paragraph as a forward to Spool Daemon | Launch post described connectors as a Spool feature |

## Notes

- Spool now registers no custom protocols. If a future need comes up, that's a focused PR.
- `~/.spool/connectors/` left over on existing user disks is harmless (a few KB of stale node_modules from old connector installs); not worth a startup cleanup pass.
- README hero screenshot (`docs/spool-v0.png`) was not updated — its content (search box) is product-direction-stable. Refresh later if it ever shows the removed UI tabs.
- `docs/superpowers/*` historical plan/spec records are git-log-style artifacts and intentionally left intact.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean (app)
- [x] `pnpm build:electron` passes (app bundle unchanged in size after dropping a handful of bytes of registration code)
- [x] Final repo sweep: `grep -r 'spool connectors\|spool connector ' --include='*.md' --include='*.tsx' --include='*.ts' --include='*.json' --include='*.yml'` returns zero outside historical superpowers archives

🤖 Generated with [Claude Code](https://claude.com/claude-code)
