### PR TITLE
fix(core): aggregate deleted-worktree sessions back into upstream project

### DIFF
--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -5,6 +5,7 @@ import { existsSync, mkdirSync, statSync } from 'node:fs'
 import { computeIdentity, type IdentityFs } from '../projects/identity.js'
 import { realFs } from '../projects/fs.js'
 import { runAgentSearchCleanup } from '../migrations/agent-search-cleanup.js'
+import { upgradeWorktreeIdentities } from '../migrations/worktree-identity-upgrade.js'
 
 export const SPOOL_DIR = process.env['SPOOL_DATA_DIR'] ?? join(homedir(), '.spool')
 export const DB_PATH = join(SPOOL_DIR, 'spool.db')
@@ -411,6 +412,19 @@ export function runMigrations(db: Database.Database): void {
       runAgentSearchCleanup(db)
     })()
     db.pragma('user_version = 9')
+  }
+
+  if (version < 10) {
+    // v10: re-classify path-kind projects that are stranded worktree cwds.
+    // Before the worktree resolvers landed, a session synced after its
+    // worktree was deleted couldn't reach the upstream git remote and was
+    // bucketed as its own path-kind project. The resolver now reads the
+    // worktree tool's persistent registry (e.g. ~/.superset/local.db) and
+    // recovers the real identity. See migrations/worktree-identity-upgrade.ts.
+    db.transaction(() => {
+      upgradeWorktreeIdentities(db, realFs)
+    })()
+    db.pragma('user_version = 10')
   }
 
   rebuildFtsTableIfEmpty(db, 'messages', 'messages_fts_trigram')

