### PR TITLE
feat(app): redesign SessionFindBar as a floating compact widget

### DIFF
--- a/packages/app/e2e/fast-search.spec.ts
+++ b/packages/app/e2e/fast-search.spec.ts
@@ -172,7 +172,7 @@ test('session page supports cmd or ctrl + f find-in-page', async () => {
   await expect(findInput).toBeFocused()
   await findInput.type('_CANARY_42')
   await expect(findInput).toHaveValue('XYLOPHONE_CANARY_42')
-  await expect(window.locator('[data-testid="session-find-status"]')).toContainText(/\d+\s*\/\s*\d+/, { timeout: 5000 })
+  await expect(window.locator('[data-testid="session-find-status"]')).toContainText(/\d+\s+of\s+\d+/, { timeout: 5000 })
   await expect(window.locator('[data-testid="session-find-active-match"]').first()).toContainText('XYLOPHONE_CANARY_42')
 })
 
@@ -189,11 +189,11 @@ test('session find supports cmd or ctrl + arrow navigation', async () => {
   const status = window.locator('[data-testid="session-find-status"]')
 
   await findInput.fill('the')
-  await expect(status).toContainText(/1\s*\/\s*[2-9]\d*/, { timeout: 5000 })
+  await expect(status).toContainText(/1\s+of\s+[2-9]\d*/, { timeout: 5000 })
 
   await window.keyboard.press(process.platform === 'darwin' ? 'Meta+ArrowRight' : 'Control+ArrowRight')
-  await expect(status).toContainText(/2\s*\/\s*[2-9]\d*/, { timeout: 5000 })
+  await expect(status).toContainText(/2\s+of\s+[2-9]\d*/, { timeout: 5000 })
 
   await window.keyboard.press(process.platform === 'darwin' ? 'Meta+ArrowLeft' : 'Control+ArrowLeft')
-  await expect(status).toContainText(/1\s*\/\s*[2-9]\d*/, { timeout: 5000 })
+  await expect(status).toContainText(/1\s+of\s+[2-9]\d*/, { timeout: 5000 })
 })

