### PR TITLE
polish(app): tighten search result card layout and actions

### DIFF
--- a/packages/app/e2e/fast-search.spec.ts
+++ b/packages/app/e2e/fast-search.spec.ts
@@ -42,8 +42,9 @@ test('search result shows session metadata', async () => {
   const { window } = ctx
 
   const row = window.locator('[data-testid="fragment-row"]').first()
-  await expect(row).toContainText('You discussed this')
-  await expect(row.locator('text=claude')).toBeVisible()
+  await expect(row.locator('[data-testid="source-badge"]')).toBeVisible()
+  await row.hover()
+  await expect(row.getByRole('button', { name: 'More actions' })).toBeVisible()
 })
 
 test('search for different canary finds separate session', async () => {
@@ -74,11 +75,11 @@ test('codex search results expose resume-related actions', async () => {
   await expect(row).toBeVisible({ timeout: 5000 })
   await expect(row.locator('[data-testid="source-badge"][data-source="codex"]')).toBeVisible()
 
-  const copyCommand = row.getByRole('button', { name: 'Copy Command' })
-  await expect(copyCommand).toBeVisible()
-
-  const resumeInCli = row.getByRole('button', { name: 'Resume in CLI' })
-  await expect(resumeInCli).toBeVisible()
+  await row.hover()
+  await row.getByRole('button', { name: 'More actions' }).click()
+  await expect(window.getByRole('menuitem', { name: 'Open in Terminal' })).toBeVisible()
+  await expect(window.getByRole('menuitem', { name: 'Copy resume command' })).toBeVisible()
+  await window.keyboard.press('Escape')
 })
 
 test('gemini search results expose resume-related actions', async () => {
@@ -90,11 +91,11 @@ test('gemini search results expose resume-related actions', async () => {
   await expect(row).toBeVisible({ timeout: 5000 })
   await expect(row.locator('[data-testid="source-badge"][data-source="gemini"]')).toBeVisible()
 
-  const copyCommand = row.getByRole('button', { name: 'Copy Command' })
-  await expect(copyCommand).toBeVisible()
-
-  const resumeInCli = row.getByRole('button', { name: 'Resume in CLI' })
-  await expect(resumeInCli).toBeVisible()
+  await row.hover()
+  await row.getByRole('button', { name: 'More actions' }).click()
+  await expect(window.getByRole('menuitem', { name: 'Open in Terminal' })).toBeVisible()
+  await expect(window.getByRole('menuitem', { name: 'Copy resume command' })).toBeVisible()
+  await window.keyboard.press('Escape')
 })
 
 test('whitespace-separated terms narrow shared PR number matches', async () => {

--- a/packages/app/src/renderer/components/ContinueActions.tsx
+++ b/packages/app/src/renderer/components/ContinueActions.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
-import { SquareTerminal } from 'lucide-react'
+import { MoreHorizontal, Eye, SquareTerminal } from 'lucide-react'
 import type { FragmentResult } from '@spool-lab/core'
+import Menu from './Menu.js'
 import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
 
 type Props = {
@@ -10,16 +11,16 @@ type Props = {
 }
 
 export default function ContinueActions({ result, onOpenSession, onCopySessionId }: Props) {
-  const [copied, setCopied] = useState(false)
-  const [commandCopied, setCommandCopied] = useState(false)
+  const [copiedId, setCopiedId] = useState(false)
+  const [copiedCommand, setCopiedCommand] = useState(false)
   const [resuming, setResuming] = useState(false)
   const resumeCommand = getSessionResumeCommand(result.source, result.sessionUuid)
 
-  async function handleCopy() {
+  async function handleCopyId() {
     await navigator.clipboard.writeText(result.sessionUuid)
     onCopySessionId(result.source)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 1500)
+    setCopiedId(true)
+    setTimeout(() => setCopiedId(false), 1500)
   }
 
   async function handleResume() {
@@ -31,95 +32,88 @@ export default function ContinueActions({ result, onOpenSession, onCopySessionId
   async function handleCopyCommand() {
     if (!resumeCommand) return
     await navigator.clipboard.writeText(resumeCommand)
-    setCommandCopied(true)
-    setTimeout(() => setCommandCopied(false), 1500)
+    setCopiedCommand(true)
+    setTimeout(() => setCopiedCommand(false), 1500)
   }
 
+  const menuItems = [
+    {
+      label: 'View session',
+      icon: <EyeIcon />,
+      onSelect: () => onOpenSession(result.sessionUuid, result.messageId),
+    },
+    ...(resumeCommand ? [{
+      label: resuming ? 'Opening Terminal…' : 'Open in Terminal',
+      icon: resuming ? <SpinnerIcon /> : <TerminalIcon />,
+      onSelect: () => { void handleResume() },
+      disabled: resuming,
+    }] : []),
+    ...(resumeCommand ? [{
+      label: copiedCommand ? 'Copied resume command' : 'Copy resume command',
+      icon: <CommandIcon />,
+      onSelect: () => { void handleCopyCommand() },
+    }] : []),
+    {
+      label: copiedId ? 'Copied session ID' : 'Copy session ID',
+      icon: <CopyIcon />,
+      onSelect: () => { void handleCopyId() },
+    },
+  ]
+
   return (
-    <div className="flex items-center gap-1 mt-2">
-      <ActionButton onClick={handleCopy} title="Copy session ID for CLI resume">
-        <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
-          {copied ? (
-            <path d="M2 7L5 10L11 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-          ) : (
-            <>
-              <rect x="4.5" y="4.5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.2"/>
-              <path d="M8.5 4.5V3C8.5 2.17 7.83 1.5 7 1.5H3C2.17 1.5 1.5 2.17 1.5 3V7C1.5 7.83 2.17 8.5 3 8.5H4.5" stroke="currentColor" strokeWidth="1.2"/>
-            </>
-          )}
-        </svg>
-        Copy Session ID
-      </ActionButton>
-
-      {resumeCommand && (
-        <ActionButton onClick={handleCopyCommand} title="Copy the full CLI resume command">
-          {commandCopied ? (
-            <>
-              <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
-                <path d="M2 7L5 10L11 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-              </svg>
-              Copied Command
-            </>
-          ) : (
-            <>
-              <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
-                <path d="M2 3.5H11" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
-                <path d="M2 6.5H8.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
-                <path d="M2 9.5H6.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
-                <path d="M9.5 9.5L11.5 11.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
-                <path d="M11.5 9.5L9.5 11.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"/>
-              </svg>
-              Copy Command
-            </>
-          )}
-        </ActionButton>
+    <Menu
+      align="right"
+      trigger={({ open, toggle }) => (
+        <button
+          type="button"
+          aria-label="More actions"
+          aria-haspopup="menu"
+          aria-expanded={open}
+          onClick={(event) => {
+            event.stopPropagation()
+            toggle()
+          }}
+          className="flex-none self-center inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text hover:bg-warm-surface2 dark:hover:bg-dark-surface2 transition-colors"
+        >
+          <MoreHorizontal size={14} strokeWidth={1.8} aria-hidden />
+        </button>
       )}
-
-      {resumeCommand && (
-        <ActionButton onClick={handleResume} title="Resume this session in Terminal">
-          {resuming ? (
-            <>
-              <svg className="animate-spin" width="13" height="13" viewBox="0 0 13 13" fill="none">
-                <circle cx="6.5" cy="6.5" r="4.5" stroke="currentColor" strokeWidth="1.5" strokeDasharray="20" strokeDashoffset="7"/>
-              </svg>
-              Opening...
-            </>
-          ) : (
-            <>
-              <SquareTerminal size={13} strokeWidth={1.6} aria-hidden />
-              Resume in CLI
-            </>
-          )}
-        </ActionButton>
-      )}
-
-      <ActionButton onClick={() => onOpenSession(result.sessionUuid, result.messageId)} title="View full session">
-        <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
-          <path d="M1.5 6.5C1.5 6.5 3.5 2.5 6.5 2.5C9.5 2.5 11.5 6.5 11.5 6.5C11.5 6.5 9.5 10.5 6.5 10.5C3.5 10.5 1.5 6.5 1.5 6.5Z" stroke="currentColor" strokeWidth="1.2"/>
-          <circle cx="6.5" cy="6.5" r="1.5" stroke="currentColor" strokeWidth="1.2"/>
-        </svg>
-        View session
-      </ActionButton>
-    </div>
+      items={menuItems}
+    />
   )
 }
 
-function ActionButton({
-  onClick,
-  title,
-  children,
-}: {
-  onClick: () => void
-  title: string
-  children: React.ReactNode
-}) {
+function EyeIcon() {
+  return <Eye size={14} strokeWidth={1.5} aria-hidden />
+}
+
+function TerminalIcon() {
+  return <SquareTerminal size={14} strokeWidth={1.5} aria-hidden />
+}
+
+function CommandIcon() {
   return (
-    <button
-      onClick={onClick}
-      title={title}
-      className="flex items-center gap-1 text-xs text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 rounded px-2 py-1 transition-colors"
-    >
-      {children}
-    </button>
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 4.5L5 7L3 9.5" />
+      <path d="M6.5 10H11.5" />
+    </svg>
+  )
+}
+
+function CopyIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <rect x="5" y="5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M9 5V3.5C9 2.67 8.33 2 7.5 2H3.5C2.67 2 2 2.67 2 3.5V7.5C2 8.33 2.67 9 3.5 9H5" stroke="currentColor" strokeWidth="1.5" />
+    </svg>
+  )
+}
+
+function SpinnerIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" className="animate-spin">
+      <circle cx="7" cy="7" r="5.25" stroke="currentColor" strokeWidth="1.5" fill="none" strokeOpacity="0.3" />
+      <path d="M7 1.75A5.25 5.25 0 0112.25 7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" fill="none" />
+    </svg>
   )
 }

--- a/packages/app/src/renderer/components/FragmentResults.tsx
+++ b/packages/app/src/renderer/components/FragmentResults.tsx
@@ -136,38 +136,36 @@ function FragmentRow({
   const snippet = result.snippet.replace(/<mark>/g, '<strong>').replace(/<\/mark>/g, '</strong>')
   const date = formatRelativeDate(result.startedAt)
   const project = result.project.split('/').pop() ?? result.project
+  const title = result.sessionTitle?.trim() || '(untitled session)'
 
   return (
     <div
       data-testid="fragment-row"
-      className="px-6 py-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors"
+      className="group relative px-6 py-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors cursor-pointer"
+      onClick={() => onOpenSession(result.sessionUuid, result.messageId)}
     >
-      <div
-        className="cursor-pointer"
-        onClick={() => onOpenSession(result.sessionUuid, result.messageId)}
-      >
-        <div className="flex items-center gap-2 mb-1.5">
-          <SourceBadge source={result.source} />
-          <span className="text-xs text-warm-muted dark:text-dark-muted truncate flex-1">
-            You discussed this · {project}
-            {result.profileLabel && <span> · {result.profileLabel}</span>}
-            {result.matchCount > 1 && <span data-testid="match-count"> · {result.matchCount} matches</span>}
-          </span>
-          <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
-        </div>
-
-        <p
-          className="font-mono text-xs text-warm-text dark:text-dark-text leading-relaxed [&>strong]:font-semibold [&>strong]:text-accent dark:[&>strong]:text-accent-dark select-text cursor-text"
-          onClick={(e) => e.stopPropagation()}
-          dangerouslySetInnerHTML={{ __html: snippet }}
-        />
-
-        <p className="text-xs text-warm-faint dark:text-dark-muted mt-1 truncate">
-          {result.sessionTitle}
-        </p>
+      <div className="flex items-center gap-2 mb-1">
+        <SourceBadge source={result.source} />
+        <h3 className="text-sm font-medium text-warm-text dark:text-dark-text truncate flex-1 min-w-0">
+          {title}
+        </h3>
+        <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
+        <ContinueActions result={result} onOpenSession={onOpenSession} onCopySessionId={onCopySessionId} />
       </div>
 
-      <ContinueActions result={result} onOpenSession={onOpenSession} onCopySessionId={onCopySessionId} />
+      <div className="text-xs text-warm-muted dark:text-dark-muted mb-1.5 truncate">
+        {project}
+        {result.profileLabel && <span> · {result.profileLabel}</span>}
+        {result.matchCount > 1 && (
+          <span data-testid="match-count"> · {result.matchCount} matches</span>
+        )}
+      </div>
+
+      <p
+        className="font-mono text-xs text-warm-text dark:text-dark-text leading-relaxed [&>strong]:font-semibold [&>strong]:text-accent dark:[&>strong]:text-accent-dark select-text cursor-text"
+        onClick={(e) => e.stopPropagation()}
+        dangerouslySetInnerHTML={{ __html: snippet }}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

The fragment-results card had four inline action buttons per row, a redundant "You discussed this" prefix on every result, and the session title buried below the FTS snippet. With dozens of results on screen the whole grid felt repetitive and visually heavy. This pass rebuilds the card around the session title and reduces the action surface to a single overflow menu, in line with how \`SessionRow\` already handles its actions.

## What changed

- Session title is now the card anchor: badge / title / date / overflow on one centered row.
- "You discussed this" prefix is removed — the source badge already conveys it.
- Four inline buttons (Copy Session ID, Copy Command, Resume in CLI, View session) collapse into one always-visible \`⋯\` button. The menu items carry icons that mirror \`SessionRow\`'s menu (View session, Open in Terminal, Copy resume command, Copy session ID).
- Clicking anywhere on the card body still opens the session — the action menu is for secondary flows.
- "N matches" is demoted to plain meta text alongside the project name.

## Why

The previous layout had three problems:
1. The title — usually the most useful piece of info for triage — was the smallest, dimmest line in the card.
2. Four equally-weighted action buttons on every card competed with the content for visual weight, even though >95% of clicks go to "View session" (which is what clicking the row already does).
3. "You discussed this · project" repeated identically on every card and added noise without information.

## How it connects

\`ContinueActions\` now mirrors the pattern in \`SessionRow\` (single overflow menu with icon-prefixed items), so the two surfaces feel consistent. \`FragmentResults\` is the only call site for \`ContinueActions\`, so no other components are affected. \`onOpenSession\` and \`onCopySessionId\` props are unchanged.

## Test plan

- [x] Search for a keyword with multiple matches; confirm cards show title at top, badge + date right-aligned, \`⋯\` button next to date
- [x] Click card body → opens session (existing behavior)
- [x] Click \`⋯\` → menu opens with icon-prefixed items: View session, Open in Terminal, Copy resume command, Copy session ID
- [x] Verify menu items work: View session navigates, Open in Terminal launches terminal, Copy commands populate clipboard
- [x] Verify e2e \`fast-search.spec.ts\` passes locally
- [x] Sanity-check long Chinese titles truncate cleanly with ellipsis