### PR TITLE
Tighten session header toolbar with icon-only resume button

### DIFF
--- a/packages/app/src/renderer/components/ContinueActions.tsx
+++ b/packages/app/src/renderer/components/ContinueActions.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { SquareTerminal } from 'lucide-react'
 import type { FragmentResult } from '@spool-lab/core'
 import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
 
@@ -85,10 +86,7 @@ export default function ContinueActions({ result, onOpenSession, onCopySessionId
             </>
           ) : (
             <>
-              <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
-                <path d="M2.5 2.5L6.5 6.5L2.5 10.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                <path d="M7.5 10.5H10.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-              </svg>
+              <SquareTerminal size={13} strokeWidth={1.6} aria-hidden />
               Resume in CLI
             </>
           )}

--- a/packages/app/src/renderer/components/PinButton.tsx
+++ b/packages/app/src/renderer/components/PinButton.tsx
@@ -27,7 +27,7 @@ export default function PinButton({ sessionUuid, pinned, onChange, size = 'sm' }
   }
 
   const dim = size === 'md' ? 'w-8 h-8' : 'w-6 h-6'
-  const icon = size === 'md' ? 16 : 11
+  const icon = size === 'md' ? 16 : 13
 
   return (
     <button

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { SquareTerminal } from 'lucide-react'
 import type { Session, Message } from '@spool-lab/core'
 import MessageBubble, { type FindRange } from './MessageBubble.js'
 import SessionFindBar from './SessionFindBar.js'
@@ -278,7 +279,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
           </p>
         </div>
 
-        <div className="flex-none self-end flex items-center gap-1.5">
+        <div className="flex-none self-end flex items-center gap-0.5">
           <PinButton
             sessionUuid={session.sessionUuid}
             pinned={pinned}
@@ -289,13 +290,11 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
             data-testid="detail-resume"
             onClick={handleResume}
             disabled={resuming}
-            title="Resume session in Terminal"
-            className="flex items-center gap-1.5 text-xs font-semibold text-white bg-accent hover:bg-accent/90 dark:bg-accent-dark dark:hover:bg-accent-dark/90 rounded-md px-3 py-1.5 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+            title={resuming ? 'Opening…' : 'Resume in Terminal'}
+            aria-label={resuming ? 'Opening…' : 'Resume in Terminal'}
+            className="inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
           >
-            <svg width="11" height="11" viewBox="0 0 11 11" fill="currentColor">
-              <path d="M3 2L9 5.5L3 9V2Z" />
-            </svg>
-            {resuming ? 'Opening…' : 'Resume in Terminal'}
+            <SquareTerminal size={13} strokeWidth={1.6} aria-hidden />
           </button>
 
           <Menu
@@ -307,9 +306,9 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
                 onClick={toggle}
                 title="More actions"
                 aria-label="More actions"
-                className="inline-flex items-center justify-center w-7 h-7 rounded-md text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors"
+                className="inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors"
               >
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
+                <svg width="13" height="13" viewBox="0 0 14 14" fill="currentColor">
                   <circle cx="3" cy="7" r="1.2" />
                   <circle cx="7" cy="7" r="1.2" />
                   <circle cx="11" cy="7" r="1.2" />

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { SquareTerminal } from 'lucide-react'
 import type { Session } from '@spool-lab/core'
 import { SourceBadge } from './Badges.js'
 import PinButton from './PinButton.js'
@@ -89,9 +90,9 @@ export default function SessionRow({ session, pinned = false, showProject = fals
                 onClick={toggle}
                 title="More actions"
                 aria-label="More actions"
-                className="inline-flex items-center justify-center w-7 h-7 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text"
+                className="inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text"
               >
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
+                <svg width="13" height="13" viewBox="0 0 14 14" fill="currentColor">
                   <circle cx="3" cy="7" r="1.2" />
                   <circle cx="7" cy="7" r="1.2" />
                   <circle cx="11" cy="7" r="1.2" />
@@ -124,11 +125,7 @@ export default function SessionRow({ session, pinned = false, showProject = fals
 }
 
 function PlayIcon() {
-  return (
-    <svg width="13" height="13" viewBox="0 0 13 13" fill="currentColor">
-      <path d="M3.5 2.5L10 6.5L3.5 10.5V2.5Z" />
-    </svg>
-  )
+  return <SquareTerminal size={13} strokeWidth={1.6} aria-hidden />
 }
 
 function TerminalIcon() {


### PR DESCRIPTION
## Summary
- Replace the prominent **Resume in Terminal** pill in the session-detail header with an icon-only ghost button. Hover shows a native tooltip; the resume action itself is unchanged.
- Switch every resume affordance (header button, row menu item, search-result CTA) to Lucide's `SquareTerminal` icon so the visual language for "open this session in a terminal" is consistent.
- Unify the three header toolbar buttons (pin / resume / more-actions) at **24×24 with a 13px icon** — previously pin rendered noticeably smaller (24×24 / 11px) than the other two (28×28 / 14px). Tighten the toolbar gap from 6px to 2px so they read as one cluster.

## Why
The header bar was visually unbalanced: a heavy filled-accent pill next to two muted ghost icons, plus mismatched icon sizes. The resume button is the same priority as the other actions on this row, so it should share the same visual weight. Standardizing on Lucide's `SquareTerminal` also matches the design rule in `DESIGN.md` that production UI uses Lucide SVGs.

## How it connects
- `SessionDetail.tsx` — header toolbar restyled; resume button is now icon-only with `title` + `aria-label` driving the tooltip and a11y label.
- `SessionRow.tsx` — the row's overflow-menu "Resume in Terminal" item uses the same icon, and the row's more-actions button is sized to match.
- `ContinueActions.tsx` — the "Resume in CLI" CTA on AI search results uses the same icon.
- `PinButton.tsx` — `sm` icon size bumped 11 → 13 so pin reads at the same optical weight as the new neighbors.

## Test plan
- [ ] Open a session — header shows **pin / square-terminal / more-actions** at the same size, tightly grouped.
- [ ] Hover the terminal icon — native tooltip reads "Resume in Terminal" (or "Opening…" while resuming).
- [ ] Click it — session resumes in the configured terminal as before.
- [ ] Open a session row's **⋯** menu — "Resume in Terminal" now uses the terminal icon.
- [ ] Run an AI search — the result card's "Resume in CLI" CTA shows the terminal icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)