### PR TITLE
feat(landing): library-first home redesign

### DIFF
--- a/packages/landing/pages/global.css
+++ b/packages/landing/pages/global.css
@@ -126,9 +126,11 @@ code, .mono {
 
 /* ── shared container ── */
 .wrap {
+  width: 100%;
   max-width: 1180px;
   margin: 0 auto;
   padding: 0 40px;
+  box-sizing: border-box;
 }
 @media (max-width: 700px) { .wrap { padding: 0 20px; } }
 

--- a/packages/landing/pages/home.css
+++ b/packages/landing/pages/home.css
@@ -1,6 +1,12 @@
-/* Homepage v2 — editorial / archive layout. Port of main 1e1c7d9. */
+/* Homepage v3 — library-first redesign. The hero IS the app shell.
+   Note: this file is bundled into every page (see layout.tsx). Selectors
+   below the SHARED block are scoped under `.home-page`; selectors above are
+   the legacy primitives that the Daemon / Blog pages depend on. Don't
+   rename or remove anything in the SHARED block without grepping the
+   other page files first. */
 
-/* ─── hero ─── */
+/* ═══════════════════ SHARED — used by /daemon and other pages ═══════════════════ */
+
 .hero {
   position: relative;
   padding: 90px 0 48px;
@@ -135,179 +141,68 @@
   border-radius: 50%;
 }
 
-/* ─── right column: specimen card ─── */
-.specimen {
-  position: relative;
-  padding: 18px 18px 16px;
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  background: var(--surface);
-  box-shadow: 0 1px 0 rgba(0,0,0,0.02), 0 20px 48px -28px rgba(40,20,0,0.25);
-  overflow: hidden;
+/* Bare <section> primitive — daemon's `.sect` blocks rely on this */
+section {
+  padding: 112px 0;
+  border-bottom: 1px solid var(--border);
 }
-[data-theme="dark"] .specimen,
-:root:not([data-theme="light"]) .specimen {
-  box-shadow: 0 1px 0 rgba(255,255,255,0.02), 0 24px 60px -28px rgba(0,0,0,0.6);
-}
-@media (prefers-color-scheme: light) {
-  :root:not([data-theme="dark"]) .specimen {
-    box-shadow: 0 1px 0 rgba(0,0,0,0.02), 0 20px 48px -28px rgba(40,20,0,0.25);
-  }
-}
-.specimen::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background-image: radial-gradient(rgba(var(--paper)/0.04) 1px, transparent 1px);
-  background-size: 4px 4px;
-  mix-blend-mode: multiply;
-  opacity: 0.5;
-}
-[data-theme="dark"] .specimen::before { mix-blend-mode: screen; opacity: 0.35; }
+section:last-of-type { border-bottom: none; }
 
-.specimen .s-top {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 14px;
-}
-.specimen .tl { display: flex; gap: 6px; }
-.specimen .tl span {
-  width: 10px; height: 10px; border-radius: 50%;
-  background: var(--border2);
-}
-.specimen .tl span:nth-child(2) { opacity: 0.7; }
-.specimen .tl span:nth-child(3) { opacity: 0.5; }
-.specimen .s-title-bar {
-  margin-left: 8px;
-  font-size: 11px;
-  color: var(--faint);
-  font-family: 'Geist Mono', monospace;
-  letter-spacing: 0.04em;
-}
-
-.s-bar {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 9999px;
-  margin-bottom: 14px;
-  box-shadow: inset 0 0 0 1px transparent, 0 0 0 3px var(--accent-weak);
-}
-.s-bar svg.search { width: 16px; height: 16px; color: var(--accent); flex-shrink: 0; }
-.s-bar .typed {
-  flex: 1;
-  font-size: 13.5px;
-  color: var(--text);
-  white-space: nowrap;
-  overflow: hidden;
-  min-width: 0;
-}
-.s-bar .caret {
-  display: inline-block;
-  width: 1px; height: 14px;
-  background: var(--accent);
-  vertical-align: -2px;
-  margin-left: 1px;
-  animation: blink 1.05s step-end infinite;
-}
-@keyframes blink { 50% { opacity: 0; } }
-.s-bar .mode {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px 8px;
-  font-size: 10.5px;
-  font-weight: 500;
-  background: var(--surface2);
-  border-radius: 9999px;
-  color: var(--muted);
-  font-family: 'Geist Mono', monospace;
-}
-.s-bar .mode.active {
-  background: var(--accent-bg);
-  color: var(--accent);
-}
-
-.s-results { display: flex; flex-direction: column; gap: 0; }
-.s-row {
-  padding: 9px 10px;
-  border-radius: 8px;
+/* Section head primitive (kicker | title+sub) — daemon uses this */
+.s-head {
   display: grid;
-  grid-template-columns: 18px 1fr auto;
-  gap: 10px;
-  align-items: center;
-  transition: background 120ms;
-  cursor: default;
+  grid-template-columns: 120px 1fr;
+  gap: 40px;
+  margin-bottom: 56px;
+  align-items: baseline;
 }
-.s-row:hover { background: var(--surface2); }
-.s-row.sel { background: var(--accent-bg); }
-.s-row .dot {
-  width: 7px; height: 7px; border-radius: 50%;
-  justify-self: center;
+@media (max-width: 700px) { .s-head { grid-template-columns: 1fr; gap: 16px; } }
+.s-num {
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--accent);
+  text-transform: uppercase;
 }
-.s-row .rtxt {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
+.s-num .line {
+  display: inline-block;
+  width: 24px; height: 1px;
+  background: var(--accent);
+  vertical-align: 4px;
+  margin-right: 8px;
 }
-.s-row .rtitle {
-  font-size: 12.5px;
+.s-title {
+  font-size: clamp(28px, 4vw, 44px);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1.05;
+  text-wrap: balance;
+}
+.s-title em {
+  font-style: italic;
   font-weight: 500;
-  color: var(--text);
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
+  color: var(--muted);
+  font-family: 'Geist', sans-serif;
 }
-.s-row .rtitle mark {
+.s-title .accent { color: var(--accent); }
+.s-sub {
+  margin-top: 16px;
+  font-size: 15.5px;
+  color: var(--muted);
+  max-width: 58ch;
+  line-height: 1.6;
+  text-wrap: pretty;
+}
+.s-sub strong { color: var(--text); font-weight: 500; }
+.s-sub code {
   background: var(--accent-weak);
   color: var(--accent);
-  padding: 0 2px;
-  border-radius: 3px;
-}
-.s-row .rmeta {
-  font-size: 10.5px;
-  font-family: 'Geist Mono', monospace;
-  color: var(--faint);
-  letter-spacing: 0.02em;
-}
-.s-row .rkey {
-  font-size: 10px;
-  font-family: 'Geist Mono', monospace;
-  color: var(--faint);
-  padding: 2px 5px;
-  border: 1px solid var(--border);
+  padding: 1px 5px;
   border-radius: 4px;
-}
-.s-row.sel .rkey { border-color: var(--accent); color: var(--accent); }
-
-.s-foot {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-top: 12px;
-  padding: 8px 10px 2px;
-  border-top: 1px solid var(--border);
-  font-size: 10.5px;
-  font-family: 'Geist Mono', monospace;
-  color: var(--faint);
-  letter-spacing: 0.03em;
-}
-.s-foot .statusdot {
-  width: 6px; height: 6px; border-radius: 50%;
-  background: #4ADE80;
-  box-shadow: 0 0 6px #4ADE8077;
-  margin-right: 6px;
-  display: inline-block;
-  vertical-align: 1px;
+  font-size: 13.5px;
 }
 
-/* ─── logo ticker strip ─── */
+/* Logo ticker strip — daemon uses this */
 .ticker {
   margin-top: 72px;
   padding: 18px 0;
@@ -363,35 +258,474 @@
   to   { transform: translateX(-50%); }
 }
 
-/* ─── section scaffolding ─── */
-section {
-  padding: 112px 0;
-  border-bottom: 1px solid var(--border);
-}
-section:last-of-type { border-bottom: none; }
+/* ═══════════════════ HOME — library-first homepage only ═══════════════════ */
 
-.s-head {
-  display: grid;
-  grid-template-columns: 120px 1fr;
-  gap: 40px;
-  margin-bottom: 56px;
-  align-items: baseline;
+/* ─────────────────────────────────────────────────────────────────
+   Hero — full app-shell render
+   ───────────────────────────────────────────────────────────────── */
+
+.home-hero {
+  padding: 64px 0 80px;
 }
-@media (max-width: 700px) { .s-head { grid-template-columns: 1fr; gap: 16px; } }
-.s-num {
+
+/* ─── Entrance animations (Linear-style) ─── */
+@keyframes hhRise {
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes hhRiseLg {
+  from { opacity: 0; transform: translateY(28px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.home-hero .hh-meta,
+.home-hero .hh-h1,
+.home-hero .hh-lede,
+.home-hero .hh-cta,
+.home-hero .hh-window {
+  opacity: 0;
+  animation: hhRise 700ms cubic-bezier(0.2, 0.7, 0.2, 1) forwards;
+}
+.home-hero .hh-meta   { animation-delay: 80ms; }
+.home-hero .hh-h1     { animation-delay: 180ms; }
+.home-hero .hh-lede   { animation-delay: 320ms; }
+.home-hero .hh-cta    { animation-delay: 460ms; }
+.home-hero .hh-window { animation: hhRiseLg 900ms cubic-bezier(0.2, 0.7, 0.2, 1) forwards; animation-delay: 620ms; }
+
+/* Sections fade in when scrolled into view */
+.reveal {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 700ms cubic-bezier(0.2, 0.7, 0.2, 1),
+              transform 700ms cubic-bezier(0.2, 0.7, 0.2, 1);
+  will-change: opacity, transform;
+}
+.reveal.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-hero .hh-meta,
+  .home-hero .hh-h1,
+  .home-hero .hh-lede,
+  .home-hero .hh-cta,
+  .home-hero .hh-window,
+  .reveal {
+    opacity: 1;
+    transform: none;
+    animation: none;
+    transition: none;
+  }
+}
+
+/* Eyebrow line above the title */
+.hh-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0 0 28px 0;
   font-family: 'Geist Mono', monospace;
   font-size: 11px;
-  letter-spacing: 0.14em;
-  color: var(--accent);
+  font-weight: 500;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
+  color: var(--muted);
 }
-.s-num .line {
+.hh-meta .pulse {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: #4ADE80;
+}
+.hh-meta .ver { color: var(--text); font-weight: 600; }
+.hh-meta .dot {
+  width: 3px; height: 3px; border-radius: 50%;
+  background: var(--faint);
+}
+
+/* App window — fills wrap content width, left-aligned to match section heads above.
+   Subtle bottom mask fades the window into the page background so it reads as
+   "scrolling continues here" rather than a hard rectangular boundary. */
+.hh-window {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 30px 80px -20px rgba(0,0,0,0.18);
+  -webkit-mask-image: linear-gradient(180deg, #000 0%, #000 78%, rgba(0,0,0,0.55) 100%);
+          mask-image: linear-gradient(180deg, #000 0%, #000 78%, rgba(0,0,0,0.55) 100%);
+}
+[data-theme="dark"] .hh-window,
+:root:not([data-theme="light"]) .hh-window {
+  box-shadow: 0 30px 80px -20px rgba(0,0,0,0.5);
+}
+
+.hh-titlebar {
+  height: 38px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 0 14px;
+}
+.hh-traffic { display: flex; gap: 8px; }
+.hh-traffic span {
+  width: 12px; height: 12px; border-radius: 50%;
+  box-shadow: inset 0 0 0 0.5px rgba(0,0,0,0.15);
+}
+.hh-traffic .r { background: #FF5F57; }
+.hh-traffic .y { background: #FEBC2E; }
+.hh-traffic .g { background: #28C840; }
+.hh-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: -0.02em;
+}
+.hh-title .a { color: var(--accent); }
+
+.hh-body {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+}
+@media (max-width: 720px) {
+  .hh-body { grid-template-columns: 1fr; min-height: 0; }
+  .hh-side { display: none; }
+}
+
+/* ────── Sidebar (dimmed) ────── */
+
+.hh-side {
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  padding: 26px 12px 0;
+}
+
+.hh-wm {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  padding: 0 8px 22px;
+  color: var(--text);
+}
+.hh-wm .a { color: var(--accent); }
+
+.hh-search {
+  display: flex; align-items: center; gap: 9px;
+  background: var(--bg);
+  border: 1px solid var(--border2);
+  border-radius: 7px;
+  padding: 8px 11px;
+  margin-bottom: 22px;
+  color: var(--faint);
+  font-size: 12.5px;
+  transition: border-color 120ms;
+}
+.hh-search:hover { border-color: var(--accent); }
+.hh-search svg { flex-shrink: 0; }
+.hh-search .ph { color: var(--faint); flex: 1; }
+.hh-search .typed {
+  flex: 1;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: clip;
+  min-width: 0;
+}
+.hh-search .typed .ph { color: var(--faint); }
+.hh-search .caret {
   display: inline-block;
-  width: 24px; height: 1px;
+  width: 1px;
+  height: 12px;
   background: var(--accent);
-  vertical-align: 4px;
-  margin-right: 8px;
+  vertical-align: -2px;
+  margin-left: 1px;
+  animation: caretBlink 1.05s step-end infinite;
 }
+@keyframes caretBlink { 50% { opacity: 0; } }
+.hh-search .kbd {
+  font-family: 'Geist Mono', monospace;
+  font-size: 10.5px;
+  background: var(--surface2);
+  padding: 2px 6px;
+  border-radius: 3.5px;
+  color: var(--muted);
+}
+
+.hh-lbl {
+  display: flex; justify-content: space-between; align-items: center;
+  font-size: 10px; font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0 8px;
+  margin-bottom: 6px;
+}
+.hh-lbl .sort {
+  font-size: 11px; font-weight: 400;
+  color: var(--faint);
+  letter-spacing: 0; text-transform: none;
+}
+
+.hh-pj {
+  display: grid;
+  grid-template-columns: 14px 1fr auto auto;
+  align-items: center;
+  gap: 9px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 80ms;
+}
+.hh-pj svg { color: var(--faint); }
+.hh-pj:hover { background: var(--surface2); }
+.hh-pj.is-active { background: var(--surface2); font-weight: 500; }
+.hh-pj.is-active svg { color: var(--text); }
+
+.hh-pj .nm {
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.hh-pj .dots { display: flex; gap: 3px; }
+.hh-pj .dots .d { width: 5px; height: 5px; border-radius: 50%; }
+.hh-pj .cnt {
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.hh-pj.is-loose .nm { color: var(--muted); }
+
+.hh-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 10px 8px;
+  opacity: 0.5;
+}
+
+.hh-foot {
+  margin-top: auto;
+  border-top: 1px solid var(--border);
+  padding: 12px 10px;
+  font-size: 11px;
+  color: var(--muted);
+  display: flex; align-items: center; gap: 8px;
+  font-family: 'Geist Mono', monospace;
+}
+.hh-foot .live { width: 6px; height: 6px; background: #4ADE80; border-radius: 50%; }
+.hh-foot strong { color: var(--text); font-weight: 600; }
+
+/* ────── Main pane (hero copy + feed) ────── */
+
+.hh-main {
+  padding: 26px 36px 24px;
+  background: var(--bg);
+  overflow: hidden;
+  min-width: 0;
+}
+@media (max-width: 720px) {
+  .hh-main { padding: 24px 20px 20px; }
+}
+
+.hh-app-h {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  margin: 0 0 6px;
+  color: var(--text);
+}
+.hh-app-sub {
+  font-size: 13px;
+  color: var(--muted);
+  margin-bottom: 18px;
+}
+
+.hh-h1 {
+  font-size: clamp(44px, 7vw, 76px);
+  font-weight: 700;
+  letter-spacing: -0.045em;
+  line-height: 1.0;
+  margin: 0 0 24px;
+  max-width: 760px;
+  color: var(--text);
+}
+.hh-h1 em {
+  font-style: italic;
+  font-weight: 500;
+  font-family: 'Geist', sans-serif;
+  color: var(--muted);
+}
+.hh-h1 .accent { color: var(--accent); font-style: normal; }
+
+.hh-lede {
+  font-size: 17px;
+  line-height: 1.55;
+  color: var(--muted);
+  max-width: 640px;
+  margin: 0 0 32px;
+}
+.hh-lede strong { color: var(--text); font-weight: 500; }
+
+.hh-cta {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 56px;
+  flex-wrap: wrap;
+}
+
+.hh-install {
+  background: var(--surface);
+  border: 1px solid var(--border2);
+  border-radius: 8px;
+  padding: 11px 14px;
+  font-family: 'Geist Mono', monospace;
+  font-size: 12.5px;
+  color: var(--text);
+  display: flex;
+  gap: 11px;
+  align-items: center;
+  cursor: pointer;
+  transition: border-color 120ms, background 120ms;
+}
+.hh-install code { background: transparent; padding: 0; color: inherit; }
+.hh-install:hover { border-color: var(--accent); background: var(--surface2); }
+.hh-install .tick { color: var(--accent); font-weight: 600; }
+.hh-install .copy { color: var(--faint); display: inline-flex; transition: color 120ms; }
+.hh-install:hover .copy { color: var(--accent); }
+.hh-install.is-copied { border-color: var(--accent); }
+.hh-install.is-copied .copy { color: var(--accent); }
+
+.hh-btn {
+  border: 1px solid var(--border2);
+  background: transparent;
+  color: var(--text);
+  padding: 11px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: border-color 120ms, color 120ms, background 120ms;
+}
+.hh-btn-p {
+  background: var(--text);
+  color: var(--bg);
+  border-color: var(--text);
+  font-weight: 600;
+}
+.hh-btn-p:hover { opacity: 0.9; }
+.hh-btn-g:hover { border-color: var(--accent); color: var(--accent); }
+
+/* ────── Feed inside hero ────── */
+
+.hh-feed { /* full opacity — the window is the product demo */ }
+
+.hh-seg {
+  display: flex; align-items: center; gap: 12px;
+  margin: 4px 0 12px;
+}
+.hh-seg-2 { margin-top: 28px; }
+.hh-seg .nm {
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.hh-seg .ct {
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px; font-weight: 500;
+  color: var(--faint);
+}
+.hh-seg .ln { flex: 1; height: 1px; background: var(--border); }
+
+.hh-row {
+  display: grid;
+  grid-template-columns: 70px 1fr auto;
+  align-items: center;
+  gap: 14px;
+  padding: 11px 6px;
+  border-bottom: 1px solid var(--border);
+  border-radius: 6px;
+}
+.hh-row:last-child { border-bottom: 0; }
+
+.hh-bd {
+  justify-self: start;
+  font-family: 'Geist Mono', monospace;
+  font-size: 10.5px;
+  font-weight: 600;
+  padding: 4px 9px;
+  border-radius: 4px;
+  letter-spacing: 0.02em;
+}
+.hh-bd-claude { background: color-mix(in srgb, var(--src-claude) 16%, transparent); color: var(--src-claude); }
+.hh-bd-codex  { background: color-mix(in srgb, var(--src-codex)  16%, transparent); color: var(--src-codex); }
+.hh-bd-gemini { background: color-mix(in srgb, var(--src-gemini) 16%, transparent); color: var(--src-gemini); }
+
+.hh-row .bod { min-width: 0; }
+.hh-row .ttl {
+  font-size: 14px; font-weight: 500;
+  color: var(--text);
+  line-height: 1.35;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.hh-row .mt {
+  font-size: 11px;
+  color: var(--muted);
+  font-family: 'Geist Mono', monospace;
+  margin-top: 4px;
+}
+.hh-row .mt .dim { color: var(--faint); }
+
+.hh-pin {
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   Pillar sections (Browse / Pin / Search)
+   ───────────────────────────────────────────────────────────────── */
+
+.home-page section {
+  padding: 128px 0;
+  border-bottom: none;
+}
+.home-page .home-hero { padding-top: 56px; padding-bottom: 96px; border-bottom: none; }
+@media (max-width: 700px) {
+  .home-page section { padding: 88px 0; }
+}
+
+/* Home-only editorial section head — overrides the shared 2-col primitive */
+.home-page .s-head.s-head-edit {
+  display: block;
+  grid-template-columns: none;
+  gap: 0;
+  margin-bottom: 56px;
+  max-width: 760px;
+}
+
+.s-kick {
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  line-height: 1;
+  margin-bottom: 18px;
+}
+.s-kick-dot { display: none; }
+
 .s-title {
   font-size: clamp(28px, 4vw, 44px);
   font-weight: 600;
@@ -406,6 +740,19 @@ section:last-of-type { border-bottom: none; }
   font-family: 'Geist', sans-serif;
 }
 .s-title .accent { color: var(--accent); }
+.s-title .kbd-h {
+  font-family: 'Geist Mono', monospace;
+  font-weight: 500;
+  font-size: 0.78em;
+  vertical-align: 0.06em;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 2px 8px;
+  margin-right: 4px;
+  letter-spacing: 0;
+}
+
 .s-sub {
   margin-top: 16px;
   font-size: 15.5px;
@@ -414,6 +761,7 @@ section:last-of-type { border-bottom: none; }
   line-height: 1.6;
   text-wrap: pretty;
 }
+.s-sub strong { color: var(--text); font-weight: 500; }
 .s-sub code {
   background: var(--accent-weak);
   color: var(--accent);
@@ -422,108 +770,734 @@ section:last-of-type { border-bottom: none; }
   font-size: 13.5px;
 }
 
-/* ─── query gallery ─── */
-.queries {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 14px;
-}
-@media (max-width: 800px) { .queries { grid-template-columns: 1fr; } }
-
-.qcard {
-  padding: 20px 22px 18px;
-  background: var(--surface);
+/* Specimen window shared by pillar sections */
+.spec-win {
+  background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 20px 50px -22px rgba(0,0,0,0.18);
+}
+[data-theme="dark"] .spec-win,
+:root:not([data-theme="light"]) .spec-win {
+  box-shadow: 0 20px 50px -22px rgba(0,0,0,0.45);
+}
+.spec-tb {
+  height: 32px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 0 12px;
+}
+.spec-traffic { display: flex; gap: 6px; }
+.spec-traffic span {
+  width: 9px; height: 9px; border-radius: 50%;
+}
+.spec-traffic .r { background: #FF5F57; }
+.spec-traffic .y { background: #FEBC2E; }
+.spec-traffic .g { background: #28C840; }
+.spec-title {
+  font-family: 'Geist Mono', monospace;
+  font-size: 10.5px;
+  color: var(--faint);
+  letter-spacing: 0.04em;
+}
+.spec-body {
+  padding: 18px 22px 22px;
+  background: var(--bg);
+}
+.spec-win.is-dim .spec-body {
+  background: color-mix(in srgb, var(--text) 8%, var(--bg));
+}
+
+/* Pillar layout: title-spec stacked (full-width specimens) */
+.pillar { }
+.pillar-spec { margin-top: 8px; }
+
+/* ─── Browse — multi-source unification diagram ─── */
+.bd {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 0.85fr);
+  gap: 28px;
+  align-items: center;
+  padding: 36px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+@media (max-width: 900px) {
+  .bd { grid-template-columns: 1fr; gap: 20px; }
+  .bd-arrow { transform: rotate(90deg); justify-self: center; }
+}
+
+.bd-sources {
   display: flex;
   flex-direction: column;
   gap: 14px;
-  transition: border-color 120ms, transform 180ms;
 }
-.qcard:hover {
-  border-color: var(--border2);
-  transform: translateY(-1px);
+.bd-src {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
 }
-.qcard .qhead {
+.bd-src-head {
   display: flex;
   align-items: center;
-  gap: 9px;
-  padding-bottom: 10px;
-  border-bottom: 1px dashed var(--border);
+  gap: 10px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
 }
-.qcard .qhead svg {
-  width: 13px; height: 13px;
-  color: var(--accent);
-  flex-shrink: 0;
-}
-.qcard .qhead .qtxt {
+.bd-src-path {
   font-family: 'Geist Mono', monospace;
-  font-size: 12.5px;
+  font-size: 11.5px;
   color: var(--text);
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  flex: 1;
-  min-width: 0;
 }
-.qcard .qhead .qkey {
+.bd-src-files {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  color: var(--muted);
+  padding-left: 22px;
+  border-left: 1px dashed var(--border2);
+}
+.bd-src-more { color: var(--faint); font-style: italic; }
+
+.bd-src-soon {
+  border-style: dashed;
+  background: transparent;
+}
+.bd-src-soon .bd-src-head { margin-bottom: 0; }
+.bd-src-soon .bd-src-path { color: var(--muted); }
+.bd-soon-badge {
+  font-family: 'Geist Mono', monospace;
+  font-size: 10.5px;
+  font-weight: 600;
+  padding: 4px 9px;
+  border-radius: 3px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: var(--accent-weak);
+  color: var(--accent);
+}
+
+.bd-arrow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  color: var(--accent);
+}
+.bd-arrow-lbl {
   font-family: 'Geist Mono', monospace;
   font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.bd-out {
+  background: var(--surface);
+  border: 1px solid var(--accent);
+  border-radius: 12px;
+  padding: 22px 24px;
+  position: relative;
+}
+.bd-out::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  border-radius: 12px;
+  pointer-events: none;
+  opacity: 0.4;
+}
+.bd-out-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.bd-out-head svg { color: var(--accent); }
+.bd-out-name {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+.bd-out-meta {
+  margin-left: auto;
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  color: var(--muted);
+}
+.bd-out-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 12px;
+}
+.bd-out-stat {
+  display: grid;
+  grid-template-columns: 8px auto 1fr;
+  align-items: baseline;
+  gap: 10px;
+}
+.bd-stat-dot { width: 8px; height: 8px; border-radius: 50%; align-self: center; }
+.bd-stat-num {
+  font-family: 'Geist Mono', monospace;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+.bd-stat-lbl {
+  font-family: 'Geist', sans-serif;
+  font-size: 13px;
+  color: var(--muted);
+}
+.bd-out-foot {
+  font-family: 'Geist', sans-serif;
+  font-size: 12px;
+  color: var(--muted);
+}
+.bd-out-foot code {
+  font-family: 'Geist Mono', monospace;
+  font-size: 11.5px;
+  color: var(--accent);
+  background: var(--accent-weak);
   padding: 2px 6px;
-  border: 1px solid var(--border2);
   border-radius: 4px;
+}
+
+/* ─── Pin — pinboard collage ─── */
+.pb {
+  position: relative;
+  padding: 60px 36px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 36px 32px;
+  background: var(--surface);
+  overflow: hidden;
+}
+.pb-cork {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 25% 30%, color-mix(in srgb, var(--text) 4%, transparent) 0.5px, transparent 0.5px),
+    radial-gradient(circle at 65% 70%, color-mix(in srgb, var(--text) 4%, transparent) 0.5px, transparent 0.5px);
+  background-size: 14px 14px, 18px 18px;
+  pointer-events: none;
+  opacity: 0.55;
+}
+@media (max-width: 700px) {
+  .pb { grid-template-columns: 1fr; padding: 40px 20px; gap: 28px; }
+}
+
+.pb-card {
+  position: relative;
+  background: var(--bg);
+  border: 1px solid var(--border2);
+  border-radius: 8px;
+  padding: 22px 22px 18px;
+  box-shadow: 0 14px 30px -12px rgba(0,0,0,0.18);
+  transition: transform 200ms ease;
+  z-index: 1;
+}
+[data-theme="dark"] .pb-card,
+:root:not([data-theme="light"]) .pb-card {
+  box-shadow: 0 14px 30px -12px rgba(0,0,0,0.5);
+}
+.pb-card:hover { transform: rotate(0) !important; z-index: 2; }
+.pb-card .hh-pin {
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  transform: translateX(-50%) rotate(-8deg);
+  width: 22px;
+  height: 22px;
+  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.25));
+}
+.pb-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 4px 0 10px;
+  flex-wrap: wrap;
+}
+.pb-card-pj {
+  font-family: 'Geist Mono', monospace;
+  font-size: 12px;
+  color: var(--muted);
+}
+.pb-card-date {
+  margin-left: auto;
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
   color: var(--faint);
 }
-.qcard .qhead .qkey.ai {
+.pb-card-title {
+  font-size: 14.5px;
+  font-weight: 500;
+  color: var(--text);
+  line-height: 1.35;
+  margin-bottom: 12px;
+  font-family: 'Geist Mono', monospace;
+}
+.pb-card-note {
+  font-size: 13px;
+  color: var(--muted);
+  font-style: italic;
+  line-height: 1.5;
+  padding-top: 10px;
+  border-top: 1px dashed var(--border);
+}
+
+/* Project view specimen */
+.ps-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+.ps-h {
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+.ps-meta {
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  color: var(--muted);
+}
+.ps-spacer { flex: 1; }
+.ps-chip {
+  font-family: 'Geist Mono', monospace;
+  font-size: 10.5px;
+  padding: 3px 9px;
+  border: 1px solid var(--border2);
+  border-radius: 999px;
+  color: var(--muted);
+}
+.ps-chip.on {
   background: var(--accent-bg);
   color: var(--accent);
   border-color: var(--accent);
 }
-.qres {
+.ps-sort {
+  font-family: 'Geist', sans-serif;
+  font-size: 12px;
+  color: var(--faint);
+}
+
+.ps-h2 {
   display: flex;
-  gap: 10px;
-  align-items: flex-start;
-  padding: 2px 0;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 4px;
 }
-.qres .qdot {
-  width: 7px; height: 7px; border-radius: 50%;
-  margin-top: 7px;
-  flex-shrink: 0;
+.ps-h2 > span:first-child {
+  font-size: 17px; font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--text);
 }
-.qres .qbody { display: flex; flex-direction: column; gap: 3px; min-width: 0; flex: 1; }
-.qres .qtitle {
-  font-size: 13px;
+
+.ps-rows { display: flex; flex-direction: column; }
+.ps-row {
+  display: grid;
+  grid-template-columns: 70px 1fr auto;
+  align-items: center;
+  gap: 14px;
+  padding: 11px 6px;
+  border-bottom: 1px solid var(--border);
+}
+.ps-row:last-child { border-bottom: 0; }
+.ps-row .bod { min-width: 0; }
+.ps-row .ttl {
+  font-size: 14px;
   font-weight: 500;
   color: var(--text);
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  line-height: 1.35;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.qres .qtitle.ai {
+.ps-row .mt {
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 4px;
+}
+.ps-seg {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 12px 6px 8px;
+}
+.ps-seg-2 { margin-top: 8px; padding-top: 18px; border-top: 1px solid var(--border); }
+.ps-seg .nm {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.ps-seg .ct {
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  color: var(--faint);
+}
+
+/* ⌘K overlay specimen — popup floating over a heavily dimmed shell */
+.cmdk-stage {
+  position: relative;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  padding: 56px 56px 64px;
+  min-height: 560px;
+  box-shadow: 0 20px 50px -22px rgba(0,0,0,0.18);
+}
+[data-theme="dark"] .cmdk-stage,
+:root:not([data-theme="light"]) .cmdk-stage {
+  box-shadow: 0 20px 50px -22px rgba(0,0,0,0.45);
+}
+@media (max-width: 700px) {
+  .cmdk-stage { padding: 32px 16px 40px; min-height: 480px; }
+}
+
+/* ghost shell behind the popup, very dim */
+.cmdk-bg {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  opacity: 0.22;
+  pointer-events: none;
+}
+.cmdk-bg-side {
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  padding: 22px 12px;
+}
+.cmdk-bg-wm {
+  height: 18px; width: 70px;
+  background: var(--text); border-radius: 3px;
+  margin-bottom: 18px;
+}
+.cmdk-bg-search {
+  height: 30px;
+  background: var(--bg);
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  margin-bottom: 18px;
+}
+.cmdk-bg-lbl {
+  height: 8px; width: 60px;
+  background: var(--muted); opacity: 0.4;
+  border-radius: 2px; margin: 0 6px 10px;
+}
+.cmdk-bg-pj {
+  height: 22px; border-radius: 5px; margin-bottom: 4px;
+  background: var(--surface);
+}
+.cmdk-bg-pj:first-of-type { background: var(--surface2); }
+.cmdk-bg-main {
+  padding: 22px 36px;
+}
+.cmdk-bg-h {
+  height: 22px; width: 220px;
+  background: var(--text); border-radius: 4px;
+  margin-bottom: 8px;
+}
+.cmdk-bg-sub {
+  height: 10px; width: 320px;
+  background: var(--muted); opacity: 0.5;
+  border-radius: 3px; margin-bottom: 26px;
+}
+.cmdk-bg-row {
+  height: 44px; border-bottom: 1px solid var(--border);
+  margin-bottom: 6px;
+}
+
+/* The popup itself */
+.cmdk-pop {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border2);
+  border-radius: 12px;
+  max-width: 720px;
+  margin: 0 auto;
+  box-shadow: 0 30px 60px -20px rgba(0,0,0,0.45),
+              0 8px 20px -6px rgba(0,0,0,0.25);
+  overflow: hidden;
+}
+
+.cmdk-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+.cmdk-bar > svg { color: var(--accent); flex-shrink: 0; }
+.cmdk-mode svg { display: block; }
+.cmdk-q {
+  flex: 1;
+  font-size: 15px;
+  color: var(--text);
   font-family: 'Geist', sans-serif;
-  white-space: normal;
-  line-height: 1.5;
-  font-size: 12.5px;
 }
-.qres .qtitle mark {
-  background: var(--accent-weak);
+.cmdk-modes {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.cmdk-mode {
+  width: 28px; height: 28px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--faint);
+  background: transparent;
+}
+.cmdk-mode.on {
+  background: var(--accent);
+  color: #fff;
+}
+
+.cmdk-scope {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.cmdk-scope-lbl {
+  font-family: 'Geist Mono', monospace;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+.cmdk-chip {
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  padding: 3px 10px;
+  border: 1px solid var(--border2);
+  border-radius: 999px;
+  color: var(--muted);
+}
+.cmdk-chip.on {
+  border-color: var(--accent);
   color: var(--accent);
-  padding: 0 2px;
-  border-radius: 3px;
 }
-.qres .qmeta {
+
+.cmdk-results {
+  display: flex;
+  flex-direction: column;
+}
+.cmdk-row {
+  display: grid;
+  grid-template-columns: 56px auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 18px;
+  border-bottom: 1px solid var(--border);
+  font-family: 'Geist Mono', monospace;
+}
+.cmdk-row:last-child { border-bottom: 0; }
+.cmdk-row:first-child { background: var(--accent-weak); }
+.cmdk-pj {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted);
+}
+.cmdk-ttl {
+  font-size: 12.5px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cmdk-ttl mark {
+  background: transparent;
+  color: var(--accent);
+  font-weight: 600;
+  padding: 0;
+}
+.cmdk-date {
+  font-size: 11px;
+  color: var(--faint);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.cmdk-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 18px;
+  border-top: 1px solid var(--border);
+  background: color-mix(in srgb, var(--text) 4%, var(--surface));
+}
+.cmdk-foot-l {
+  font-family: 'Geist', sans-serif;
+  font-size: 12px;
+  color: var(--muted);
+}
+.cmdk-foot-r {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  color: var(--muted);
+}
+.cmdk-kbd {
+  font-family: 'Geist Mono', monospace;
+  font-size: 10.5px;
+  padding: 2px 6px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+}
+
+/* Search overlay specimen (legacy — kept for safety, no longer used) */
+.ps-overlay {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.ps-ovbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  box-shadow: 0 0 0 3px var(--accent-weak);
+  flex-wrap: wrap;
+}
+.ps-ovbar svg { color: var(--accent); flex-shrink: 0; }
+.ps-typed {
+  flex: 1;
+  font-size: 13.5px;
+  color: var(--text);
+  min-width: 120px;
+}
+.ps-scope {
+  font-family: 'Geist Mono', monospace;
+  font-size: 10.5px;
+  padding: 3px 9px;
+  background: var(--surface2);
+  color: var(--muted);
+  border-radius: 999px;
+}
+.ps-mode-wrap {
+  display: inline-flex;
+  background: var(--surface2);
+  border-radius: 999px;
+  padding: 2px;
+}
+.ps-mode {
+  font-family: 'Geist Mono', monospace;
+  font-size: 10.5px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  color: var(--muted);
+}
+.ps-mode.on {
+  background: var(--bg);
+  color: var(--accent);
+  font-weight: 600;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+}
+.ps-agent {
   font-family: 'Geist Mono', monospace;
   font-size: 10.5px;
   color: var(--faint);
-  letter-spacing: 0.02em;
-}
-.qres .qsrc {
-  font-family: 'Geist Mono', monospace;
-  font-size: 9.5px;
-  padding: 1px 5px;
-  border-radius: 3px;
-  font-weight: 500;
-  flex-shrink: 0;
-  margin-top: 4px;
 }
 
-/* ─── agent block ─── */
+.ps-ai-card {
+  background: var(--accent-bg);
+  border-left: 3px solid var(--accent);
+  border-radius: 0 8px 8px 0;
+  padding: 14px 18px;
+}
+.ps-ai-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.ps-ai-tag {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+}
+.ps-ai-chip {
+  font-family: 'Geist Mono', monospace;
+  font-size: 10px;
+  padding: 2px 8px;
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  color: var(--accent);
+  letter-spacing: 0.02em;
+}
+.ps-ai-body {
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--text);
+  margin-bottom: 12px;
+}
+.ps-ai-body em {
+  font-family: 'Geist Mono', monospace;
+  font-style: normal;
+  font-size: 12.5px;
+  color: var(--accent);
+}
+.ps-ai-frags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.ps-frag {
+  font-family: 'Geist Mono', monospace;
+  font-size: 10.5px;
+  padding: 3px 9px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--muted);
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   Agent block (kept from previous design, lightly adapted)
+   ───────────────────────────────────────────────────────────────── */
+
 .agent {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -598,74 +1572,56 @@ section:last-of-type { border-bottom: none; }
   border-radius: 0 4px 4px 0;
 }
 
-/* ─── sources ledger ─── */
-.sources-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0;
-  border-top: 1px solid var(--border);
-  border-left: 1px solid var(--border);
-}
-@media (max-width: 900px) { .sources-grid { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 560px) { .sources-grid { grid-template-columns: 1fr; } }
-.src-cell {
-  border-right: 1px solid var(--border);
+/* ─────────────────────────────────────────────────────────────────
+   Daemon callout band
+   ───────────────────────────────────────────────────────────────── */
+
+.daemon-cta {
+  padding: 56px 0;
   border-bottom: 1px solid var(--border);
-  padding: 20px 22px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-height: 118px;
-  transition: background 80ms;
-  position: relative;
 }
-.src-cell:hover { background: var(--surface); }
-.src-cell .topline {
+.dc-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
+  gap: 32px;
+  padding: 28px 32px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  flex-wrap: wrap;
 }
-.src-cell .srcname {
+.dc-text { flex: 1; min-width: 280px; }
+.dc-eyebrow {
+  font-family: 'Geist Mono', monospace;
+  font-size: 10.5px;
   font-weight: 500;
-  font-size: 14px;
-}
-.src-cell .srcname .swatch {
-  display: inline-block;
-  width: 7px; height: 7px;
-  border-radius: 50%;
-  margin-right: 8px;
-  vertical-align: 2px;
-}
-.src-cell .srckind {
-  font-family: 'Geist Mono', monospace;
-  font-size: 9.5px;
-  color: var(--faint);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-.src-cell .srcmeta {
-  margin-top: auto;
-  font-family: 'Geist Mono', monospace;
-  font-size: 11px;
+  letter-spacing: 0.14em;
   color: var(--muted);
-  display: flex;
-  align-items: center;
-  gap: 10px;
+  text-transform: uppercase;
+  margin-bottom: 10px;
 }
-.src-cell .srcmeta .count { color: var(--text); font-weight: 500; }
-.src-cell.add {
-  background: transparent;
-  color: var(--faint);
+.dc-text h3 {
+  font-size: clamp(18px, 2.4vw, 22px);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.35;
+  color: var(--text);
+  text-wrap: balance;
+  max-width: 56ch;
 }
-.src-cell.add .plus {
-  font-size: 22px; line-height: 1;
+.dc-text h3 em {
+  font-style: italic;
+  font-weight: 500;
   color: var(--accent);
-  font-weight: 300;
+  font-family: 'Geist', sans-serif;
 }
-.src-cell.add:hover { color: var(--text); }
+.dc-btn { white-space: nowrap; }
 
-/* ─── principles strip ─── */
+/* ─────────────────────────────────────────────────────────────────
+   Principles strip
+   ───────────────────────────────────────────────────────────────── */
+
 .principles {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -673,6 +1629,7 @@ section:last-of-type { border-bottom: none; }
 }
 @media (max-width: 900px) { .principles { grid-template-columns: repeat(2, 1fr); } }
 @media (max-width: 520px) { .principles { grid-template-columns: 1fr; } }
+
 .principle {
   padding-top: 16px;
   border-top: 1px solid var(--text);
@@ -706,7 +1663,10 @@ section:last-of-type { border-bottom: none; }
   white-space: nowrap;
 }
 
-/* ─── final cta ─── */
+/* ─────────────────────────────────────────────────────────────────
+   Final CTA
+   ───────────────────────────────────────────────────────────────── */
+
 .final {
   padding: 120px 0;
   text-align: left;
@@ -739,11 +1699,4 @@ section:last-of-type { border-bottom: none; }
   font-size: 11px;
   color: var(--faint);
   letter-spacing: 0.04em;
-}
-
-/* via-daemon badge inside QueriesSection capture card meta */
-.qres .qmeta .via-daemon {
-  color: var(--accent);
-  border-bottom: 1px dotted color-mix(in srgb, var(--accent) 45%, transparent);
-  padding-bottom: 0;
 }

--- a/packages/landing/pages/index.server.ts
+++ b/packages/landing/pages/index.server.ts
@@ -4,9 +4,9 @@ export interface Props {}
 
 export const loader = defineHandler<Props>(() => ({}));
 
-const TITLE = "Spool — A local search engine for your thinking";
+const TITLE = "Spool — Your AI session library";
 const DESC =
-  "A local search engine for your thinking. Spool indexes every Claude, Codex and Gemini session — alongside your stars, bookmarks, and saves — into a single search box that lives on your machine. Your agents can search it too.";
+  "Every Claude, Codex, and Gemini session you've ever had, in one local library. Browse by project, pin what matters, and search across everything with ⌘K. Local-first; nothing leaves your machine.";
 
 export const head = defineHead(() => ({
   title: TITLE,
@@ -38,7 +38,7 @@ export const head = defineHead(() => ({
         "@type": "SoftwareApplication",
         name: "Spool",
         description:
-          "A local search engine for your thinking. Search your Claude Code sessions, Codex history, Gemini chats, GitHub stars, and 50+ sources — locally, instantly. Your AI agents can search too.",
+          "Your local AI session library. Browse, pin, and search every Claude Code, Codex, and Gemini session you've ever had — entirely on your machine. Your AI agents can query it too via the /spool skill.",
         url: "https://spool.pro",
         applicationCategory: "DeveloperApplication",
         operatingSystem: "macOS",

--- a/packages/landing/pages/index.tsx
+++ b/packages/landing/pages/index.tsx
@@ -1,103 +1,263 @@
 import { useEffect, useRef, useState } from "react";
 
-const PHRASES = [
-  "refresh token rotation",
-  "how did we fix the 3am cookie bug",
-  "local-first sync approaches",
-  "what did I ship last week",
-  "build on last month\u2019s caching talk",
-];
-
-const TICKER_ITEMS = [
-  { name: "Claude Code", color: "var(--src-claude)", count: "342" },
-  { name: "Codex CLI", color: "var(--src-codex)", count: "57" },
-  { name: "Gemini CLI", color: "var(--src-gemini)", count: "41" },
-  { name: "ChatGPT", color: "var(--src-chatgpt)", count: "128" },
-  { name: "Cursor", color: "#6B5B8A", count: "76" },
-  { name: "Warp AI", color: "#7AB8FF", count: "19" },
-  { name: "Aider", color: "#B85C38", count: "22" },
-];
-
 const INSTALL_CMD = "curl -fsSL https://spool.pro/install.sh | bash";
 
-const SearchIcon = ({ className, size = 16 }: { className?: string; size?: number }) => (
-  <svg
-    className={className}
-    width={size}
-    height={size}
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <circle cx="11" cy="11" r="8" />
-    <path d="m21 21-4.3-4.3" />
-  </svg>
-);
-
 export default function HomePage() {
+  useScrollReveal();
   return (
-    <>
+    <div className="home-page">
       <main className="wrap">
-        <div className="hero">
-          <HeroLeft />
-          <Specimen />
-        </div>
+        <Hero />
       </main>
 
-      <Ticker />
-
       <main className="wrap">
-        <GallerySection />
+        <BrowseSection />
+        <PinSection />
+        <SearchSection />
         <AgentSection />
         <PrinciplesSection />
         <FinalCTA />
       </main>
-    </>
+    </div>
   );
 }
 
-function HeroLeft() {
+function useScrollReveal() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (typeof IntersectionObserver === "undefined") {
+      document.querySelectorAll(".reveal").forEach((el) => el.classList.add("is-visible"));
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("is-visible");
+            io.unobserve(entry.target);
+          }
+        }
+      },
+      { rootMargin: "0px 0px -10% 0px", threshold: 0.05 }
+    );
+    document.querySelectorAll(".reveal").forEach((el) => io.observe(el));
+    return () => io.disconnect();
+  }, []);
+}
+
+/* ───────────────────────────── Hero ───────────────────────────── */
+
+function Hero() {
   return (
-    <div className="hero-left">
-      <div className="eyebrow">
-        <span className="pulse" /> v0.3 · local-first · macOS
+    <section className="home-hero">
+      <div className="hh-meta">
+        <span className="pulse" />
+        <span className="ver">v0.4.1</span>
+        <span className="dot" />
+        <span>local-first</span>
+        <span className="dot" />
+        <span>macOS · Apple Silicon</span>
+        <span className="dot" />
+        <span>MIT</span>
       </div>
-      <h1 className="display">
-        A local
+
+      <h1 className="hh-h1">
+        Your AI session
         <br />
-        search engine
-        <br />
-        for your
-        <br />
-        <em>
-          thinking<span className="accent">.</span>
-        </em>
+        <em>library</em>
+        <span className="accent">.</span>
       </h1>
-      <p className="lede">
-        Spool quietly indexes every Claude, Codex and Gemini session you've ever had into a single
-        search box that lives on your machine. Your agents can search it too.
+
+      <p className="hh-lede">
+        Every Claude, Codex, and Gemini session in one place. Browsable, pinnable, searchable —{" "}
+        <strong>and never leaves your machine</strong>.
       </p>
 
-      <div className="cta-row">
+      <div className="hh-cta">
         <InstallPill />
-        <a href="https://github.com/spool-lab/spool" className="btn primary">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.6-4-1.6-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-5.9 0-1.3.5-2.3 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17.3 4.7 18.3 5 18.3 5c.7 1.7.2 2.9.1 3.2.8.9 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .3" />
-          </svg>
+        <a href="https://github.com/spool-lab/spool" className="hh-btn hh-btn-p">
+          <GhIcon />
           Star on GitHub
+        </a>
+        <a href="/docs/installation" className="hh-btn hh-btn-g">
+          Read the docs →
         </a>
       </div>
 
-      <div className="meta-row">
-        <span>MIT</span>
-        <span className="dotsep" />
-        <span>Apple Silicon</span>
-        <span className="dotsep" />
-        <span>Built in the open</span>
+      <div className="hh-window">
+        <div className="hh-titlebar">
+          <span className="hh-traffic">
+            <span className="r" />
+            <span className="y" />
+            <span className="g" />
+          </span>
+          <span className="hh-title">
+            Spool<span className="a">.</span>
+          </span>
+          <span />
+        </div>
+
+        <div className="hh-body">
+          <HeroSidebar />
+          <HeroMain />
+        </div>
       </div>
+    </section>
+  );
+}
+
+const HERO_PROJECTS = [
+  { name: "harbor", count: 142, dots: ["claude", "codex"], active: true },
+  { name: "tide", count: 87, dots: ["claude", "gemini"] },
+  { name: "prism", count: 53, dots: ["claude"] },
+  { name: "forge", count: 41, dots: ["codex", "claude"] },
+  { name: "ledger", count: 38, dots: ["gemini", "codex"] },
+  { name: "atlas", count: 27, dots: ["claude"] },
+  { name: "terra", count: 22, dots: ["gemini"] },
+  { name: "relay", count: 19, dots: ["claude", "codex"] },
+  { name: "vault", count: 14, dots: ["codex"] },
+] as const;
+
+function HeroSidebar() {
+  return (
+    <aside className="hh-side">
+      <div className="hh-wm">
+        Spool<span className="a">.</span>
+      </div>
+
+      <div className="hh-search">
+        <SearchIcon size={12} />
+        <span className="ph">Search…</span>
+        <span className="kbd">⌘K</span>
+      </div>
+
+      <div className="hh-lbl">
+        <span>Projects</span>
+        <span className="sort">recent ▾</span>
+      </div>
+
+      {HERO_PROJECTS.map((p) => (
+        <div key={p.name} className={`hh-pj${p.active ? " is-active" : ""}`}>
+          <FolderIcon />
+          <span className="nm">{p.name}</span>
+          <span className="dots">
+            {p.dots.map((src, i) => (
+              <span key={i} className="d" style={{ background: `var(--src-${src})` }} />
+            ))}
+          </span>
+          <span className="cnt">{p.count}</span>
+        </div>
+      ))}
+
+      <div className="hh-divider" />
+      <div className="hh-pj is-loose">
+        <FolderIcon dashed />
+        <span className="nm">Loose</span>
+        <span />
+        <span className="cnt">8</span>
+      </div>
+
+      <div className="hh-foot">
+        <span className="live" />
+        <span>
+          <strong>462</strong> sessions · live
+        </span>
+      </div>
+    </aside>
+  );
+}
+
+function HeroMain() {
+  return (
+    <div className="hh-main">
+      <h2 className="hh-app-h">AI Session Library</h2>
+      <div className="hh-app-sub">
+        All your AI conversations, organized by your code projects.
+      </div>
+
+      <div className="hh-feed">
+        <div className="hh-seg">
+          <span className="nm">Pinned</span>
+          <span className="ct">3 sessions</span>
+          <span className="ln" />
+        </div>
+
+        <SessionRow
+          src="claude"
+          title="auth middleware: JWT rotation with refresh tokens"
+          meta="harbor · today · 42 messages · claude-sonnet-4-6"
+          pinned
+        />
+        <SessionRow
+          src="claude"
+          title="webhook idempotency keys: design + migration plan"
+          meta="ledger · 2d ago · 38 messages · claude-sonnet-4-6"
+          pinned
+        />
+        <SessionRow
+          src="gemini"
+          title="RAG pipeline: llamaindex vs custom orchestration"
+          meta="atlas · 4d ago · 27 messages · gemini-2.5-pro"
+          pinned
+        />
+        <SessionRow
+          src="codex"
+          title="shared VPC peering: terraform module spec"
+          meta="terra · 5d ago · 19 messages · gpt-5-codex"
+          pinned
+        />
+
+        <div className="hh-seg hh-seg-2">
+          <span className="nm">Today</span>
+          <span className="ln" />
+        </div>
+
+        <SessionRow
+          src="claude"
+          title="rate limit middleware: token bucket impl"
+          meta="harbor · 1h ago · 24 messages · claude-sonnet-4-6"
+        />
+        <SessionRow
+          src="claude"
+          title="gesture-handler v3 upgrade: breaking changes"
+          meta="tide · today · 16 messages · claude-sonnet-4-6"
+        />
+        <SessionRow
+          src="codex"
+          title="checkout funnel A/B: pricing page variant"
+          meta="tide · today · 16 messages · gpt-5-codex"
+        />
+      </div>
+    </div>
+  );
+}
+
+function SessionRow({
+  src,
+  title,
+  meta,
+  pinned,
+}: {
+  src: "claude" | "codex" | "gemini";
+  title: string;
+  meta: string;
+  pinned?: boolean;
+}) {
+  const dimSeparators = (text: string) =>
+    text.split(" · ").map((part, i, arr) => (
+      <span key={i}>
+        {part}
+        {i < arr.length - 1 && <span className="dim"> · </span>}
+      </span>
+    ));
+  return (
+    <div className="hh-row">
+      <span className={`hh-bd hh-bd-${src}`}>{src}</span>
+      <div className="bod">
+        <div className="ttl">{title}</div>
+        <div className="mt">{dimSeparators(meta)}</div>
+      </div>
+      {pinned ? <PinIcon /> : <span />}
     </div>
   );
 }
@@ -113,7 +273,7 @@ function InstallPill() {
   return (
     <button
       type="button"
-      className={`install${copied ? " copied" : ""}`}
+      className={`hh-install${copied ? " is-copied" : ""}`}
       onClick={onClick}
       aria-label="Copy install command"
     >
@@ -121,11 +281,11 @@ function InstallPill() {
       <code>{INSTALL_CMD}</code>
       <span className="copy">
         {copied ? (
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <polyline points="20 6 9 17 4 12" />
           </svg>
         ) : (
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
             <rect x="9" y="9" width="13" height="13" rx="2" />
             <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
           </svg>
@@ -135,399 +295,462 @@ function InstallPill() {
   );
 }
 
-function Specimen() {
+/* ─────────────────── Pillar sections (Browse / Pin / Search) ─────────────────── */
+
+function PillarHead({
+  kicker,
+  title,
+  sub,
+}: {
+  kicker: string;
+  title: React.ReactNode;
+  sub: React.ReactNode;
+}) {
   return (
-    <div className="specimen">
-      <div className="s-top">
-        <div className="tl">
-          <span />
-          <span />
-          <span />
-        </div>
-        <div className="s-title-bar">spool · 720 × 480</div>
-      </div>
-
-      <div className="s-bar">
-        <SearchIcon className="search" />
-        <span className="typed">
-          <TypedPhrases />
-          <span className="caret" />
-        </span>
-        <span className="mode active">Fast</span>
-        <span className="mode">AI</span>
-      </div>
-
-      <div className="s-results">
-        <div className="s-row sel">
-          <span className="dot" style={{ background: "var(--src-claude)" }} />
-          <div className="rtxt">
-            <div className="rtitle">
-              auth-middleware — <mark>cookie-based refresh</mark> with rotation
-            </div>
-            <div className="rmeta">You discussed this · Mar 15 · 42 msgs · ~/projects/api-core</div>
-          </div>
-          <span className="rkey">↵</span>
-        </div>
-        <div className="s-row">
-          <span className="dot" style={{ background: "var(--src-claude)" }} />
-          <div className="rtxt">
-            <div className="rtitle">
-              <mark>express-jwt</mark> rotation edge cases
-            </div>
-            <div className="rmeta">You discussed this · Mar 12 · 18 msgs</div>
-          </div>
-          <span className="rkey">↓</span>
-        </div>
-        <div className="s-row">
-          <span className="dot" style={{ background: "var(--src-codex)" }} />
-          <div className="rtxt">
-            <div className="rtitle">
-              codex · <mark>session refresh</mark> implementation spike
-            </div>
-            <div className="rmeta">You discussed this · Jan 09 · 24 msgs</div>
-          </div>
-          <span className="rkey">↓</span>
-        </div>
-        <div className="s-row">
-          <span className="dot" style={{ background: "var(--src-gemini)" }} />
-          <div className="rtxt">
-            <div className="rtitle">
-              gemini · jwt <mark>refresh</mark> w/ redis ttl
-            </div>
-            <div className="rmeta">You discussed this · Dec 21 · 9 msgs</div>
-          </div>
-          <span className="rkey">↓</span>
-        </div>
-        <div className="s-row">
-          <span className="dot" style={{ background: "var(--src-chatgpt)" }} />
-          <div className="rtxt">
-            <div className="rtitle">
-              chatgpt · auth rewrite plan
-            </div>
-            <div className="rmeta">You discussed this · Nov 04 · 31 msgs</div>
-          </div>
-          <span className="rkey">↓</span>
-        </div>
-      </div>
-
-      <div className="s-foot">
-        <span>
-          <span className="statusdot" />
-          1,847 sessions indexed · 4 agents
-        </span>
-        <span>synced 14s ago</span>
-      </div>
+    <div className="s-head s-head-edit">
+      <div className="s-kick">{kicker}</div>
+      <h2 className="s-title">{title}</h2>
+      <p className="s-sub">{sub}</p>
     </div>
   );
 }
 
-function TypedPhrases() {
-  const [text, setText] = useState("");
-  const stateRef = useRef({ phrase: 0, char: 0, deleting: false, pause: 0 });
-  useEffect(() => {
-    let timer: ReturnType<typeof setTimeout>;
-    const tick = () => {
-      const s = stateRef.current;
-      const phrase = PHRASES[s.phrase]!;
-      if (s.pause > 0) {
-        s.pause--;
-        timer = setTimeout(tick, 28);
-        return;
-      }
-      if (!s.deleting) {
-        setText(phrase.substring(0, s.char + 1));
-        s.char++;
-        if (s.char === phrase.length) {
-          s.deleting = true;
-          s.pause = 70;
-        }
-      } else {
-        setText(phrase.substring(0, s.char - 1));
-        s.char--;
-        if (s.char === 0) {
-          s.deleting = false;
-          s.phrase = (s.phrase + 1) % PHRASES.length;
-          s.pause = 12;
-        }
-      }
-      timer = setTimeout(tick, s.deleting ? 22 : 55 + Math.random() * 40);
-    };
-    tick();
-    return () => clearTimeout(timer);
-  }, []);
-  return <span>{text}</span>;
-}
-
-function Ticker() {
-  const items = [...TICKER_ITEMS, ...TICKER_ITEMS];
+function BrowseSection() {
   return (
-    <div className="ticker">
-      <span className="label">· Agent sessions</span>
-      <div className="ticker-track">
-        {items.map((item, i) => (
-          <span className="ticker-item" key={i}>
-            <span className="ico">
-              <span
-                style={{
-                  width: 8,
-                  height: 8,
-                  borderRadius: "50%",
-                  background: item.color,
-                  display: "inline-block",
-                }}
-              />
-            </span>
-            {item.name}
-            <span className="count">{item.count}</span>
-          </span>
-        ))}
-      </div>
-    </div>
-  );
-}
+    <section className="pillar reveal">
+      <PillarHead
+        kicker="Browse"
+        title={
+          <>
+            One project, <em>every agent</em>, one view
+            <span className="accent">.</span>
+          </>
+        }
+        sub="Spool watches Claude, Codex, and Gemini session directories today — and we're adding more agents as fast as they ship. Sessions are grouped by working directory, so opening a project shows everything you discussed there, regardless of which agent you used."
+      />
 
-function GallerySection() {
-  return (
-    <section id="gallery">
-      <div className="s-head">
-        <div className="s-num">
-          <span className="line" />
-          01 · QUERIES
-        </div>
-        <div>
-          <h2 className="s-title">
-            The things you <em>almost</em> remembered<span className="accent">.</span>
-          </h2>
-          <p className="s-sub">
-            Five months of AI sessions across four agents. Spool takes all of it and answers the
-            question you can only half-formulate — in monospace, with receipts.
-          </p>
-        </div>
-      </div>
-
-      <div className="queries">
-        <QCard
-          query="the claude session where I fixed the auth bug"
-          mode="fast"
-          results={[
-            {
-              color: "var(--src-claude)",
-              title: <><mark>auth-middleware</mark> — jwt rotation fix</>,
-              meta: "You discussed this · Mar 15 · 42 msgs",
-              src: "claude",
-              srcColor: "var(--src-claude)",
-              srcPct: 16,
-            },
-            {
-              color: "var(--src-claude)",
-              title: <>auth spike — "why does the <mark>cookie expire at 3am</mark>"</>,
-              meta: "You discussed this · Mar 11 · 8 msgs",
-              src: "claude",
-              srcColor: "var(--src-claude)",
-              srcPct: 16,
-            },
-          ]}
-        />
-        <QCard
-          query="the gemini session about RAG pipelines"
-          mode="fast"
-          results={[
-            {
-              color: "var(--src-gemini)",
-              title: <>gemini · <mark>llama-index</mark> vs. custom orchestration</>,
-              meta: "You discussed this · Mar 02 · 18 msgs",
-              src: "gemini",
-              srcColor: "var(--src-gemini)",
-              srcPct: 18,
-            },
-            {
-              color: "var(--src-gemini)",
-              title: <>gemini · embedding store benchmarks</>,
-              meta: "You discussed this · Feb 19 · 11 msgs",
-              src: "gemini",
-              srcColor: "var(--src-gemini)",
-              srcPct: 18,
-            },
-          ]}
-        />
-        <QCard
-          query="what did I ship last week"
-          mode="ai"
-          results={[
-            {
-              color: "var(--accent)",
-              ai: true,
-              title: (
-                <>
-                  Three features across <em>api-core</em> and <em>billing</em>:{" "}
-                  <mark>jwt rotation</mark>, stripe webhook retries, and the admin-audit middleware.
-                  Eight Claude sessions, two PRs.
-                </>
-              ),
-              meta: "Claude says · via ACP · local · 8 fragments",
-              src: "ai",
-              srcColor: "var(--accent)",
-              srcBg: "var(--accent-bg)",
-            },
-          ]}
-        />
-        <QCard
-          query="that repo I starred about local-first sync"
-          mode="fast"
-          results={[
-            {
-              color: "var(--src-github)",
-              title: <><mark>jlongster/crdt-example-app</mark> — SQLite CRDT sync</>,
-              meta: <>You starred this · Jan 09 · <span className="via-daemon">via daemon</span></>,
-              src: "github",
-              srcColor: "var(--src-github)",
-              srcPct: 20,
-            },
-            {
-              color: "var(--src-claude)",
-              title: <>claude · we compared this approach to electric-sql</>,
-              meta: "You discussed this · Jan 12 · 22 msgs",
-              src: "claude",
-              srcColor: "var(--src-claude)",
-              srcPct: 16,
-            },
-          ]}
-        />
-        <QCard
-          query="that codex session on B+ trees"
-          mode="fast"
-          results={[
-            {
-              color: "var(--src-codex)",
-              title: <>codex · <mark>B+ tree</mark> write path spike</>,
-              meta: "You discussed this · Jan 30 · 27 msgs",
-              src: "codex",
-              srcColor: "var(--src-codex)",
-              srcPct: 18,
-            },
-            {
-              color: "var(--src-codex)",
-              title: <>codex · leaf-node split edge case</>,
-              meta: "You discussed this · Dec 21 · 14 msgs",
-              src: "codex",
-              srcColor: "var(--src-codex)",
-              srcPct: 18,
-            },
-          ]}
-        />
-        <QCard
-          query="chatgpt plan for the auth rewrite"
-          mode="fast"
-          results={[
-            {
-              color: "var(--src-chatgpt)",
-              title: <>chatgpt · <mark>auth rewrite</mark> step-by-step plan</>,
-              meta: "You discussed this · Nov 04 · 31 msgs",
-              src: "chatgpt",
-              srcColor: "var(--src-chatgpt)",
-              srcPct: 18,
-            },
-            {
-              color: "var(--src-chatgpt)",
-              title: <>chatgpt · migration risk matrix</>,
-              meta: "You discussed this · Oct 28 · 12 msgs",
-              src: "chatgpt",
-              srcColor: "var(--src-chatgpt)",
-              srcPct: 18,
-            },
-          ]}
-        />
+      <div className="pillar-spec">
+        <BrowseDiagram />
       </div>
     </section>
   );
 }
 
-type QResult = {
-  color: string;
-  title: React.ReactNode;
-  meta: React.ReactNode;
-  src: string;
-  srcColor: string;
-  srcPct?: number;
-  srcBg?: string;
-  ai?: boolean;
-};
-
-function QCard({ query, mode, results }: { query: string; mode: "fast" | "ai"; results: QResult[] }) {
+function BrowseDiagram() {
   return (
-    <div className="qcard">
-      <div className="qhead">
-        <SearchIcon size={13} />
-        <span className="qtxt">{query}</span>
-        <span className={`qkey${mode === "ai" ? " ai" : ""}`}>{mode}</span>
-      </div>
-      {results.map((r, i) => {
-        const srcStyle = r.srcBg
-          ? { background: r.srcBg, color: r.srcColor }
-          : {
-              background: `color-mix(in srgb, ${r.srcColor} ${r.srcPct ?? 18}%, transparent)`,
-              color: r.srcColor,
-            };
-        return (
-          <div className="qres" key={i}>
-            <span className="qdot" style={{ background: r.color }} />
-            <div className="qbody">
-              <div className={`qtitle${r.ai ? " ai" : ""}`}>{r.title}</div>
-              <div className="qmeta">{r.meta}</div>
-            </div>
-            <span className="qsrc" style={srcStyle}>
-              {r.src}
-            </span>
+    <div className="bd">
+      <div className="bd-sources">
+        <div className="bd-src">
+          <div className="bd-src-head">
+            <span className={`hh-bd hh-bd-claude`}>claude</span>
+            <span className="bd-src-path">~/.claude/projects/-Users-you-harbor</span>
           </div>
-        );
-      })}
+          <div className="bd-src-files">
+            <span>0e1f88a2-09b3-4cae-…jsonl</span>
+            <span>4c3d12f0-91e8-44b1-…jsonl</span>
+            <span>7a55b1ee-2c0f-49b7-…jsonl</span>
+            <span className="bd-src-more">+ 39 sessions</span>
+          </div>
+        </div>
+
+        <div className="bd-src">
+          <div className="bd-src-head">
+            <span className={`hh-bd hh-bd-codex`}>codex</span>
+            <span className="bd-src-path">~/.codex/sessions/2026/05/06/harbor</span>
+          </div>
+          <div className="bd-src-files">
+            <span>rollout-2026-05-06T11-4-…jsonl</span>
+            <span>rollout-2026-05-04T09-1-…jsonl</span>
+            <span className="bd-src-more">+ 16 sessions</span>
+          </div>
+        </div>
+
+        <div className="bd-src">
+          <div className="bd-src-head">
+            <span className={`hh-bd hh-bd-gemini`}>gemini</span>
+            <span className="bd-src-path">~/.gemini/tmp/harbor-PROJECT/chats</span>
+          </div>
+          <div className="bd-src-files">
+            <span>chat-2026-05-05.json</span>
+            <span>chat-2026-04-22.json</span>
+            <span className="bd-src-more">+ 11 sessions</span>
+          </div>
+        </div>
+
+        <div className="bd-src bd-src-soon">
+          <div className="bd-src-head">
+            <span className="bd-soon-badge">soon</span>
+            <span className="bd-src-path">cursor · windsurf · aider · zed · …</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="bd-arrow" aria-hidden>
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M5 12h14M13 5l7 7-7 7" />
+        </svg>
+        <span className="bd-arrow-lbl">grouped by working dir</span>
+      </div>
+
+      <div className="bd-out">
+        <div className="bd-out-head">
+          <FolderIcon />
+          <span className="bd-out-name">harbor</span>
+          <span className="bd-out-meta">142 sessions · 3 agents</span>
+        </div>
+        <div className="bd-out-stats">
+          <div className="bd-out-stat">
+            <span className="bd-stat-dot" style={{ background: "var(--src-claude)" }} />
+            <span className="bd-stat-num">87</span>
+            <span className="bd-stat-lbl">claude</span>
+          </div>
+          <div className="bd-out-stat">
+            <span className="bd-stat-dot" style={{ background: "var(--src-codex)" }} />
+            <span className="bd-stat-num">42</span>
+            <span className="bd-stat-lbl">codex</span>
+          </div>
+          <div className="bd-out-stat">
+            <span className="bd-stat-dot" style={{ background: "var(--src-gemini)" }} />
+            <span className="bd-stat-num">13</span>
+            <span className="bd-stat-lbl">gemini</span>
+          </div>
+        </div>
+        <div className="bd-out-foot">All under <code>/Users/you/code/harbor</code></div>
+      </div>
     </div>
   );
 }
 
-function AgentSection() {
+function PinSection() {
   return (
-    <section id="agents">
-      <div className="s-head">
-        <div className="s-num">
-          <span className="line" />
-          02 · AGENTS
-        </div>
-        <div>
-          <h2 className="s-title">
-            Your agent is already your best <em>search engine</em> — once it can read you
+    <section className="pillar reveal">
+      <PillarHead
+        kicker="Pin"
+        title={
+          <>
+            The ten that <em>matter</em>, on top
             <span className="accent">.</span>
-          </h2>
-          <p className="s-sub">
-            The <code>/spool</code> skill gives Claude Code, Codex, Gemini CLI — any ACP agent — a
-            way to search your session index mid-conversation. No cloud round-trip. No copy-paste.
-            Just context flowing back in.
-          </p>
+          </>
+        }
+        sub="One click pins a session in its project — and onto the global Library Home. The ones you keep coming back to stay where you'll find them. No folders, no tags, no ceremony."
+      />
+
+      <div className="pillar-spec">
+        <PinBoard />
+      </div>
+    </section>
+  );
+}
+
+function PinBoard() {
+  const pins = [
+    {
+      rotate: -2.4,
+      src: "claude" as const,
+      project: "harbor",
+      title: "auth middleware: JWT rotation with refresh tokens",
+      note: "the canonical rotation discussion — link this anywhere auth comes up",
+      date: "Mar 15",
+    },
+    {
+      rotate: 1.6,
+      src: "gemini" as const,
+      project: "atlas",
+      title: "RAG pipeline: llamaindex vs custom orchestration",
+      note: "decision tree we worked out before the spike",
+      date: "Apr 02",
+    },
+    {
+      rotate: -0.8,
+      src: "codex" as const,
+      project: "ledger",
+      title: "webhook idempotency keys: design + migration plan",
+      note: "every part of the design that survived review is here",
+      date: "Apr 18",
+    },
+    {
+      rotate: 2.8,
+      src: "claude" as const,
+      project: "tide",
+      title: "B+ tree write path spike — leaf split edge case",
+      note: "you'll forget the off-by-one. don't reinvent it.",
+      date: "Jan 30",
+    },
+  ];
+
+  return (
+    <div className="pb">
+      <div className="pb-cork" aria-hidden />
+      {pins.map((p, i) => (
+        <div className="pb-card" key={i} style={{ transform: `rotate(${p.rotate}deg)` }}>
+          <PinIcon />
+          <div className="pb-card-meta">
+            <span className={`hh-bd hh-bd-${p.src}`}>{p.src}</span>
+            <span className="pb-card-pj">{p.project}</span>
+            <span className="pb-card-date">{p.date}</span>
+          </div>
+          <div className="pb-card-title">{p.title}</div>
+          <div className="pb-card-note">{p.note}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SearchSection() {
+  return (
+    <section className="pillar reveal">
+      <PillarHead
+        kicker="Search"
+        title={
+          <>
+            <span className="kbd-h">⌘K</span> from anywhere — Fast or <em>AI</em>
+            <span className="accent">.</span>
+          </>
+        }
+        sub={
+          <>
+            <strong>Fast</strong> runs FTS5 across every indexed session, instantly.{" "}
+            <strong>AI</strong> hands the query to an agent on your machine, which synthesizes an
+            answer with sources. The <code>local</code> label never goes away.
+          </>
+        }
+      />
+
+      <div className="pillar-spec">
+        <CmdKOverlay />
+      </div>
+    </section>
+  );
+}
+
+/* ───────────────────────── ⌘K overlay specimen ───────────────────────── */
+
+function CmdKOverlay() {
+  return (
+    <div className="cmdk-stage">
+      {/* faint shell hint behind the popup */}
+      <div className="cmdk-bg" aria-hidden>
+        <div className="cmdk-bg-side">
+          <div className="cmdk-bg-wm" />
+          <div className="cmdk-bg-search" />
+          <div className="cmdk-bg-lbl" />
+          <div className="cmdk-bg-pj" />
+          <div className="cmdk-bg-pj" />
+          <div className="cmdk-bg-pj" />
+          <div className="cmdk-bg-pj" />
+          <div className="cmdk-bg-pj" />
+          <div className="cmdk-bg-pj" />
+          <div className="cmdk-bg-pj" />
+        </div>
+        <div className="cmdk-bg-main">
+          <div className="cmdk-bg-h" />
+          <div className="cmdk-bg-sub" />
+          <div className="cmdk-bg-row" />
+          <div className="cmdk-bg-row" />
+          <div className="cmdk-bg-row" />
+          <div className="cmdk-bg-row" />
+          <div className="cmdk-bg-row" />
         </div>
       </div>
+
+      <div className="cmdk-pop">
+        <div className="cmdk-bar">
+          <SearchIcon size={16} />
+          <span className="cmdk-q">refresh token rotation</span>
+          <span className="cmdk-modes">
+            <span className="cmdk-mode on" title="Fast">
+              <BoltIcon />
+            </span>
+            <span className="cmdk-mode" title="AI">
+              <SparkleIcon />
+            </span>
+          </span>
+        </div>
+
+        <div className="cmdk-scope">
+          <span className="cmdk-scope-lbl">SEARCHING:</span>
+          <span className="cmdk-chip">in: project</span>
+          <span className="cmdk-chip on">All projects</span>
+        </div>
+
+        <div className="cmdk-results">
+          <CmdKRow
+            src="claude"
+            project="harbor"
+            title={<>auth middleware: JWT <mark>rotation</mark> with <mark>refresh tokens</mark></>}
+            date="today"
+          />
+          <CmdKRow
+            src="claude"
+            project="tide"
+            title={<><mark>refresh token rotation</mark> edge cases — concurrent requests</>}
+            date="2d ago"
+          />
+          <CmdKRow
+            src="codex"
+            project="harbor"
+            title={<>jwt vs opaque <mark>tokens</mark>: short-lived access + rotating <mark>refresh</mark></>}
+            date="5d ago"
+          />
+          <CmdKRow
+            src="gemini"
+            project="ledger"
+            title={<>session <mark>refresh</mark> with redis TTL spike</>}
+            date="Jan 22"
+          />
+          <CmdKRow
+            src="claude"
+            project="atlas"
+            title={<>webhook idempotency keys: <mark>token</mark> expiry handling</>}
+            date="Jan 14"
+          />
+        </div>
+
+        <div className="cmdk-foot">
+          <span className="cmdk-foot-l">View all results ›</span>
+          <span className="cmdk-foot-r">
+            <span className="cmdk-kbd">↩</span>
+            30 results
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CmdKRow({
+  src,
+  project,
+  title,
+  date,
+}: {
+  src: "claude" | "codex" | "gemini";
+  project: string;
+  title: React.ReactNode;
+  date: string;
+}) {
+  return (
+    <div className="cmdk-row">
+      <span className={`hh-bd hh-bd-${src}`}>{src}</span>
+      <span className="cmdk-pj">{project}</span>
+      <span className="cmdk-ttl">{title}</span>
+      <span className="cmdk-date">{date}</span>
+    </div>
+  );
+}
+
+function BoltIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M14.5 2 3 14h7l-1.5 8L21 10h-7l.5-8z" />
+    </svg>
+  );
+}
+
+function SparkleIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M12 2.5l2 6.5 6.5 2-6.5 2-2 6.5-2-6.5L3.5 11l6.5-2 2-6.5z" />
+    </svg>
+  );
+}
+
+/* ───────────────────────── Generic specimen window ───────────────────────── */
+
+function SpecimenWindow({
+  title,
+  children,
+  dim,
+}: {
+  title: string;
+  children: React.ReactNode;
+  dim?: boolean;
+}) {
+  return (
+    <div className={`spec-win${dim ? " is-dim" : ""}`}>
+      <div className="spec-tb">
+        <span className="spec-traffic">
+          <span className="r" />
+          <span className="y" />
+          <span className="g" />
+        </span>
+        <span className="spec-title">{title}</span>
+        <span />
+      </div>
+      <div className="spec-body">{children}</div>
+    </div>
+  );
+}
+
+function PSRow({
+  src,
+  title,
+  meta,
+  pinned,
+}: {
+  src: "claude" | "codex" | "gemini";
+  title: string;
+  meta: string;
+  pinned?: boolean;
+}) {
+  return (
+    <div className="ps-row">
+      <span className={`hh-bd hh-bd-${src}`}>{src}</span>
+      <div className="bod">
+        <div className="ttl">{title}</div>
+        <div className="mt">{meta}</div>
+      </div>
+      {pinned ? <PinIcon /> : <span />}
+    </div>
+  );
+}
+
+/* ─────────────────────────── Agent integration ─────────────────────────── */
+
+function AgentSection() {
+  return (
+    <section className="agent-sec reveal">
+      <PillarHead
+        kicker="Agents"
+        title={
+          <>
+            Your agent reads your <em>library</em> too
+            <span className="accent">.</span>
+          </>
+        }
+        sub={
+          <>
+            Drop the <code>/spool</code> skill into Claude Code and ask things like
+            "build on the auth-middleware discussion from last week." It shells out to{" "}
+            <code>spool search</code>, returns matching fragments, and lets the agent load any
+            session in full. Any tool-using agent can do the same via the CLI.
+          </>
+        }
+      />
 
       <div className="agent">
         <div className="notes">
           <div>
             <h3>01 — Ask what it ought to know.</h3>
             <p>
-              "Build on the auth middleware discussion from last week." The agent invokes{" "}
-              <code>/spool</code>, Spool searches your session index, and fragments flow back into
-              the conversation window.
+              "Build on the auth-middleware discussion from last week." Claude invokes{" "}
+              <code>/spool</code>, the skill runs <code>spool search</code> against your local
+              index, and matching fragments flow back into the conversation.
             </p>
           </div>
           <div>
-            <h3>02 — Every agent equally first-class.</h3>
+            <h3>02 — Sources don't decide retrievability.</h3>
             <p>
-              A Claude session, an old Codex run, a Gemini brainstorm — all retrievable by the same
-              search. The agent doesn't care which model produced it; neither should you.
+              A Claude session, an old Codex run, a Gemini brainstorm — all indexed under the same
+              project, all returned by the same search. Whichever agent later asks gets all of it.
             </p>
           </div>
           <div>
-            <h3>03 — The trust label is load-bearing.</h3>
+            <h3>03 — The CLI is the public surface.</h3>
             <p>
-              Every answer is stamped <code>via ACP · local</code>. Inference runs where you are.
-              Your thinking is never the product.
+              The skill is a thin wrapper around <code>spool search --json</code>. Any tool-using
+              agent — or any script — can talk to your library the same way. Local in, local out.
             </p>
           </div>
         </div>
@@ -546,7 +769,7 @@ function AgentSection() {
           <div className="out">
             <div className="line">
               <span className="sys">◉</span>{" "}
-              <span className="sys">/spool — searching your sessions…</span>
+              <span className="sys">/spool — searching your library…</span>
             </div>
             <div className="frag">
               <span
@@ -589,34 +812,50 @@ function AgentSection() {
             </div>
           </div>
 
-          <div className="inject">→ 3 fragments loaded into context. via ACP · local</div>
+          <div className="inject">→ 3 fragments loaded into context · local</div>
         </div>
       </div>
     </section>
   );
 }
 
+/* ──────────────────────────── Principles ──────────────────────────── */
 
 function PrinciplesSection() {
   const principles = [
-    { n: "i.", title: "Local, always.", body: "Your index, your embeddings, your queries — all on-device. Nothing is uploaded to sync a \"cloud profile.\" There is no cloud profile." },
-    { n: "ii.", title: "Search is the interface.", body: "Not a sidebar. Not a dashboard. One box, one input, instant results — the shape of the product is the shape of the question." },
-    { n: "iii.", title: "First-person metadata.", body: "\"You discussed this\" beats \"Claude Code · Mar 15.\" The archive is yours; the language should say so." },
-    { n: "iv.", title: "Agents are citizens.", body: "A search engine humans can use and agents can query reaches a different ceiling. Both, from day one." },
+    {
+      n: "i.",
+      title: "Library, not search box.",
+      body: "The shell is the home — sidebar of projects, main pane of sessions. ⌘K is one entry point among several, not the whole product.",
+    },
+    {
+      n: "ii.",
+      title: "Local, always.",
+      body: "On-device index, on-device queries, on-device inference. Your machine is the only place your sessions ever live.",
+    },
+    {
+      n: "iii.",
+      title: "First-person metadata.",
+      body: "\"You discussed this · Mar 15\" beats \"Claude Code · Mar 15.\" The library is yours; the language should say so.",
+    },
+    {
+      n: "iv.",
+      title: "Agents read it too.",
+      body: "Anything humans can browse, an agent can query. The /spool skill ships with the repo; the same JSON CLI is your public surface.",
+    },
   ];
   return (
-    <section>
-      <div className="s-head">
-        <div className="s-num">
-          <span className="line" />
-          03 · PRINCIPLES
-        </div>
-        <div>
-          <h2 className="s-title">
-            Rules of the <em>house</em><span className="accent">.</span>
-          </h2>
-        </div>
-      </div>
+    <section className="reveal">
+      <PillarHead
+        kicker="House rules"
+        title={
+          <>
+            Four things we won't <em>compromise</em>
+            <span className="accent">.</span>
+          </>
+        }
+        sub="Spool's defaults aren't accidents. These are the four lines we won't cross."
+      />
 
       <div className="principles">
         {principles.map((p) => (
@@ -631,25 +870,144 @@ function PrinciplesSection() {
   );
 }
 
+/* ──────────────────────────── Final CTA ──────────────────────────── */
+
 function FinalCTA() {
   return (
-    <section className="final">
+    <section className="final reveal">
       <div className="big">
-        Your thinking,
+        Your sessions,
         <br />
-        <em>searchable</em>
+        <em>finally findable</em>
         <span className="accent">.</span>
       </div>
       <div className="row">
         <InstallPill />
-        <a href="https://github.com/spool-lab/spool" className="btn primary">
+        <a href="https://github.com/spool-lab/spool" className="hh-btn hh-btn-p">
+          <GhIcon />
           Star on GitHub
         </a>
-        <a href="/docs/installation" className="btn">
+        <a href="/docs/installation" className="hh-btn hh-btn-g">
           Read the docs →
         </a>
       </div>
       <div className="plat">macOS · Apple Silicon · MIT · Built in the open</div>
     </section>
+  );
+}
+
+/* ──────────────────────────── Icons ──────────────────────────── */
+
+function SearchIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  );
+}
+
+const TYPED_QUERIES = [
+  "refresh token rotation",
+  "the gemini RAG session",
+  "what did I ship last week",
+  "redis ttl edge cases",
+  "auth middleware rewrite",
+];
+
+function TypedQuery() {
+  const [text, setText] = useState(TYPED_QUERIES[0]!);
+  const stateRef = useRef({ phrase: 0, char: TYPED_QUERIES[0]!.length, deleting: false, pause: 90 });
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    const tick = () => {
+      const s = stateRef.current;
+      const phrase = TYPED_QUERIES[s.phrase]!;
+      if (s.pause > 0) {
+        s.pause--;
+        timer = setTimeout(tick, 30);
+        return;
+      }
+      if (!s.deleting) {
+        setText(phrase.substring(0, s.char + 1));
+        s.char++;
+        if (s.char === phrase.length) {
+          s.deleting = true;
+          s.pause = 80;
+        }
+      } else {
+        setText(phrase.substring(0, s.char - 1));
+        s.char--;
+        if (s.char === 0) {
+          s.deleting = false;
+          s.phrase = (s.phrase + 1) % TYPED_QUERIES.length;
+          s.pause = 18;
+        }
+      }
+      timer = setTimeout(tick, s.deleting ? 28 : 60 + Math.random() * 40);
+    };
+    tick();
+    return () => clearTimeout(timer);
+  }, []);
+  return (
+    <>
+      {text}
+      <span className="caret" />
+    </>
+  );
+}
+
+function PinIcon() {
+  return (
+    <svg
+      className="hh-pin"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M15 4.5l-4 4l-4 1.5l-1.5 1.5l7 7l1.5 -1.5l1.5 -4l4 -4" />
+      <path d="M9 15l-4.5 4.5" fill="none" />
+      <path d="M14.5 4l5.5 5.5" fill="none" />
+    </svg>
+  );
+}
+
+function FolderIcon({ dashed }: { dashed?: boolean }) {
+  return (
+    <svg
+      width="14"
+      height="11"
+      viewBox="0 0 14 11"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={dashed ? { strokeDasharray: "2 2", opacity: 0.6 } : undefined}
+    >
+      <path d="M1 3.5a1 1 0 0 1 1-1h3l1.5 1.5h5.5a1 1 0 0 1 1 1V9a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V3.5z" />
+    </svg>
+  );
+}
+
+function GhIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.6-4-1.6-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-5.9 0-1.3.5-2.3 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17.3 4.7 18.3 5 18.3 5c.7 1.7.2 2.9.1 3.2.8.9 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .3" />
+    </svg>
   );
 }


### PR DESCRIPTION
## Summary

Repositions the `/` page around Spool's library-first product (the v0.4.x shell with sidebar of projects, main pane of sessions, and ⌘K as one of several entry points). The previous "local search engine for your thinking" framing no longer matches what users see after install.

## What changed

- **Hero** is a faithful render of the actual app shell (sidebar + AI Session Library main pane), preceded by a single mono-caps eyebrow line and the H1 / lede / CTA stack. The window is wider than tall and fades into the page background at the bottom via a `mask-image`.
- **Five sections, five visual mediums** to avoid app-shell repetition:
  - **Browse** — multi-source unification diagram (real agent paths flowing into one project card; \"soon\" badge for future agents)
  - **Pin** — pinboard collage with the actual pushpin SVG from the app
  - **Search** — ⌘K popup with Fast results and highlighted matches
  - **Agents** — terminal demo of the `/spool` skill calling `spool search`
  - **House rules** — four principles refreshed for library-first positioning
- Removed the old `Ticker`, `GallerySection`, and Spool Daemon callout — the hero already conveys agent coverage; the daemon page is its own page.
- **Reveal-on-scroll** for sections below the fold (IntersectionObserver) + staggered hero entrance (CSS keyframes), respecting `prefers-reduced-motion`.
- Final CTA copy: \"Your sessions, *finally findable*.\"
- Page title + description rewritten for the new positioning.

## Why

- v0.4.x shipped a library-first shell (#124, #125, #126, #127, #128, #133); the product no longer fits the search-engine pitch the previous landing leaned on.
- README and DESIGN.md were already rewritten for library-first (#134, #135); this lines up the marketing surface with the same direction.

## How it connects

- The home page is wrapped in a new \`.home-page\` div so its CSS overrides don't leak into other pages.
- The Daemon and Blog pages depend on a block of shared primitives in `home.css` (`.hero`, `.eyebrow`, `.display`, `.lede`, `.cta-row`, `.install`, `.btn`, `.meta-row`, `.ticker*`, default `section` / `.s-head` styles, `@keyframes pulse` / `slide`) — those are kept intact at the top of `home.css` with a comment marking them as shared. Don't rename or remove anything in that block without grepping the other page TSX files first.
- Mock data uses fictional project names (`harbor`, `tide`, `prism`, …) and plausible engineering session titles. No real user data.