### PR TITLE
fix(app): wire up the agent-search Continue in button

### DIFF
--- a/packages/app/src/main/acp.ts
+++ b/packages/app/src/main/acp.ts
@@ -281,6 +281,7 @@ export class AcpManager {
     _context: FragmentResult[],
     onChunk: (text: string) => void,
     onToolCall?: (event: ToolCallEvent) => void,
+    onSessionStarted?: (info: { sessionUuid: string; source: SessionSource; cwd: string }) => void,
   ): Promise<string> {
     const agents = await this.detectAgents()
     const agent = agents.find(a => a.id === agentId)
@@ -298,7 +299,7 @@ export class AcpManager {
     if (config.acpMode === 'websocket') {
       return this.queryViaWebSocket(config, prompt, onChunk, onToolCall)
     }
-    return this.queryViaAcp(agentId, config, prompt, onChunk, onToolCall, userQuery)
+    return this.queryViaAcp(agentId, config, prompt, onChunk, onToolCall, userQuery, onSessionStarted)
   }
 
   /**
@@ -315,6 +316,7 @@ export class AcpManager {
     onChunk: (text: string) => void,
     onToolCall?: (event: ToolCallEvent) => void,
     userQuery?: string,
+    onSessionStarted?: (info: { sessionUuid: string; source: SessionSource; cwd: string }) => void,
   ): Promise<string> {
     // Dynamically import the ESM-only ACP SDK
     const acp = await import('@agentclientprotocol/sdk')
@@ -578,6 +580,7 @@ export class AcpManager {
             title: userQuery,
             cwd: stableCwd,
           })
+          onSessionStarted?.({ sessionUuid: sessionId, source, cwd: stableCwd })
         } catch (e) {
           console.error('[acp] failed to record Spool-authored session:', e)
         }

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -406,6 +406,8 @@ ipcMain.handle('spool:ai-search', async (_e, { query, agentId, context }: { quer
       mainWindow?.webContents.send('spool:ai-chunk', { text })
     }, (toolCall) => {
       mainWindow?.webContents.send('spool:ai-tool-call', toolCall)
+    }, (info) => {
+      mainWindow?.webContents.send('spool:ai-session-started', info)
     })
     mainWindow?.webContents.send('spool:ai-done', { fullText })
     return { ok: true, fullText }

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -124,6 +124,12 @@ const api = {
     return () => ipcRenderer.removeListener('spool:ai-tool-call', handler)
   },
 
+  onAiSessionStarted: (cb: (data: { sessionUuid: string; source: string; cwd: string }) => void) => {
+    const handler = (_: Electron.IpcRendererEvent, data: unknown) => cb(data as { sessionUuid: string; source: string; cwd: string })
+    ipcRenderer.on('spool:ai-session-started', handler)
+    return () => ipcRenderer.removeListener('spool:ai-session-started', handler)
+  },
+
   onSyncProgress: (cb: (e: { phase: string; count: number; total: number }) => void) => {
     const handler = (_: Electron.IpcRendererEvent, data: unknown) => cb(data as { phase: string; count: number; total: number })
     ipcRenderer.on('spool:sync-progress', handler)

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -64,6 +64,7 @@ export default function App() {
   const [aiAgent, setAiAgent] = useState('claude')
   const [availableAgents, setAvailableAgents] = useState<AgentInfo[]>([])
   const [aiToolCalls, setAiToolCalls] = useState<Map<string, { title: string; status: string; kind?: string | undefined }>>(new Map())
+  const [aiSession, setAiSession] = useState<{ sessionUuid: string; source: string; cwd: string } | null>(null)
   const aiAnswerRef = useRef('')
 
   // Settings & modals
@@ -203,7 +204,10 @@ export default function App() {
         return next
       })
     })
-    return () => { offChunk(); offDone(); offToolCall?.() }
+    const offSession = window.spool.onAiSessionStarted?.((info) => {
+      setAiSession(info)
+    })
+    return () => { offChunk(); offDone(); offToolCall?.(); offSession?.() }
   }, [])
 
   useEffect(() => {
@@ -296,6 +300,7 @@ export default function App() {
     setAiError(null)
     setAiStreaming(true)
     setAiToolCalls(new Map())
+    setAiSession(null)
 
     window.spool.aiSearch(q, aiAgent, fragmentContext).catch((err) => {
       setAiError(String(err))
@@ -571,6 +576,11 @@ export default function App() {
                       sources={fragmentSources}
                       error={aiError}
                       toolCalls={aiToolCalls}
+                      {...(aiSession ? {
+                        onResume: () => {
+                          void window.spool.resumeCLI(aiSession.sessionUuid, aiSession.source, aiSession.cwd)
+                        },
+                      } : {})}
                     />
                   )}
                   {searchMode === 'ai' && fragmentSources.length > 0 && (aiAnswer || aiStreaming) && (

--- a/packages/app/src/renderer/components/AiAnswerCard.tsx
+++ b/packages/app/src/renderer/components/AiAnswerCard.tsx
@@ -106,8 +106,9 @@ export default function AiAnswerCard({ answer, streaming, agentName, sources, er
         </div>
       )}
 
-      {/* CTA */}
-      {!streaming && answer && (
+      {/* CTA — only shown when a resume target is wired (i.e. agent has a
+          source we persisted a session row for: claude/codex/gemini). */}
+      {!streaming && answer && onResume && (
         <button
           onClick={onResume}
           className="inline-flex items-center gap-1.5 text-xs font-medium text-accent dark:text-accent-dark bg-transparent border border-accent dark:border-accent-dark rounded-md px-3 py-1.5 cursor-pointer hover:bg-accent-bg dark:hover:bg-accent-bg-dark transition-colors"


### PR DESCRIPTION
## What

Wires up the "Continue in Claude Code →" button on the agent-search answer card. The button existed but the click was a silent no-op because:

1. `App.tsx` mounted `<AiAnswerCard>` without passing the `onResume` prop, so the button's `onClick` was `undefined`.
2. The agent-search session UUID and source were never plumbed from main to renderer, so even if the click had fired there was nothing to resume against.

After this PR: clicking the button opens the user's terminal and runs `cd <cwd> && claude --resume <uuid>` (or the equivalent for codex / gemini), reopening the conversation right where it left off.

## Changes

- `acp.ts`: optional `onSessionStarted` callback that fires right after `insertSpoolAuthoredSession` succeeds, with `{ sessionUuid, source, cwd }`. Inside the same `try/catch` as the DB write, so a DB failure can't half-surface an unrecorded session to the UI.
- `main/index.ts`: forwards the callback via a new `spool:ai-session-started` IPC event (symmetric with the existing chunk / tool-call channels).
- `preload`: exposes `onAiSessionStarted` with the same unsubscribe shape as the other AI events.
- `App.tsx`: holds the session info in state, resets to `null` on each new query, spreads `onResume` only when set (`exactOptionalPropertyTypes` rejects passing `undefined`).
- `AiAnswerCard`: gates the button render on `onResume` being defined, so unsupported agents (`kimi` / `opencode` / `alma` — no `SessionSource`, no Spool-authored row, nothing to resume) don't show a dead button.

## How it connects

Final visible polish on the agent-search redesign track (#150-#154). The Spool-authored session row written by #151 is now reachable from the UI.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Manual e2e in dev: ran an agent-search query, clicked the button, terminal opened with `cd ~/.spool/agent-search-sessions && claude --resume <uuid>` and Claude rehydrated the conversation
- [x] Verified the button hides during streaming and reappears on completion
- [x] Verified the button stays hidden when no `aiSession` info has arrived (e.g. mid-streaming or for unsupported agents)