### PR TITLE
Harden DB migrations with explicit guards + pre-destructive backups

### DIFF
--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { existsSync, mkdirSync, statSync } from 'node:fs'
 import { computeIdentity, type IdentityFs } from '../projects/identity.js'
 import { realFs } from '../projects/fs.js'
@@ -228,22 +228,29 @@ export function runMigrations(db: Database.Database): void {
   // the next sequential version number.
   const version = (db.pragma('user_version') as [{ user_version: number }])[0].user_version
 
-  // Historical connector migrations (v1-v3): all operate on the captures /
-  // connector_sync_state tables that were dropped in v5. Wrapped to no-op
-  // when those tables aren't present (fresh install on the post-v5 schema).
+  // Historical connector migrations (v1-v3): all operate on tables that v5
+  // dropped (connector_sync_state, captures, capture_connectors,
+  // captures_fts*). Guard each on the relevant table existing — fresh
+  // installs (post-v5 schema) skip these without ever touching the SQL.
   if (version < 1) {
-    try { db.exec('ALTER TABLE connector_sync_state ADD COLUMN last_error_at TEXT') } catch {}
+    if (tableExists(db, 'connector_sync_state')) {
+      db.exec('ALTER TABLE connector_sync_state ADD COLUMN last_error_at TEXT')
+    }
     db.pragma('user_version = 1')
   }
 
   if (version < 2) {
-    try { db.exec("INSERT INTO captures_fts(captures_fts) VALUES('rebuild')") } catch {}
-    try { db.exec("INSERT INTO captures_fts_trigram(captures_fts_trigram) VALUES('rebuild')") } catch {}
+    if (tableExists(db, 'captures_fts')) {
+      db.exec("INSERT INTO captures_fts(captures_fts) VALUES('rebuild')")
+    }
+    if (tableExists(db, 'captures_fts_trigram')) {
+      db.exec("INSERT INTO captures_fts_trigram(captures_fts_trigram) VALUES('rebuild')")
+    }
     db.pragma('user_version = 2')
   }
 
   if (version < 3) {
-    try {
+    if (tableExists(db, 'captures') && tableExists(db, 'capture_connectors')) {
       db.transaction(() => {
         db.exec(`
           INSERT OR IGNORE INTO capture_connectors (capture_id, connector_id)
@@ -263,7 +270,7 @@ export function runMigrations(db: Database.Database): void {
         `)
         db.exec(`DROP INDEX IF EXISTS idx_captures_source`)
       })()
-    } catch {}
+    }
     db.pragma('user_version = 3')
   }
 
@@ -289,8 +296,9 @@ export function runMigrations(db: Database.Database): void {
     // SQLite can't ALTER a CHECK constraint, so we rebuild the stars table.
     // For users who never had the wide CHECK (fresh install on post-v5
     // schema), the rebuild is a no-op rename round-trip — safe and cheap.
-    // Captures data is dropped without backup; users were directed to Spool
-    // Daemon for connector functionality.
+    // Captures data is dropped here; users were directed to Spool Daemon for
+    // connector functionality. We snapshot first so the data is recoverable.
+    backupBeforeDestructive(db, 4)
     db.transaction(() => {
       db.exec(`DROP TRIGGER IF EXISTS captures_fts_insert`)
       db.exec(`DROP TRIGGER IF EXISTS captures_fts_delete`)
@@ -355,6 +363,7 @@ export function runMigrations(db: Database.Database): void {
   }
 
   if (version < 7) {
+    backupBeforeDestructive(db, 6)
     db.transaction(() => {
       db.exec(`
         CREATE TABLE pins (
@@ -391,6 +400,43 @@ export function backfillProjectIdentities(db: Database.Database, fs: IdentityFs)
       update.run(id.kind, id.key, id.displayName, r.id)
     }
   })()
+}
+
+function tableExists(db: Database.Database, name: string): boolean {
+  const row = db.prepare(
+    `SELECT name FROM sqlite_master WHERE type IN ('table','virtual') AND name = ?`,
+  ).get(name) as { name: string } | undefined
+  return row !== undefined
+}
+
+/**
+ * Snapshot the DB to `<dbDir>/backups/spool-pre-v{fromVersion+1}-<ts>.db`
+ * via VACUUM INTO, before a destructive migration runs.
+ *
+ * Returns the backup file path on success, or null when a backup is skipped:
+ *   - in-memory DBs (db.memory)
+ *   - fresh-install / no-data DBs (sessions table empty or missing)
+ *
+ * Each call writes to a distinct path; v5 and v7 produce separate files.
+ */
+export function backupBeforeDestructive(
+  db: Database.Database,
+  fromVersion: number,
+): string | null {
+  if (db.memory) return null
+  const dbPath = db.name
+  if (!dbPath) return null
+  if (!tableExists(db, 'sessions')) return null
+
+  const sessions = db.prepare(`SELECT COUNT(*) AS c FROM sessions`).get() as { c: number }
+  if (sessions.c === 0) return null
+
+  const backupDir = join(dirname(dbPath), 'backups')
+  mkdirSync(backupDir, { recursive: true })
+  const ts = new Date().toISOString().replace(/[:.]/g, '-')
+  const backupPath = join(backupDir, `spool-pre-v${fromVersion + 1}-${ts}.db`)
+  db.exec(`VACUUM INTO '${backupPath.replace(/'/g, "''")}'`)
+  return backupPath
 }
 
 function rebuildFtsTableIfEmpty(

--- a/packages/core/src/db/migration-backup.test.ts
+++ b/packages/core/src/db/migration-backup.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import Database from 'better-sqlite3'
+import { backupBeforeDestructive, runMigrations } from './db.js'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+function seedDataDb(dbPath: string) {
+  const db = new Database(dbPath)
+  db.exec(`
+    CREATE TABLE sources (
+      id INTEGER PRIMARY KEY, name TEXT NOT NULL UNIQUE,
+      base_path TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    INSERT INTO sources (name, base_path) VALUES ('claude','~/.claude/projects');
+    CREATE TABLE projects (id INTEGER PRIMARY KEY, source_id INTEGER, slug TEXT, display_path TEXT, display_name TEXT);
+    INSERT INTO projects (source_id, slug, display_path, display_name) VALUES (1,'p','/p','p');
+    CREATE TABLE sessions (
+      id INTEGER PRIMARY KEY, project_id INTEGER, source_id INTEGER,
+      session_uuid TEXT NOT NULL UNIQUE, file_path TEXT NOT NULL UNIQUE,
+      started_at TEXT NOT NULL, ended_at TEXT NOT NULL
+    );
+    INSERT INTO sessions (project_id, source_id, session_uuid, file_path, started_at, ended_at)
+      VALUES (1,1,'sess-1','/fake/1.jsonl','2026-01-01','2026-01-01');
+  `)
+  db.close()
+}
+
+describe('backupBeforeDestructive', () => {
+  it('writes a VACUUM INTO snapshot to <dbDir>/backups for a populated file DB', () => {
+    const dir = makeTempDir('spool-backup-')
+    const dbPath = join(dir, 'spool.db')
+    seedDataDb(dbPath)
+
+    const db = new Database(dbPath)
+    const result = backupBeforeDestructive(db, 4)
+    db.close()
+
+    expect(result).not.toBeNull()
+    expect(result!.startsWith(join(dir, 'backups'))).toBe(true)
+    expect(result!).toMatch(/spool-pre-v5-.*\.db$/)
+    expect(statSync(result!).size).toBeGreaterThan(0)
+
+    // Backup is a valid SQLite DB containing the seeded session
+    const backupDb = new Database(result!, { readonly: true })
+    const row = backupDb.prepare(`SELECT session_uuid FROM sessions`).get() as { session_uuid: string }
+    expect(row.session_uuid).toBe('sess-1')
+    backupDb.close()
+  })
+
+  it('encodes the source version in the filename (pre-v{N+1})', () => {
+    const dir = makeTempDir('spool-backup-vers-')
+    const dbPath = join(dir, 'spool.db')
+    seedDataDb(dbPath)
+
+    const db = new Database(dbPath)
+    const v5 = backupBeforeDestructive(db, 4) // pre-v5
+    const v7 = backupBeforeDestructive(db, 6) // pre-v7
+    db.close()
+
+    expect(v5!).toMatch(/spool-pre-v5-/)
+    expect(v7!).toMatch(/spool-pre-v7-/)
+    expect(v5).not.toBe(v7)
+
+    const files = readdirSync(join(dir, 'backups'))
+    expect(files.length).toBe(2)
+  })
+
+  it('returns null and writes nothing for an in-memory DB', () => {
+    const db = new Database(':memory:')
+    db.exec(`CREATE TABLE sessions (session_uuid TEXT)`)
+    db.prepare(`INSERT INTO sessions VALUES ('x')`).run()
+    const result = backupBeforeDestructive(db, 4)
+    expect(result).toBeNull()
+    db.close()
+  })
+
+  it('returns null and writes nothing when the DB has no session data', () => {
+    const dir = makeTempDir('spool-backup-empty-')
+    const dbPath = join(dir, 'spool.db')
+    const seed = new Database(dbPath)
+    seed.exec(`CREATE TABLE sessions (session_uuid TEXT)`)
+    seed.close()
+
+    const db = new Database(dbPath)
+    const result = backupBeforeDestructive(db, 4)
+    db.close()
+
+    expect(result).toBeNull()
+    // backups dir is not created when there's nothing to back up
+    let backupsExisted = true
+    try { readdirSync(join(dir, 'backups')) } catch { backupsExisted = false }
+    expect(backupsExisted).toBe(false)
+  })
+})
+
+describe('migration backup integration', () => {
+  it('writes a pre-v5 backup when migrating a populated v4 DB through head', () => {
+    // Seed a v4 DB with session data, then run migrations and check that
+    // a backups/spool-pre-v5-*.db file was written by the v5 destructive step.
+    const dir = makeTempDir('spool-mig-backup-v5-')
+    const dbPath = join(dir, 'spool.db')
+    const seed = new Database(dbPath)
+    seed.pragma('journal_mode = WAL')
+    seed.exec(`
+      CREATE TABLE sources (id INTEGER PRIMARY KEY, name TEXT UNIQUE, base_path TEXT, created_at TEXT);
+      INSERT INTO sources (name, base_path) VALUES ('claude','~/.claude');
+      CREATE TABLE projects (id INTEGER PRIMARY KEY, source_id INTEGER, slug TEXT, display_path TEXT, display_name TEXT, last_synced TEXT);
+      INSERT INTO projects (source_id, slug, display_path, display_name) VALUES (1,'p','/p','p');
+      CREATE TABLE sessions (
+        id INTEGER PRIMARY KEY, project_id INTEGER, source_id INTEGER,
+        session_uuid TEXT UNIQUE, file_path TEXT UNIQUE,
+        started_at TEXT, ended_at TEXT, message_count INTEGER DEFAULT 0
+      );
+      INSERT INTO sessions (project_id, source_id, session_uuid, file_path, started_at, ended_at)
+        VALUES (1,1,'sess-survive','/fake/s.jsonl','2026-01-01','2026-01-01');
+      CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id INTEGER, source_id INTEGER, role TEXT, content_text TEXT, timestamp TEXT, is_sidechain INTEGER DEFAULT 0, tool_names TEXT DEFAULT '[]', seq INTEGER);
+      CREATE VIRTUAL TABLE messages_fts USING fts5(content_text, content='messages', content_rowid='id');
+      CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(content_text, content='messages', content_rowid='id', tokenize='trigram');
+      CREATE TABLE sync_log (id INTEGER PRIMARY KEY, source_id INTEGER, file_path TEXT, status TEXT, message TEXT, synced_at TEXT);
+      CREATE TABLE session_search (session_id INTEGER PRIMARY KEY, title TEXT DEFAULT '', user_text TEXT DEFAULT '', assistant_text TEXT DEFAULT '', updated_at TEXT);
+      CREATE VIRTUAL TABLE session_search_fts USING fts5(title, user_text, assistant_text, content='session_search', content_rowid='session_id');
+      CREATE VIRTUAL TABLE session_search_fts_trigram USING fts5(title, user_text, assistant_text, content='session_search', content_rowid='session_id', tokenize='trigram');
+      CREATE TABLE stars (
+        item_type TEXT NOT NULL CHECK (item_type IN ('session','capture')),
+        item_uuid TEXT NOT NULL,
+        starred_at TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (item_type, item_uuid)
+      );
+    `)
+    seed.pragma('user_version = 4')
+    seed.close()
+
+    const db = new Database(dbPath)
+    db.pragma('journal_mode = WAL')
+    runMigrations(db)
+    db.close()
+
+    const backups = readdirSync(join(dir, 'backups'))
+    expect(backups.some(f => /^spool-pre-v5-.*\.db$/.test(f))).toBe(true)
+  })
+
+  it('skips backup on a fresh-install migration (no prior session data)', () => {
+    const dir = makeTempDir('spool-mig-backup-fresh-')
+    const dbPath = join(dir, 'spool.db')
+
+    const db = new Database(dbPath)
+    db.pragma('journal_mode = WAL')
+    runMigrations(db)
+    db.close()
+
+    let backupsExisted = true
+    try { readdirSync(join(dir, 'backups')) } catch { backupsExisted = false }
+    expect(backupsExisted).toBe(false)
+  })
+})

--- a/packages/core/src/db/migration-smoke.test.ts
+++ b/packages/core/src/db/migration-smoke.test.ts
@@ -1,0 +1,331 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import Database from 'better-sqlite3'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+/**
+ * End-to-end smoke: simulate the real getDB() entry point that the app and
+ * CLI use, for both fresh installs and every historically-released DB
+ * version, then exercise the resulting DB through the public query API.
+ *
+ * The intent is to prove neither new users nor old users crash during
+ * migration AND that the migrated DB is functionally usable afterwards.
+ */
+
+async function loadGetDB(spoolDir: string) {
+  vi.stubEnv('SPOOL_DATA_DIR', spoolDir)
+  vi.resetModules()
+  return await import('./db.js')
+}
+
+function exerciseDb(db: Database.Database, sessionUuid: string) {
+  // Insert a new session through the post-migration schema
+  const sourceId = (db.prepare(`SELECT id FROM sources WHERE name = 'claude'`).get() as { id: number }).id
+  const projectId = Number(
+    db.prepare(
+      `INSERT INTO projects (source_id, slug, display_path, display_name, identity_kind, identity_key)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(sourceId, `slug-${sessionUuid}`, '/smoke/p', 'p', 'path', '/smoke/p').lastInsertRowid,
+  )
+  db.prepare(`
+    INSERT INTO sessions (project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count)
+    VALUES (?, ?, ?, ?, 'smoke', '2026-04-30T00:00:00Z', '2026-04-30T00:01:00Z', 0)
+  `).run(projectId, sourceId, sessionUuid, `/smoke/${sessionUuid}.jsonl`)
+
+  // Pin + verify (uses the post-v7 pins table)
+  db.prepare(`INSERT INTO pins (session_uuid) VALUES (?)`).run(sessionUuid)
+  const pinned = db.prepare(`SELECT session_uuid FROM pins WHERE session_uuid = ?`).get(sessionUuid)
+  expect(pinned).toEqual({ session_uuid: sessionUuid })
+
+  // The post-v6 view exists and responds
+  const view = db.prepare(`SELECT name FROM sqlite_master WHERE type='view' AND name='project_groups_v'`).get()
+  expect(view).toBeDefined()
+}
+
+function seedV0(dbPath: string) {
+  const seed = new Database(dbPath)
+  seed.exec(`
+    CREATE TABLE sources (
+      id INTEGER PRIMARY KEY, name TEXT NOT NULL UNIQUE,
+      base_path TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    INSERT INTO sources (name, base_path) VALUES
+      ('claude','~/.claude/projects'),('codex','~/.codex/sessions'),
+      ('gemini','~/.gemini/tmp'),('connector','<plugin>');
+    CREATE TABLE projects (
+      id INTEGER PRIMARY KEY, source_id INTEGER NOT NULL REFERENCES sources(id),
+      slug TEXT NOT NULL, display_path TEXT NOT NULL, display_name TEXT NOT NULL,
+      last_synced TEXT, UNIQUE (source_id, slug)
+    );
+    CREATE TABLE sessions (
+      id INTEGER PRIMARY KEY, project_id INTEGER NOT NULL REFERENCES projects(id),
+      source_id INTEGER NOT NULL REFERENCES sources(id),
+      session_uuid TEXT NOT NULL UNIQUE, file_path TEXT NOT NULL UNIQUE,
+      title TEXT, started_at TEXT NOT NULL, ended_at TEXT NOT NULL,
+      message_count INTEGER NOT NULL DEFAULT 0, has_tool_use INTEGER NOT NULL DEFAULT 0,
+      cwd TEXT, model TEXT, raw_file_mtime TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE messages (
+      id INTEGER PRIMARY KEY, session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      source_id INTEGER NOT NULL REFERENCES sources(id),
+      msg_uuid TEXT, parent_uuid TEXT, role TEXT NOT NULL,
+      content_text TEXT NOT NULL DEFAULT '', timestamp TEXT NOT NULL,
+      is_sidechain INTEGER NOT NULL DEFAULT 0, tool_names TEXT NOT NULL DEFAULT '[]',
+      seq INTEGER NOT NULL
+    );
+    CREATE VIRTUAL TABLE messages_fts USING fts5(content_text, content='messages', content_rowid='id');
+    CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(content_text, content='messages', content_rowid='id', tokenize='trigram');
+    CREATE TABLE sync_log (
+      id INTEGER PRIMARY KEY, source_id INTEGER NOT NULL REFERENCES sources(id),
+      file_path TEXT NOT NULL, status TEXT NOT NULL, message TEXT,
+      synced_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE session_search (
+      session_id INTEGER PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+      title TEXT NOT NULL DEFAULT '', user_text TEXT NOT NULL DEFAULT '',
+      assistant_text TEXT NOT NULL DEFAULT '',
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE VIRTUAL TABLE session_search_fts USING fts5(title, user_text, assistant_text, content='session_search', content_rowid='session_id');
+    CREATE VIRTUAL TABLE session_search_fts_trigram USING fts5(title, user_text, assistant_text, content='session_search', content_rowid='session_id', tokenize='trigram');
+    CREATE TABLE captures (
+      id INTEGER PRIMARY KEY, source_id INTEGER NOT NULL REFERENCES sources(id),
+      capture_uuid TEXT NOT NULL UNIQUE, url TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT '', content_text TEXT NOT NULL DEFAULT '',
+      author TEXT, platform TEXT NOT NULL, platform_id TEXT,
+      content_type TEXT NOT NULL DEFAULT 'page', thumbnail_url TEXT,
+      metadata TEXT NOT NULL DEFAULT '{}', captured_at TEXT NOT NULL,
+      indexed_at TEXT NOT NULL DEFAULT (datetime('now')), raw_json TEXT
+    );
+    CREATE VIRTUAL TABLE captures_fts USING fts5(title, content_text, content='captures', content_rowid='id');
+    CREATE VIRTUAL TABLE captures_fts_trigram USING fts5(title, content_text, content='captures', content_rowid='id', tokenize='trigram');
+    CREATE TABLE capture_connectors (
+      capture_id INTEGER NOT NULL REFERENCES captures(id) ON DELETE CASCADE,
+      connector_id TEXT NOT NULL, PRIMARY KEY (capture_id, connector_id)
+    );
+    CREATE TABLE connector_sync_state (
+      connector_id TEXT PRIMARY KEY, head_cursor TEXT, head_item_id TEXT,
+      tail_cursor TEXT, tail_complete INTEGER NOT NULL DEFAULT 0,
+      last_forward_sync_at TEXT, last_backfill_sync_at TEXT,
+      total_synced INTEGER NOT NULL DEFAULT 0, consecutive_errors INTEGER NOT NULL DEFAULT 0,
+      enabled INTEGER NOT NULL DEFAULT 1, config_json TEXT NOT NULL DEFAULT '{}'
+    );
+  `)
+
+  // Pre-existing user data: a session and a capture with connectorId metadata
+  // so v1, v2, v3 all have something to do.
+  seed.prepare("INSERT INTO projects (source_id, slug, display_path, display_name) VALUES (1, 'p', '/p', 'p')").run()
+  seed.prepare(`
+    INSERT INTO sessions (project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count)
+    VALUES (1, 1, 'old-sess', '/old/sess.jsonl', 'old', '2026-01-01T00:00:00Z', '2026-01-01T00:01:00Z', 1)
+  `).run()
+  seed.prepare(`
+    INSERT INTO captures (source_id, capture_uuid, url, title, content_text, platform, captured_at, metadata)
+    VALUES (4, 'c1', 'https://x.com/1', 'A tweet', 'tweet text', 'twitter', '2026-01-01T00:00:00Z',
+      '{"connectorId":"twitter-bookmarks"}')
+  `).run()
+  seed.prepare("INSERT INTO connector_sync_state (connector_id) VALUES ('twitter-bookmarks')").run()
+  seed.pragma('user_version = 0')
+  seed.close()
+}
+
+function seedV4WithStars(dbPath: string) {
+  // v4 schema with both kinds of stars (session + capture). v5 should
+  // preserve the session star (later promoted to a pin in v7) and drop
+  // the capture star.
+  seedV0(dbPath)
+  const upgrade = new Database(dbPath)
+  upgrade.exec(`
+    ALTER TABLE connector_sync_state ADD COLUMN last_error_at TEXT;
+    CREATE TABLE stars (
+      item_type  TEXT NOT NULL CHECK (item_type IN ('session', 'capture')),
+      item_uuid  TEXT NOT NULL,
+      starred_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (item_type, item_uuid)
+    );
+    INSERT INTO stars (item_type, item_uuid, starred_at)
+      VALUES ('session','old-sess','2026-03-15 12:00:00'),
+             ('capture','c1','2026-03-15 12:00:00');
+  `)
+  upgrade.pragma('user_version = 4')
+  upgrade.close()
+}
+
+function seedV6(dbPath: string) {
+  // post-v6 schema: stars (narrow CHECK) still exists; identity columns
+  // present on projects.
+  const seed = new Database(dbPath)
+  seed.exec(`
+    CREATE TABLE sources (
+      id INTEGER PRIMARY KEY, name TEXT NOT NULL UNIQUE, base_path TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    INSERT INTO sources (name, base_path) VALUES
+      ('claude','~/.claude/projects'),('codex','~/.codex/sessions'),('gemini','~/.gemini/tmp');
+    CREATE TABLE projects (
+      id INTEGER PRIMARY KEY, source_id INTEGER NOT NULL REFERENCES sources(id),
+      slug TEXT NOT NULL, display_path TEXT NOT NULL, display_name TEXT NOT NULL,
+      identity_kind TEXT, identity_key TEXT, last_synced TEXT,
+      UNIQUE (source_id, slug)
+    );
+    INSERT INTO projects (source_id, slug, display_path, display_name, identity_kind, identity_key)
+      VALUES (1, 'p', '/p', 'p', 'path', '/p');
+    CREATE TABLE sessions (
+      id INTEGER PRIMARY KEY, project_id INTEGER NOT NULL REFERENCES projects(id),
+      source_id INTEGER NOT NULL REFERENCES sources(id),
+      session_uuid TEXT NOT NULL UNIQUE, file_path TEXT NOT NULL UNIQUE,
+      title TEXT, started_at TEXT NOT NULL, ended_at TEXT NOT NULL,
+      message_count INTEGER NOT NULL DEFAULT 0, has_tool_use INTEGER NOT NULL DEFAULT 0,
+      cwd TEXT, model TEXT, raw_file_mtime TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    INSERT INTO sessions (project_id, source_id, session_uuid, file_path, title, started_at, ended_at)
+      VALUES (1, 1, 'v6-sess', '/v6/s.jsonl', 't', '2026-04-01', '2026-04-01');
+    CREATE TABLE messages (
+      id INTEGER PRIMARY KEY, session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      source_id INTEGER NOT NULL REFERENCES sources(id),
+      msg_uuid TEXT, parent_uuid TEXT, role TEXT NOT NULL,
+      content_text TEXT NOT NULL DEFAULT '', timestamp TEXT NOT NULL,
+      is_sidechain INTEGER NOT NULL DEFAULT 0, tool_names TEXT NOT NULL DEFAULT '[]',
+      seq INTEGER NOT NULL
+    );
+    CREATE VIRTUAL TABLE messages_fts USING fts5(content_text, content='messages', content_rowid='id');
+    CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(content_text, content='messages', content_rowid='id', tokenize='trigram');
+    CREATE TABLE sync_log (id INTEGER PRIMARY KEY, source_id INTEGER, file_path TEXT, status TEXT, message TEXT, synced_at TEXT);
+    CREATE TABLE session_search (
+      session_id INTEGER PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+      title TEXT NOT NULL DEFAULT '', user_text TEXT NOT NULL DEFAULT '',
+      assistant_text TEXT NOT NULL DEFAULT '',
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE VIRTUAL TABLE session_search_fts USING fts5(title, user_text, assistant_text, content='session_search', content_rowid='session_id');
+    CREATE VIRTUAL TABLE session_search_fts_trigram USING fts5(title, user_text, assistant_text, content='session_search', content_rowid='session_id', tokenize='trigram');
+    CREATE TABLE stars (
+      item_type  TEXT NOT NULL CHECK (item_type = 'session'),
+      item_uuid  TEXT NOT NULL,
+      starred_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (item_type, item_uuid)
+    );
+    INSERT INTO stars (item_type, item_uuid, starred_at)
+      VALUES ('session', 'v6-sess', '2026-04-15 09:00:00');
+    CREATE VIEW project_groups_v AS
+      SELECT identity_kind, identity_key, MIN(display_name) AS display_name,
+             '' AS sources_csv, 0 AS session_count, NULL AS last_session_at
+      FROM projects WHERE identity_kind IS NOT NULL
+      GROUP BY identity_kind, identity_key;
+  `)
+  seed.pragma('user_version = 6')
+  seed.close()
+}
+
+describe('migration smoke (full path through getDB)', () => {
+  it('new user: fresh install lands at head and DB is functional', async () => {
+    const spoolDir = makeTempDir('spool-smoke-fresh-')
+    const dbModule = await loadGetDB(spoolDir)
+    const db = dbModule.getDB()
+
+    expect(dbModule.wasNewDb()).toBe(true)
+    expect(dbModule.getInitialUserVersion()).toBe(0)
+    expect((db.pragma('user_version') as Array<{ user_version: number }>)[0].user_version)
+      .toBeGreaterThanOrEqual(7)
+
+    exerciseDb(db, 'fresh-uuid')
+    db.close()
+  })
+
+  it('old user (v0): full historical schema with capture+session data migrates and DB is functional', async () => {
+    const spoolDir = makeTempDir('spool-smoke-v0-')
+    seedV0(join(spoolDir, 'spool.db'))
+
+    const dbModule = await loadGetDB(spoolDir)
+    const db = dbModule.getDB()
+
+    expect(dbModule.wasNewDb()).toBe(false)
+    expect(dbModule.getInitialUserVersion()).toBe(0)
+    expect((db.pragma('user_version') as Array<{ user_version: number }>)[0].user_version)
+      .toBeGreaterThanOrEqual(7)
+
+    // Old session preserved
+    const oldSess = db.prepare(`SELECT session_uuid FROM sessions WHERE session_uuid='old-sess'`).get()
+    expect(oldSess).toEqual({ session_uuid: 'old-sess' })
+
+    // New session/pin still works post-migration
+    exerciseDb(db, 'v0-newuser')
+    db.close()
+  })
+
+  it('old user (v4 with starred session + capture): session pin survives, capture star dropped, DB functional', async () => {
+    const spoolDir = makeTempDir('spool-smoke-v4-')
+    seedV4WithStars(join(spoolDir, 'spool.db'))
+
+    const dbModule = await loadGetDB(spoolDir)
+    const db = dbModule.getDB()
+
+    expect(dbModule.getInitialUserVersion()).toBe(4)
+
+    // v5 narrows stars CHECK + drops captures (and capture star);
+    // v7 promotes session star to pin.
+    const pins = db.prepare(`SELECT session_uuid FROM pins ORDER BY session_uuid`).all()
+    expect(pins).toEqual([{ session_uuid: 'old-sess' }])
+
+    exerciseDb(db, 'v4-newuser')
+    db.close()
+  })
+
+  it('old user (v6 with starred session): star migrates to pin and DB is functional', async () => {
+    const spoolDir = makeTempDir('spool-smoke-v6-')
+    seedV6(join(spoolDir, 'spool.db'))
+
+    const dbModule = await loadGetDB(spoolDir)
+    const db = dbModule.getDB()
+
+    expect(dbModule.getInitialUserVersion()).toBe(6)
+    expect((db.pragma('user_version') as Array<{ user_version: number }>)[0].user_version)
+      .toBeGreaterThanOrEqual(7)
+
+    const pins = db.prepare(`SELECT session_uuid, pinned_at FROM pins`).all()
+    expect(pins).toEqual([{ session_uuid: 'v6-sess', pinned_at: '2026-04-15 09:00:00' }])
+
+    exerciseDb(db, 'v6-newuser')
+    db.close()
+  })
+
+  it('idempotent: re-opening an already-migrated DB is a no-op', async () => {
+    const spoolDir = makeTempDir('spool-smoke-reopen-')
+
+    // First open: fresh install, runs full migration
+    const m1 = await loadGetDB(spoolDir)
+    const db1 = m1.getDB()
+    db1.close()
+
+    // Second open: DB exists, already at head, should not re-run anything
+    vi.resetModules()
+    const m2 = await loadGetDB(spoolDir)
+    const db2 = m2.getDB()
+    expect(m2.wasNewDb()).toBe(false)
+    expect(m2.getInitialUserVersion()).toBeGreaterThanOrEqual(7)
+    expect((db2.pragma('user_version') as Array<{ user_version: number }>)[0].user_version)
+      .toBeGreaterThanOrEqual(7)
+    exerciseDb(db2, 'reopen-uuid')
+    db2.close()
+  })
+})

--- a/packages/core/src/db/migration-v1-v3.test.ts
+++ b/packages/core/src/db/migration-v1-v3.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import Database from 'better-sqlite3'
+import { runMigrations } from './db.js'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+/**
+ * Build a DB with the FULL pre-v1 schema (connector_sync_state without
+ * last_error_at, captures with connectorId in metadata, captures_fts populated
+ * but FTS empty so v2 has work to do, capture_connectors empty so v3 has work
+ * to do) and exercise the entire v1→v7 path.
+ *
+ * Goal: prove v1-v3 don't break the chain on a populated historical DB.
+ * v5 erases all connector tables, so end-state is the post-v7 schema. The
+ * value is in *getting there* without throwing.
+ */
+function seedV0(dbPath: string) {
+  const seed = new Database(dbPath)
+  seed.pragma('journal_mode = WAL')
+  seed.pragma('foreign_keys = ON')
+  seed.exec(`
+    CREATE TABLE sources (
+      id INTEGER PRIMARY KEY, name TEXT NOT NULL UNIQUE,
+      base_path TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    INSERT INTO sources (name, base_path) VALUES
+      ('claude','~/.claude/projects'),('codex','~/.codex/sessions'),
+      ('gemini','~/.gemini/tmp'),('connector','<plugin>');
+
+    CREATE TABLE projects (
+      id INTEGER PRIMARY KEY, source_id INTEGER NOT NULL REFERENCES sources(id),
+      slug TEXT NOT NULL, display_path TEXT NOT NULL, display_name TEXT NOT NULL,
+      last_synced TEXT, UNIQUE (source_id, slug)
+    );
+    CREATE TABLE sessions (
+      id INTEGER PRIMARY KEY, project_id INTEGER NOT NULL REFERENCES projects(id),
+      source_id INTEGER NOT NULL REFERENCES sources(id),
+      session_uuid TEXT NOT NULL UNIQUE, file_path TEXT NOT NULL UNIQUE,
+      title TEXT, started_at TEXT NOT NULL, ended_at TEXT NOT NULL,
+      message_count INTEGER NOT NULL DEFAULT 0, has_tool_use INTEGER NOT NULL DEFAULT 0,
+      cwd TEXT, model TEXT, raw_file_mtime TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE messages (
+      id INTEGER PRIMARY KEY, session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      source_id INTEGER NOT NULL REFERENCES sources(id),
+      msg_uuid TEXT, parent_uuid TEXT, role TEXT NOT NULL,
+      content_text TEXT NOT NULL DEFAULT '', timestamp TEXT NOT NULL,
+      is_sidechain INTEGER NOT NULL DEFAULT 0, tool_names TEXT NOT NULL DEFAULT '[]',
+      seq INTEGER NOT NULL
+    );
+    CREATE VIRTUAL TABLE messages_fts USING fts5(content_text, content='messages', content_rowid='id');
+    CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(content_text, content='messages', content_rowid='id', tokenize='trigram');
+    CREATE TABLE sync_log (
+      id INTEGER PRIMARY KEY, source_id INTEGER NOT NULL REFERENCES sources(id),
+      file_path TEXT NOT NULL, status TEXT NOT NULL, message TEXT,
+      synced_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE session_search (
+      session_id INTEGER PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+      title TEXT NOT NULL DEFAULT '', user_text TEXT NOT NULL DEFAULT '',
+      assistant_text TEXT NOT NULL DEFAULT '',
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE VIRTUAL TABLE session_search_fts USING fts5(title, user_text, assistant_text, content='session_search', content_rowid='session_id');
+    CREATE VIRTUAL TABLE session_search_fts_trigram USING fts5(title, user_text, assistant_text, content='session_search', content_rowid='session_id', tokenize='trigram');
+
+    CREATE TABLE captures (
+      id INTEGER PRIMARY KEY, source_id INTEGER NOT NULL REFERENCES sources(id),
+      capture_uuid TEXT NOT NULL UNIQUE, url TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT '', content_text TEXT NOT NULL DEFAULT '',
+      author TEXT, platform TEXT NOT NULL, platform_id TEXT,
+      content_type TEXT NOT NULL DEFAULT 'page', thumbnail_url TEXT,
+      metadata TEXT NOT NULL DEFAULT '{}', captured_at TEXT NOT NULL,
+      indexed_at TEXT NOT NULL DEFAULT (datetime('now')), raw_json TEXT
+    );
+    CREATE VIRTUAL TABLE captures_fts USING fts5(title, content_text, content='captures', content_rowid='id');
+    CREATE VIRTUAL TABLE captures_fts_trigram USING fts5(title, content_text, content='captures', content_rowid='id', tokenize='trigram');
+    CREATE TABLE capture_connectors (
+      capture_id INTEGER NOT NULL REFERENCES captures(id) ON DELETE CASCADE,
+      connector_id TEXT NOT NULL, PRIMARY KEY (capture_id, connector_id)
+    );
+    -- Pre-v1: connector_sync_state WITHOUT last_error_at
+    CREATE TABLE connector_sync_state (
+      connector_id TEXT PRIMARY KEY, head_cursor TEXT, head_item_id TEXT,
+      tail_cursor TEXT, tail_complete INTEGER NOT NULL DEFAULT 0,
+      last_forward_sync_at TEXT, last_backfill_sync_at TEXT,
+      total_synced INTEGER NOT NULL DEFAULT 0, consecutive_errors INTEGER NOT NULL DEFAULT 0,
+      enabled INTEGER NOT NULL DEFAULT 1, config_json TEXT NOT NULL DEFAULT '{}'
+    );
+  `)
+
+  seed.prepare("INSERT INTO projects (source_id, slug, display_path, display_name) VALUES (1, 'p', '/p', 'p')").run()
+  seed.prepare(`
+    INSERT INTO sessions (project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count)
+    VALUES (1, 1, 'sess-uuid', '/fake/sess.jsonl', 'A session', '2026-01-01T00:00:00Z', '2026-01-01T00:01:00Z', 1)
+  `).run()
+  // v3 fixture: capture with connectorId in metadata (not yet promoted to capture_connectors)
+  seed.prepare(`
+    INSERT INTO captures (source_id, capture_uuid, url, title, content_text, platform, captured_at, metadata)
+    VALUES (4, 'cap-uuid', 'https://x.com/1', 'A tweet', 'tweet text', 'twitter', '2026-01-01T00:00:00Z',
+      '{"connectorId":"twitter-bookmarks","extra":"keep"}')
+  `).run()
+  seed.prepare("INSERT INTO connector_sync_state (connector_id) VALUES ('twitter-bookmarks')").run()
+
+  seed.pragma('user_version = 0')
+  seed.close()
+}
+
+describe('migration v1-v3 (historical connector path)', () => {
+  it('migrates a populated v0 DB cleanly to head without errors', () => {
+    const dir = makeTempDir('spool-v0-mig-')
+    const dbPath = join(dir, 'spool.db')
+    seedV0(dbPath)
+
+    const db = new Database(dbPath)
+    db.pragma('journal_mode = WAL')
+    db.pragma('foreign_keys = ON')
+    expect(() => runMigrations(db)).not.toThrow()
+
+    // Reached head version
+    const v = (db.pragma('user_version') as Array<{ user_version: number }>)[0].user_version
+    expect(v).toBeGreaterThanOrEqual(7)
+
+    // Connector tables erased by v5
+    const tableNames = new Set(
+      (db.prepare(`SELECT name FROM sqlite_master WHERE type='table'`).all() as { name: string }[])
+        .map(r => r.name),
+    )
+    expect(tableNames.has('captures')).toBe(false)
+    expect(tableNames.has('capture_connectors')).toBe(false)
+    expect(tableNames.has('connector_sync_state')).toBe(false)
+
+    // 'connector' source row dropped by v5
+    const sources = (db.prepare('SELECT name FROM sources').all() as { name: string }[]).map(s => s.name)
+    expect(sources.sort()).toEqual(['claude', 'codex', 'gemini'])
+
+    // Session preserved
+    const sess = db.prepare("SELECT session_uuid FROM sessions WHERE session_uuid='sess-uuid'").get() as { session_uuid: string }
+    expect(sess.session_uuid).toBe('sess-uuid')
+
+    db.close()
+  })
+
+  it('runs cleanly on a fresh DB where the historical connector tables never existed', () => {
+    // This is the post-v5 fresh-install path: runMigrations CREATEs the
+    // current schema (no captures/connector_sync_state), then walks v1-v7.
+    // v1-v3 must be no-ops without throwing.
+    const db = new Database(':memory:')
+    expect(() => runMigrations(db)).not.toThrow()
+
+    const v = (db.pragma('user_version') as Array<{ user_version: number }>)[0].user_version
+    expect(v).toBeGreaterThanOrEqual(7)
+
+    db.close()
+  })
+
+  it('does not leave behind connector tables on a fresh DB', () => {
+    const db = new Database(':memory:')
+    runMigrations(db)
+    const names = new Set(
+      (db.prepare(`SELECT name FROM sqlite_master WHERE type='table'`).all() as { name: string }[])
+        .map(r => r.name),
+    )
+    expect(names.has('captures')).toBe(false)
+    expect(names.has('captures_fts')).toBe(false)
+    expect(names.has('capture_connectors')).toBe(false)
+    expect(names.has('connector_sync_state')).toBe(false)
+    db.close()
+  })
+})

--- a/packages/core/src/db/migration-v4.test.ts
+++ b/packages/core/src/db/migration-v4.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import Database from 'better-sqlite3'
+import { runMigrations } from './db.js'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+/**
+ * Seed a v3 DB: post-v3 schema (connector tables present + last_error_at on
+ * connector_sync_state, no stars table yet). v4 should create the wide-CHECK
+ * stars table; v5 then narrows it; v7 drops it for pins.
+ */
+function seedV3(dbPath: string) {
+  const seed = new Database(dbPath)
+  seed.pragma('journal_mode = WAL')
+  seed.pragma('foreign_keys = ON')
+  seed.exec(`
+    CREATE TABLE sources (
+      id INTEGER PRIMARY KEY, name TEXT NOT NULL UNIQUE,
+      base_path TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    INSERT INTO sources (name, base_path) VALUES
+      ('claude','~/.claude/projects'),('codex','~/.codex/sessions'),
+      ('gemini','~/.gemini/tmp'),('connector','<plugin>');
+
+    CREATE TABLE projects (
+      id INTEGER PRIMARY KEY, source_id INTEGER NOT NULL REFERENCES sources(id),
+      slug TEXT NOT NULL, display_path TEXT NOT NULL, display_name TEXT NOT NULL,
+      last_synced TEXT, UNIQUE (source_id, slug)
+    );
+    CREATE TABLE sessions (
+      id INTEGER PRIMARY KEY, project_id INTEGER NOT NULL REFERENCES projects(id),
+      source_id INTEGER NOT NULL REFERENCES sources(id),
+      session_uuid TEXT NOT NULL UNIQUE, file_path TEXT NOT NULL UNIQUE,
+      title TEXT, started_at TEXT NOT NULL, ended_at TEXT NOT NULL,
+      message_count INTEGER NOT NULL DEFAULT 0, has_tool_use INTEGER NOT NULL DEFAULT 0,
+      cwd TEXT, model TEXT, raw_file_mtime TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE messages (
+      id INTEGER PRIMARY KEY, session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      source_id INTEGER NOT NULL REFERENCES sources(id),
+      msg_uuid TEXT, parent_uuid TEXT, role TEXT NOT NULL,
+      content_text TEXT NOT NULL DEFAULT '', timestamp TEXT NOT NULL,
+      is_sidechain INTEGER NOT NULL DEFAULT 0, tool_names TEXT NOT NULL DEFAULT '[]',
+      seq INTEGER NOT NULL
+    );
+    CREATE VIRTUAL TABLE messages_fts USING fts5(content_text, content='messages', content_rowid='id');
+    CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(content_text, content='messages', content_rowid='id', tokenize='trigram');
+    CREATE TABLE sync_log (
+      id INTEGER PRIMARY KEY, source_id INTEGER NOT NULL REFERENCES sources(id),
+      file_path TEXT NOT NULL, status TEXT NOT NULL, message TEXT,
+      synced_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE session_search (
+      session_id INTEGER PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+      title TEXT NOT NULL DEFAULT '', user_text TEXT NOT NULL DEFAULT '',
+      assistant_text TEXT NOT NULL DEFAULT '',
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE VIRTUAL TABLE session_search_fts USING fts5(title, user_text, assistant_text, content='session_search', content_rowid='session_id');
+    CREATE VIRTUAL TABLE session_search_fts_trigram USING fts5(title, user_text, assistant_text, content='session_search', content_rowid='session_id', tokenize='trigram');
+
+    CREATE TABLE captures (
+      id INTEGER PRIMARY KEY, source_id INTEGER NOT NULL REFERENCES sources(id),
+      capture_uuid TEXT NOT NULL UNIQUE, url TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT '', content_text TEXT NOT NULL DEFAULT '',
+      author TEXT, platform TEXT NOT NULL, platform_id TEXT,
+      content_type TEXT NOT NULL DEFAULT 'page', thumbnail_url TEXT,
+      metadata TEXT NOT NULL DEFAULT '{}', captured_at TEXT NOT NULL,
+      indexed_at TEXT NOT NULL DEFAULT (datetime('now')), raw_json TEXT
+    );
+    CREATE VIRTUAL TABLE captures_fts USING fts5(title, content_text, content='captures', content_rowid='id');
+    CREATE VIRTUAL TABLE captures_fts_trigram USING fts5(title, content_text, content='captures', content_rowid='id', tokenize='trigram');
+    CREATE TABLE capture_connectors (
+      capture_id INTEGER NOT NULL REFERENCES captures(id) ON DELETE CASCADE,
+      connector_id TEXT NOT NULL, PRIMARY KEY (capture_id, connector_id)
+    );
+    CREATE TABLE connector_sync_state (
+      connector_id TEXT PRIMARY KEY, head_cursor TEXT, head_item_id TEXT,
+      tail_cursor TEXT, tail_complete INTEGER NOT NULL DEFAULT 0,
+      last_forward_sync_at TEXT, last_backfill_sync_at TEXT,
+      total_synced INTEGER NOT NULL DEFAULT 0, consecutive_errors INTEGER NOT NULL DEFAULT 0,
+      enabled INTEGER NOT NULL DEFAULT 1, config_json TEXT NOT NULL DEFAULT '{}',
+      last_error_at TEXT
+    );
+  `)
+
+  seed.prepare("INSERT INTO projects (source_id, slug, display_path, display_name) VALUES (1, 'p', '/p', 'p')").run()
+  seed.prepare(`
+    INSERT INTO sessions (project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count)
+    VALUES (1, 1, 'sess-uuid', '/fake/sess.jsonl', 'A session', '2026-01-01T00:00:00Z', '2026-01-01T00:01:00Z', 1)
+  `).run()
+
+  seed.pragma('user_version = 3')
+  seed.close()
+}
+
+describe('migration v4 (introduce stars table)', () => {
+  it('migrates a v3 DB cleanly through head: stars created in v4, dropped in v7, pins empty', () => {
+    const dir = makeTempDir('spool-v4-mig-')
+    const dbPath = join(dir, 'spool.db')
+    seedV3(dbPath)
+
+    const db = new Database(dbPath)
+    db.pragma('journal_mode = WAL')
+    db.pragma('foreign_keys = ON')
+    expect(() => runMigrations(db)).not.toThrow()
+
+    const v = (db.pragma('user_version') as Array<{ user_version: number }>)[0].user_version
+    expect(v).toBeGreaterThanOrEqual(7)
+
+    const tables = new Set(
+      (db.prepare(`SELECT name FROM sqlite_master WHERE type='table'`).all() as { name: string }[])
+        .map(r => r.name),
+    )
+    expect(tables.has('stars')).toBe(false) // dropped by v7
+    expect(tables.has('pins')).toBe(true)
+
+    // v3 DB had no stars to migrate, so pins is empty
+    const pinCount = db.prepare('SELECT COUNT(*) AS c FROM pins').get() as { c: number }
+    expect(pinCount.c).toBe(0)
+
+    db.close()
+  })
+
+  it('drops a legacy session_stars table if one is present', () => {
+    // v4 migration begins with `DROP TABLE IF EXISTS session_stars`. Verify
+    // that pre-v4 schemas which somehow had a session_stars table get cleaned up.
+    const dir = makeTempDir('spool-v4-legacy-')
+    const dbPath = join(dir, 'spool.db')
+    seedV3(dbPath)
+
+    const seed = new Database(dbPath)
+    seed.exec(`CREATE TABLE session_stars (session_uuid TEXT PRIMARY KEY)`)
+    seed.prepare(`INSERT INTO session_stars (session_uuid) VALUES ('legacy-uuid')`).run()
+    seed.close()
+
+    const db = new Database(dbPath)
+    runMigrations(db)
+
+    const tables = new Set(
+      (db.prepare(`SELECT name FROM sqlite_master WHERE type='table'`).all() as { name: string }[])
+        .map(r => r.name),
+    )
+    expect(tables.has('session_stars')).toBe(false)
+
+    db.close()
+  })
+})


### PR DESCRIPTION
## What

Hardens `packages/core/src/db/db.ts` migration runner along three axes:

1. **Replace `try { ... } catch {}` in v1–v3 with explicit `tableExists()` guards.** v1–v3 all operate on tables (`connector_sync_state`, `captures`, `capture_connectors`, `captures_fts*`) that v5 dropped. The historical try/catch was there so fresh installs on the post-v5 schema wouldn't crash when those tables don't exist. The new guards express that intent explicitly and stop swallowing genuine errors.

2. **Add `backupBeforeDestructive(db, fromVersion)` and wire it into v5 and v7.** Both migrations drop tables irreversibly (v5 drops `captures` + connector tables; v7 drops `stars`). The helper takes a `VACUUM INTO` snapshot to `<dbDir>/backups/spool-pre-v{N+1}-<ts>.db` before each destructive step. Skips in-memory DBs and empty / no-data DBs so fresh-install paths don't write spurious backups.

3. **Comprehensive migration tests.** Coverage went from 79 → 95 tests. New files:
   - `migration-v1-v3.test.ts` — characterizes the v0→head historical path on a populated old schema, plus fresh-install no-op verification.
   - `migration-v4.test.ts` — exercises the v3→head path, including legacy `session_stars` cleanup.
   - `migration-backup.test.ts` — unit tests for the helper (file-backed, in-memory, empty DB, version encoding) and integration assertions that v5 actually writes a backup file.
   - `migration-smoke.test.ts` — end-to-end smoke through `getDB()` simulating fresh install, v0/v4/v6 starting users, and idempotent re-open. Each test inserts a session + pin + queries pins back to prove the migrated DB is functionally usable, not just structurally correct.

## Why

The migration runner has accumulated 7 versions worth of surface area, with v6 and v7 landing in the past week (project identity, stars→pins). Two specific risks were worth addressing now rather than waiting for a real incident:

- **Silent catches mask failures.** If a v1–v3 ALTER/INSERT broke for a non-table-missing reason (e.g., disk full, locked DB, partial corruption), the migration would still bump `user_version` and move on. The guard pattern is both clearer in intent and lets real errors propagate.
- **Destructive migrations had no recovery path.** v5 drops captures data (users were redirected to Spool Daemon) and v7 drops the stars table. If anything goes wrong post-merge — a future-version migration discovers it needed that data, a user wants their old data back — there's nothing to fall back to. `VACUUM INTO` is cheap, atomic at the SQLite level, and skipped on no-data DBs so the cost is zero for fresh installs.

A heavier framework migration (Drizzle migrations, Umzug, etc.) was considered and rejected: it would split schema between the fresh-install `CREATE TABLE` block and per-version migration files (drift risk), and add packaging complexity for a single-user local SQLite store. The targeted fixes here address the actual failure modes without buying a framework.

## How it connects

Touches only `packages/core/src/db/db.ts` plus new test files in the same directory. No public API changes beyond exporting `backupBeforeDestructive` for testing. The behavior change for end users is: a `backups/` directory may appear next to `spool.db` after a major version upgrade, and previously-silent v1–v3 errors would now surface (they have not surfaced in any reported issue, so this is purely a defensive change).

## Test plan

- [x] `pnpm -C packages/core test` → 95/95 pass (was 79)
- [x] `pnpm -C packages/core build` → clean typecheck
- [x] `pnpm -C packages/app build` → clean typecheck
- [x] Smoke covers: new user (fresh install), old user at v0 with full historical schema + connector data, old user at v4 with starred session + capture, old user at v6 with starred session, idempotent re-open of an already-migrated DB
- [x] Backup helper: file-backed populated DB writes valid SQLite snapshot; in-memory DB returns null; empty DB returns null; v5 and v7 produce distinct backup files