--- a/packages/core/src/migrations/worktree-identity-upgrade.test.ts
+++ b/packages/core/src/migrations/worktree-identity-upgrade.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import Database from 'better-sqlite3'
+import { runMigrations } from '../db/db.js'
+import { upgradeWorktreeIdentities } from './worktree-identity-upgrade.js'
+import type { IdentityFs } from '../projects/identity.js'
+
+let db: Database.Database
+
+beforeEach(() => {
+  db = new Database(':memory:')
+  runMigrations(db)
+})
+
+afterEach(() => {
+  db.close()
+})
+
+function seedProject(opts: {
+  slug: string
+  displayPath: string
+  displayName: string
+  identityKind: string
+  identityKey: string
+}): number {
+  const r = db.prepare(
+    `INSERT INTO projects (source_id, slug, display_path, display_name, identity_kind, identity_key)
+     VALUES (1, ?, ?, ?, ?, ?)`,
+  ).run(opts.slug, opts.displayPath, opts.displayName, opts.identityKind, opts.identityKey)
+  return Number(r.lastInsertRowid)
+}
+
+function makeFs(opts: {
+  liveGitRoots?: Record<string, { remote?: string; commonDir?: string }>
+}): IdentityFs {
+  const live = opts.liveGitRoots ?? {}
+  return {
+    exists: (p: string) => {
+      // Path exists if it's a known live git root or its .git child.
+      for (const root of Object.keys(live)) {
+        if (p === root || p === `${root}/.git`) return true
+      }
+      return false
+    },
+    readText: () => null,
+    spawn: (_cmd, args, callOpts) => {
+      const ctx = live[callOpts.cwd]
+      if (!ctx) return { stdout: '', exitCode: 1 }
+      if (args.includes('remote.origin.url') && ctx.remote) {
+        return { stdout: ctx.remote + '\n', exitCode: 0 }
+      }
+      if (args.includes('--git-common-dir') && ctx.commonDir) {
+        return { stdout: ctx.commonDir + '\n', exitCode: 0 }
+      }
+      return { stdout: '', exitCode: 1 }
+    },
+  }
+}
+
+describe('upgradeWorktreeIdentities', () => {
+  it('is a no-op when no path-kind projects exist', () => {
+    const result = upgradeWorktreeIdentities(db, makeFs({}))
+    expect(result).toEqual({ examined: 0, upgraded: 0 })
+  })
+
+  it('upgrades a path-kind row whose identity_key resolves to a live git repo', () => {
+    // The row's identity_key happens to BE a live git repo path. computeIdentity
+    // will find .git there and return git_remote — migration upgrades the row.
+    const id = seedProject({
+      slug: 'foo', displayPath: '/repos/foo', displayName: 'foo',
+      identityKind: 'path', identityKey: '/repos/foo',
+    })
+    const fs = makeFs({
+      liveGitRoots: { '/repos/foo': { remote: 'git@github.com:owner/foo.git' } },
+    })
+    const result = upgradeWorktreeIdentities(db, fs)
+    expect(result).toEqual({ examined: 1, upgraded: 1 })
+
+    const row = db.prepare(`SELECT identity_kind, identity_key FROM projects WHERE id = ?`).get(id) as
+      { identity_kind: string; identity_key: string }
+    expect(row.identity_kind).toBe('git_remote')
+    expect(row.identity_key).toBe('github.com/owner/foo')
+  })
+
+  it('leaves rows alone when computeIdentity still returns path', () => {
+    // No live git root at this path — recompute also yields path-kind. Don't
+    // touch the row (keeps migration idempotent on legitimately ad-hoc dirs).
+    const id = seedProject({
+      slug: 'scratch', displayPath: '/Users/me/scratch', displayName: 'scratch',
+      identityKind: 'path', identityKey: '/Users/me/scratch',
+    })
+    const before = db.prepare(`SELECT * FROM projects WHERE id = ?`).get(id) as Record<string, unknown>
+    const result = upgradeWorktreeIdentities(db, makeFs({}))
+    expect(result).toEqual({ examined: 1, upgraded: 0 })
+    const after = db.prepare(`SELECT * FROM projects WHERE id = ?`).get(id) as Record<string, unknown>
+    expect(after).toEqual(before)
+  })
+
+  it('leaves git_remote and other non-path rows untouched', () => {
+    const id = seedProject({
+      slug: 'spool', displayPath: '/Users/me/spool', displayName: 'spool',
+      identityKind: 'git_remote', identityKey: 'github.com/spool-lab/spool',
+    })
+    upgradeWorktreeIdentities(db, makeFs({
+      liveGitRoots: { '/Users/me/spool': { remote: 'something-else' } },
+    }))
+    const row = db.prepare(`SELECT identity_kind, identity_key FROM projects WHERE id = ?`).get(id) as
+      { identity_kind: string; identity_key: string }
+    expect(row.identity_kind).toBe('git_remote')
+    expect(row.identity_key).toBe('github.com/spool-lab/spool')
+  })
+
+  it('is idempotent on a second run', () => {
+    seedProject({
+      slug: 'foo', displayPath: '/repos/foo', displayName: 'foo',
+      identityKind: 'path', identityKey: '/repos/foo',
+    })
+    const fs = makeFs({
+      liveGitRoots: { '/repos/foo': { remote: 'git@github.com:owner/foo.git' } },
+    })
+    const first = upgradeWorktreeIdentities(db, fs)
+    const second = upgradeWorktreeIdentities(db, fs)
+    expect(first.upgraded).toBe(1)
+    expect(second.upgraded).toBe(0)
+    expect(second.examined).toBe(0)  // already non-path, not even examined
+  })
+})

