### PR TITLE
fix(core): repair title_source column when v8 was bumped without the ALTER

### DIFF
--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -391,6 +391,13 @@ export function runMigrations(db: Database.Database): void {
     db.pragma('user_version = 8')
   }
 
+  // Schema sanity: re-check critical columns that should be present at the
+  // current schema version, regardless of user_version. Repairs DBs where a
+  // version pragma was bumped (by experimental code, a manual upgrade, or a
+  // half-finished migration) without the corresponding column being added.
+  // Each check is a fast no-op when the column already exists.
+  ensureSchemaSanity(db)
+
   rebuildFtsTableIfEmpty(db, 'messages', 'messages_fts_trigram')
   rebuildFtsTableIfEmpty(db, 'session_search', 'session_search_fts')
   rebuildFtsTableIfEmpty(db, 'session_search', 'session_search_fts_trigram')
@@ -424,6 +431,12 @@ function tableExists(db: Database.Database, name: string): boolean {
 function columnExists(db: Database.Database, table: string, column: string): boolean {
   const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>
   return rows.some(r => r.name === column)
+}
+
+function ensureSchemaSanity(db: Database.Database): void {
+  if (!columnExists(db, 'sessions', 'title_source')) {
+    db.exec(`ALTER TABLE sessions ADD COLUMN title_source TEXT NOT NULL DEFAULT 'derived'`)
+  }
 }
 
 /**

--- a/packages/core/src/db/migration-v8.test.ts
+++ b/packages/core/src/db/migration-v8.test.ts
@@ -117,6 +117,32 @@ describe('migration v8 (title_source column)', () => {
     db.close()
   })
 
+  it('repairs DBs where user_version was bumped to 8 but title_source column is missing', async () => {
+    // Simulates a DB that ran experimental code which bumped user_version to 8
+    // but never ran the column-add (or crashed mid-migration). The version
+    // guard alone would skip the ALTER and leave the schema broken; the
+    // unconditional schema-sanity check at the end of runMigrations repairs it.
+    const spoolDir = makeTempDir('spool-v8-repair-')
+    const dbPath = join(spoolDir, 'spool.db')
+    seedV7(dbPath)
+    const seed = new Database(dbPath)
+    seed.pragma('user_version = 8')  // bump but don't add the column
+    seed.close()
+
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDir)
+    vi.resetModules()
+    const dbModule = await import('./db.js')
+    const db = dbModule.getDB()
+
+    const cols = db.prepare("PRAGMA table_info(sessions)").all() as Array<{ name: string }>
+    expect(cols.map(c => c.name)).toContain('title_source')
+
+    const row = db.prepare('SELECT title_source FROM sessions WHERE session_uuid = ?').get('sess-a') as { title_source: string }
+    expect(row.title_source).toBe('derived')
+
+    db.close()
+  })
+
   it('fresh install creates sessions table with title_source column', async () => {
     const spoolDir = makeTempDir('spool-v8-fresh-')
     vi.stubEnv('SPOOL_DATA_DIR', spoolDir)


### PR DESCRIPTION
## What

Adds an unconditional \`ensureSchemaSanity()\` pass at the end of \`runMigrations\` that re-checks critical columns and repairs any that are missing — independent of \`user_version\`. Today only one column is checked (\`sessions.title_source\`); the helper is extensible.

## Why

The v8 migration shipped in #150 placed its \`columnExists()\` guard *inside* the \`if (version < 8)\` branch:

\`\`\`ts
if (version < 8) {
  if (!columnExists(db, 'sessions', 'title_source')) {
    db.exec(\`ALTER TABLE sessions ADD COLUMN title_source ...\`)
  }
  db.pragma('user_version = 8')
}
\`\`\`

That handles the normal v7→v8 path correctly. But a DB whose \`user_version\` had already been bumped to 8 by experimental code — and whose ALTER never ran — would skip the entire branch on subsequent boots and silently leave the schema broken. Every code path that reads or writes \`title_source\` (sync, agent-search session creation, future user-rename UI) would then fail.

In practice this only affected dev DBs running unmerged branches (one known case: my own machine, discovered while testing #151). No real users hit it. But the bug class — "version pragma bumped but column missing" — can recur any time we ship an additive migration, so the fix is a defensive sanity check that runs every startup.

## How it connects

This unblocks #151 and any future PR that reads \`title_source\`. It also establishes a pattern (the \`ensureSchemaSanity\` helper) that future migrations can extend with their own column checks — preventing the same trap.

## Test plan

- [x] New test \`repairs DBs where user_version was bumped to 8 but title_source column is missing\` — seeds a v7 schema, manually bumps \`user_version = 8\` without the ALTER, runs migrations, verifies the column is now present and existing rows have the default value
- [x] Existing v7→v8 upgrade test still passes
- [x] Existing v8→v8 idempotency test still passes
- [x] All 110 core tests pass; tsc clean