### PR TITLE
perf(app): memoize message bubbles + drop pin-toggle loading flash

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef, startTransition, useDeferredValue } from 'react'
+import { useEffect, useState, useCallback, useRef, memo, startTransition, useDeferredValue } from 'react'
 import type { FragmentResult, SearchResult, StatusInfo } from '@spool-lab/core'
 import { type SearchMode } from './components/SearchBar.js'
 import FragmentResults from './components/FragmentResults.js'
@@ -623,7 +623,7 @@ function ResumeToast({ command }: { command: string }) {
   )
 }
 
-function AgentSelector({ agents, activeAgent, onSelect }: {
+const AgentSelector = memo(function AgentSelector({ agents, activeAgent, onSelect }: {
   agents: AgentInfo[]
   activeAgent: string
   onSelect: (id: string) => void
@@ -669,5 +669,5 @@ function AgentSelector({ agents, activeAgent, onSelect }: {
       )}
     </div>
   )
-}
+})
 

--- a/packages/app/src/renderer/components/LibraryLanding.tsx
+++ b/packages/app/src/renderer/components/LibraryLanding.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import type { Session } from '@spool-lab/core'
 import SessionRow from './SessionRow.js'
 
@@ -20,7 +20,6 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId }: Props
 
   useEffect(() => {
     let cancelled = false
-    setRecentSessions(null)
     Promise.all([
       window.spool.listPinnedSessions(),
       window.spool.listSessions(200),
@@ -53,7 +52,10 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId }: Props
     setReloadKey(k => k + 1)
   }
 
-  const buckets = recentSessions ? bucketByDate(recentSessions) : []
+  const buckets = useMemo(
+    () => (recentSessions ? bucketByDate(recentSessions) : []),
+    [recentSessions],
+  )
   const totalSessions = (pinnedSessions.length) + (recentSessions?.length ?? 0)
 
   return (

--- a/packages/app/src/renderer/components/MessageBubble.tsx
+++ b/packages/app/src/renderer/components/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { memo, type ReactNode } from 'react'
 import type { Message } from '@spool-lab/core'
 
 export type FindRange = {
@@ -14,7 +14,7 @@ interface Props {
   onActiveMatchRef?: ((node: HTMLElement | null) => void) | undefined
 }
 
-export default function MessageBubble({
+function MessageBubble({
   message,
   findRanges = [],
   matchIndexOffset = 0,
@@ -113,3 +113,5 @@ function renderHighlightedText(
 function formatTime(iso: string): string {
   try { return new Date(iso).toLocaleTimeString() } catch { return '' }
 }
+
+export default memo(MessageBubble)

--- a/packages/app/src/renderer/components/ProjectView.tsx
+++ b/packages/app/src/renderer/components/ProjectView.tsx
@@ -33,6 +33,10 @@ export default function ProjectView({ identityKey, onOpenSession, onCopySessionI
   }, [identityKey])
 
   useEffect(() => {
+    setSessions(null)
+  }, [identityKey, sortOrder, activeSources])
+
+  useEffect(() => {
     let cancelled = false
     window.spool.listProjectGroups()
       .then(groups => {
@@ -45,7 +49,6 @@ export default function ProjectView({ identityKey, onOpenSession, onCopySessionI
 
   useEffect(() => {
     let cancelled = false
-    setSessions(null)
     const sourcesArray = Array.from(activeSources)
     const sharedOptions = {
       ...(sourcesArray.length > 0 ? { sources: sourcesArray } : {}),

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -40,12 +40,17 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
     let offset = 0
     const rangesByMessage = new Map<number, { ranges: FindRange[]; offset: number }>()
 
-    for (const message of messages) {
-      const ranges = normalizedFindQuery
-        ? getFindRanges(message.contentText || (message.role === 'system' ? '(summary)' : ''), normalizedFindQuery)
-        : []
-      rangesByMessage.set(message.id, { ranges, offset })
-      offset += ranges.length
+    if (normalizedFindQuery) {
+      for (const message of messages) {
+        const ranges = getFindRanges(
+          message.contentText || (message.role === 'system' ? '(summary)' : ''),
+          normalizedFindQuery,
+        )
+        if (ranges.length > 0) {
+          rangesByMessage.set(message.id, { ranges, offset })
+          offset += ranges.length
+        }
+      }
     }
 
     return {
@@ -341,7 +346,10 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
       {/* Messages */}
       <div className="flex-1 overflow-y-auto divide-y divide-warm-border/50 dark:divide-dark-border/50">
         {messages.map((msg) => {
-          const matchState = messageFindRanges.get(msg.id)
+          const matchState = showFindBar ? messageFindRanges.get(msg.id) : undefined
+          const containsActive = matchState != null
+            && activeMatchIndex >= matchState.offset
+            && activeMatchIndex < matchState.offset + matchState.ranges.length
 
           return (
           <div
@@ -355,10 +363,10 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
           >
             <MessageBubble
               message={msg}
-              findRanges={showFindBar ? matchState?.ranges : undefined}
+              findRanges={matchState?.ranges}
               matchIndexOffset={matchState?.offset}
-              activeMatchIndex={showFindBar ? activeMatchIndex : -1}
-              onActiveMatchRef={bindActiveFindMatch}
+              activeMatchIndex={containsActive ? activeMatchIndex : -1}
+              onActiveMatchRef={containsActive ? bindActiveFindMatch : undefined}
             />
           </div>
           )


### PR DESCRIPTION
## What

Three small renderer-only perf wins that sit on top of the recent library-first redesign. No IPC, sync, or DB code touched.

- `MessageBubble` is wrapped in `React.memo`. `SessionDetail`'s find-in-page memo no longer creates a Map entry for messages with zero matches, and the active match index + active-match ref are passed only to the bubble that contains the active match.
- `LibraryLanding` no longer resets `recentSessions` to `null` on the reload triggered by a pin toggle, and `bucketByDate` moves into `useMemo`.
- `ProjectView` splits the effect that resets `sessions` to `null` (real reloads: identity / sort / source filter) from the silent reload triggered by a pin toggle.
- `AgentSelector` is wrapped in `React.memo`.

## Why

After the library redesign shipped (#122–#128), three perf hotspots were visible without needing 100k-session libraries to reproduce:

1. **Find-in-page typed slowly on long sessions.** A session with 1k+ messages re-rendered every `MessageBubble` on every keystroke, because the `messageFindRanges` map produced a fresh `[]` ref for non-matching messages and `activeMatchIndex` + `onActiveMatchRef` were passed unchanged to all bubbles.
2. **Pin / unpin flashed the whole feed to "Loading…".** Both `LibraryLanding` and `ProjectView` set their list state to `null` inside the same effect that handled refetches, so the optimistic update was immediately erased and the user saw a flicker before the refetched data came back.
3. **`AgentSelector` re-rendered on every sync progress event.** `App` re-renders on every progress chunk during a sync; `AgentSelector` is mounted in the results header and the search overlay, and without memo its body ran each time.

## How it connects

- The MessageBubble change preserves the existing find/highlight contract: only the message that contains the active match receives a non-`-1` `activeMatchIndex` and the `bindActiveFindMatch` callback. Highlight color, scroll-to-active behavior, match counts, and `data-testid="session-find-active-match"` selectors are unchanged.
- The pin/unpin paths still end in a backend refetch — the optimistic state and the refetch result already match, so removing the `setRecentSessions(null)` / `setSessions(null)` lines just makes the reconciliation silent. Real reloads (identity / sort / source-filter changes in `ProjectView`) keep their loading state via a dedicated effect.
- The `AgentSelector` memo is a strict superset: agents/activeAgent/onSelect are all stable refs across App renders that don't actually change agent state, so the shallow compare holds.

## Test plan

- [x] `pnpm exec tsc -p packages/app/tsconfig.json --noEmit` clean
- [x] `pnpm --filter @spool/app exec vitest run src/` — 12/12 pass
- [x] Manual: long session find-in-page — typing feels responsive, ⌘← / ⌘→ navigates, active highlight tracks, match count correct
- [x] Manual: home feed pin → moves to PINNED with no Loading flash
- [x] Manual: home feed unpin → leaves PINNED and reappears in the right date bucket with no flash
- [x] Manual: project view pin/unpin — same, no flash
- [x] Manual: project view sort change / source filter / project switch — still flash to "Loading sessions…" (intended)
- [x] Manual: ⌘K agent dropdown opens, selects, persists
- [x] Manual: search → result → SessionDetail target highlight still flashes for 2s