### PR TITLE
fix(app): clarify sync progress label as file count

### DIFF
--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -164,7 +164,7 @@ function getSyncStatusText(
 ): string {
   if (syncStatus) {
     if (syncStatus.phase === 'scanning') return 'Scanning…'
-    if (syncStatus.phase === 'syncing') return `Indexing ${syncStatus.count}/${syncStatus.total}`
+    if (syncStatus.phase === 'syncing') return `Indexing ${syncStatus.count}/${syncStatus.total} files`
     if (syncStatus.phase === 'indexing') return 'Building index…'
     if (syncStatus.phase === 'done' && status) {
       return `${status.totalSessions} sessions · now`


### PR DESCRIPTION
## What

Change the sidebar sync status text during the ${'`'}syncing${'`'} phase from ${'`'}Indexing N/M${'`'} to ${'`'}Indexing N/M files${'`'}.

## Why

The numerator/denominator come from ${'`'}pendingFiles.length${'`'} in the syncer (count of session files whose mtime differs from the indexed mtime), but the label read as session count. The post-sync total then comes from a different query (${'`'}SELECT COUNT(*) FROM sessions${'`'}), so users saw "Indexing 540/616" mid-sync settle to "422 sessions · now" and assumed the indexer dropped sessions.

The two numbers are not comparable by design:

- One session file can update an existing session (no new row).
- One session file can yield no session (empty / unparseable / filtered).
- Multiple files from different sources can dedupe against the same conversation.

## How it connects

- Only the ${'`'}getSyncStatusText${'`'} branch for ${'`'}phase === 'syncing'${'`'} changes. Other phases (${'`'}Scanning…${'`'}, ${'`'}Building index…${'`'}, post-sync total) are unchanged.
- ${'`'}components/StatusBar.tsx${'`'} has a similar string but is no longer mounted anywhere; left untouched here, should be cleaned up as a separate dead-code removal.

## Test plan

- [x] ${'`'}pnpm exec tsc -p packages/app/tsconfig.json --noEmit${'`'} clean
- [x] ${'`'}pnpm --filter @spool/app exec vitest run src/${'`'} — 12/12 pass
- [x] e2e helper at ${'`'}helpers/launch.ts:69${'`'} still matches (regex looks for ${'`'}N sessions${'`'} after sync, not the in-flight label)
- [ ] Manual: trigger sync, confirm ${'`'}Indexing N/M files${'`'} during the syncing phase