### PR TITLE
perf(app): dedup sync-time status fetches + consolidate search refresh

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -179,19 +179,29 @@ export default function App() {
 
   useEffect(() => {
     if (!window.spool) return
-    window.spool.getStatus().then(setStatus).catch(console.error)
     window.spool.getRuntimeInfo?.().then(setRuntimeInfo).catch(console.error)
-  }, [syncStatus])
+  }, [])
+
+  useEffect(() => {
+    if (!window.spool) return
+    if (syncStatus && syncStatus.phase !== 'done') return
+    window.spool.getStatus().then(setStatus).catch(console.error)
+  }, [syncStatus?.phase])
 
   useEffect(() => {
     if (!window.spool) return () => {}
+    const scheduleSearchRefresh = () => {
+      if (!query.trim() || searchMode !== 'fast') return
+      if (syncRefreshTimer.current) clearTimeout(syncRefreshTimer.current)
+      syncRefreshTimer.current = setTimeout(() => {
+        syncRefreshTimer.current = null
+        doSearch(query)
+      }, 250)
+    }
     const offProgress = window.spool.onSyncProgress((e) => {
       setSyncStatus(e)
-      if (query.trim() && searchMode === 'fast' && (e.phase === 'syncing' || e.phase === 'indexing')) {
-        if (syncRefreshTimer.current) clearTimeout(syncRefreshTimer.current)
-        syncRefreshTimer.current = setTimeout(() => {
-          doSearch(query)
-        }, 250)
+      if (e.phase === 'syncing' || e.phase === 'indexing') {
+        scheduleSearchRefresh()
       }
       if (e.phase === 'done') {
         if (syncRefreshTimer.current) {
@@ -199,13 +209,12 @@ export default function App() {
           syncRefreshTimer.current = null
         }
         setTimeout(() => setSyncStatus(null), 3000)
-        window.spool.getStatus().then(setStatus).catch(console.error)
         if (query.trim() && searchMode === 'fast') doSearch(query)
       }
     })
     const offNew = window.spool.onNewSessions(() => {
       window.spool.getStatus().then(setStatus).catch(console.error)
-      if (query.trim() && searchMode === 'fast') doSearch(query)
+      scheduleSearchRefresh()
     })
     return () => { offProgress(); offNew() }
   }, [query, searchMode])
@@ -451,6 +460,7 @@ export default function App() {
         }}
         onOpenSearch={handleSearchOpen}
         syncStatus={syncStatus}
+        status={status}
         showSourceDots={sidebarShowSourceDots}
         showSessionCount={sidebarShowSessionCount}
         onSettingsClick={() => { setSettingsTab('general'); setShowSettings(true) }}

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -9,12 +9,13 @@ type Props = {
   onSelectHome?: () => void
   onOpenSearch?: () => void
   syncStatus?: { phase: string; count: number; total: number } | null
+  status?: StatusInfo | null
   onSettingsClick?: () => void
   showSourceDots?: boolean
   showSessionCount?: boolean
 }
 
-export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHome, onOpenSearch, syncStatus, onSettingsClick, showSourceDots = true, showSessionCount = true }: Props) {
+export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHome, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true }: Props) {
   const [groups, setGroups] = useState<ProjectGroup[] | null>(null)
   const [projectsOpen, setProjectsOpen] = useState(true)
 
@@ -24,7 +25,7 @@ export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHo
       .then(result => { if (!cancelled) setGroups(result) })
       .catch(() => { if (!cancelled) setGroups([]) })
     return () => { cancelled = true }
-  }, [syncStatus?.phase])
+  }, [status?.totalSessions])
 
   const visibleGroups = (groups ?? []).filter(g => g.sessionCount > 0)
   const projectGroups = visibleGroups.filter(g => g.identityKind !== 'loose')
@@ -113,6 +114,7 @@ export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHo
 
       <SidebarStatus
         syncStatus={syncStatus ?? null}
+        status={status ?? null}
         {...(onSettingsClick ? { onSettingsClick } : {})}
       />
     </aside>
