### PR TITLE
chore(npm): clean dist before tsc; bump cli + core to 0.4.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "type": "module",
   "bin": {
@@ -20,7 +20,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc && chmod +x bin/spool.js",
+    "build": "pnpm run clean && tsc && chmod +x bin/spool.js",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "test": "vitest run",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",
@@ -20,7 +20,7 @@
   "scripts": {
     "rebuild:native": "pnpm run rebuild:native:node",
     "rebuild:native:node": "node ../../scripts/rebuild-better-sqlite3-node.mjs",
-    "build": "tsc",
+    "build": "pnpm run clean && tsc",
     "dev": "tsc --watch",
     "test": "pnpm run rebuild:native && vitest run",
     "clean": "rm -rf dist",


### PR DESCRIPTION
The 0.4.0 npm publish shipped stale dist artifacts (`commands/connector.js` + `connector-shared.js` in cli, the entire `connectors/` subtree in core). tsc only writes new files — it doesn't delete outputs whose source has been removed.

Functional impact: none (the CLI entry doesn't import the orphans, so they never execute), but the npm tarballs are ~37 kB heavier than they should be and the situation is misleading.

## Fix

- Prepend `pnpm run clean` (already defined as `rm -rf dist` in both packages) to the `build` script. Every fresh build now starts from an empty `dist/`.
- Bump `@spool-lab/cli` and `@spool-lab/core` to `0.4.1` so the clean build can be published. App / landing / root stay at `0.4.0`; the Electron release on GitHub is unaffected by this fix and there's no reason to cut another DMG just for npm hygiene.

## Verified locally

- `pnpm --filter @spool-lab/core build` → `dist/` no longer contains a `connectors/` subtree
- `pnpm --filter @spool-lab/cli build` → `dist/commands/` contains only `list / search / show / status / sync` (no `connector*`)
- `pnpm install --frozen-lockfile` clean

## Test plan
- [x] Clean build verified end-to-end on both packages
- [x] Lockfile unchanged (workspace package version bumps don't propagate there)
- [ ] After merge: pull main, run `pnpm publish -r --no-git-checks` to ship the clean 0.4.1