### PR TITLE
feat(app): centralize keyboard shortcuts via stack-based useHotkeys hook

### DIFF
--- a/packages/app/e2e/settings.spec.ts
+++ b/packages/app/e2e/settings.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, waitForSync, type AppContext } from './helpers/launch'
+
+let ctx: AppContext
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+const cmdK = process.platform === 'darwin' ? 'Meta+k' : 'Control+k'
+
+test('Esc closes Settings panel', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  await window.locator('[data-testid="settings-button"]').click()
+  await expect(window.locator('[data-testid="settings-panel"]')).toBeVisible()
+
+  await window.keyboard.press('Escape')
+  await expect(window.locator('[data-testid="settings-panel"]')).toBeHidden()
+})
+
+test('cmd/ctrl+K opens search overlay on home', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  await expect(window.locator('[data-testid="search-overlay"]')).toBeHidden()
+  await window.keyboard.press(cmdK)
+  await expect(window.locator('[data-testid="search-overlay"]')).toBeVisible()
+  // Overlay's Esc handler lives on its input — wait for focus before pressing.
+  await expect(window.locator('[data-testid="search-overlay-input"]')).toBeFocused()
+  await window.keyboard.press('Escape')
+  await expect(window.locator('[data-testid="search-overlay"]')).toBeHidden()
+})
+
+test('cmd/ctrl+K is suppressed while Settings is open', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  await window.locator('[data-testid="settings-button"]').click()
+  await expect(window.locator('[data-testid="settings-panel"]')).toBeVisible()
+
+  await window.keyboard.press(cmdK)
+  // Search overlay must NOT open while Settings is on top
+  await expect(window.locator('[data-testid="search-overlay"]')).toBeHidden()
+  await expect(window.locator('[data-testid="settings-panel"]')).toBeVisible()
+
+  // Esc closes Settings; then ⌘K should work again
+  await window.keyboard.press('Escape')
+  await expect(window.locator('[data-testid="settings-panel"]')).toBeHidden()
+
+  await window.keyboard.press(cmdK)
+  await expect(window.locator('[data-testid="search-overlay"]')).toBeVisible()
+  await expect(window.locator('[data-testid="search-overlay-input"]')).toBeFocused()
+  await window.keyboard.press('Escape')
+})

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,7 +15,7 @@
     "build:electron": "pnpm run build:core && electron-vite build",
     "preview": "electron-vite preview",
     "clean": "rm -rf out dist-electron",
-    "test:e2e": "pnpm run build:core && pnpm run rebuild:native:electron && npx playwright test --config e2e/playwright.config.ts"
+    "test:e2e": "pnpm run build:core && pnpm run rebuild:native:electron && electron-vite build && npx playwright test --config e2e/playwright.config.ts"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.17.1",

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -18,6 +18,7 @@ import type { ProjectSessionSortOrder } from '@spool-lab/core'
 import { defaultThemeEditorState, type ThemeEditorStateV1 } from './theme/editorTypes.js'
 import { applyEditorTheme } from './theme/applyEditorTheme.js'
 import { loadThemeEditorState, saveThemeEditorState } from './theme/persist.js'
+import { useHotkeys } from './hooks/useHotkeys.js'
 
 type View = 'search' | 'session'
 type SettingsTab = 'general' | 'appearance' | 'sources' | 'agent'
@@ -389,19 +390,10 @@ export default function App() {
     setView('search')
   }, [activeProjectKey])
 