--- a/packages/core/src/migrations/worktree-identity-upgrade.ts
+++ b/packages/core/src/migrations/worktree-identity-upgrade.ts
@@ -1,0 +1,61 @@
+import type Database from 'better-sqlite3'
+import { computeIdentity, type IdentityFs } from '../projects/identity.js'
+
+/**
+ * v10 data migration: re-classify historical `path`-kind project rows whose
+ * `identity_key` is a worktree path that has since been deleted.
+ *
+ * Before the worktree resolvers landed, a session synced AFTER its worktree
+ * was torn down had no way to recover its upstream remote — `computeIdentity`
+ * would walk up looking for `.git`, find nothing (the worktree was gone),
+ * and fall through to `path` kind. That created an orphan project per
+ * deleted worktree, even when the user had a perfectly good `spool` project
+ * already grouped under `git_remote: github.com/spool-lab/spool`.
+ *
+ * This migration re-runs `computeIdentity` against the stored `identity_key`.
+ * The resolver chain (default: superset) now reads the worktree tool's
+ * persistent registry to find the upstream main-repo path, runs git on it,
+ * and returns a real `git_remote` / `git_common_dir` identity. Same identity
+ * tuple as the parent project → `project_groups_v` collapses them into one
+ * row in the sidebar without any explicit row merging.
+ *
+ * Idempotent: re-running sees no `path`-kind candidates that resolve to a
+ * different identity, so it's a no-op on the second pass. Rows that still
+ * fail to resolve (e.g. genuine ad-hoc paths, or worktree tools we don't
+ * have a resolver for yet) stay untouched.
+ */
+
+export interface WorktreeUpgradeResult {
+  examined: number
+  upgraded: number
+}
+
+export function upgradeWorktreeIdentities(
+  db: Database.Database,
+  fs: IdentityFs,
+): WorktreeUpgradeResult {
+  const rows = db.prepare(
+    `SELECT id, identity_key FROM projects WHERE identity_kind = 'path'`,
+  ).all() as Array<{ id: number; identity_key: string }>
+
+  if (rows.length === 0) return { examined: 0, upgraded: 0 }
+
+  const update = db.prepare(
+    `UPDATE projects
+     SET identity_kind = ?, identity_key = ?, display_name = ?
+     WHERE id = ?`,
+  )
+
+  let upgraded = 0
+  for (const row of rows) {
+    const id = computeIdentity(row.identity_key, fs)
+    // Only upgrade when the resolver produced something stronger than path.
+    // (`loose` shouldn't happen here since we feed it a real cwd, but skip
+    // defensively to avoid demoting rows.)
+    if (id.kind === 'path' || id.kind === 'loose') continue
+    update.run(id.kind, id.key, id.displayName, row.id)
+    upgraded += 1
+  }
+
+  return { examined: rows.length, upgraded }
+}

--- a/packages/core/src/projects/identity.test.ts
+++ b/packages/core/src/projects/identity.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect } from 'vitest'
 import { homedir } from 'node:os'
 import { computeIdentity, normalizeGitRemote } from './identity.js'
+import type { WorktreeUpstreamResolver } from './worktree-resolvers.js'
 
 const noFs = {
   exists: () => false,
   readText: () => null,
   spawn: () => ({ stdout: '', exitCode: 1 }),
 }