--- a/packages/app/e2e/session-detail.spec.ts
+++ b/packages/app/e2e/session-detail.spec.ts
@@ -145,7 +145,7 @@ test('handles 1500-message session: virtualization + deep find', async () => {
   const isMac = process.platform === 'darwin'
   await window.keyboard.press(isMac ? 'Meta+f' : 'Control+f')
   await window.locator('[data-testid="session-find-input"]').fill('SPOOLDEEPMARKER')
-  await expect(window.locator('[data-testid="session-find-status"]')).toContainText('1 / 1', {
+  await expect(window.locator('[data-testid="session-find-status"]')).toContainText('1 of 1', {
     timeout: 5000,
   })
   await expect(window.locator('[data-testid="session-find-active-match"]')).toHaveCount(1)

--- a/packages/app/e2e/session-detail.spec.ts
+++ b/packages/app/e2e/session-detail.spec.ts
@@ -117,7 +117,7 @@ test('find-in-page matches rendered text, not markdown source', async () => {
   await window.keyboard.press(isMac ? 'Meta+f' : 'Control+f')
 
   await window.locator('[data-testid="session-find-input"]').fill('XYZMARKDOWN')
-  await expect(window.locator('[data-testid="session-find-status"]')).toContainText(/^\d+ \/ \d+$/)
+  await expect(window.locator('[data-testid="session-find-status"]')).toContainText(/^\d+ of \d+$/)
   await expect(window.locator('[data-testid="session-find-active-match"]')).toHaveCount(1)
 
   await window.locator('[data-testid="session-find-input"]').fill('**XYZMARKDOWN**')

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -257,7 +257,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
   const resumeCommandAvailable = Boolean(session && getSessionResumeCommand(session.source, session.sessionUuid))
 
   return (
-    <div className="flex flex-col h-full" data-testid="session-detail">
+    <div className="relative flex flex-col h-full" data-testid="session-detail">
       {/* Session header */}
       <div className="flex-none flex items-start gap-3 px-6 pt-3 pb-3 border-b border-warm-border dark:border-dark-border">
         {onBack && (

--- a/packages/app/src/renderer/components/SessionFindBar.tsx
+++ b/packages/app/src/renderer/components/SessionFindBar.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react'
+import { ChevronUp, ChevronDown, X } from 'lucide-react'
 
 type Props = {
   visible: boolean
@@ -27,8 +28,9 @@ export default function SessionFindBar({
 }: Props) {
   const inputRef = useRef<HTMLInputElement>(null)
   const selectionRef = useRef<{ start: number; end: number } | null>(null)
-  const previousShortcutLabel = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform) ? '⌘←' : 'Ctrl+←'
-  const nextShortcutLabel = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform) ? '⌘→' : 'Ctrl+→'
+  const isMacLike = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform)
+  const previousShortcutLabel = isMacLike ? '⌘←' : 'Ctrl+←'
+  const nextShortcutLabel = isMacLike ? '⌘→' : 'Ctrl+→'
 
   const rememberSelection = useCallback((input: HTMLInputElement) => {
     const start = input.selectionStart ?? input.value.length
@@ -75,13 +77,16 @@ export default function SessionFindBar({
   const hasQuery = query.trim().length > 0
   const hasMatches = matches > 0
   const statusLabel = !hasQuery
-    ? 'Type to find in this session'
+    ? ''
     : hasMatches
-      ? `${activeMatchOrdinal} / ${matches}`
+      ? `${activeMatchOrdinal} of ${matches}`
       : 'No matches'
 
   return (
-    <div className="flex items-center gap-2 border-b border-warm-border dark:border-dark-border px-4 py-2 bg-warm-surface/70 dark:bg-dark-surface/70 backdrop-blur-sm">
+    <div
+      className="absolute top-8 right-4 z-20 flex items-center gap-0.5 rounded-md border border-warm-border dark:border-dark-border bg-warm-bg/95 dark:bg-dark-surface2/95 backdrop-blur-sm shadow-[0_4px_12px_rgba(0,0,0,0.06)] dark:shadow-[0_4px_12px_rgba(0,0,0,0.4)] pl-2 pr-1 py-0.5 w-[320px] animate-in fade-in transition-[border-color,box-shadow] focus-within:border-accent/55 dark:focus-within:border-accent-dark/60 focus-within:shadow-[0_0_0_3px_rgba(200,90,0,0.10),0_4px_12px_rgba(0,0,0,0.06)] dark:focus-within:shadow-[0_0_0_3px_rgba(240,112,32,0.15),0_4px_12px_rgba(0,0,0,0.4)]"
+      role="search"
+    >
       <input
         ref={inputRef}
         type="text"
@@ -108,44 +113,46 @@ export default function SessionFindBar({
           }
         }}
         placeholder="Find in session…"
-        className="min-w-0 flex-1 rounded-full border border-warm-border dark:border-dark-border bg-warm-bg/90 dark:bg-dark-bg px-3 py-1.5 text-sm text-warm-text dark:text-dark-text outline-none placeholder:text-warm-faint dark:placeholder:text-dark-muted transition-[border-color,box-shadow,background-color] focus:border-accent/45 dark:focus:border-accent-dark/55 focus:bg-white dark:focus:bg-dark-surface2 focus:shadow-[0_0_0_3px_rgba(200,90,0,0.08)] dark:focus:shadow-[0_0_0_3px_rgba(240,112,32,0.12)]"
+        className="flex-1 min-w-0 bg-transparent text-[13px] text-warm-text dark:text-dark-text outline-none placeholder:text-warm-faint dark:placeholder:text-dark-muted"
         autoComplete="off"
         spellCheck={false}
         data-testid="session-find-input"
       />
       <span
-        className="min-w-24 text-right text-xs text-warm-muted dark:text-dark-muted"
+        className="flex-none font-mono text-[11px] tabular-nums text-warm-muted dark:text-dark-muted whitespace-nowrap pl-1"
         data-testid="session-find-status"
       >
         {statusLabel}
       </span>
+      <div className="flex-none w-px h-4 bg-warm-border dark:bg-dark-border mx-0.5" />
       <button
         type="button"
         onClick={onPrevious}
         disabled={!hasQuery || !hasMatches}
-        className="rounded-full border border-warm-border dark:border-dark-border px-2 py-1 text-xs text-warm-muted dark:text-dark-muted transition-colors enabled:hover:text-warm-text enabled:hover:border-accent enabled:dark:hover:text-dark-text disabled:opacity-40"
+        className="flex-none inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted transition-colors enabled:hover:bg-warm-surface enabled:hover:text-warm-text enabled:dark:hover:bg-dark-surface enabled:dark:hover:text-dark-text disabled:opacity-40"
         aria-label={`Previous match (${previousShortcutLabel})`}
         title={`Previous match (${previousShortcutLabel})`}
       >
-        Prev
+        <ChevronUp size={12} strokeWidth={1.8} aria-hidden />
       </button>
       <button
         type="button"
         onClick={onNext}
         disabled={!hasQuery || !hasMatches}
-        className="rounded-full border border-warm-border dark:border-dark-border px-2 py-1 text-xs text-warm-muted dark:text-dark-muted transition-colors enabled:hover:text-warm-text enabled:hover:border-accent enabled:dark:hover:text-dark-text disabled:opacity-40"
+        className="flex-none inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted transition-colors enabled:hover:bg-warm-surface enabled:hover:text-warm-text enabled:dark:hover:bg-dark-surface enabled:dark:hover:text-dark-text disabled:opacity-40"
         aria-label={`Next match (${nextShortcutLabel})`}
         title={`Next match (${nextShortcutLabel})`}
       >
-        Next
+        <ChevronDown size={12} strokeWidth={1.8} aria-hidden />
       </button>
       <button
         type="button"
         onClick={onClose}
-        className="rounded-full border border-warm-border dark:border-dark-border px-2 py-1 text-xs text-warm-muted dark:text-dark-muted transition-colors hover:text-warm-text hover:border-accent dark:hover:text-dark-text"
+        className="flex-none inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted transition-colors hover:bg-warm-surface hover:text-warm-text dark:hover:bg-dark-surface dark:hover:text-dark-text"
         aria-label="Close find in session"
+        title="Close (Esc)"
       >
-        Close
+        <X size={12} strokeWidth={1.8} aria-hidden />
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary

- Replace the full-width sticky bar with a floating Notion-style widget anchored at top-right of SessionDetail. Bottom edge sits flush with the header divider — no content gets pushed down.
- Compact form: 320px wide, ~26px tall, rounded-md, soft shadow on warm-bg with backdrop blur.
- Lucide chevron-up / chevron-down / X icons (24px buttons) replace the verbose Prev/Next/Close text buttons.
- Match count format "1 of N" inline next to the input, font-mono tabular-nums so the digits stay stable as you navigate.
- focus-within: warm amber border + 3px soft ring, matching SearchBar's focus treatment.

## Why

Inspired by Notion's in-page find, but matched to Spool's warm palette + Geist typography. The previous bar took a full row across the top of the messages area, pushed content down, and used three text buttons that were heavier than necessary for a transient action.

## How it connects

- Only `SessionFindBar.tsx` (rewrite) + `SessionDetail.tsx` (root made `relative` so absolute positioning anchors correctly) + the e2e count assertion.
- All keyboard behavior preserved: Cmd+F open, Cmd+←/→ prev/next, Enter / Shift+Enter, Esc close. data-testids unchanged so existing e2e selectors still resolve.
- Overlays the header's pin/terminal/menu while find is open. Acceptable trade-off — find is a transient mode and the icons reappear on close.

## Test plan

- [x] `pnpm --filter @spool/app exec tsc --noEmit` clean
- [x] `pnpm --filter @spool/app exec vitest run src` — 28 passing
- [x] e2e `session-detail.spec.ts` — 5/5 passing (count assertion now matches "1 of 1")
- [x] Manual QA: Cmd+F opens floating bar; Esc closes; chevron prev/next cycles; focus ring shows on click; positions correctly across light/dark theme.