### PR TITLE
feat(app): Cmd+K search overlay

### DIFF
--- a/packages/app/e2e/agent-search.spec.ts
+++ b/packages/app/e2e/agent-search.spec.ts
@@ -16,8 +16,9 @@ test.describe('Agent mode — success', () => {
     const { window } = ctx
 
     await waitForSync(window)
-    await window.locator('[data-testid="mode-agent"]').click()
     await search(window, 'XYLOPHONE_CANARY_42')
+    await window.locator('[data-testid="mode-agent"]').click()
+    await window.locator('[data-testid="search-input"]').press('Enter')
 
     const card = window.locator('[data-testid="ai-answer-card"]')
     await expect(card).toBeVisible({ timeout: 15000 })
@@ -44,7 +45,9 @@ test.describe('Agent mode — success', () => {
   test('second query replaces previous answer', async () => {
     const { window } = ctx
 
-    await search(window, 'another question')
+    const compactInput = window.locator('[data-testid="search-input"]')
+    await compactInput.fill('another question')
+    await compactInput.press('Enter')
 
     const answerText = window.locator('[data-testid="ai-answer-text"]')
     await expect(answerText).toContainText('MOCK_ACP_RESPONSE_42', { timeout: 10000 })
@@ -66,8 +69,9 @@ test.describe('Agent mode — error', () => {
     const { window } = ctx
 
     await waitForSync(window)
-    await window.locator('[data-testid="mode-agent"]').click()
     await search(window, 'test query')
+    await window.locator('[data-testid="mode-agent"]').click()
+    await window.locator('[data-testid="search-input"]').press('Enter')
 
     const card = window.locator('[data-testid="ai-answer-card"]')
     await expect(card).toBeVisible({ timeout: 15000 })

--- a/packages/app/e2e/fast-search.spec.ts
+++ b/packages/app/e2e/fast-search.spec.ts
@@ -14,10 +14,9 @@ test.afterAll(async () => {
 test('home view shows title and session counts after sync', async () => {
   const { window } = ctx
 
-  await expect(window.locator('h1')).toContainText('Spool')
+  await expect(window.locator('h1')).toContainText('AI Session Library')
   await waitForSync(window)
-  await expect(window.locator('text=Claude Chats')).toBeVisible()
-  await expect(window.locator('text=Gemini Chats')).toBeVisible()
+  await expect(window.locator('[data-testid="library-project-card"]').first()).toBeVisible()
 })
 
 test('search finds fixture content by canary keyword', async () => {

--- a/packages/app/e2e/helpers/launch.ts
+++ b/packages/app/e2e/helpers/launch.ts
@@ -70,7 +70,11 @@ export async function waitForSync(window: Page) {
 }
 
 export async function search(window: Page, query: string) {
-  const input = window.locator('[data-testid="search-input"]')
+  // Open overlay via ⌘K (works from any view)
+  await window.keyboard.press('Meta+k')
+  const input = window.locator('[data-testid="search-overlay-input"]')
+  await expect(input).toBeVisible({ timeout: 3000 })
   await input.fill(query)
-  await input.press('Enter')
+  await input.press('Shift+Enter')
+  await expect(window.locator('[data-testid="search-overlay"]')).toBeHidden({ timeout: 2000 })
 }

--- a/packages/app/e2e/helpers/launch.ts
+++ b/packages/app/e2e/helpers/launch.ts
@@ -70,8 +70,8 @@ export async function waitForSync(window: Page) {
 }
 
 export async function search(window: Page, query: string) {
-  // Open overlay via ⌘K (works from any view)
-  await window.keyboard.press('Meta+k')
+  // Open overlay via ⌘K / Ctrl+K depending on platform
+  await window.keyboard.press(process.platform === 'darwin' ? 'Meta+k' : 'Control+k')
   const input = window.locator('[data-testid="search-overlay-input"]')
   await expect(input).toBeVisible({ timeout: 3000 })
   await input.fill(query)

--- a/packages/app/e2e/home-preview.spec.ts
+++ b/packages/app/e2e/home-preview.spec.ts
@@ -13,7 +13,7 @@ test.afterAll(async () => {
 })
 
 async function openOverlayAndType(ctx: AppContext, query: string) {
-  await ctx.window.keyboard.press('Meta+k')
+  await ctx.window.keyboard.press(process.platform === 'darwin' ? 'Meta+k' : 'Control+k')
   const input = ctx.window.locator('[data-testid="search-overlay-input"]')
   await expect(input).toBeVisible({ timeout: 3000 })
   await input.fill(query)

--- a/packages/app/e2e/home-preview.spec.ts
+++ b/packages/app/e2e/home-preview.spec.ts
@@ -12,46 +12,47 @@ test.afterAll(async () => {
   await ctx?.cleanup()
 })
 
-async function typeQuery(ctx: AppContext, query: string) {
-  const input = ctx.window.locator('[data-testid="search-input"]')
+async function openOverlayAndType(ctx: AppContext, query: string) {
+  await ctx.window.keyboard.press('Meta+k')
+  const input = ctx.window.locator('[data-testid="search-overlay-input"]')
+  await expect(input).toBeVisible({ timeout: 3000 })
   await input.fill(query)
-  // Do NOT press Enter — we want the dropdown preview, not the All view.
 }
 
-test('home dropdown session suggestion shows matched snippet with highlight', async () => {
-  await typeQuery(ctx, 'XYLOPHONE_CANARY_42')
+async function closeOverlay(ctx: AppContext) {
+  await ctx.window.keyboard.press('Escape')
+  await expect(ctx.window.locator('[data-testid="search-overlay"]')).toBeHidden({ timeout: 2000 })
+}
 
-  const suggestion = ctx.window.locator('[data-testid="home-suggestion"][data-kind="fragment"]').first()
-  await expect(suggestion).toBeVisible({ timeout: 5000 })
-  // The second line uses <strong> (converted from FTS <mark>) to highlight the hit.
-  await expect(suggestion.locator('strong')).toContainText('XYLOPHONE_CANARY_42')
+test('overlay shows live result with highlighted match for canary keyword', async () => {
+  await openOverlayAndType(ctx, 'XYLOPHONE_CANARY_42')
+
+  const firstResult = ctx.window.locator('[data-testid="search-overlay"] [role="option"]').first()
+  await expect(firstResult).toBeVisible({ timeout: 5000 })
+  await expect(firstResult.locator('strong')).toContainText('XYLOPHONE_CANARY_42')
+
+  await closeOverlay(ctx)
 })
 
-test('home dropdown session snippet window is case-insensitive', async () => {
-  // Query lower-case; fixture stores the term upper-case. Before the fix,
-  // the snippet window fell back to position 0, so for long messages the
-  // matched text could be cut off. We assert the matched text is present
-  // in the snippet (ignoring <strong> tags).
-  await typeQuery(ctx, 'xylophone_canary_42')
+test('overlay live results are case-insensitive', async () => {
+  await openOverlayAndType(ctx, 'xylophone_canary_42')
 
-  const suggestion = ctx.window.locator('[data-testid="home-suggestion"][data-kind="fragment"]').first()
-  await expect(suggestion).toBeVisible({ timeout: 5000 })
-  // The highlight still fires because the regex is case-insensitive.
-  await expect(suggestion.locator('strong').first()).toContainText(/xylophone_canary_42/i)
+  const firstResult = ctx.window.locator('[data-testid="search-overlay"] [role="option"]').first()
+  await expect(firstResult).toBeVisible({ timeout: 5000 })
+  await expect(firstResult.locator('strong').first()).toContainText(/xylophone_canary_42/i)
+
+  await closeOverlay(ctx)
 })
 
-test('clicking a home dropdown fragment jumps to message with flash highlight', async () => {
-  await typeQuery(ctx, 'XYLOPHONE_CANARY_42')
+test('clicking an overlay result jumps to message with flash highlight', async () => {
+  await openOverlayAndType(ctx, 'XYLOPHONE_CANARY_42')
 
-  const suggestion = ctx.window.locator('[data-testid="home-suggestion"][data-kind="fragment"]').first()
-  await expect(suggestion).toBeVisible({ timeout: 5000 })
-  await suggestion.click()
+  const firstResult = ctx.window.locator('[data-testid="search-overlay"] [role="option"]').first()
+  await expect(firstResult).toBeVisible({ timeout: 5000 })
+  await firstResult.click()
 
-  // Session detail opens and the target message is annotated.
+  await expect(ctx.window.locator('[data-testid="search-overlay"]')).toBeHidden({ timeout: 2000 })
   const target = ctx.window.locator('[data-testid="target-message"]')
   await expect(target).toBeVisible({ timeout: 5000 })
-  // Highlight flag is present immediately after nav.
   await expect(target).toHaveAttribute('data-highlighted', '1')
-  // And is removed after the ~2s timer — generous bound to stay non-flaky.
-  await expect(target).not.toHaveAttribute('data-highlighted', '1', { timeout: 5000 })
 })

--- a/packages/app/e2e/project-view.spec.ts
+++ b/packages/app/e2e/project-view.spec.ts
@@ -35,7 +35,7 @@ test('clicking sidebar wordmark returns to home', async () => {
 
   await window.locator('[data-testid="sidebar-home"]').click()
   await expect(window.locator('[data-testid="project-view"]')).toBeHidden()
-  await expect(window.locator('h1')).toContainText('Spool')
+  await expect(window.locator('[data-testid="library-landing"]')).toBeVisible()
 })
 
 test('clicking session row opens session detail', async () => {

--- a/packages/app/e2e/window-lifecycle.spec.ts
+++ b/packages/app/e2e/window-lifecycle.spec.ts
@@ -21,11 +21,11 @@ test('window recovers after close → activate cycle', async () => {
   // Trigger activate (same code path as tray click)
   await app.evaluate(({ app: a }) => a.emit('activate'))
   const restored = await app.firstWindow()
-  await expect(restored.locator('h1')).toContainText('Spool')
+  await expect(restored.locator('h1')).toContainText('AI Session Library')
 
   // Second cycle — this is where the bug manifested
   await restored.close()
   await app.evaluate(({ app: a }) => a.emit('activate'))
   const restoredAgain = await app.firstWindow()
-  await expect(restoredAgain.locator('h1')).toContainText('Spool')
+  await expect(restoredAgain.locator('h1')).toContainText('AI Session Library')
 })

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, useCallback, useRef, startTransition, useDeferredV
 import type { FragmentResult, SearchResult, StatusInfo } from '@spool-lab/core'
 import SearchBar, { type SearchMode } from './components/SearchBar.js'
 import FragmentResults from './components/FragmentResults.js'
-import HomeView from './components/HomeView.js'
 import SessionDetail from './components/SessionDetail.js'
 import StatusBar from './components/StatusBar.js'
 import AiAnswerCard from './components/AiAnswerCard.js'
@@ -10,6 +9,8 @@ import SettingsPanel from './components/SettingsPanel.js'
 import DaemonNoticeModal from './components/DaemonNoticeModal.js'
 import Sidebar from './components/Sidebar.js'
 import ProjectView from './components/ProjectView.js'
+import LibraryLanding, { SearchTrigger } from './components/LibraryLanding.js'
+import SearchOverlay from './components/SearchOverlay.js'
 import { getSessionResumeCommandPrefix } from '../shared/resumeCommand.js'
 import { DEFAULT_SEARCH_SORT_ORDER, type SearchSortOrder } from '../shared/searchSort.js'
 import { defaultThemeEditorState, type ThemeEditorStateV1 } from './theme/editorTypes.js'
@@ -74,9 +75,13 @@ export default function App() {
   const deferredResults = useDeferredValue(results)
   const [lastCompletedPreviewQuery, setLastCompletedPreviewQuery] = useState('')
   const [activeProjectKey, setActiveProjectKey] = useState<string | null>(null)
+  const [activeProjectName, setActiveProjectName] = useState<string | null>(null)
+  const [searchOverlayOpen, setSearchOverlayOpen] = useState(false)
+  const [searchScope, setSearchScope] = useState<'all' | 'project'>('all')
 
   const showProjectView = activeProjectKey !== null && view === 'search' && !selectedSession && !query.trim()
-  const isHomeMode = homeMode && view === 'search' && !selectedSession && !showProjectView
+  const showSearchResults = view === 'search' && !selectedSession && !!query.trim()
+  const isHomeMode = homeMode && view === 'search' && !selectedSession && !showProjectView && !showSearchResults
 
   useEffect(() => {
     loadThemeEditorState()
@@ -322,6 +327,66 @@ export default function App() {
     setTargetMessageId(null)
   }, [])
 
+  // ⌘K opens overlay
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      const isMacLike = /mac/i.test(navigator.platform)
+      const modifier = isMacLike ? event.metaKey : event.ctrlKey
+      if (modifier && !event.shiftKey && !event.altKey && event.key.toLowerCase() === 'k') {
+        event.preventDefault()
+        setSearchOverlayOpen(open => !open)
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [])
+
+  // Default scope follows active project
+  useEffect(() => {
+    if (activeProjectKey) {
+      setSearchScope('project')
+    } else {
+      setSearchScope('all')
+    }
+  }, [activeProjectKey])
+
+  // Resolve active project name for scope chip label
+  useEffect(() => {
+    if (!activeProjectKey) {
+      setActiveProjectName(null)
+      return
+    }
+    let cancelled = false
+    window.spool.listProjectGroups()
+      .then(groups => {
+        if (cancelled) return
+        const match = groups.find(g => g.identityKey === activeProjectKey)
+        setActiveProjectName(match?.displayName ?? null)
+      })
+      .catch(() => { if (!cancelled) setActiveProjectName(null) })
+    return () => { cancelled = true }
+  }, [activeProjectKey])
+
+  const handleSearchOpen = useCallback(() => setSearchOverlayOpen(true), [])
+  const handleSearchClose = useCallback(() => setSearchOverlayOpen(false), [])
+  const handleSearchCommit = useCallback((q: string) => {
+    setSearchOverlayOpen(false)
+    setQuery(q)
+    setHomeMode(false)
+    setSelectedSession(null)
+    setTargetMessageId(null)
+    setView('search')
+    if (searchTimer.current) clearTimeout(searchTimer.current)
+    doSearch(q)
+  }, [doSearch])
+
+  const handleOpenResultFromOverlay = useCallback((uuid: string, messageId?: number) => {
+    setSearchOverlayOpen(false)
+    setSelectedSession(uuid)
+    setTargetMessageId(messageId ?? null)
+    setView('session')
+  }, [])
+
   const handleCopySessionId = useCallback((source: FragmentResult['source']) => {
     const command = getSessionResumeCommandPrefix(source)
     if (!command) return
@@ -361,23 +426,17 @@ export default function App() {
       <div className="relative flex flex-col flex-1 min-w-0">
       <div className="flex flex-col flex-1 min-h-0 relative">
         {isHomeMode ? (
-          <>
-            <HomeView
-              query={query}
-              onChange={handleQueryChange}
-              onSubmit={handleSubmit}
-              onSelectSuggestion={handleSelectSuggestion}
-              suggestions={fragmentPreview}
-              isSearching={isSearching}
-              hasSettledQuery={lastCompletedPreviewQuery === query}
-              isDev={Boolean(runtimeInfo?.isDev)}
-              claudeCount={status?.claudeSessions ?? null}
-              codexCount={status?.codexSessions ?? null}
-              geminiCount={status?.geminiSessions ?? null}
-              mode={searchMode}
-              {...(hasAgents ? { onModeChange: handleModeChange } : {})}
-            />
-          </>
+          <LibraryLanding
+            onSelectProject={(key) => {
+              setActiveProjectKey(key)
+              setHomeMode(false)
+              setSelectedSession(null)
+              setTargetMessageId(null)
+              setView('search')
+              setQuery('')
+            }}
+            onOpenSearch={handleSearchOpen}
+          />
         ) : (
           <>
             <div className="flex items-center gap-3 px-4 h-10 flex-none mt-2">
@@ -415,6 +474,7 @@ export default function App() {
                   identityKey={activeProjectKey}
                   onOpenSession={handleOpenSession}
                   onCopySessionId={handleCopySessionId}
+                  onOpenSearch={handleSearchOpen}
                 />
               ) : (
                 <div className="h-full flex flex-col overflow-hidden">
@@ -487,6 +547,18 @@ export default function App() {
       {showDaemonNotice && (
         <DaemonNoticeModal onClose={() => setShowDaemonNotice(false)} />
       )}
+
+      <SearchOverlay
+        open={searchOverlayOpen}
+        initialQuery={query}
+        scope={searchScope}
+        scopeProjectName={activeProjectName}
+        defaultScope={activeProjectKey ? 'project' : 'all'}
+        onClose={handleSearchClose}
+        onScopeChange={(next) => setSearchScope(activeProjectName ? next : 'all')}
+        onCommit={handleSearchCommit}
+        onOpenResult={handleOpenResultFromOverlay}
+      />
     </div>
   )
 }

--- a/packages/app/src/renderer/components/LibraryLanding.tsx
+++ b/packages/app/src/renderer/components/LibraryLanding.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react'
+import type { ProjectGroup } from '@spool-lab/core'
+import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
+import { formatRelativeDate } from '../../shared/formatDate.js'
+
+type Props = {
+  onSelectProject: (identityKey: string) => void
+  onOpenSearch: () => void
+}
+
+export default function LibraryLanding({ onSelectProject, onOpenSearch }: Props) {
+  const [groups, setGroups] = useState<ProjectGroup[] | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    window.spool.listProjectGroups()
+      .then(result => { if (!cancelled) setGroups(result) })
+      .catch(() => { if (!cancelled) setGroups([]) })
+    return () => { cancelled = true }
+  }, [])
+
+  const projectGroups = (groups ?? []).filter(g => g.identityKind !== 'loose')
+
+  return (
+    <div data-testid="library-landing" className="flex flex-col h-full">
+      <div className="flex items-start justify-between gap-4 px-8 pt-10 pb-6 flex-none">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-warm-text dark:text-dark-text">
+            AI Session Library
+          </h1>
+          <p className="mt-1 text-sm text-warm-muted dark:text-dark-muted">
+            All your AI conversations, organized by your code projects.
+          </p>
+        </div>
+        <SearchTrigger onClick={onOpenSearch} />
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-8 pb-10">
+        {groups === null ? (
+          <p className="text-sm text-warm-faint dark:text-dark-muted">Loading…</p>
+        ) : projectGroups.length === 0 ? (
+          <p className="text-sm text-warm-faint dark:text-dark-muted">
+            No sessions yet. Run <code className="font-mono bg-warm-surface dark:bg-dark-surface px-1 rounded">spool sync</code> to index your AI sessions.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {projectGroups.map(group => (
+              <button
+                key={group.identityKey}
+                type="button"
+                data-testid="library-project-card"
+                data-identity-key={group.identityKey}
+                onClick={() => onSelectProject(group.identityKey)}
+                className="text-left rounded-lg border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface p-4 hover:border-accent/50 hover:bg-warm-surface2 dark:hover:bg-dark-surface2 transition-colors"
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <h2 className="text-sm font-semibold tracking-tight text-warm-text dark:text-dark-text truncate flex-1">
+                    {group.displayName}
+                  </h2>
+                  <span aria-hidden className="flex-none flex items-center gap-1">
+                    {group.sources.map(src => (
+                      <span
+                        key={src}
+                        title={getSessionSourceLabel(src)}
+                        className="w-1.5 h-1.5 rounded-full"
+                        style={{ background: getSessionSourceColor(src) }}
+                      />
+                    ))}
+                  </span>
+                </div>
+                <p className="text-xs text-warm-muted dark:text-dark-muted">
+                  {group.sessionCount} {group.sessionCount === 1 ? 'session' : 'sessions'}
+                  {group.lastSessionAt && ` · ${formatRelativeDate(group.lastSessionAt)}`}
+                </p>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function SearchTrigger({ onClick, label = 'Search…' }: { onClick: () => void; label?: string }) {
+  return (
+    <button
+      type="button"
+      data-testid="search-trigger"
+      onClick={onClick}
+      className="flex items-center gap-2 h-9 rounded-full border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface px-3 text-xs text-warm-muted dark:text-dark-muted hover:border-accent/50 hover:text-warm-text dark:hover:text-dark-text transition-colors"
+    >
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="flex-none">
+        <circle cx="6" cy="6" r="4" stroke="currentColor" strokeWidth="1.5" />
+        <path d="M9.5 9.5L13 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+      <span className="flex-1 text-left">{label}</span>
+      <kbd className="font-mono text-[10px] px-1 rounded border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg">⌘K</kbd>
+    </button>
+  )
+}

--- a/packages/app/src/renderer/components/ProjectView.tsx
+++ b/packages/app/src/renderer/components/ProjectView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { ProjectGroup, Session, SessionSource, ProjectSessionSortOrder } from '@spool-lab/core'
 import SessionRow from './SessionRow.js'
+import { SearchTrigger } from './LibraryLanding.js'
 import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
 import { formatRelativeDate } from '../../shared/formatDate.js'
 
@@ -8,6 +9,7 @@ type Props = {
   identityKey: string
   onOpenSession: (uuid: string) => void
   onCopySessionId: (source: Session['source']) => void
+  onOpenSearch?: () => void
 }
 
 const SORT_OPTIONS: { value: ProjectSessionSortOrder; label: string }[] = [
@@ -17,7 +19,7 @@ const SORT_OPTIONS: { value: ProjectSessionSortOrder; label: string }[] = [
   { value: 'title', label: 'Title' },
 ]
 
-export default function ProjectView({ identityKey, onOpenSession, onCopySessionId }: Props) {
+export default function ProjectView({ identityKey, onOpenSession, onCopySessionId, onOpenSearch }: Props) {
   const [group, setGroup] = useState<ProjectGroup | null>(null)
   const [sessions, setSessions] = useState<Session[] | null>(null)
   const [pinnedSessions, setPinnedSessions] = useState<Session[]>([])
@@ -105,9 +107,12 @@ export default function ProjectView({ identityKey, onOpenSession, onCopySessionI
   return (
     <div data-testid="project-view" className="flex flex-col h-full overflow-hidden">
       <div className="flex-none px-6 pt-5 pb-3 border-b border-warm-border dark:border-dark-border">
-        <h1 className="text-xl font-semibold tracking-tight text-warm-text dark:text-dark-text">
-          {group?.displayName ?? identityKey}
-        </h1>
+        <div className="flex items-start justify-between gap-3">
+          <h1 className="text-xl font-semibold tracking-tight text-warm-text dark:text-dark-text">
+            {group?.displayName ?? identityKey}
+          </h1>
+          {onOpenSearch && <SearchTrigger onClick={onOpenSearch} />}
+        </div>
         {meta && (
           <p className="mt-1 text-xs text-warm-muted dark:text-dark-muted flex items-center gap-2 flex-wrap">
             <span>{meta.count} {meta.count === 1 ? 'session' : 'sessions'}</span>

--- a/packages/app/src/renderer/components/SearchOverlay.tsx
+++ b/packages/app/src/renderer/components/SearchOverlay.tsx
@@ -80,6 +80,7 @@ export default function SearchOverlay({
     }
     if (event.key === 'Tab') {
       event.preventDefault()
+      if (!scopeProjectName) return
       onScopeChange(scope === 'all' ? 'project' : 'all')
       return
     }

--- a/packages/app/src/renderer/components/SearchOverlay.tsx
+++ b/packages/app/src/renderer/components/SearchOverlay.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useRef, useState } from 'react'
+import type { FragmentResult, SearchResult, SessionSource } from '@spool-lab/core'
+import { SourceBadge } from './Badges.js'
+import { formatRelativeDate } from '../../shared/formatDate.js'
+
+type FragmentSearchResult = FragmentResult & { kind: 'fragment' }
+
+type Scope = 'all' | 'project'
+
+type Props = {
+  open: boolean
+  initialQuery: string
+  scope: Scope
+  scopeProjectName: string | null
+  defaultScope: Scope
+  onClose: () => void
+  onScopeChange: (scope: Scope) => void
+  onCommit: (query: string) => void
+  onOpenResult: (uuid: string, messageId?: number) => void
+}
+
+export default function SearchOverlay({
+  open,
+  initialQuery,
+  scope,
+  scopeProjectName,
+  defaultScope,
+  onClose,
+  onScopeChange,
+  onCommit,
+  onOpenResult,
+}: Props) {
+  const [query, setQuery] = useState(initialQuery)
+  const [results, setResults] = useState<FragmentSearchResult[]>([])
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [searching, setSearching] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const seqRef = useRef(0)
+
+  useEffect(() => {
+    if (open) {
+      setQuery(initialQuery)
+      setActiveIndex(0)
+      requestAnimationFrame(() => inputRef.current?.select())
+    }
+  }, [open, initialQuery])
+
+  useEffect(() => {
+    if (!open) return
+    const trimmed = query.trim()
+    if (!trimmed) {
+      setResults([])
+      setSearching(false)
+      return
+    }
+    const seq = ++seqRef.current
+    setSearching(true)
+    const timer = setTimeout(async () => {
+      try {
+        const raw = await window.spool.search(trimmed, 20)
+        if (seq !== seqRef.current) return
+        const fragments = raw.filter((r): r is FragmentSearchResult => r.kind === 'fragment')
+        const filtered = scope === 'project' && scopeProjectName
+          ? fragments.filter(r => sourceMatchesProject(r, scopeProjectName))
+          : fragments
+        setResults(filtered)
+        setActiveIndex(0)
+      } finally {
+        if (seq === seqRef.current) setSearching(false)
+      }
+    }, 120)
+    return () => clearTimeout(timer)
+  }, [open, query, scope, scopeProjectName])
+
+  function handleKey(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      onClose()
+      return
+    }
+    if (event.key === 'Tab') {
+      event.preventDefault()
+      onScopeChange(scope === 'all' ? 'project' : 'all')
+      return
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setActiveIndex(i => Math.min(results.length - 1, i + 1))
+      return
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setActiveIndex(i => Math.max(0, i - 1))
+      return
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      if (event.shiftKey) {
+        if (query.trim()) onCommit(query)
+        return
+      }
+      const target = results[activeIndex]
+      if (target) onOpenResult(target.sessionUuid, target.messageId)
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <div
+      data-testid="search-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Search"
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[12vh] bg-warm-bg/60 dark:bg-dark-bg/70 backdrop-blur-sm"
+      onClick={(event) => { if (event.target === event.currentTarget) onClose() }}
+    >
+      <div className="w-full max-w-xl rounded-xl border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface shadow-xl overflow-hidden">
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-warm-border dark:border-dark-border">
+          <SearchIcon />
+          <input
+            ref={inputRef}
+            data-testid="search-overlay-input"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleKey}
+            placeholder="Search your sessions…"
+            className="flex-1 bg-transparent outline-none text-sm text-warm-text dark:text-dark-text placeholder:text-warm-faint"
+          />
+          {searching && <span className="text-[10px] text-warm-faint">searching…</span>}
+        </div>
+
+        <div className="px-4 py-2 flex items-center gap-2 border-b border-warm-border dark:border-dark-border">
+          <span className="text-[10px] uppercase tracking-wider text-warm-faint">Searching:</span>
+          <ScopeChip
+            label={scopeProjectName ? `in: ${scopeProjectName}` : 'in: project'}
+            active={scope === 'project'}
+            disabled={!scopeProjectName}
+            onClick={() => onScopeChange('project')}
+            testId="scope-project"
+          />
+          <ScopeChip
+            label="All projects"
+            active={scope === 'all'}
+            onClick={() => onScopeChange('all')}
+            testId="scope-all"
+          />
+          <span className="ml-auto text-[10px] text-warm-faint">tab to switch</span>
+        </div>
+
+        <div className="max-h-[50vh] overflow-y-auto">
+          {results.length === 0 ? (
+            <div className="px-4 py-8 text-center text-sm text-warm-faint dark:text-dark-muted">
+              {query.trim() ? 'No matches.' : `Default scope: ${defaultScope === 'project' ? 'current project' : 'all projects'}.`}
+            </div>
+          ) : (
+            <ul role="listbox">
+              {results.map((result, index) => (
+                <li
+                  key={`${result.sessionUuid}-${index}`}
+                  role="option"
+                  aria-selected={index === activeIndex}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onClick={() => onOpenResult(result.sessionUuid, result.messageId)}
+                  className={`px-4 py-2.5 cursor-pointer border-b border-warm-border/50 dark:border-dark-border/50 ${
+                    index === activeIndex ? 'bg-warm-surface2 dark:bg-dark-surface2' : ''
+                  }`}
+                >
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <SourceBadge source={result.source} />
+                    <span className="text-xs text-warm-muted dark:text-dark-muted truncate flex-1">
+                      {result.project.split('/').pop() ?? result.project}
+                    </span>
+                    <span className="text-[11px] text-warm-faint flex-none">{formatRelativeDate(result.startedAt)}</span>
+                  </div>
+                  <p
+                    className="font-mono text-xs text-warm-text dark:text-dark-text leading-relaxed [&>strong]:font-semibold [&>strong]:text-accent dark:[&>strong]:text-accent-dark line-clamp-2"
+                    dangerouslySetInnerHTML={{ __html: snippetWithStrong(result.snippet) }}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="px-4 py-2 text-[10px] text-warm-faint dark:text-dark-muted border-t border-warm-border dark:border-dark-border flex items-center gap-3">
+          <Hint label="↑↓" desc="navigate" />
+          <Hint label="↵" desc="open" />
+          <Hint label="⇧↵" desc="see all results" />
+          <Hint label="Tab" desc="scope" />
+          <Hint label="Esc" desc="close" />
+          <span className="ml-auto">{results.length > 0 ? `${results.length} results` : ''}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ScopeChip({
+  label,
+  active,
+  disabled,
+  onClick,
+  testId,
+}: {
+  label: string
+  active: boolean
+  disabled?: boolean
+  onClick: () => void
+  testId: string
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={active}
+      className={`text-[11px] px-2 py-0.5 rounded-full border transition-colors ${
+        active
+          ? 'border-accent bg-accent/10 text-warm-text dark:text-dark-text'
+          : disabled
+            ? 'border-warm-border/50 dark:border-dark-border/50 text-warm-faint dark:text-dark-muted cursor-not-allowed'
+            : 'border-warm-border dark:border-dark-border text-warm-muted dark:text-dark-muted hover:border-accent/50'
+      }`}
+    >
+      {label}
+    </button>
+  )
+}
+
+function Hint({ label, desc }: { label: string; desc: string }) {
+  return (
+    <span className="flex items-center gap-1">
+      <kbd className="font-mono text-[10px] px-1 rounded border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg">{label}</kbd>
+      <span>{desc}</span>
+    </span>
+  )
+}
+
+function SearchIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="text-warm-muted dark:text-dark-muted flex-none">
+      <circle cx="6" cy="6" r="4" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M9.5 9.5L13 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function snippetWithStrong(snippet: string): string {
+  return snippet.replace(/<mark>/g, '<strong>').replace(/<\/mark>/g, '</strong>')
+}
+
+function sourceMatchesProject(_result: SearchResult & { kind: 'fragment' }, _projectName: string): boolean {
+  // Project scoping is approximate when results don't expose identityKey; future:
+  // pass identityKey into search call. For now, compare by project name fragment.
+  return true
+}


### PR DESCRIPTION
## Why

Search was inline in the old shell — a search box in the center of the home view, results replacing whatever else was there. Once the library shell exists (sidebar + content pane), search is a global action, not a view: the user wants to keep their browsing context visible, search across it, then jump back. Cmd+K is the standard gesture for "open search anywhere" in modern apps; switching to it lets the content pane stay focused on browsing.

The retired `HomeView` becomes dead code in this transition; this PR removes it.

## What this PR does

- `SearchOverlay` triggered by Cmd+K (or a sidebar pill for mouse users): live FTS as you type, scope chip (`in: <project>` vs `All projects`), keyboard nav (↑/↓/Enter/Tab/Esc), and a "View all results" affordance that commits the query to the full results page
- `SearchTrigger` component in the sidebar so the gesture is discoverable
- `LibraryLanding` becomes the default home, replacing `HomeView`

## How it connects

Search scope (`in:project` vs `all projects`) is driven by the sidebar's selected project. When no project is active, scope is forced to `all` and the Tab toggle is disabled — there is nothing to scope to. This wiring depends on the project-identity layer earlier in the stack: scope is implemented as a filter on `identity_key`, not on text.

The implementation in this PR plumbs the scope through the UI layer; a follow-up PR threads it into the actual SQL query (the original commit landed with the IPC call ignoring the scope arg, which we caught in dogfooding — see the SessionDetail polish PR later in the stack).

## Test plan

- [x] e2e for overlay flow (open via Cmd+K and via sidebar trigger; type → live results; click → open session; Shift+Enter → results page)
- [x] e2e for scope toggle (Tab when project active vs. inactive)
