### PR TITLE
feat(app): keyboard hints + boundary scroll for cmdk overlay

### DIFF
--- a/packages/app/e2e/home-preview.spec.ts
+++ b/packages/app/e2e/home-preview.spec.ts
@@ -59,3 +59,58 @@ test('clicking an overlay result jumps to message with flash highlight', async (
   await expect(target).toBeVisible({ timeout: 5000 })
   await expect(target).toHaveAttribute('data-highlighted', '1')
 })
+
+test('overlay footer shows keyboard hints', async () => {
+  const overlay = ctx.window.locator('[data-testid="search-overlay"]')
+  if (!(await overlay.isVisible().catch(() => false))) {
+    await ctx.window.locator('[data-testid="search-trigger"]').first().click()
+  }
+  await expect(overlay).toBeVisible({ timeout: 3000 })
+
+  // Recents state: navigate + open + close hints
+  await expect(overlay.getByText('navigate')).toBeVisible()
+  await expect(overlay.getByText('open', { exact: true })).toBeVisible()
+  await expect(overlay.getByText('close')).toBeVisible()
+
+  // Typing a query that yields results adds the "view all" hint
+  await ctx.window.locator('[data-testid="search-overlay-input"]').fill('XYLOPHONE_CANARY_42')
+  await expect(overlay.locator('[role="option"]').first()).toBeVisible({ timeout: 5000 })
+  await expect(overlay.getByText('view all')).toBeVisible()
+
+  await closeOverlay(ctx)
+})
+
+test('arrow-down navigation keeps the active item in view at the bottom', async () => {
+  const overlay = ctx.window.locator('[data-testid="search-overlay"]')
+  if (!(await overlay.isVisible().catch(() => false))) {
+    await ctx.window.locator('[data-testid="search-trigger"]').first().click()
+  }
+  await expect(overlay).toBeVisible({ timeout: 3000 })
+
+  const input = ctx.window.locator('[data-testid="search-overlay-input"]')
+  await expect(input).toBeFocused()
+
+  // Recents list — press Down to the last option, then verify it is in viewport
+  // (i.e. the scroll container scrolled to follow the active item).
+  const options = overlay.locator('[role="option"]')
+  const count = await options.count()
+  expect(count).toBeGreaterThan(0)
+
+  for (let i = 0; i < count + 5; i++) {
+    await ctx.window.keyboard.press('ArrowDown')
+  }
+
+  const last = options.nth(count - 1)
+  await expect(last).toHaveAttribute('aria-selected', 'true')
+  await expect(last).toBeInViewport()
+
+  // ArrowUp back to the top should also keep the active item in view.
+  for (let i = 0; i < count + 5; i++) {
+    await ctx.window.keyboard.press('ArrowUp')
+  }
+  const first = options.first()
+  await expect(first).toHaveAttribute('aria-selected', 'true')
+  await expect(first).toBeInViewport()
+
+  await closeOverlay(ctx)
+})