-  // ⌘K opens overlay
-  useEffect(() => {
-    const handler = (event: KeyboardEvent) => {
-      const isMacLike = /mac/i.test(navigator.platform)
-      const modifier = isMacLike ? event.metaKey : event.ctrlKey
-      if (modifier && !event.shiftKey && !event.altKey && event.key.toLowerCase() === 'k') {
-        event.preventDefault()
-        setSearchOverlayOpen(open => !open)
-      }
-    }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
-  }, [])
+  // ⌘K opens overlay (suppressed when a modal layer is on top, e.g. Settings)
+  useHotkeys({
+    'mod+k': () => setSearchOverlayOpen(open => !open),
+  })
 
   // Default scope follows active project
   useEffect(() => {

--- a/packages/app/src/renderer/components/Menu.tsx
+++ b/packages/app/src/renderer/components/Menu.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import { useHotkeys } from '../hooks/useHotkeys.js'
 
 type MenuItem = {
   label: string
@@ -24,16 +25,12 @@ export default function Menu({ trigger, items, align = 'right', testId }: Props)
     function handleClickOutside(event: MouseEvent) {
       if (!containerRef.current?.contains(event.target as Node)) setOpen(false)
     }
-    function handleKey(event: KeyboardEvent) {
-      if (event.key === 'Escape') setOpen(false)
-    }
     window.addEventListener('mousedown', handleClickOutside)
-    window.addEventListener('keydown', handleKey)
-    return () => {
-      window.removeEventListener('mousedown', handleClickOutside)
-      window.removeEventListener('keydown', handleKey)
-    }
+    return () => window.removeEventListener('mousedown', handleClickOutside)
   }, [open])
+
+  const close = useCallback(() => setOpen(false), [])
+  useHotkeys({ Escape: close }, { active: open, modal: true })
 
   return (
     <div ref={containerRef} className="relative inline-block" data-testid={testId}>

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -10,6 +10,7 @@ import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
 import { getSessionSourceColor, getSessionSourceShortLabel } from '../../shared/sessionSources.js'
 import { formatRelativeDate } from '../../shared/formatDate.js'
 import { useIsDark } from '../hooks/useIsDark.js'
+import { useHotkeys } from '../hooks/useHotkeys.js'
 import { extractRenderedText } from '../markdown/extractRenderedText.js'
 
 type Props = {
@@ -34,7 +35,6 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
   const [activeMatchIndex, setActiveMatchIndex] = useState(0)
   const listRef = useRef<MessageListHandle>(null)
   const activeFindMatchRef = useRef<HTMLElement | null>(null)
-  const isMacLike = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform)
   const isDark = useIsDark()
 
   const normalizedFindQuery = findQuery.trim().toLocaleLowerCase()
@@ -143,57 +143,18 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
     setFindResultNonce((value) => value + 1)
   }, [showFindBar, totalFindMatches, activeMatchIndex])
 
