### PR TITLE
fix(app): swap SessionDetail virtualization to react-virtuoso

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -34,6 +34,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-markdown": "^9",
+    "react-virtuoso": "^4.18.6",
     "rehype-sanitize": "^6",
     "remark": "^15",
     "remark-gfm": "^4",

--- a/packages/app/src/renderer/components/MessageList.tsx
+++ b/packages/app/src/renderer/components/MessageList.tsx
@@ -1,5 +1,5 @@
-import { forwardRef, useImperativeHandle, useRef, useEffect, useMemo, useCallback } from 'react'
-import { useVirtualizer } from '@tanstack/react-virtual'
+import { forwardRef, useImperativeHandle, useMemo, useRef } from 'react'
+import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
 import type { Message } from '@spool-lab/core'
 import MessageBubble, { type FindRange } from './MessageBubble.js'
 
@@ -27,7 +27,7 @@ const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
   { messages, isDark, showFindBar, messageFindRanges, activeMatchIndex, onActiveMatchRef, targetMessageId, showTargetHighlight },
   ref,
 ) {
-  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const virtuosoRef = useRef<VirtuosoHandle | null>(null)
 
   const idToIndex = useMemo(() => {
     const map = new Map<number, number>()
@@ -35,92 +35,71 @@ const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
     return map
   }, [messages])
 
-  const estimateSize = useCallback((index: number) => {
-    const m = messages[index]
-    if (!m) return 120
-    if (m.role === 'system') return 44
-    const len = m.contentText?.length ?? 0
-    // Markdown adds ~30% height vs plain text; code blocks/lists/headings push
-    // further. Err on the over-estimate side — gaps close on measure, but
-    // under-estimates cause rows to land at colliding translateY values.
-    return Math.min(2400, Math.max(120, Math.ceil(len / 50) * 26 + 96))
-  }, [messages])
-
-  const virtualizer = useVirtualizer({
-    count: messages.length,
-    getScrollElement: () => scrollRef.current,
-    estimateSize,
-    overscan: 6,
-    getItemKey: (index) => messages[index]?.id ?? index,
-  })
+  // Captured once at mount: Virtuoso reads this before its first paint, so the
+  // target row is already centered when the user sees the list. Subsequent
+  // target changes (same session, different match) flow through the imperative
+  // scrollToMessageId handle. Cross-session navigation is expected to remount
+  // this component (parent should pass `key={sessionUuid}`), which re-engages
+  // initialTopMostItemIndex with the fresh target.
+  const initialIndex = useMemo(() => {
+    if (targetMessageId == null) return undefined
+    const idx = idToIndex.get(targetMessageId)
+    return idx == null ? undefined : { index: idx, align: 'center' as const }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useImperativeHandle(ref, () => ({
     scrollToMessageId(id) {
       const idx = idToIndex.get(id)
       if (idx == null) return
-      virtualizer.scrollToIndex(idx, { align: 'center' })
+      virtuosoRef.current?.scrollToIndex({ index: idx, align: 'center' })
     },
-  }), [virtualizer, idToIndex])
+  }), [idToIndex])
 
