### PR TITLE
feat(app): sort sidebar projects

### DIFF
--- a/packages/app/src/main/acp.ts
+++ b/packages/app/src/main/acp.ts
@@ -43,6 +43,8 @@ export interface AgentsConfig {
   sidebarShowSourceDots?: boolean
   /** Show session count in sidebar project rows (default: true) */
   sidebarShowSessionCount?: boolean
+  /** Sort order for the sidebar project list (default: 'recent') */
+  sidebarSortOrder?: 'recent' | 'name' | 'most_sessions'
   /** Custom agent definitions (extend beyond builtins) */
   customAgents?: Record<string, {
     name?: string

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -86,8 +86,8 @@ const searchCache = new SearchCache()
 function createWindow(): BrowserWindow {
   const win = new BrowserWindow({
     title: isDevMode ? 'Spool DEV' : 'Spool',
-    width: 1180,
-    height: 780,
+    width: 1080,
+    height: 740,
     minWidth: 800,
     minHeight: 520,
     backgroundColor: nativeTheme.shouldUseDarkColors ? '#141410' : '#FAFAF8',

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import type { FragmentResult, Session, Message, StatusInfo, SyncResult, SearchResult, ProjectGroup, ListSessionsByIdentityOptions } from '@spool-lab/core'
 import type { SearchSortOrder } from '../shared/searchSort.js'
+import type { SidebarSortOrder } from '../shared/sidebarSort.js'
 import type { ThemeEditorStateV1 } from '../renderer/theme/editorTypes.js'
 
 export interface AgentInfo {
@@ -23,6 +24,7 @@ export interface AgentsConfig {
   terminal?: string
   sidebarShowSourceDots?: boolean
   sidebarShowSessionCount?: boolean
+  sidebarSortOrder?: SidebarSortOrder
   customAgents?: Record<string, {
     name?: string
     bin: string

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -12,6 +12,7 @@ import LibraryLanding, { SearchTrigger } from './components/LibraryLanding.js'
 import SearchOverlay from './components/SearchOverlay.js'
 import { getSessionResumeCommandPrefix } from '../shared/resumeCommand.js'
 import { DEFAULT_SEARCH_SORT_ORDER, type SearchSortOrder } from '../shared/searchSort.js'
+import { DEFAULT_SIDEBAR_SORT_ORDER, type SidebarSortOrder } from '../shared/sidebarSort.js'
 import { defaultThemeEditorState, type ThemeEditorStateV1 } from './theme/editorTypes.js'
 import { applyEditorTheme } from './theme/applyEditorTheme.js'
 import { loadThemeEditorState, saveThemeEditorState } from './theme/persist.js'
@@ -70,6 +71,7 @@ export default function App() {
   const [defaultSearchSort, setDefaultSearchSort] = useState<SearchSortOrder>(DEFAULT_SEARCH_SORT_ORDER)
   const [sidebarShowSourceDots, setSidebarShowSourceDots] = useState(true)
   const [sidebarShowSessionCount, setSidebarShowSessionCount] = useState(true)
+  const [sidebarSortOrder, setSidebarSortOrder] = useState<SidebarSortOrder>(DEFAULT_SIDEBAR_SORT_ORDER)
   const [resumeToastCommand, setResumeToastCommand] = useState<string | null>(null)
   const [themeEditor, setThemeEditor] = useState<ThemeEditorStateV1>(() => defaultThemeEditorState())
   const themeHydrated = useRef(false)
@@ -133,6 +135,7 @@ export default function App() {
       setDefaultSearchSort(config.defaultSearchSort ?? DEFAULT_SEARCH_SORT_ORDER)
       setSidebarShowSourceDots(config.sidebarShowSourceDots ?? true)
       setSidebarShowSessionCount(config.sidebarShowSessionCount ?? true)
+      setSidebarSortOrder(config.sidebarSortOrder ?? DEFAULT_SIDEBAR_SORT_ORDER)
       const defaultId = config.defaultAgent && ready.find(a => a.id === config.defaultAgent)
         ? config.defaultAgent
         : ready[0]?.id
@@ -142,6 +145,17 @@ export default function App() {
 
   // Detect available ACP agents on mount
   useEffect(() => { refreshAgents() }, [])
+
+  const handleSidebarSortChange = useCallback(async (next: SidebarSortOrder) => {
+    setSidebarSortOrder(next)
+    if (!window.spool?.setAgentsConfig) return
+    try {
+      const config = await window.spool.getAgentsConfig()
+      await window.spool.setAgentsConfig({ ...config, sidebarSortOrder: next })
+    } catch (err) {
+      console.error(err)
+    }
+  }, [])
 
   useEffect(() => {
     return () => {
@@ -463,6 +477,8 @@ export default function App() {
         status={status}
         showSourceDots={sidebarShowSourceDots}
         showSessionCount={sidebarShowSessionCount}
+        sortOrder={sidebarSortOrder}
+        onSortOrderChange={handleSidebarSortChange}
         onSettingsClick={() => { setSettingsTab('general'); setShowSettings(true) }}
       />
       <div className="relative flex flex-col flex-1 min-w-0">

--- a/packages/app/src/renderer/components/LibraryLanding.tsx
+++ b/packages/app/src/renderer/components/LibraryLanding.tsx
@@ -69,7 +69,7 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId }: Props
         </p>
       </div>
 
-      <div className="flex-1 overflow-y-auto pb-12">
+      <div className="flex-1 overflow-y-auto pb-12 [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]">
         {recentSessions === null ? (
           <p className="px-6 py-6 text-sm text-warm-faint dark:text-dark-muted">Loading…</p>
         ) : totalSessions === 0 ? (

--- a/packages/app/src/renderer/components/ProjectView.tsx
+++ b/packages/app/src/renderer/components/ProjectView.tsx
@@ -212,7 +212,7 @@ export default function ProjectView({ identityKey, onOpenSession, onCopySessionI
 
       </div>
 
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]">
         {sessions === null ? (
           <div className="px-4 py-8 text-center text-sm text-warm-faint dark:text-dark-muted">
             Loading sessions…

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -344,7 +344,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
       />
 
       {/* Messages */}
-      <div className="flex-1 overflow-y-auto divide-y divide-warm-border/50 dark:divide-dark-border/50">
+      <div className="flex-1 overflow-y-auto divide-y divide-warm-border/50 dark:divide-dark-border/50 [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]">
         {messages.map((msg) => {
           const matchState = showFindBar ? messageFindRanges.get(msg.id) : undefined
           const containsActive = matchState != null

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -1,7 +1,13 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { ProjectGroup, SessionSource, StatusInfo } from '@spool-lab/core'
 import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
+import {
+  DEFAULT_SIDEBAR_SORT_ORDER,
+  SIDEBAR_SORT_OPTIONS,
+  type SidebarSortOrder,
+} from '../../shared/sidebarSort.js'
 import { SearchTrigger } from './LibraryLanding.js'
+import Menu from './Menu.js'
 
 type Props = {
   activeIdentityKey: string | null
@@ -13,9 +19,11 @@ type Props = {
   onSettingsClick?: () => void
   showSourceDots?: boolean
   showSessionCount?: boolean
+  sortOrder?: SidebarSortOrder
+  onSortOrderChange?: (next: SidebarSortOrder) => void
 }
 
-export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHome, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true }: Props) {
+export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHome, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true, sortOrder = DEFAULT_SIDEBAR_SORT_ORDER, onSortOrderChange }: Props) {
   const [groups, setGroups] = useState<ProjectGroup[] | null>(null)
   const [projectsOpen, setProjectsOpen] = useState(true)
 
@@ -28,7 +36,10 @@ export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHo
   }, [status?.totalSessions])
 
   const visibleGroups = (groups ?? []).filter(g => g.sessionCount > 0)
-  const projectGroups = visibleGroups.filter(g => g.identityKind !== 'loose')
+  const projectGroups = useMemo(
+    () => sortProjectGroups(visibleGroups.filter(g => g.identityKind !== 'loose'), sortOrder),
+    [visibleGroups, sortOrder],
+  )
   const looseGroup = visibleGroups.find(g => g.identityKind === 'loose')
 
   return (
@@ -54,27 +65,58 @@ export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHo
         </div>
       )}
 
-      <button
-        type="button"
-        data-testid="sidebar-projects-toggle"
-        aria-expanded={projectsOpen}
-        onClick={() => setProjectsOpen(open => !open)}
-        className="group mx-2 px-2 py-1 flex-none flex items-center gap-1 text-[10px] font-semibold tracking-[0.08em] text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text rounded-md select-none"
-      >
-        <span>PROJECTS</span>
-        <svg
-          width="9"
-          height="9"
-          viewBox="0 0 9 9"
-          fill="none"
-          aria-hidden="true"
-          className={`flex-none transition-all opacity-0 group-hover:opacity-100 ${projectsOpen ? 'rotate-90' : ''}`}
+      <div className="group mx-2 px-2 py-1 flex-none flex items-center gap-1">
+        <button
+          type="button"
+          data-testid="sidebar-projects-toggle"
+          aria-expanded={projectsOpen}
+          onClick={() => setProjectsOpen(open => !open)}
+          className="flex-1 flex items-center gap-1 text-left text-[10px] font-semibold tracking-[0.08em] text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text rounded-md select-none"
         >
-          <path d="M3 1.5L6 4.5L3 7.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      </button>
+          <span>PROJECTS</span>
+          <svg
+            width="9"
+            height="9"
+            viewBox="0 0 9 9"
+            fill="none"
+            aria-hidden="true"
+            className={`flex-none transition-all opacity-0 group-hover:opacity-100 ${projectsOpen ? 'rotate-90' : ''}`}
+          >
+            <path d="M3 1.5L6 4.5L3 7.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+        {onSortOrderChange && (
+          <Menu
+            align="right"
+            testId="sidebar-sort-menu"
+            trigger={({ open, toggle }) => (
+              <button
+                type="button"
+                data-testid="sidebar-sort-trigger"
+                onClick={toggle}
+                title="Sort projects"
+                aria-label="Sort projects"
+                aria-haspopup="menu"
+                aria-expanded={open}
+                className={`flex-none inline-flex items-center justify-end h-4 transition-opacity text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text ${
+                  open ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                }`}
+              >
+                <svg width="11" height="11" viewBox="0 0 11 11" fill="none" aria-hidden>
+                  <path d="M0.75 2.5h9.5M2 5.5h7M4 8.5h3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+                </svg>
+              </button>
+            )}
+            items={SIDEBAR_SORT_OPTIONS.map(option => ({
+              label: option.label,
+              active: sortOrder === option.value,
+              onSelect: () => onSortOrderChange(option.value),
+            }))}
+          />
+        )}
+      </div>
 
-      <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-3 scrollbar-none">
+      <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-3 scrollbar-none [mask-image:linear-gradient(to_bottom,black_calc(100%_-_20px),transparent)]">
         {projectsOpen && (
           groups === null ? (
             <SidebarSkeleton />
@@ -280,4 +322,30 @@ function SidebarSkeleton() {
       ))}
     </div>
   )
+}
+
+function sortProjectGroups(groups: ProjectGroup[], order: SidebarSortOrder): ProjectGroup[] {
+  const sorted = [...groups]
+  switch (order) {
+    case 'name':
+      sorted.sort((a, b) => a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' }))
+      return sorted
+    case 'most_sessions':
+      sorted.sort((a, b) => {
+        if (b.sessionCount !== a.sessionCount) return b.sessionCount - a.sessionCount
+        return compareLastSessionAtDesc(a, b)
+      })
+      return sorted
+    case 'recent':
+    default:
+      sorted.sort(compareLastSessionAtDesc)
+      return sorted
+  }
+}
+
+function compareLastSessionAtDesc(a: ProjectGroup, b: ProjectGroup): number {
+  if (!a.lastSessionAt && !b.lastSessionAt) return 0
+  if (!a.lastSessionAt) return 1
+  if (!b.lastSessionAt) return -1
+  return b.lastSessionAt.localeCompare(a.lastSessionAt)
 }

--- a/packages/app/src/shared/sidebarSort.ts
+++ b/packages/app/src/shared/sidebarSort.ts
@@ -1,0 +1,9 @@
+export type SidebarSortOrder = 'recent' | 'name' | 'most_sessions'
+
+export const DEFAULT_SIDEBAR_SORT_ORDER: SidebarSortOrder = 'recent'
+
+export const SIDEBAR_SORT_OPTIONS: Array<{ value: SidebarSortOrder; label: string }> = [
+  { value: 'recent', label: 'Recent activity' },
+  { value: 'name', label: 'Name (A–Z)' },
+  { value: 'most_sessions', label: 'Most sessions' },
+]


### PR DESCRIPTION
## What

Three changes that grew out of the same iteration on the library shell.

### 1. Sidebar project sort menu
Hover-revealed sort icon next to the **PROJECTS** label opens a small menu with:

- **Recent activity** (default) — `lastSessionAt DESC`
- **Name (A–Z)** — locale-aware, case-insensitive `localeCompare`
- **Most sessions** — `sessionCount DESC`, ties broken by recency

Selection persists on `AgentsConfig` (sits alongside the existing `sidebarShowSourceDots` / `sidebarShowSessionCount` flags) so it survives restarts. Sorting happens in JS over the existing `listProjectGroups` payload — no DB query or IPC contract changes. The Loose ("no-git") group stays pinned to the bottom regardless of order.

### 2. Scroll fade-out on main surfaces
A `mask-image: linear-gradient` over the last 20–24px on every scrollable list:

- Sidebar project list
- `LibraryLanding` feed
- `ProjectView` session list
- `SessionDetail` message list

Half-clipped rows at the scroll edge now read as "more below, keep scrolling" instead of "broken edge".

### 3. Default window 1180×780 → 1080×740
The library redesign had stretched the default further than DESIGN.md's "compact utility, ~960px" stance. Brings it back closer to spec. Min sizes (`800×520`) unchanged so users can still resize.

## Why

The sort menu is the gap most directly visible at scale: at hundreds of sessions across 30+ projects, recency is the only ordering and the tail of the list becomes unfindable without knowing roughly when something was last touched. Three options are enough — a symmetric fourth (`First started`) was considered and dropped because it has near-zero usage value at this granularity.

The fade-out and the window-size tweak fall out of the same observation: the sidebar (and main feed) at default size always shows N+½ rows, and there's no window height that fixes that for everyone (project counts vary, system DPI varies). Treating it as a visual-affordance problem — fade the edge — is robust across all sizes; treating it as a sizing problem only solves it for one specific row count. Pulling the default down rather than pushing it up matches the "compact utility" direction in `DESIGN.md`.

## How it connects

- The sort options mirror parts of the `ProjectView` sort menu (`Recent` / `Most messages` / `Title`) but at project granularity. Wording and the ✓-active pattern match the existing `Menu` component.
- Sort persistence is wired through the existing `getAgentsConfig` / `setAgentsConfig` IPC. App owns local state and writes through on change; no new IPC handler.
- The Sidebar consumes `status` from props and now also `sortOrder` / `onSortOrderChange`, so the App is the single source of truth for sidebar pref state.
- The `[mask-image:linear-gradient(to_bottom,...)]` Tailwind arbitrary value works directly in Chromium (no `-webkit-` prefix needed).

## Test plan

- [x] tsc clean
- [x] vitest 12/12 pass
- [x] Manual: hover PROJECTS, sort icon appears, all three options change order
- [x] Manual: choose Most sessions, restart — selection restored
- [x] Manual: Loose group stays at the bottom across all sort orders
- [x] Manual: bottom edge of all four scroll surfaces fades out
- [x] Manual: default-launched window is 1080×740, sidebar still scrolls projects
