### PR TITLE
feat(app): unify worktree group headers as quiet section labels

### DIFF
--- a/packages/app/src/renderer/components/ProjectView.tsx
+++ b/packages/app/src/renderer/components/ProjectView.tsx
@@ -417,8 +417,9 @@ function DirectoryGroupSection({
   onOpenSession: (uuid: string) => void
   onCopySessionId: (source: Session['source']) => void
 }) {
-  const { name, tail } = formatCwdLabel(cwd, projectDisplayPath)
+  const { name } = formatCwdLabel(cwd, projectDisplayPath)
   const count = sessions.length
+  const tooltip = cwd === '(unknown)' ? undefined : cwd
 
   return (
     <div data-testid="project-view-directory-group" data-cwd={cwd}>
@@ -427,28 +428,25 @@ function DirectoryGroupSection({
         onClick={onToggleOpen}
         aria-expanded={open}
         aria-label={open ? 'Collapse directory' : 'Expand directory'}
-        title={cwd === '(unknown)' ? undefined : cwd}
-        className="w-full flex items-baseline gap-2 px-6 py-1.5 text-left transition-colors hover:bg-warm-surface/60 dark:hover:bg-dark-surface/60"
+        title={tooltip}
+        className="group w-full flex items-center gap-2 px-6 pt-3 pb-1 text-left text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75 select-none"
       >
-        <span className="text-[13px] font-medium text-warm-text dark:text-dark-text truncate">
+        <span className="font-mono text-[11px] font-medium truncate">
           {name}
         </span>
-        {tail && (
-          <span className="font-mono text-[11px] text-warm-faint/80 dark:text-dark-muted/80 truncate">
-            {tail}
-          </span>
-        )}
         <span className="ml-auto flex items-center gap-2 flex-none self-center">
-          <span className="font-mono text-[10px] tabular-nums text-warm-faint dark:text-dark-muted">
-            {count}
-          </span>
+          {count > 1 && (
+            <span className="font-mono text-[10px] tabular-nums">
+              {count}
+            </span>
+          )}
           <svg
             width="9"
             height="9"
             viewBox="0 0 9 9"
             fill="none"
             aria-hidden
-            className={`transition-transform text-warm-faint dark:text-dark-muted ${open ? 'rotate-90' : ''}`}
+            className={`flex-none transition-all opacity-30 group-hover:opacity-100 ${open ? 'rotate-90' : ''}`}
           >
             <path d="M3 1.5L6 4.5L3 7.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
           </svg>


### PR DESCRIPTION
## Summary
- Replace the heavy 13px worktree group header with a uniform 11px Geist Mono section-label style, matching the existing PINNED header treatment.
- Show the session count only when ≥ 2; single-session worktrees render just name + chevron.
- Move the chevron to the trailing slot and bind it to `opacity-30 → group-hover:opacity-100`, with the worktree name doing `text-faint → hover:text-text` — no background hover, mirroring CollapsibleSection.
- Switch padding to canonical `pt-3 pb-1` so each worktree group has a clear top break instead of bleeding into the prior group's last session row.

## Why
Projects with many worktrees (e.g. spool itself today: ~12 worktrees, mostly 1 session each) ended up with header rows almost as visually loud as the session beneath them. The mixed-treatment header (full for ≥ 2 sessions, would-be-thin for 1) also produced an irregular vertical rhythm. Unifying on the quiet style keeps worktrees as first-class collapsible containers while letting sessions remain the visual focus.

## How it connects
`DirectoryGroupSection` is the only renderer for worktree groups inside `ProjectView`. The new style intentionally mirrors `CollapsibleSection` from `LibraryLanding` (used by PINNED / TODAY / etc.) so all section labels in the main pane now read as one family. Hover-state semantics (text brightens, chevron opacity rises, no bg) are identical.

## Test plan
- [x] Type check passes (`pnpm exec tsc --noEmit` in `packages/app`).
- [ ] Visual: open a project with multiple worktrees, confirm uniform thin header rhythm and clear group separation.
- [ ] Visual: open a project with one multi-session worktree alongside several single-session ones, confirm count appears only on the multi-session group.
- [ ] Interaction: click each worktree header, confirm collapse/expand still works and chevron rotates.
- [ ] Hover: confirm worktree name + count brighten together and chevron opacity jumps to 100% with no background change.
- [ ] Tooltip: hover over a worktree header, confirm the full cwd is shown.