-  // When the message set changes (e.g., session swap), reset scroll to top and re-measure.
-  useEffect(() => {
-    if (scrollRef.current) scrollRef.current.scrollTop = 0
-    virtualizer.measure()
-  }, [messages, virtualizer])
-
-  const items = virtualizer.getVirtualItems()
+  if (messages.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-warm-faint dark:text-dark-muted">
+        <p className="text-sm">No messages to display.</p>
+      </div>
+    )
+  }
 
   return (
-    <div
-      ref={scrollRef}
-      className="flex-1 overflow-y-auto [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]"
+    <Virtuoso
+      ref={virtuosoRef}
+      data={messages}
+      computeItemKey={(_index, msg) => msg.id}
+      {...(initialIndex ? { initialTopMostItemIndex: initialIndex } : {})}
+      increaseViewportBy={400}
       data-testid="message-list-scroll"
-    >
-      <div style={{ height: virtualizer.getTotalSize(), position: 'relative', width: '100%' }}>
-        {items.map((virtualRow) => {
-          const msg = messages[virtualRow.index]
-          if (!msg) return null
-          const matchState = showFindBar ? messageFindRanges.get(msg.id) : undefined
-          const containsActive = matchState != null
-            && activeMatchIndex >= matchState.offset
-            && activeMatchIndex < matchState.offset + matchState.ranges.length
-          const isTarget = msg.id === targetMessageId
+      className="flex-1 [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]"
+      itemContent={(index, msg) => {
+        const matchState = showFindBar ? messageFindRanges.get(msg.id) : undefined
+        const containsActive = matchState != null
+          && activeMatchIndex >= matchState.offset
+          && activeMatchIndex < matchState.offset + matchState.ranges.length
+        const isTarget = msg.id === targetMessageId
 
-          return (
-            <div
-              key={virtualRow.key}
-              data-index={virtualRow.index}
-              ref={virtualizer.measureElement}
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                transform: `translateY(${virtualRow.start}px)`,
-                width: '100%',
-              }}
-              {...(isTarget ? { 'data-testid': 'target-message' } : {})}
-              {...(isTarget && showTargetHighlight ? { 'data-highlighted': '1' } : {})}
-              className={`border-b border-warm-border/50 dark:border-dark-border/50 transition-colors duration-700 ${
-                isTarget && showTargetHighlight ? 'bg-accent/10 dark:bg-accent-dark/10' : ''
-              }`}
-            >
-              <MessageBubble
-                message={msg}
-                isDark={isDark}
-                {...(matchState ? { findRanges: matchState.ranges, matchIndexOffset: matchState.offset } : {})}
-                activeMatchIndex={containsActive ? activeMatchIndex : -1}
-                {...(containsActive ? { onActiveMatchRef } : {})}
-              />
-            </div>
-          )
-        })}
-      </div>
-      {messages.length === 0 && (
-        <div className="flex items-center justify-center h-32 text-warm-faint dark:text-dark-muted">
-          <p className="text-sm">No messages to display.</p>
-        </div>
-      )}
-    </div>
+        return (
+          <div
+            data-index={index}
+            {...(isTarget ? { 'data-testid': 'target-message' } : {})}
+            {...(isTarget && showTargetHighlight ? { 'data-highlighted': '1' } : {})}
+            className={`border-b border-warm-border/50 dark:border-dark-border/50 transition-colors duration-700 ${
+              isTarget && showTargetHighlight ? 'bg-accent/10 dark:bg-accent-dark/10' : ''
+            }`}
+          >
+            <MessageBubble
+              message={msg}
+              isDark={isDark}
+              {...(matchState ? { findRanges: matchState.ranges, matchIndexOffset: matchState.offset } : {})}
+              activeMatchIndex={containsActive ? activeMatchIndex : -1}
+              {...(containsActive ? { onActiveMatchRef } : {})}
+            />
+          </div>
+        )
+      }}
+    />
   )
 })
 

--- a/packages/app/src/renderer/components/MessageList.tsx
+++ b/packages/app/src/renderer/components/MessageList.tsx
@@ -52,7 +52,7 @@ const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
     scrollToMessageId(id) {
       const idx = idToIndex.get(id)
       if (idx == null) return
-      virtuosoRef.current?.scrollToIndex({ index: idx, align: 'center' })
+      virtuosoRef.current?.scrollIntoView({ index: idx, align: 'center', behavior: 'auto' })
     },
   }), [idToIndex])
 
@@ -69,6 +69,7 @@ const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
       ref={virtuosoRef}
       data={messages}
       computeItemKey={(_index, msg) => msg.id}
+      defaultItemHeight={64}
       {...(initialIndex ? { initialTopMostItemIndex: initialIndex } : {})}
       increaseViewportBy={400}
       data-testid="message-list-scroll"

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -362,6 +362,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
 
       {/* Messages */}
       <MessageList
+        key={session.sessionUuid}
         ref={listRef}
         messages={messages}
         isDark={isDark}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       react-markdown:
         specifier: ^9
         version: 9.1.0(@types/react@19.2.14)(react@19.2.5)