@@ -121,18 +123,13 @@ export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHo
 
 function SidebarStatus({
   syncStatus,
+  status,
   onSettingsClick,
 }: {
   syncStatus: { phase: string; count: number; total: number } | null
+  status: StatusInfo | null
   onSettingsClick?: () => void
 }) {
-  const [status, setStatus] = useState<StatusInfo | null>(null)
-
-  useEffect(() => {
-    if (!window.spool) return
-    window.spool.getStatus().then(setStatus).catch(() => {})
-  }, [syncStatus])
-
   const text = getSyncStatusText(syncStatus, status)
   const isOk = !syncStatus || syncStatus.phase === 'done'
 


### PR DESCRIPTION
## What

Reduce the IPC traffic + React work triggered on every sync phase transition. Renderer + IPC orchestration only; no DB, sync engine, or main-process logic touched.

- App owns `status` and passes it down to `Sidebar`. `SidebarStatus` reads it from props instead of running its own `getStatus`.
- The App-level `getStatus` / `getRuntimeInfo` effect was keyed on the whole `syncStatus` object. `runtimeInfo` is now mount-only; `status` is re-fetched only when the sync phase reaches `done`.
- `Sidebar`'s `listProjectGroups` effect is now keyed on `status.totalSessions`, so the `project_groups_v` aggregation runs once on mount and once per sync that actually grows the session count.
- `onSyncProgress` and `onNewSessions` now share a single 250ms debounced search-refresh helper.

## Why

After the library redesign shipped (#122–#128), every sync phase change (`scanning` → `syncing` → `indexing` → `done`) triggered three independent IPC paths in the renderer:

1. App's `useEffect([syncStatus])` ran `getStatus` + `getRuntimeInfo`.
2. `Sidebar`'s `useEffect([syncStatus?.phase])` ran `listProjectGroups` — an aggregation view over the sessions table.
3. `SidebarStatus`'s own `useEffect([syncStatus])` ran `getStatus` again.

That's roughly 12 IPC round-trips per sync just to refresh status + project counts, of which two were duplicate `getStatus` calls and four were full `project_groups_v` aggregations. Separately, `onNewSessions` fired `doSearch` directly with no debounce, racing the debounced `onSyncProgress` refresh and stacking overlapping FTS queries when many session files landed at once.

## How it connects

- `SidebarStatus` was already rendering `getSyncStatusText(syncStatus, status)` — it just needed `status` from props instead of its own state. The rendered text (`"X sessions · 5m"` / `"Scanning…"` / `"Indexing N/M"` / `"Building index…"`) is unchanged.
- Keying `listProjectGroups` on `status.totalSessions` matches the actual signal: project rows can change only when the underlying session count changes, and `status` is now updated exactly when sync transitions to `done`. On mount, `status` starts `null` so the aggregation still runs once for the initial population.
- The shared `scheduleSearchRefresh` helper preserves the existing 250ms trailing-debounce semantics for `syncing` / `indexing` progress, and now extends them to `onNewSessions`. The immediate `doSearch(query)` on `phase === 'done'` is preserved so the user always sees the post-sync result without an extra 250ms wait.

## Trade-off

Project counts in the sidebar no longer climb mid-sync; they jump at `done`. The intermediate counts came from aggregating partial state, and the cost (one `project_groups_v` aggregation per phase boundary) outweighed the value of the animation. If progressive updates are wanted later, a `totalSessions`-bucketed throttle is the right shape — phase-keyed refetches were just the wrong signal.

## Test plan

- [x] `pnpm exec tsc -p packages/app/tsconfig.json --noEmit` clean
- [x] `pnpm --filter @spool/app exec vitest run src/` — 12/12 pass
- [x] Manual: cold start — sidebar populates with project rows + correct counts; bottom status shows ${'`'}N sessions · …${'`'}
- [x] Manual: trigger sync via DevTools `window.spool.syncNow()` — sidebar status text walks through Scanning → Indexing N/M → Building index → final count, and project rows refresh once at done
- [x] Manual: with a committed search query open, trigger a sync — results refresh smoothly during sync (no jitter from stacked refetches), and reflect final state at done
- [x] Manual: pin/unpin still silent (PR #130 behavior preserved)