--- a/packages/app/src/renderer/components/SearchOverlay.tsx
+++ b/packages/app/src/renderer/components/SearchOverlay.tsx
@@ -47,6 +47,7 @@ export default function SearchOverlay({
   const [activeIndex, setActiveIndex] = useState(0)
   const [searching, setSearching] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
   const seqRef = useRef(0)
 
   const showRecents = !query.trim()
@@ -54,6 +55,11 @@ export default function SearchOverlay({
   const flatRecents = useMemo(() => buckets.flatMap(b => b.sessions), [buckets])
 
   useEffect(() => { setActiveIndex(0) }, [showRecents, scope])
+
+  useEffect(() => {
+    const el = listRef.current?.querySelector<HTMLElement>('[aria-selected="true"]')
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex, showRecents, results.length, flatRecents.length])
 
   useEffect(() => {
     if (open) {
@@ -212,7 +218,7 @@ export default function SearchOverlay({
           )}
         </div>
 
-        <div className="min-h-[220px] max-h-[min(420px,55vh)] overflow-y-auto">
+        <div ref={listRef} className="min-h-[220px] max-h-[min(420px,55vh)] overflow-y-auto">
           {showRecents ? (
             flatRecents.length === 0 ? (
               <div className="min-h-[220px] flex items-center justify-center px-4 text-center text-sm text-warm-faint dark:text-dark-muted">
@@ -298,31 +304,52 @@ export default function SearchOverlay({
           )}
         </div>
 
-        {showRecents && flatRecents.length > 0 ? (
-          <div className="w-full px-4 py-2 text-[11px] border-t border-warm-border dark:border-dark-border flex items-center justify-end text-warm-faint dark:text-dark-muted">
-            <span>{flatRecents.length} recent {flatRecents.length === 1 ? 'session' : 'sessions'}</span>
+        <div className="w-full px-4 py-2 text-[11px] border-t border-warm-border dark:border-dark-border flex items-center justify-between text-warm-faint dark:text-dark-muted gap-3">
+          <div className="flex items-center gap-3 flex-wrap">
+            {(showRecents ? flatRecents.length > 0 : results.length > 0) && (
+              <>
+                <Hint keys={['↑', '↓']} label="navigate" />
+                <Hint keys={['↵']} label={mode === 'ai' ? 'ask' : 'open'} />
+              </>
+            )}
+            {!showRecents && results.length > 0 && mode !== 'ai' && (
+              <Hint keys={['⇧', '↵']} label="view all" />
+            )}
+            <Hint keys={['esc']} label="close" />
           </div>
-        ) : results.length > 0 && (
-          <button
-            type="button"
-            data-testid="search-overlay-view-all"
-            onClick={() => { if (query.trim()) onCommit(query) }}
-            className="w-full px-4 py-2 text-[11px] border-t border-warm-border dark:border-dark-border flex items-center justify-between text-warm-muted dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
-          >
-            <span className="flex items-center gap-1.5">
-              <span>View all results</span>
-              <svg width="9" height="9" viewBox="0 0 10 10" fill="none" aria-hidden>
-                <path d="M3 2.5L6 5L3 7.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-            </span>
-            <span className="flex items-center gap-2">
-              <kbd className="font-mono text-[9.5px] px-1 py-px rounded border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg">⇧↵</kbd>
-              <span className="text-warm-faint">{results.length} results</span>
-            </span>
-          </button>
-        )}
+          <div className="flex-none">
+            {showRecents && flatRecents.length > 0 ? (
+              <span>{flatRecents.length} recent {flatRecents.length === 1 ? 'session' : 'sessions'}</span>
+            ) : results.length > 0 ? (
+              <button
+                type="button"
+                data-testid="search-overlay-view-all"
+                onClick={() => { if (query.trim()) onCommit(query) }}
+                className="text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition-colors"
+              >
+                {results.length} results →
+              </button>
+            ) : null}
+          </div>
+        </div>
       </div>
     </div>
+  )
+}
+
+function Hint({ keys, label }: { keys: string[]; label: string }) {
+  return (
+    <span className="flex items-center gap-1">
+      {keys.map((k, i) => (
+        <kbd
+          key={i}
+          className="font-mono text-[9.5px] px-1 py-px rounded border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg text-warm-muted dark:text-dark-muted"
+        >
+          {k}
+        </kbd>
+      ))}
+      <span>{label}</span>
+    </span>
   )
 }
 


### PR DESCRIPTION
## Summary
- Surface the existing cmdk shortcuts in the overlay footer so users don't have to discover them
- Fix arrow-key navigation losing the active item past the bottom of the visible scroll area

## What
- `SearchOverlay` footer is now a unified hint bar — `↑↓ navigate`, `↵ open` (or `ask` in agent mode), `⇧↵ view all` (when results), `esc close` — with the recents count or `View all results →` action on the right
- Active option is now scrolled into view (`block: 'nearest'`) whenever the keyboard moves the selection, so navigating past the visible window keeps the highlight on screen

## Why it connects
- The popup already supports ⌘K / arrows / Tab / ⇧↵, but only Tab was hinted; the rest were invisible to users until they tried them
- Several recents/results lists overflow the 420px max-height — without scroll-into-view the user could keep pressing ↓ and lose track of which row was active

## Test plan
- [x] Typecheck (`tsc --noEmit`)
- [x] Manual verification in dev: footer shows correct hints in recents / fast results / agent / empty states; ↓ past the end and ↑ past the top both keep the active row in view
- [x] e2e: new specs `overlay footer shows keyboard hints` and `arrow-down navigation keeps the active item in view at the bottom` pass on macos + ubuntu CI