-  useEffect(() => {
-    const handler = (event: KeyboardEvent) => {
-      const hasPrimaryModifier = isMacLike
-        ? event.metaKey && !event.ctrlKey
-        : event.ctrlKey && !event.metaKey
+  useHotkeys({
+    'mod+f': () => {
+      setShowFindBar(true)
+      setFindFocusNonce((value) => value + 1)
+    },
+  })
 
-      const isFindShortcut = (event.metaKey || event.ctrlKey)
-        && !event.altKey
-        && !event.shiftKey
-        && event.key.toLowerCase() === 'f'
-
-      const isFindPreviousShortcut = showFindBar
-        && hasPrimaryModifier
-        && !event.altKey
-        && !event.shiftKey
-        && event.key === 'ArrowLeft'
-
-      const isFindNextShortcut = showFindBar
-        && hasPrimaryModifier
-        && !event.altKey
-        && !event.shiftKey
-        && event.key === 'ArrowRight'
-
-      if (isFindShortcut) {
-        event.preventDefault()
-        setShowFindBar(true)
-        setFindFocusNonce((value) => value + 1)
-        return
-      }
-
-      if (isFindPreviousShortcut) {
-        event.preventDefault()
-        findPrevious()
-        return
-      }
-
-      if (isFindNextShortcut) {
-        event.preventDefault()
-        findNext()
-        return
-      }
-
-      if (event.key === 'Escape' && showFindBar) {
-        event.preventDefault()
-        closeFindBar()
-      }
-    }
-
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
-  }, [closeFindBar, findNext, findPrevious, isMacLike, showFindBar])
+  useHotkeys({
+    Escape: closeFindBar,
+    'mod+arrowleft': findPrevious,
+    'mod+arrowright': findNext,
+  }, { active: showFindBar })
 
   useEffect(() => {
     if (!showFindBar || totalFindMatches === 0) return

--- a/packages/app/src/renderer/components/SettingsPanel.tsx
+++ b/packages/app/src/renderer/components/SettingsPanel.tsx
@@ -4,6 +4,7 @@ import { DEFAULT_SEARCH_SORT_ORDER, SEARCH_SORT_OPTIONS, type SearchSortOrder } 
 import type { ThemeEditorStateV1 } from '../theme/editorTypes.js'
 import ThemeEditorSection from './ThemeEditorSection.js'
 import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
+import { useHotkeys } from '../hooks/useHotkeys.js'
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -105,8 +106,10 @@ export default function SettingsPanel({
 }: Props) {
   const [tab, setTab] = useState<SettingsTab>(initialTab)
 
+  useHotkeys({ Escape: onClose }, { modal: true })
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+    <div data-testid="settings-panel" className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
       <div className="w-[720px] h-[560px] max-w-[calc(100vw-32px)] max-h-[calc(100vh-32px)] bg-warm-bg dark:bg-dark-bg border border-warm-border dark:border-dark-border rounded-[10px] shadow-xl overflow-hidden flex">
         {/* Sidebar */}
         <div className="w-[176px] flex-none bg-warm-surface dark:bg-dark-surface border-r border-warm-border dark:border-dark-border flex flex-col py-3">

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -186,6 +186,7 @@ function SidebarStatus({
       {onSettingsClick && (
         <button
           type="button"
+          data-testid="settings-button"
           onClick={onSettingsClick}
           title="Settings"
           aria-label="Settings"

--- a/packages/app/src/renderer/hooks/useHotkeys.test.ts
+++ b/packages/app/src/renderer/hooks/useHotkeys.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeCombo,
+  eventToCombo,
+  dispatchHotkey,
+  type HotkeyLayer,
+} from './useHotkeys.js'
+
+function layer(bindings: Record<string, () => void>, modal = false): HotkeyLayer {
+  return {
+    bindingsRef: { current: bindings },
+    modalRef: { current: modal },
+  }
+}
+
+describe('normalizeCombo', () => {
+  it('lowercases and sorts modifiers consistently', () => {
+    expect(normalizeCombo('Shift+Meta+K', true)).toBe('meta+shift+k')
+    expect(normalizeCombo('K+Meta+Shift', true)).toBe('meta+shift+k')
+  })
+
+  it('resolves `mod` to meta on mac, ctrl elsewhere', () => {
+    expect(normalizeCombo('mod+k', true)).toBe('meta+k')
+    expect(normalizeCombo('mod+k', false)).toBe('ctrl+k')
+  })
+
+  it('accepts alias modifiers', () => {
+    expect(normalizeCombo('cmd+k', true)).toBe('meta+k')
+    expect(normalizeCombo('command+k', true)).toBe('meta+k')
+    expect(normalizeCombo('control+k', false)).toBe('ctrl+k')
+    expect(normalizeCombo('option+k', true)).toBe('alt+k')
+  })
+
+  it('aliases arrow + esc keys', () => {
+    expect(normalizeCombo('mod+left', true)).toBe('meta+arrowleft')
+    expect(normalizeCombo('Esc', true)).toBe('escape')
+  })
+})
+
+describe('eventToCombo', () => {
+  it('builds combo string from KeyboardEvent fields', () => {
+    expect(eventToCombo({
+      ctrlKey: false, metaKey: true, altKey: false, shiftKey: false, key: 'k',
+    })).toBe('meta+k')
+  })
+
+  it('omits modifier keys when pressed alone', () => {
+    expect(eventToCombo({
+      ctrlKey: false, metaKey: true, altKey: false, shiftKey: false, key: 'Meta',
+    })).toBe('meta')
+  })
+
+  it('orders modifiers same as normalizeCombo so they match', () => {
+    const event = { ctrlKey: false, metaKey: true, altKey: false, shiftKey: true, key: 'K' }
+    expect(eventToCombo(event)).toBe(normalizeCombo('mod+shift+k', true))
+  })
+
+  it('aliases ArrowLeft → arrowleft', () => {
+    expect(eventToCombo({
+      ctrlKey: false, metaKey: true, altKey: false, shiftKey: false, key: 'ArrowLeft',
+    })).toBe('meta+arrowleft')
+  })
+})
+
+describe('dispatchHotkey', () => {
+  it('returns the matching handler from the top layer', () => {
+    const fn = () => {}
+    const result = dispatchHotkey('escape', [layer({ escape: fn })])
+    expect(result).toEqual({ kind: 'handled', layerIndex: 0, handler: fn })
+  })
+
+  it('top layer wins over lower layer for the same combo', () => {
+    const lower = () => {}
+    const upper = () => {}
+    const result = dispatchHotkey('escape', [
+      layer({ escape: lower }),
+      layer({ escape: upper }),
+    ])
+    expect(result.kind).toBe('handled')
+    if (result.kind === 'handled') {
+      expect(result.handler).toBe(upper)
+      expect(result.layerIndex).toBe(1)
+    }
+  })
+
+  it('falls through to lower layer when top has no binding (non-modal)', () => {
+    const lower = () => {}
+    const result = dispatchHotkey('meta+k', [
+      layer({ 'meta+k': lower }),
+      layer({ escape: () => {} }), // top layer, no meta+k
+    ])
+    expect(result.kind).toBe('handled')
+    if (result.kind === 'handled') {
+      expect(result.handler).toBe(lower)
+      expect(result.layerIndex).toBe(0)
+    }
+  })
+
+  it('modal layer swallows unbound combos so they do not fall through', () => {
+    const lower = () => {}
+    const result = dispatchHotkey('meta+k', [
+      layer({ 'meta+k': lower }),
+      layer({ escape: () => {} }, true), // modal
+    ])
+    expect(result).toEqual({ kind: 'swallowed' })
+  })
+
+  it('modal layer still serves its own bindings before swallowing', () => {
+    const lowerFn = () => {}
+    const modalEsc = () => {}
+    const result = dispatchHotkey('escape', [
+      layer({ 'meta+k': lowerFn }),
+      layer({ escape: modalEsc }, true),
+    ])
+    expect(result.kind).toBe('handled')
+    if (result.kind === 'handled') expect(result.handler).toBe(modalEsc)
+  })
+
+  it('returns unhandled when no layer binds the combo', () => {
+    const result = dispatchHotkey('meta+x', [layer({ escape: () => {} })])
+    expect(result).toEqual({ kind: 'unhandled' })
+  })
+
+  it('returns unhandled on empty stack', () => {
+    expect(dispatchHotkey('escape', [])).toEqual({ kind: 'unhandled' })
+  })
+})

--- a/packages/app/src/renderer/hooks/useHotkeys.ts
+++ b/packages/app/src/renderer/hooks/useHotkeys.ts
@@ -1,0 +1,127 @@
+import { useEffect, useRef } from 'react'
+
+// Stack-based hotkey dispatcher.
+//
+// - Top layer is consulted first; first match wins.
+// - A `modal` layer also blocks unbound combos from falling through to lower
+//   layers (so opening Settings suppresses global ⌘K, etc.).
+// - `mod` resolves to ⌘ on macOS and Ctrl elsewhere.
+
+type Handler = (event: KeyboardEvent) => void
+type Bindings = Record<string, Handler>
+export type HotkeyLayer = {
+  bindingsRef: { current: Bindings }
+  modalRef: { current: boolean }
+}
+
+const stack: HotkeyLayer[] = []
+let installed = false
+
+const isMac = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform)
+
+const KEY_ALIASES: Record<string, string> = {
+  esc: 'escape',
+  left: 'arrowleft',
+  right: 'arrowright',
+  up: 'arrowup',
+  down: 'arrowdown',
+  ' ': 'space',
+}
+
+const MODIFIER_ORDER = ['ctrl', 'meta', 'alt', 'shift']
+
+function normalizePart(part: string, mac: boolean): string {
+  const p = part.trim().toLowerCase()
+  if (p === 'mod') return mac ? 'meta' : 'ctrl'
+  if (p === 'cmd' || p === 'command') return 'meta'
+  if (p === 'control') return 'ctrl'
+  if (p === 'option' || p === 'opt') return 'alt'
+  return KEY_ALIASES[p] ?? p
+}
+
+function sortParts(parts: string[]): string[] {
+  return [...parts].sort((a, b) => {
+    const ai = MODIFIER_ORDER.indexOf(a)
+    const bi = MODIFIER_ORDER.indexOf(b)
+    if (ai === -1 && bi === -1) return a.localeCompare(b)
+    if (ai === -1) return 1
+    if (bi === -1) return -1
+    return ai - bi
+  })
+}
+
+export function normalizeCombo(combo: string, mac: boolean = isMac): string {
+  return sortParts(combo.split('+').map((p) => normalizePart(p, mac))).join('+')
+}
+
+type EventLike = Pick<KeyboardEvent, 'ctrlKey' | 'metaKey' | 'altKey' | 'shiftKey' | 'key'>
+
+export function eventToCombo(event: EventLike): string {
+  const parts: string[] = []
+  if (event.ctrlKey) parts.push('ctrl')
+  if (event.metaKey) parts.push('meta')
+  if (event.altKey) parts.push('alt')
+  if (event.shiftKey) parts.push('shift')
+  const raw = event.key.toLowerCase()
+  if (!['control', 'meta', 'alt', 'shift'].includes(raw)) {
+    parts.push(KEY_ALIASES[raw] ?? raw)
+  }
+  return sortParts(parts).join('+')
+}
+
+export type DispatchResult =
+  | { kind: 'handled'; layerIndex: number; handler: Handler }
+  | { kind: 'swallowed' }
+  | { kind: 'unhandled' }
+
+export function dispatchHotkey(combo: string, layers: HotkeyLayer[]): DispatchResult {
+  for (let i = layers.length - 1; i >= 0; i--) {
+    const layer = layers[i]
+    if (!layer) continue
+    const handler = layer.bindingsRef.current[combo]
+    if (handler) return { kind: 'handled', layerIndex: i, handler }
+    if (layer.modalRef.current) return { kind: 'swallowed' }
+  }
+  return { kind: 'unhandled' }
+}
+
+function install() {
+  if (installed) return
+  installed = true
+  window.addEventListener('keydown', (event) => {
+    const combo = eventToCombo(event)
+    const result = dispatchHotkey(combo, stack)
+    if (result.kind === 'handled') {
+      event.preventDefault()
+      result.handler(event)
+    }
+  })
+}
+
+export function useHotkeys(
+  bindings: Bindings,
+  options: { active?: boolean; modal?: boolean } = {},
+) {
+  const { active = true, modal = false } = options
+
+  const bindingsRef = useRef<Bindings>({})
+  const next: Bindings = {}
+  for (const [combo, handler] of Object.entries(bindings)) {
+    next[normalizeCombo(combo)] = handler
+  }
+  bindingsRef.current = next
+
+  const modalRef = useRef(modal)
+  modalRef.current = modal
+
+  useEffect(() => {
+    if (!active) return
+    install()
+    const layer: HotkeyLayer = { bindingsRef, modalRef }
+    stack.push(layer)
+    return () => {
+      const i = stack.lastIndexOf(layer)
+      if (i >= 0) stack.splice(i, 1)
+    }
+  }, [active])
+}


### PR DESCRIPTION
## Summary

- Replaces ad-hoc `window.addEventListener('keydown', ...)` listeners (Settings, Menu, SessionDetail's Esc/⌘F/⌘←/⌘→, App's ⌘K) with a single `useHotkeys` hook.
- LIFO stack: only the topmost active layer responds. `modal: true` blocks unbound combos from falling through to lower layers — so opening Settings now suppresses global ⌘K, and pressing Esc inside a Menu nested in Settings closes only the Menu.
- Cross-platform `mod` modifier (⌘ on macOS, Ctrl elsewhere) plus cmd/control/option/arrow/esc aliases.
- Unit tests for normalize + dispatch and a new e2e spec covering Esc-closes-Settings, ⌘K opening on home, and ⌘K suppression while a modal is on top.
- Fixes `test:e2e` to run `electron-vite build` before Playwright. Without it, the renderer bundle was stale or missing and tests launched against a blank window.

## Why

- Multiple keydown listeners were competing for Esc: a Menu opened inside SettingsPanel would have both close at once.
- Global ⌘K leaked through any open modal, layering the search overlay on top of Settings with confusing close ordering.
- Adding new shortcuts in this state would re-introduce the same conflicts — every site hand-rolled modifier detection.

## Test plan

- [x] `npx vitest run src/renderer/hooks/useHotkeys.test.ts` — 15 unit tests pass
- [x] `pnpm run test:e2e` — 39 pass, 1 pre-existing flake (`project-view.spec.ts:51 changing sort order`) unrelated to this change; reproduces on clean main
- [x] Manual: open Settings → Esc closes; open Settings → ⌘K does not open overlay; close Settings → ⌘K opens overlay; ⌘F in session detail still toggles find bar; ⌘← / ⌘→ navigate matches