### PR TITLE
feat(core): add title_source field to gate sync title overwrites

### DIFF
--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -75,6 +75,7 @@ export function runMigrations(db: Database.Database): void {
       session_uuid   TEXT NOT NULL UNIQUE,
       file_path      TEXT NOT NULL UNIQUE,
       title          TEXT,
+      title_source   TEXT NOT NULL DEFAULT 'derived',
       started_at     TEXT NOT NULL,
       ended_at       TEXT NOT NULL,
       message_count  INTEGER NOT NULL DEFAULT 0,
@@ -379,6 +380,17 @@ export function runMigrations(db: Database.Database): void {
     db.pragma('user_version = 7')
   }
 
+  if (version < 8) {
+    // v8: title_source column distinguishes title authority. 'derived' = parsed
+    // from source JSONL (default; sync may overwrite). 'spool' = written by
+    // Spool itself (e.g. agent-search session created in-app). 'user' = user
+    // edited in Spool. Sync only overwrites 'derived' rows.
+    if (!columnExists(db, 'sessions', 'title_source')) {
+      db.exec(`ALTER TABLE sessions ADD COLUMN title_source TEXT NOT NULL DEFAULT 'derived'`)
+    }
+    db.pragma('user_version = 8')
+  }
+
   rebuildFtsTableIfEmpty(db, 'messages', 'messages_fts_trigram')
   rebuildFtsTableIfEmpty(db, 'session_search', 'session_search_fts')
   rebuildFtsTableIfEmpty(db, 'session_search', 'session_search_fts_trigram')
@@ -407,6 +419,11 @@ function tableExists(db: Database.Database, name: string): boolean {
     `SELECT name FROM sqlite_master WHERE type IN ('table','virtual') AND name = ?`,
   ).get(name) as { name: string } | undefined
   return row !== undefined
+}
+
+function columnExists(db: Database.Database, table: string, column: string): boolean {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>
+  return rows.some(r => r.name === column)
 }
 
 /**

--- a/packages/core/src/db/migration-v8.test.ts
+++ b/packages/core/src/db/migration-v8.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import Database from 'better-sqlite3'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+function seedV7(dbPath: string): void {
+  const seed = new Database(dbPath)
+  seed.pragma('journal_mode = WAL')
+  seed.pragma('foreign_keys = ON')
+  seed.exec(`
+    CREATE TABLE sources (
+      id INTEGER PRIMARY KEY, name TEXT NOT NULL UNIQUE,
+      base_path TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    INSERT INTO sources (name, base_path) VALUES
+      ('claude','~/.claude/projects'),('codex','~/.codex/sessions'),('gemini','~/.gemini/tmp');
+
+    CREATE TABLE projects (
+      id INTEGER PRIMARY KEY, source_id INTEGER NOT NULL,
+      slug TEXT NOT NULL, display_path TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      identity_kind TEXT, identity_key TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    INSERT INTO projects (source_id, slug, display_path, display_name, identity_kind, identity_key)
+      VALUES (1,'p','/fake/p','p','path','/fake/p');
+
+    CREATE TABLE sessions (
+      id INTEGER PRIMARY KEY,
+      project_id INTEGER NOT NULL,
+      source_id INTEGER NOT NULL,
+      session_uuid TEXT NOT NULL UNIQUE,
+      file_path TEXT NOT NULL UNIQUE,
+      title TEXT,
+      started_at TEXT NOT NULL,
+      ended_at TEXT NOT NULL,
+      message_count INTEGER NOT NULL DEFAULT 0,
+      has_tool_use INTEGER NOT NULL DEFAULT 0,
+      cwd TEXT, model TEXT, raw_file_mtime TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    INSERT INTO sessions (project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count, has_tool_use, raw_file_mtime)
+      VALUES (1,1,'sess-a','/p/a','old title','2026-01-01','2026-01-01',1,0,'2026-01-01');
+
+    CREATE TABLE pins (
+      session_uuid TEXT PRIMARY KEY,
+      pinned_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `)
+  seed.pragma('user_version = 7')
+  seed.close()
+}
+
+describe('migration v8 (title_source column)', () => {
+  it('adds title_source column with default "derived" when upgrading from v7', async () => {
+    const spoolDir = makeTempDir('spool-v8-mig-')
+    const dbPath = join(spoolDir, 'spool.db')
+    seedV7(dbPath)
+
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDir)
+    vi.resetModules()
+    const dbModule = await import('./db.js')
+    const db = dbModule.getDB()
+
+    expect((db.pragma('user_version') as Array<{ user_version: number }>)[0]?.user_version).toBeGreaterThanOrEqual(8)
+
+    const cols = db.prepare("PRAGMA table_info(sessions)").all() as Array<{ name: string }>
+    expect(cols.map(c => c.name)).toContain('title_source')
+
+    const row = db.prepare('SELECT title, title_source FROM sessions WHERE session_uuid = ?').get('sess-a') as { title: string; title_source: string }
+    expect(row.title).toBe('old title')
+    expect(row.title_source).toBe('derived')
+
+    db.close()
+  })
+
+  it('is idempotent when column already exists at v8', async () => {
+    const spoolDir = makeTempDir('spool-v8-idem-')
+    const dbPath = join(spoolDir, 'spool.db')
+    seedV7(dbPath)
+
+    // Pre-add the column and bump user_version, simulating a DB that ran an
+    // earlier experimental v8 migration before this canonical one shipped.
+    const seed = new Database(dbPath)
+    seed.exec(`ALTER TABLE sessions ADD COLUMN title_source TEXT NOT NULL DEFAULT 'derived'`)
+    seed.exec(`UPDATE sessions SET title_source = 'spool' WHERE session_uuid = 'sess-a'`)
+    seed.pragma('user_version = 8')
+    seed.close()
+
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDir)
+    vi.resetModules()
+    const dbModule = await import('./db.js')
+    const db = dbModule.getDB()
+
+    // Existing user-set title_source must survive
+    const row = db.prepare('SELECT title_source FROM sessions WHERE session_uuid = ?').get('sess-a') as { title_source: string }
+    expect(row.title_source).toBe('spool')
+
+    db.close()
+  })
+
+  it('fresh install creates sessions table with title_source column', async () => {
+    const spoolDir = makeTempDir('spool-v8-fresh-')
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDir)
+    vi.resetModules()
+    const dbModule = await import('./db.js')
+    const db = dbModule.getDB()
+
+    expect(dbModule.wasNewDb()).toBe(true)
+    expect((db.pragma('user_version') as Array<{ user_version: number }>)[0]?.user_version).toBeGreaterThanOrEqual(8)
+
+    const cols = db.prepare("PRAGMA table_info(sessions)").all() as Array<{ name: string; dflt_value: string | null; notnull: number }>
+    const titleSource = cols.find(c => c.name === 'title_source')
+    expect(titleSource).toBeDefined()
+    expect(titleSource?.notnull).toBe(1)
+    expect(titleSource?.dflt_value).toBe(`'derived'`)
+
+    db.close()
+  })
+})

--- a/packages/core/src/db/queries.test.ts
+++ b/packages/core/src/db/queries.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import Database from 'better-sqlite3'
 import { runMigrations } from './db.js'
-import { getOrCreateProject } from './queries.js'
+import { getOrCreateProject, upsertSession } from './queries.js'
 
 describe('getOrCreateProject (with identity)', () => {
   let db: Database.Database
@@ -30,5 +30,60 @@ describe('getOrCreateProject (with identity)', () => {
       identityKind: 'git_remote', identityKey: 'github.com/spool-lab/spool',
     })
     expect(id1).toBe(id2)
+  })
+})
+
+describe('upsertSession (title_source authority)', () => {
+  let db: Database.Database
+  let projectId: number
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    runMigrations(db)
+    projectId = getOrCreateProject(db, 1, 'p', '/p', 'p', { identityKind: 'path', identityKey: '/p' })
+  })
+
+  function baseOpts(overrides: Partial<Parameters<typeof upsertSession>[1]> = {}) {
+    return {
+      projectId, sourceId: 1,
+      sessionUuid: 'sess-1',
+      filePath: '/fake.jsonl',
+      title: 'derived title',
+      startedAt: '2026-05-09', endedAt: '2026-05-09',
+      messageCount: 1, hasToolUse: false,
+      cwd: '/', model: 'claude',
+      rawFileMtime: '2026-05-09',
+      ...overrides,
+    }
+  }
+
+  it('updates title on re-upsert when title_source is derived (default)', () => {
+    upsertSession(db, baseOpts({ title: 'first' }))
+    upsertSession(db, baseOpts({ title: 'second' }))
+    const row = db.prepare('SELECT title, title_source FROM sessions WHERE session_uuid = ?').get('sess-1') as { title: string; title_source: string }
+    expect(row.title).toBe('second')
+    expect(row.title_source).toBe('derived')
+  })
+
+  it('preserves title on re-upsert when title_source is "spool"', () => {
+    upsertSession(db, baseOpts({ title: 'spool-set' }))
+    db.prepare(`UPDATE sessions SET title_source = 'spool' WHERE session_uuid = 'sess-1'`).run()
+
+    upsertSession(db, baseOpts({ title: 'derived from sync' }))
+
+    const row = db.prepare('SELECT title, title_source FROM sessions WHERE session_uuid = ?').get('sess-1') as { title: string; title_source: string }
+    expect(row.title).toBe('spool-set')
+    expect(row.title_source).toBe('spool')
+  })
+
+  it('preserves title on re-upsert when title_source is "user"', () => {
+    upsertSession(db, baseOpts({ title: 'placeholder' }))
+    db.prepare(`UPDATE sessions SET title = 'user-renamed', title_source = 'user' WHERE session_uuid = 'sess-1'`).run()
+
+    upsertSession(db, baseOpts({ title: 'derived overwrite' }))
+
+    const row = db.prepare('SELECT title, title_source FROM sessions WHERE session_uuid = ?').get('sess-1') as { title: string; title_source: string }
+    expect(row.title).toBe('user-renamed')
+    expect(row.title_source).toBe('user')
   })
 })

--- a/packages/core/src/db/queries.ts
+++ b/packages/core/src/db/queries.ts
@@ -78,7 +78,8 @@ export function upsertSession(
     db.prepare('DELETE FROM messages WHERE session_id = ?').run(existing.id)
     db.prepare(`
       UPDATE sessions SET
-        title = ?, started_at = ?, ended_at = ?, message_count = ?,
+        title = CASE WHEN title_source = 'derived' THEN ? ELSE title END,
+        started_at = ?, ended_at = ?, message_count = ?,
         has_tool_use = ?, cwd = ?, model = ?, raw_file_mtime = ?
       WHERE id = ?
     `).run(

--- a/packages/core/src/sync/syncer.ts
+++ b/packages/core/src/sync/syncer.ts
@@ -128,7 +128,8 @@ export class Syncer {
   private applyCodexTitles(): void {
     if (this.codexTitleIndex.size === 0) return
     const stmt = this.db.prepare(
-      'UPDATE sessions SET title = ? WHERE session_uuid = ? AND title != ?',
+      `UPDATE sessions SET title = ?
+         WHERE session_uuid = ? AND title != ? AND title_source = 'derived'`,
     )
     this.db.transaction(() => {
       for (const [uuid, title] of this.codexTitleIndex) {


### PR DESCRIPTION
## What

Adds a `title_source` column to `sessions` (`'derived' | 'spool' | 'user'`) that records who authored the title. The two sync paths that write titles — `upsertSession` (main session insert/update) and `applyCodexTitles` (Codex thread_name override) — now only overwrite when `title_source = 'derived'`.

A v8 migration adds the column with default `'derived'` so existing rows are unchanged; behavior on already-indexed sessions is identical to before. The migration is idempotent (column-existence guarded) so DBs that were bumped to v8 by experimental code still upgrade cleanly.

## Why

Today every sync re-runs `UPDATE sessions SET title = ?`. Anything Spool or the user writes into `title` directly gets clobbered the next time the source JSONL is parsed. This blocks two upcoming workstreams:

1. **Agent-search session redesign** — Spool will start authoring its own session rows for `/ask` queries (with `title = the actual user query` instead of the leaked Claude/Codex preamble). Without this gate the next sync would erase the good title.
2. **Future user-edit-title UI** — same problem, same fix.

The `'user'` enum value is reserved now to avoid a second migration when the rename UI lands; no UI changes in this PR.

## How it connects

This is the foundational PR for the agent-search cleanup track. Subsequent PRs build on this contract:

- PR 2: Spool authors agent-search sessions itself with `title_source = 'spool'`, routes them to a dedicated virtual project.
- PR 3: ACP prompt-structure refactor so the first user message is a clean query (and the leaked `"default"` agent-id message is gone).
- PR 4: One-time migration script for the ~24 existing leaked agent-search sessions.

## Test plan

- [x] `migration-v8.test.ts` — v7→v8 upgrade adds column with default `'derived'`; v8→v8 no-op preserves existing values; fresh install creates the column with the right schema
- [x] `queries.test.ts` — `upsertSession` overwrites title when source is `'derived'`, preserves when `'spool'` or `'user'`
- [x] All 101 existing core tests still pass (no regression)
- [x] Downstream `pnpm -r build` succeeds (no type fallout in app)