+      react-virtuoso:
+        specifier: ^4.18.6
+        version: 4.18.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       rehype-sanitize:
         specifier: ^6
         version: 6.0.0
@@ -2786,6 +2789,12 @@ packages:
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
+
+  react-virtuoso@4.18.6:
+    resolution: {integrity: sha512-CrT3P6HyjJMHZVWSste2bG2q5aWGlHfW2QuySZjiFwB2Qok/xsvgy+k8Z2jeDP8PP5KsBip7zNrl/F0QoxeyKw==}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18 || >= 19'
+      react-dom: '>=16 || >=17 || >= 18 || >=19'
 
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
@@ -6355,6 +6364,11 @@ snapshots:
       - supports-color
 
   react-refresh@0.17.0: {}
+
+  react-virtuoso@4.18.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   react@19.2.5: {}
 


### PR DESCRIPTION
## Summary

Opening a session from a search result frequently produced a large blank gap between the target message and surrounding messages. Root cause: \`@tanstack/react-virtual\`'s \`scrollToIndex\` set scrollTop using initial estimate-based item positions, then \`measureElement\` reported real heights and reflowed translateY values — but scrollTop didn't re-anchor, so the user landed in a stale region of the document.

This PR replaces the MessageList virtualization layer with \`react-virtuoso\`. Virtuoso reads \`initialTopMostItemIndex\` before its first paint, so the target row is already in the right place when the user sees it — there is no estimate-driven layout pass that the user can perceive.

## What changed

- Add \`react-virtuoso\` dependency.
- Rewrite \`MessageList.tsx\` around \`Virtuoso\` (\`data\`, \`itemContent\`, \`computeItemKey\`, \`increaseViewportBy\`, \`initialTopMostItemIndex\`).
- Keep the external surface identical: \`Props\` and \`MessageListHandle\` (\`scrollToMessageId\`) are unchanged, so \`SessionDetail\` doesn't need to know which library is underneath.
- Add \`key={session.sessionUuid}\` on \`MessageList\` in \`SessionDetail\` so cross-session navigation remounts the list, re-engaging \`initialTopMostItemIndex\` with the new target.
- Preserve all existing test hooks: \`data-testid="message-list-scroll"\`, \`data-testid="target-message"\`, \`data-highlighted="1"\`, \`data-index\` on each rendered row, plus the find-bar / active-match wiring.

## Why react-virtuoso (vs. fixing the existing implementation)

The "fix" path required custom estimate tuning, a post-mount stabilization rAF loop, user-scroll cancellation, and a mask/reveal pass to hide intermediate frames. That replicates a subset of what virtuoso does internally, and adds three places to maintain. Virtuoso is purpose-built for variable-height content with scroll-to-index, used by chat / docs / feed apps for exactly this scenario, and ships a measurement cache that also speeds up repeat visits to the same session.

## How it connects

The MessageList is the only virtualized surface in the app. \`SessionDetail\` consumes it through a stable \`Props\` + \`MessageListHandle\` contract that has not changed in this PR. Find-bar (\`SessionFindBar\`) integration goes through \`itemContent\`'s closure — the per-row \`messageFindRanges\` / \`activeMatchIndex\` mapping is identical to the previous implementation. The scroll-fade mask (\`mask-image:linear-gradient...\`) is now applied via Virtuoso's outer scroller className.

## Test plan

- [ ] Open a session from a search result whose match is mid-session — target row should be centered on first paint, no visible jump from the top
- [ ] Open multiple search results one after another, all hitting the same session — second click should still center the new target (imperative \`scrollToMessageId\` path)
- [ ] Open a session from sidebar with no target — list renders from the top
- [ ] Run the 1500-message session e2e test (\`session-detail.spec.ts\`) — \`[data-testid="message-list-scroll"] [data-index]\` count stays under 35 (virtualization still active)
- [ ] Cmd+F find-in-page still highlights matches; \`session-find-active-match\` resolves; arrow navigation works
- [ ] Target highlight (accent flash) still fires for ~2s
- [ ] Bottom scroll-fade mask still visible