### PR TITLE
feat(app): library home interaction polish

### DIFF
--- a/packages/app/src/renderer/components/LibraryLanding.tsx
+++ b/packages/app/src/renderer/components/LibraryLanding.tsx
@@ -71,7 +71,7 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId }: Props
 
       <div className="flex-1 overflow-y-auto pb-12 [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]">
         {recentSessions === null ? (
-          <p className="px-6 py-6 text-sm text-warm-faint dark:text-dark-muted">Loading…</p>
+          <SessionRowsSkeleton count={6} />
         ) : totalSessions === 0 ? (
           <p className="px-6 py-6 text-sm text-warm-faint dark:text-dark-muted">
             No sessions yet. Run <code className="font-mono bg-warm-surface dark:bg-dark-surface px-1 rounded">spool sync</code> to index your AI sessions.
@@ -159,12 +159,30 @@ export function CollapsibleSection({
           viewBox="0 0 12 12"
           fill="none"
           aria-hidden
-          className={`flex-none transition-all opacity-0 group-hover:opacity-100 ${open ? 'rotate-90' : ''}`}
+          className={`flex-none transition-all opacity-30 group-hover:opacity-100 ${open ? 'rotate-90' : ''}`}
         >
           <path d="M4 2L8 6L4 10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       </button>
       {open && children}
+    </div>
+  )
+}
+
+function SessionRowsSkeleton({ count }: { count: number }) {
+  return (
+    <div aria-hidden>
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="flex items-start gap-3 px-5 py-3">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1.5">
+              <div className="h-4 w-12 rounded bg-warm-surface2 dark:bg-dark-surface2 opacity-60 animate-pulse" />
+              <div className="h-4 w-1/2 rounded bg-warm-surface2 dark:bg-dark-surface2 opacity-60 animate-pulse" />
+            </div>
+            <div className="h-3 w-1/3 rounded bg-warm-surface2 dark:bg-dark-surface2 opacity-60 animate-pulse" />
+          </div>
+        </div>
+      ))}
     </div>
   )
 }

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -90,7 +90,7 @@ export default function SessionRow({ session, pinned = false, showProject = fals
                 onClick={toggle}
                 title="More actions"
                 aria-label="More actions"
-                className="inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text"
+                className="inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75"
               >
                 <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
                   <circle cx="3" cy="7" r="1.2" />

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -80,7 +80,7 @@ export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHo
             viewBox="0 0 12 12"
             fill="none"
             aria-hidden="true"
-            className={`flex-none transition-all opacity-0 group-hover:opacity-100 ${projectsOpen ? 'rotate-90' : ''}`}
+            className={`flex-none transition-all opacity-30 group-hover:opacity-100 ${projectsOpen ? 'rotate-90' : ''}`}
           >
             <path d="M4 2L8 6L4 10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
@@ -99,7 +99,7 @@ export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHo
                 aria-haspopup="menu"
                 aria-expanded={open}
                 className={`flex-none inline-flex items-center justify-end h-4 transition-opacity text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text ${
-                  open ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                  open ? 'opacity-100' : 'opacity-30 group-hover:opacity-100'
                 }`}
               >
                 <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>


### PR DESCRIPTION
## Summary
Second polish PR following the spec drift fixes in #142. Surface-level discoverability + loading-state cleanup on Library Home and Sidebar — no spec drift, no behavior changes beyond the visible interactions called out.

## What changed

**Discoverability — fade chevrons in, don't hide them**
- Sidebar `PROJECTS` toggle chevron: `opacity-0` → `opacity-30`, hover lifts to `opacity-100`
- Library Home section headers (`PINNED`, `TODAY`, `YESTERDAY`, …): same change
- Sidebar sort-menu icon (closed state): same pattern; menu-open state still pins to 100%

A fully-hidden chevron meant new users had no static cue that sections were collapsible — they had to mouse over to discover. Soft static affordance ↔ full opacity on hover preserves the calm aesthetic while making the interaction visible from the start.

**Loading skeleton on Library Home**
- Replaces the bare `"Loading…"` text with six skeleton rows (badge + title + meta blocks)
- Uses the same `bg-surface2 / animate-pulse / opacity-60` pattern as `SidebarSkeleton` (already shipped) — they now feel like a coordinated pair
- No layout jump from text → list when sessions arrive; the loading shape already mirrors the final shape

**Hover transition consistency**
- `SessionRow` kebab button picks up `transition-colors duration-75` to match the 80ms hover spec (the row, the pin, the project rows already had it; the kebab was the holdout)

## Why
Polish round building on #141 (spec) and #142 (drift fixes). The sidebar loaded with no chevron at all under the `PROJECTS` label, and Library Home loaded with a single grey "Loading…" line that abruptly snapped to a populated list. These were the two most visible "doesn't quite feel finished" moments in the library shell, and they're cheap to fix.

## How it connects
This is the interaction-polish slice of the planned three-PR polish stack (after #141 spec + #142 drift). The third PR is a smaller copy / empty-state pass — it'll address the stale `spool sync` empty-state copy and warm up the new-user landing surface.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] CI: e2e + unit (sidebar, project-view, pin, home-preview, agent-search, fast-search)
- [ ] Visual smoke: `PROJECTS` chevron visible at low opacity at rest; lifts to full on sidebar hover
- [ ] Visual smoke: section chevrons (PINNED / TODAY / YESTERDAY) same behavior on Library Home
- [ ] Visual smoke: open sort menu — sort icon stays full opacity
- [ ] Visual smoke: cold-start the app — Library Home shows skeleton rows, then transitions to populated list without a layout jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)