+
+// Empty resolver chain so unit tests don't reach into a dev machine's real
+// ~/.superset/local.db. Tests for resolver behavior pass an explicit chain.
+const noResolvers: WorktreeUpstreamResolver[] = []
 
 describe('normalizeGitRemote', () => {
   it('strips .git and lowercases host', () => {
@@ -25,17 +30,17 @@ describe('normalizeGitRemote', () => {
 
 describe('computeIdentity', () => {
   it('returns loose for null cwd', () => {
-    const id = computeIdentity(null, noFs)
+    const id = computeIdentity(null, noFs, noResolvers)
     expect(id.kind).toBe('loose')
     expect(id.key).toBe('loose')
   })
 
   it('returns loose for home dir', () => {
     const home = homedir()
-    expect(computeIdentity(home, noFs).kind).toBe('loose')
-    expect(computeIdentity(`${home}/Desktop`, noFs).kind).toBe('loose')
-    expect(computeIdentity(`${home}/Downloads`, noFs).kind).toBe('loose')
-    expect(computeIdentity('/tmp', noFs).kind).toBe('loose')
+    expect(computeIdentity(home, noFs, noResolvers).kind).toBe('loose')
+    expect(computeIdentity(`${home}/Desktop`, noFs, noResolvers).kind).toBe('loose')
+    expect(computeIdentity(`${home}/Downloads`, noFs, noResolvers).kind).toBe('loose')
+    expect(computeIdentity('/tmp', noFs, noResolvers).kind).toBe('loose')
   })
 
   it('uses git remote when available', () => {
@@ -50,7 +55,7 @@ describe('computeIdentity', () => {
         return { stdout: '', exitCode: 1 }
       },
     }
-    const id = computeIdentity('/Users/chen/Code/spool', fs)
+    const id = computeIdentity('/Users/chen/Code/spool', fs, noResolvers)
     expect(id.kind).toBe('git_remote')
     expect(id.key).toBe('github.com/spool-lab/spool')
   })
@@ -67,7 +72,7 @@ describe('computeIdentity', () => {
         return { stdout: '', exitCode: 1 }
       },
     }
-    const id = computeIdentity('/Users/chen/local-only', fs)
+    const id = computeIdentity('/Users/chen/local-only', fs, noResolvers)
     expect(id.kind).toBe('git_common_dir')
     expect(id.key).toBe('/Users/chen/local-only/.git')
   })
@@ -79,7 +84,7 @@ describe('computeIdentity', () => {
         p.endsWith('package.json') ? '{"name":"my-proj"}' : null,
       spawn: () => ({ stdout: '', exitCode: 1 }),
     }
-    const id = computeIdentity('/Users/chen/proj/src', fs)
+    const id = computeIdentity('/Users/chen/proj/src', fs, noResolvers)
     expect(id.kind).toBe('manifest_path')
     expect(id.key).toBe('/Users/chen/proj')
     expect(id.displayName).toBe('my-proj')
@@ -91,10 +96,72 @@ describe('computeIdentity', () => {
       readText: () => null,
       spawn: () => ({ stdout: '', exitCode: 1 }),
     }
-    const id = computeIdentity('/Users/chen/scratch/notes', fs)
+    const id = computeIdentity('/Users/chen/scratch/notes', fs, noResolvers)
     expect(id.kind).toBe('path')
     expect(id.key).toBe('/Users/chen/scratch/notes')
     expect(id.displayName).toBe('notes')
+  })
+
+  it('uses worktree resolver to recover identity when cwd is dead', () => {
+    // Simulates: worktree at /wt/proj/branch was deleted before sync. The
+    // resolver knows the upstream main repo lives at /repos/proj. Recursing
+    // into computeIdentity on that path finds .git + remote and returns
+    // git_remote — same identity as a session in the live main repo.
+    const fs = {
+      exists: (p: string) => p === '/repos/proj' || p === '/repos/proj/.git',
+      readText: () => null,
+      spawn: (_cmd: string, args: string[], opts: { cwd: string }) => {
+        if (opts.cwd === '/repos/proj' && args.includes('remote.origin.url')) {
+          return { stdout: 'git@github.com:foo/proj.git\n', exitCode: 0 }
+        }
+        return { stdout: '', exitCode: 1 }
+      },
+    }
+    const resolver: WorktreeUpstreamResolver = {
+      name: 'fake',
+      resolve: (cwd) => cwd === '/wt/proj/branch' ? '/repos/proj' : null,
+    }
+    const id = computeIdentity('/wt/proj/branch', fs, [resolver])
+    expect(id.kind).toBe('git_remote')
+    expect(id.key).toBe('github.com/foo/proj')
+  })
+
+  it('falls through to path when resolver returns null', () => {
+    const resolver: WorktreeUpstreamResolver = { name: 'fake', resolve: () => null }
+    const id = computeIdentity('/wt/proj/branch', noFs, [resolver])
+    expect(id.kind).toBe('path')
+    expect(id.key).toBe('/wt/proj/branch')
+  })
+
+  it('falls through to path when resolver returns a non-existent upstream', () => {
+    const resolver: WorktreeUpstreamResolver = {
+      name: 'fake',
+      resolve: () => '/repos/missing',
+    }
+    const id = computeIdentity('/wt/proj/branch', noFs, [resolver])
+    expect(id.kind).toBe('path')
+  })
+
+  it('does not invoke resolvers when cwd is alive', () => {
+    // cwd has .git → git_remote returns immediately; resolver must not run
+    // (would otherwise risk overriding a healthy local probe).
+    const fs = {
+      exists: (p: string) => p.endsWith('/.git') || p === '/Users/me/repo',
+      readText: () => null,
+      spawn: (_cmd: string, args: string[]) => {
+        if (args.includes('remote.origin.url'))
+          return { stdout: 'https://github.com/foo/repo\n', exitCode: 0 }
+        return { stdout: '', exitCode: 1 }
+      },
+    }
+    let resolverCalled = false
+    const resolver: WorktreeUpstreamResolver = {
+      name: 'fake',
+      resolve: () => { resolverCalled = true; return '/elsewhere' },
+    }
+    const id = computeIdentity('/Users/me/repo', fs, [resolver])
+    expect(id.kind).toBe('git_remote')
+    expect(resolverCalled).toBe(false)
   })
 
   it('absolutizes a relative git_common_dir against gitRoot', () => {
@@ -109,7 +176,7 @@ describe('computeIdentity', () => {
         return { stdout: '', exitCode: 1 }
       },
     }
-    const id = computeIdentity('/Users/chen/Code/spool-wt', fs)
+    const id = computeIdentity('/Users/chen/Code/spool-wt', fs, noResolvers)
     expect(id.kind).toBe('git_common_dir')
     expect(id.key).toBe('/Users/chen/Code/shared.git')   // resolved up one level
   })

--- a/packages/core/src/projects/identity.ts
+++ b/packages/core/src/projects/identity.ts
@@ -2,6 +2,7 @@ import { homedir } from 'node:os'
 import { dirname, join, isAbsolute, resolve } from 'node:path'
 import type { ProjectIdentity, ProjectIdentityKind } from '../types.js'
 import { fallbackDisplayName } from './display-name.js'
+import { DEFAULT_RESOLVERS, type WorktreeUpstreamResolver } from './worktree-resolvers.js'
 
 export interface IdentityFs {
   exists(path: string): boolean
@@ -35,7 +36,11 @@ export function normalizeGitRemote(url: string): string | null {
   return s.toLowerCase()
 }
 
-export function computeIdentity(cwd: string | null, fs: IdentityFs): ProjectIdentity {
+export function computeIdentity(
+  cwd: string | null,
+  fs: IdentityFs,
+  resolvers: readonly WorktreeUpstreamResolver[] = DEFAULT_RESOLVERS,
+): ProjectIdentity {
   if (!cwd) return loose()
 
   const home = homedir()
@@ -80,7 +85,23 @@ export function computeIdentity(cwd: string | null, fs: IdentityFs): ProjectIden
     }
   }
 
-  // 3. path
+  // 3. worktree resolvers — recover identity for sessions whose cwd has been
+  // deleted (e.g. superset/git worktree torn down before Spool synced). The
+  // resolver returns the upstream main-repo path; we recurse with empty
+  // resolvers to prevent loops and to ensure the upstream goes through the
+  // normal git/manifest detection on a real, existing path.
+  if (!fs.exists(cwd) && resolvers.length > 0) {
+    for (const r of resolvers) {
+      const upstream = r.resolve(cwd)
+      if (!upstream || !fs.exists(upstream)) continue
+      const id = computeIdentity(upstream, fs, [])
+      if (id.kind === 'git_remote' || id.kind === 'git_common_dir' || id.kind === 'manifest_path') {
+        return id
+      }
+    }
+  }
+
+  // 4. path
   return {
     kind: 'path',
     key: cwd,

--- a/packages/core/src/projects/worktree-resolvers.test.ts
+++ b/packages/core/src/projects/worktree-resolvers.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import Database from 'better-sqlite3'
+import { supersetResolver, _resetSupersetCacheForTests } from './worktree-resolvers.js'
+
+let tmpHome: string
+const originalHome = process.env['HOME']
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'spool-superset-test-'))
+  process.env['HOME'] = tmpHome
+  mkdirSync(join(tmpHome, '.superset'), { recursive: true })
+  _resetSupersetCacheForTests()
+})
+
+afterEach(() => {
+  if (originalHome) process.env['HOME'] = originalHome
+  else delete process.env['HOME']
+  try { rmSync(tmpHome, { recursive: true, force: true }) } catch { /* ignore */ }
+  _resetSupersetCacheForTests()
+})
+
+function supersetDbPath() { return join(tmpHome, '.superset', 'local.db') }
+
+function createSupersetSchema(): Database.Database {
+  const db = new Database(supersetDbPath())
+  db.exec(`
+    CREATE TABLE projects (
+      id TEXT PRIMARY KEY,
+      main_repo_path TEXT NOT NULL,
+      name TEXT NOT NULL,
+      worktree_base_dir TEXT
+    );
+    CREATE TABLE settings (
+      id INTEGER PRIMARY KEY DEFAULT 1,
+      worktree_base_dir TEXT
+    );
+  `)
+  return db
+}
+
+describe('supersetResolver', () => {
+  it('returns null when superset DB is absent', () => {
+    expect(supersetResolver.resolve('/some/path')).toBeNull()
+  })
+
+  it('matches a worktree under the default base dir', () => {
+    const db = createSupersetSchema()
+    db.prepare(
+      `INSERT INTO projects (id, main_repo_path, name, worktree_base_dir) VALUES (?, ?, ?, ?)`,
+    ).run('proj1', '/Users/me/github/spool', 'spool', null)
+    db.close()
+
+    const cwd = join(tmpHome, '.superset', 'worktrees', 'spool', 'feat-branch')
+    expect(supersetResolver.resolve(cwd)).toBe('/Users/me/github/spool')
+  })
+
+  it('matches when project has a custom worktree_base_dir', () => {
+    const db = createSupersetSchema()
+    db.prepare(
+      `INSERT INTO projects (id, main_repo_path, name, worktree_base_dir) VALUES (?, ?, ?, ?)`,
+    ).run('proj1', '/repos/customproj', 'customproj', '/custom/wt-base')
+    db.close()
+
+    expect(supersetResolver.resolve('/custom/wt-base/customproj/branch-x'))
+      .toBe('/repos/customproj')
+  })
+
+  it('falls back to global settings worktree_base_dir', () => {
+    const db = createSupersetSchema()
+    db.prepare(
+      `INSERT INTO projects (id, main_repo_path, name, worktree_base_dir) VALUES (?, ?, ?, ?)`,
+    ).run('proj1', '/repos/p', 'p', null)
+    db.prepare(
+      `INSERT INTO settings (id, worktree_base_dir) VALUES (1, ?)`,
+    ).run('/global/wts')
+    db.close()
+
+    expect(supersetResolver.resolve('/global/wts/p/branch')).toBe('/repos/p')
+  })
+
+  it('returns null when cwd does not match any project convention', () => {
+    const db = createSupersetSchema()
+    db.prepare(
+      `INSERT INTO projects (id, main_repo_path, name, worktree_base_dir) VALUES (?, ?, ?, ?)`,
+    ).run('proj1', '/repos/spool', 'spool', null)
+    db.close()
+
+    const cwd = join(tmpHome, '.superset', 'worktrees', 'unknown-project', 'branch')
+    expect(supersetResolver.resolve(cwd)).toBeNull()
+  })
+
+  it('does not match when project name is only a string prefix', () => {
+    // "spool-foo" must not be matched by project name "spool" — the path
+    // segment boundary is required.
+    const db = createSupersetSchema()
+    db.prepare(
+      `INSERT INTO projects (id, main_repo_path, name, worktree_base_dir) VALUES (?, ?, ?, ?)`,
+    ).run('proj1', '/repos/spool', 'spool', null)
+    db.close()
+
+    const cwd = join(tmpHome, '.superset', 'worktrees', 'spool-foo', 'branch')
+    expect(supersetResolver.resolve(cwd)).toBeNull()
+  })
+
+  it('returns null gracefully on malformed schema', () => {
+    const db = new Database(supersetDbPath())
+    db.exec(`CREATE TABLE projects (id TEXT)`)  // missing required columns
+    db.close()
+
+    expect(supersetResolver.resolve('/anything')).toBeNull()
+  })
+})

--- a/packages/core/src/projects/worktree-resolvers.ts
+++ b/packages/core/src/projects/worktree-resolvers.ts
@@ -1,0 +1,91 @@
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import Database from 'better-sqlite3'
+
+// Resolve home at call time (not module load) so tests can redirect via
+// process.env.HOME. node:os.homedir() reads the OS user info on POSIX and
+// ignores HOME, hence the explicit check first.
+function getHome(): string {
+  return process.env['HOME'] || homedir()
+}
+
+/**
+ * Recovers the upstream main-repo path of a worktree session whose `cwd`
+ * has already been deleted at sync time. This is the only signal that lets
+ * Spool group such sessions under their real project — Claude Code's JSONL
+ * carries `cwd` and `gitBranch` but no remote URL.
+ *
+ * Each implementation reads a worktree-tool-specific persistent store. If
+ * the store is missing or the cwd doesn't match anything, return null and
+ * the next resolver in the chain (or the existing path-kind fallback) wins.
+ */
+export interface WorktreeUpstreamResolver {
+  name: string
+  resolve(cwd: string): string | null
+}
+
+function supersetDbPath(): string { return join(getHome(), '.superset', 'local.db') }
+function supersetDefaultBase(): string { return join(getHome(), '.superset', 'worktrees') }
+
+interface SupersetProjectRow {
+  name: string
+  main_repo_path: string
+  worktree_base_dir: string | null
+}
+
+let _supersetCache: { projects: SupersetProjectRow[]; globalBase: string } | null = null
+
+function loadSupersetProjects(): { projects: SupersetProjectRow[]; globalBase: string } | null {
+  if (_supersetCache) return _supersetCache
+  const dbPath = supersetDbPath()
+  if (!existsSync(dbPath)) return null
+
+  let db: Database.Database | null = null
+  try {
+    db = new Database(dbPath, { readonly: true, fileMustExist: true })
+
+    const settings = db.prepare(
+      `SELECT worktree_base_dir FROM settings WHERE id = 1`,
+    ).get() as { worktree_base_dir: string | null } | undefined
+    const globalBase = settings?.worktree_base_dir || supersetDefaultBase()
+
+    const projects = db.prepare(
+      `SELECT name, main_repo_path, worktree_base_dir FROM projects`,
+    ).all() as SupersetProjectRow[]
+
+    _supersetCache = { projects, globalBase }
+    return _supersetCache
+  } catch {
+    return null
+  } finally {
+    try { db?.close() } catch { /* ignore */ }
+  }
+}
+
+/** Test hook: reset the in-process cache so tests can stub the DB. */
+export function _resetSupersetCacheForTests(): void {
+  _supersetCache = null
+}
+
+export const supersetResolver: WorktreeUpstreamResolver = {
+  name: 'superset',
+  resolve(cwd: string): string | null {
+    const data = loadSupersetProjects()
+    if (!data) return null
+    for (const p of data.projects) {
+      if (!p.main_repo_path) continue
+      const base = p.worktree_base_dir || data.globalBase
+      // Convention enforced by superset: <base>/<project-name>/<branch>
+      const projectDir = join(base, p.name)
+      if (cwd === projectDir || cwd.startsWith(projectDir + '/')) {
+        return p.main_repo_path
+      }
+    }
+    return null
+  },
+}
+
+export const DEFAULT_RESOLVERS: readonly WorktreeUpstreamResolver[] = Object.freeze([
+  supersetResolver,
+])


### PR DESCRIPTION
## What

Worktree sessions whose `cwd` was deleted before sync were bucketed into their own `path`-kind project — `equinox-warbler` sitting alongside `spool` in the sidebar — instead of grouping under the parent repo.

This change adds a resolver chain that recovers the upstream main-repo path when local probes can't, plus a one-shot v10 data migration that re-classifies existing stranded rows.

## Why

`computeIdentity(cwd)` derives a project's grouping key by trying, in order: `git config remote.origin.url`, `git rev-parse --git-common-dir`, manifest discovery, and finally a `path`-kind fallback keyed by `cwd` itself. Crucially, `getOrCreateProject` is **first-write-wins** — once a project row gets an identity, later syncs never re-derive it.

The bug is purely about *when* the first sync happens. If Spool watcher is running while the worktree is alive, every probe succeeds and the session lands under `git_remote: <upstream>`. If the worktree is deleted before Spool catches up, every filesystem probe fails because the directory is gone, and the row gets stamped as `path: <dead-cwd>` — permanently divorced from the parent project.

Spool's app-side watcher only runs while the GUI is open, so this isn't an edge case for users who use a worktree tool and Spool occasionally rather than continuously.

## Investigation summary

I considered three recovery strategies before settling on the resolver approach:

**(A) Spool watcher always-on / first-stamp at watch-event time.** Doesn't help retrospectively — the bug only happens when the first sync is *after* deletion. There's no headless background sync service today (the existing `spool-daemon` is for connector subsystems, not session sync); building one is a much larger product change than this fix.

**(B) Use the main repo's `.git/worktrees/<name>/` stale entry to reverse-map a dead worktree path.** Empirically tested on this repo: superset uses `git worktree remove` (proper cleanup), so the main repo retains **no** record of removed worktrees. Even if it did, Spool has no global registry of which main repos to scan — only paths it's already seen via prior non-worktree sessions. Both preconditions failing makes this path unreliable.

**(C) Read the worktree tool's own persistent registry.** superset stores `(name, main_repo_path, worktree_base_dir)` in `~/.superset/local.db`. The `projects` table survives worktree deletion (only the `worktrees` table row is removed). The path convention `<base>/<project-name>/<branch>` is enforced by superset, so a dead `cwd` reverse-maps deterministically to a `main_repo_path` that's still alive.

I chose (C). It's authoritative, deterministic, and works for the actual observed bug. The resolver is interface-driven (`WorktreeUpstreamResolver`), so other tools (`gt`, `charm worktree`, etc.) can be added as separate resolvers without touching `computeIdentity`.

## How

- `packages/core/src/projects/worktree-resolvers.ts` — interface + `supersetResolver` reading `~/.superset/local.db` read-only with a per-process projects cache. Gracefully returns null on missing file, locked DB, or schema drift.
- `packages/core/src/projects/identity.ts` — `computeIdentity` gains an optional `resolvers` arg (defaults to `DEFAULT_RESOLVERS`). When `cwd` doesn't exist after the git/manifest probes, walks the resolver chain; for any resolver that returns a still-existing upstream path, recurses into `computeIdentity(upstream, fs, [])` to extract its real identity. Empty resolvers in recursion prevents loops and keeps the upstream pass through normal git/manifest detection.
- `packages/core/src/migrations/worktree-identity-upgrade.ts` — v10 migration that re-runs `computeIdentity` on every existing `path`-kind row. The new resolver branch lets stranded worktree rows now resolve to `git_remote`/`git_common_dir`. Idempotent: a second run sees no `path`-kind candidates that resolve differently. Genuinely ad-hoc paths (no upstream available) stay untouched.
- Sidebar grouping is via `project_groups_v` (`GROUP BY identity_kind, identity_key`), so an upgraded row automatically merges into the existing parent group — no row deletion or session reassignment needed.

## Trade-off acknowledged

This couples `@spool-lab/core` to superset's SQLite schema. The coupling is isolated to one file (`worktree-resolvers.ts`) reading three columns: `projects.name`, `projects.main_repo_path`, `projects.worktree_base_dir`, plus `settings.worktree_base_dir`. Schema additions don't affect us; column removals trigger graceful fallback to the existing `path`-kind behavior. Worth the cost for the user value — superset is the predominant worktree tool in this user base. Other tools get their own resolver as needed.

## Test plan

- [x] New unit tests in `worktree-resolvers.test.ts` (7 tests) cover: missing DB, default base match, custom per-project base, global settings base, non-matching path, prefix-collision rejection, malformed schema.
- [x] New unit tests in `identity.test.ts` cover: resolver hit recovers `git_remote`, resolver-returns-null falls through to path, resolver-returns-nonexistent-upstream falls through, alive `cwd` does not invoke resolvers.
- [x] New integration tests in `worktree-identity-upgrade.test.ts` (5 tests) cover: empty DB, upgrade live-git path-kind row, leave true-path rows alone, leave non-path identities untouched, idempotency.
- [x] Existing tests in `identity.test.ts` updated to pass `[]` resolvers explicitly so they remain hermetic against the dev machine's real `~/.superset/local.db`.
- [x] Full `@spool-lab/core` test suite passes: 154/154.
- [x] `tsc --noEmit` clean.
- [x] **End-to-end verification**: copied `~/.spool/spool.db` to `/tmp`, ran `upgradeWorktreeIdentities` against the copy. The lone `path`-kind worktree row (`equinox-warbler`, identity_key `/Users/chen/.superset/worktrees/spool/equinox-warbler`) was upgraded in place to `git_remote: github.com/spool-lab/spool` with display_name `spool`. The other 15 path-kind rows (legitimate ad-hoc dirs) were untouched. Migration result: `{ examined: 16, upgraded: 1 }`.