### PR TITLE
fix(app): isolate ~/.spool in e2e via SPOOL_HOME

### DIFF
--- a/packages/app/e2e/helpers/launch.ts
+++ b/packages/app/e2e/helpers/launch.ts
@@ -29,6 +29,7 @@ export async function launchApp(opts: { mockAgent?: 'success' | 'error' } = {}):
     ...process.env as Record<string, string>,
     SPOOL_DATA_DIR: join(tmpDir, 'data'),
     SPOOL_ELECTRON_USER_DATA_DIR: join(tmpDir, 'electron-user-data'),
+    SPOOL_HOME: join(tmpDir, 'spool-home'),
     SPOOL_CLAUDE_DIR: claudeDir,
     SPOOL_CODEX_DIR: codexDir,
     SPOOL_GEMINI_DIR: geminiCliHome,

--- a/packages/app/e2e/project-view.spec.ts
+++ b/packages/app/e2e/project-view.spec.ts
@@ -53,14 +53,14 @@ test('changing sort order reloads sessions', async () => {
   await waitForSync(window)
 
   await window.locator('[data-testid="sidebar-project-row"]').first().click()
-  await expect(window.locator('[data-testid="session-row"]').first()).toBeVisible({ timeout: 5000 })
+  const firstRow = window.locator('[data-testid="session-row"]').first()
+  await expect(firstRow).toBeVisible({ timeout: 5000 })
 
-  const recentFirst = await window.locator('[data-testid="session-row"]').first().getAttribute('data-session-uuid')
+  const recentFirst = await firstRow.getAttribute('data-session-uuid')
+  expect(recentFirst).not.toBeNull()
 
   await window.locator('[data-testid="project-sort"]').click()
   await window.getByRole('menuitem', { name: 'Oldest' }).click()
-  await expect(window.locator('[data-testid="session-row"]').first()).toBeVisible({ timeout: 5000 })
 
-  const oldestFirst = await window.locator('[data-testid="session-row"]').first().getAttribute('data-session-uuid')
-  expect(oldestFirst).not.toBe(recentFirst)
+  await expect(firstRow).not.toHaveAttribute('data-session-uuid', recentFirst!, { timeout: 5000 })
 })

--- a/packages/app/src/main/acp.ts
+++ b/packages/app/src/main/acp.ts
@@ -160,7 +160,12 @@ const BUILTIN_AGENT_CONFIGS: Record<string, AgentConfig> = {
   },
 }
 
-const AGENTS_CONFIG_PATH = join(homedir(), '.spool', 'agents.json')
+function spoolHomeDir(): string {
+  const override = process.env['SPOOL_HOME']?.trim()
+  return override && override.length > 0 ? override : join(homedir(), '.spool')
+}
+
+const AGENTS_CONFIG_PATH = join(spoolHomeDir(), 'agents.json')
 
 /**
  * Stable cwd for ACP agent subprocesses spawned by agent search. Using a
@@ -169,7 +174,7 @@ const AGENTS_CONFIG_PATH = join(homedir(), '.spool', 'agents.json')
  * each agent writes downstream in a known, recognizable location and prevents
  * polluting unrelated projects in the library.
  */
-const SPOOL_AGENT_SEARCH_CWD = join(homedir(), '.spool', 'agent-search-sessions')
+const SPOOL_AGENT_SEARCH_CWD = join(spoolHomeDir(), 'agent-search-sessions')
 
 function ensureAgentSearchCwd(): string {
   mkdirSync(SPOOL_AGENT_SEARCH_CWD, { recursive: true })
@@ -196,7 +201,7 @@ function loadAgentsConfig(): AgentsConfig | null {
 }
 
 function saveAgentsConfig(config: AgentsConfig): void {
-  const dir = join(homedir(), '.spool')
+  const dir = spoolHomeDir()
   mkdirSync(dir, { recursive: true })
   writeFileSync(AGENTS_CONFIG_PATH, JSON.stringify(config, null, 2), 'utf8')
 }


### PR DESCRIPTION
## Summary

- The main process reads/writes user config at `~/.spool/agents.json`, hard-coded against `homedir()`. Playwright e2e isolated `SPOOL_DATA_DIR` and `SPOOL_ELECTRON_USER_DATA_DIR` but not this path, so a developer's real config (e.g. `projectSortOrder: "oldest"`) leaked into tests — `project-view.spec.ts › changing sort order reloads sessions` would pass on fresh installs but fail locally because the "default" view was already the user's persisted choice.
- Resolves the spool home dir via `spoolHomeDir()`, honoring a `SPOOL_HOME` override; `launchApp()` now sets it to a fresh tmp dir.
- Hardens the sort-order assertion: the previous `toBeVisible` check was satisfied by the still-mounted pre-click rows, so the read could land before React's effects had cleared/refetched. Switched to `not.toHaveAttribute('data-session-uuid', recentFirst)` so Playwright polls until the list actually updates.

## Test plan

- [x] `npx playwright test e2e/project-view.spec.ts` — 4/4 pass
- [x] `npx playwright test -g "changing sort order" --repeat-each 3` — 3/3 pass
- [x] Verified locally with `~/.spool/agents.json` containing `projectSortOrder: "oldest"` (the original failure mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)