### PR TITLE
feat(core): aggregate Codex non-project chats under a synthetic project

### DIFF
--- a/packages/core/src/projects/identity-synthesizers.test.ts
+++ b/packages/core/src/projects/identity-synthesizers.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { codexScratchSynthesizer } from './identity-synthesizers.js'
+
+describe('codexScratchSynthesizer', () => {
+  let originalHome: string | undefined
+
+  beforeEach(() => {
+    originalHome = process.env['HOME']
+    process.env['HOME'] = '/Users/chen'
+  })
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env['HOME']
+    else process.env['HOME'] = originalHome
+  })
+
+  it('matches Codex non-project chat workspaces', () => {
+    const id = codexScratchSynthesizer.synthesize(
+      '/Users/chen/Documents/Codex/2026-05-11/codex-project',
+    )
+    expect(id).toEqual({
+      kind: 'synthetic',
+      key: 'codex:scratch',
+      displayName: 'Codex Chats',
+      displayPath: '/Users/chen/Documents/Codex',
+    })
+  })
+
+  it('returns the same key for any date or slug', () => {
+    const a = codexScratchSynthesizer.synthesize(
+      '/Users/chen/Documents/Codex/2026-05-11/new-chat',
+    )
+    const b = codexScratchSynthesizer.synthesize(
+      '/Users/chen/Documents/Codex/2027-01-02/something-else',
+    )
+    expect(a?.key).toBe('codex:scratch')
+    expect(b?.key).toBe('codex:scratch')
+  })
+
+  it('ignores cwds outside ~/Documents/Codex/', () => {
+    expect(codexScratchSynthesizer.synthesize('/Users/chen/Code/spool')).toBeNull()
+    expect(codexScratchSynthesizer.synthesize('/Users/chen/Documents/other')).toBeNull()
+    // Documents/Codex itself (no trailing date dir) is not a scratch workspace.
+    expect(codexScratchSynthesizer.synthesize('/Users/chen/Documents/Codex')).toBeNull()
+  })
+
+  it('honors $HOME override', () => {
+    process.env['HOME'] = '/tmp/fake-home'
+    expect(
+      codexScratchSynthesizer.synthesize(
+        '/Users/chen/Documents/Codex/2026-05-11/x',
+      ),
+    ).toBeNull()
+    expect(
+      codexScratchSynthesizer.synthesize(
+        '/tmp/fake-home/Documents/Codex/2026-05-11/x',
+      )?.key,
+    ).toBe('codex:scratch')
+  })
+})

--- a/packages/core/src/projects/identity-synthesizers.ts
+++ b/packages/core/src/projects/identity-synthesizers.ts
@@ -1,0 +1,45 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import type { ProjectIdentity } from '../types.js'
+
+// Resolved at call time so process.env.HOME overrides take effect in tests.
+function getHome(): string {
+  return process.env['HOME'] || homedir()
+}
+
+/**
+ * Collapses sessions whose cwd is a known "scratch workspace" pattern into a
+ * single synthetic project — the workspace dir itself carries no useful
+ * identity signal (no .git, no manifest), so without this each chat shows up
+ * as its own sidebar entry.
+ *
+ * Each synthesizer matches a cwd and returns a stable identity shared by all
+ * sessions in that scope. Returns null to defer to the next rule.
+ */
+export interface IdentitySynthesizer {
+  name: string
+  synthesize(cwd: string): ProjectIdentity | null
+}
+
+/**
+ * Codex desktop creates one disposable workspace per non-project chat at
+ * `~/Documents/Codex/<YYYY-MM-DD>/<slug>/`. Group every such chat under a
+ * single synthetic "Codex" project so they don't litter the sidebar.
+ */
+export const codexScratchSynthesizer: IdentitySynthesizer = {
+  name: 'codex-scratch',
+  synthesize(cwd: string): ProjectIdentity | null {
+    const root = join(getHome(), 'Documents', 'Codex')
+    if (!cwd.startsWith(root + '/')) return null
+    return {
+      kind: 'synthetic',
+      key: 'codex:scratch',
+      displayName: 'Codex Chats',
+      displayPath: root,
+    }
+  },
+}
+
+export const DEFAULT_SYNTHESIZERS: readonly IdentitySynthesizer[] = Object.freeze([
+  codexScratchSynthesizer,
+])

--- a/packages/core/src/projects/identity.test.ts
+++ b/packages/core/src/projects/identity.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { homedir } from 'node:os'
 import { computeIdentity, normalizeGitRemote } from './identity.js'
 import type { WorktreeUpstreamResolver } from './worktree-resolvers.js'
+import type { IdentitySynthesizer } from './identity-synthesizers.js'
 
 const noFs = {
   exists: () => false,
@@ -12,6 +13,7 @@ const noFs = {
 // Empty resolver chain so unit tests don't reach into a dev machine's real
 // ~/.superset/local.db. Tests for resolver behavior pass an explicit chain.
 const noResolvers: WorktreeUpstreamResolver[] = []
+const noSynthesizers: IdentitySynthesizer[] = []
 
 describe('normalizeGitRemote', () => {
   it('strips .git and lowercases host', () => {
@@ -30,17 +32,17 @@ describe('normalizeGitRemote', () => {
 
 describe('computeIdentity', () => {
   it('returns loose for null cwd', () => {
-    const id = computeIdentity(null, noFs, noResolvers)
+    const id = computeIdentity(null, noFs, noResolvers, noSynthesizers)
     expect(id.kind).toBe('loose')
     expect(id.key).toBe('loose')
   })
 
   it('returns loose for home dir', () => {
     const home = homedir()
-    expect(computeIdentity(home, noFs, noResolvers).kind).toBe('loose')
-    expect(computeIdentity(`${home}/Desktop`, noFs, noResolvers).kind).toBe('loose')
-    expect(computeIdentity(`${home}/Downloads`, noFs, noResolvers).kind).toBe('loose')
-    expect(computeIdentity('/tmp', noFs, noResolvers).kind).toBe('loose')
+    expect(computeIdentity(home, noFs, noResolvers, noSynthesizers).kind).toBe('loose')
+    expect(computeIdentity(`${home}/Desktop`, noFs, noResolvers, noSynthesizers).kind).toBe('loose')
+    expect(computeIdentity(`${home}/Downloads`, noFs, noResolvers, noSynthesizers).kind).toBe('loose')
+    expect(computeIdentity('/tmp', noFs, noResolvers, noSynthesizers).kind).toBe('loose')
   })
 
   it('uses git remote when available', () => {
@@ -55,7 +57,7 @@ describe('computeIdentity', () => {
         return { stdout: '', exitCode: 1 }
       },
     }
-    const id = computeIdentity('/Users/chen/Code/spool', fs, noResolvers)
+    const id = computeIdentity('/Users/chen/Code/spool', fs, noResolvers, noSynthesizers)
     expect(id.kind).toBe('git_remote')
     expect(id.key).toBe('github.com/spool-lab/spool')
   })
@@ -72,7 +74,7 @@ describe('computeIdentity', () => {
         return { stdout: '', exitCode: 1 }
       },
     }
-    const id = computeIdentity('/Users/chen/local-only', fs, noResolvers)
+    const id = computeIdentity('/Users/chen/local-only', fs, noResolvers, noSynthesizers)
     expect(id.kind).toBe('git_common_dir')
     expect(id.key).toBe('/Users/chen/local-only/.git')
   })
@@ -84,7 +86,7 @@ describe('computeIdentity', () => {
         p.endsWith('package.json') ? '{"name":"my-proj"}' : null,
       spawn: () => ({ stdout: '', exitCode: 1 }),
     }
-    const id = computeIdentity('/Users/chen/proj/src', fs, noResolvers)
+    const id = computeIdentity('/Users/chen/proj/src', fs, noResolvers, noSynthesizers)
     expect(id.kind).toBe('manifest_path')
     expect(id.key).toBe('/Users/chen/proj')
     expect(id.displayName).toBe('my-proj')
@@ -96,7 +98,7 @@ describe('computeIdentity', () => {
       readText: () => null,
       spawn: () => ({ stdout: '', exitCode: 1 }),
     }
-    const id = computeIdentity('/Users/chen/scratch/notes', fs, noResolvers)
+    const id = computeIdentity('/Users/chen/scratch/notes', fs, noResolvers, noSynthesizers)
     expect(id.kind).toBe('path')
     expect(id.key).toBe('/Users/chen/scratch/notes')
     expect(id.displayName).toBe('notes')
@@ -121,14 +123,14 @@ describe('computeIdentity', () => {
       name: 'fake',
       resolve: (cwd) => cwd === '/wt/proj/branch' ? '/repos/proj' : null,
     }
-    const id = computeIdentity('/wt/proj/branch', fs, [resolver])
+    const id = computeIdentity('/wt/proj/branch', fs, [resolver], noSynthesizers)
     expect(id.kind).toBe('git_remote')
     expect(id.key).toBe('github.com/foo/proj')
   })
 
   it('falls through to path when resolver returns null', () => {
     const resolver: WorktreeUpstreamResolver = { name: 'fake', resolve: () => null }
-    const id = computeIdentity('/wt/proj/branch', noFs, [resolver])
+    const id = computeIdentity('/wt/proj/branch', noFs, [resolver], noSynthesizers)
     expect(id.kind).toBe('path')
     expect(id.key).toBe('/wt/proj/branch')
   })
@@ -138,7 +140,7 @@ describe('computeIdentity', () => {
       name: 'fake',
       resolve: () => '/repos/missing',
     }
-    const id = computeIdentity('/wt/proj/branch', noFs, [resolver])
+    const id = computeIdentity('/wt/proj/branch', noFs, [resolver], noSynthesizers)
     expect(id.kind).toBe('path')
   })
 
@@ -159,7 +161,7 @@ describe('computeIdentity', () => {
       name: 'fake',
       resolve: () => { resolverCalled = true; return '/elsewhere' },
     }
-    const id = computeIdentity('/Users/me/repo', fs, [resolver])
+    const id = computeIdentity('/Users/me/repo', fs, [resolver], noSynthesizers)
     expect(id.kind).toBe('git_remote')
     expect(resolverCalled).toBe(false)
   })
@@ -176,8 +178,48 @@ describe('computeIdentity', () => {
         return { stdout: '', exitCode: 1 }
       },
     }
-    const id = computeIdentity('/Users/chen/Code/spool-wt', fs, noResolvers)
+    const id = computeIdentity('/Users/chen/Code/spool-wt', fs, noResolvers, noSynthesizers)
     expect(id.kind).toBe('git_common_dir')
     expect(id.key).toBe('/Users/chen/Code/shared.git')   // resolved up one level
+  })
+
+  it('runs synthesizers after worktree resolvers, before path fallback', () => {
+    const synth: IdentitySynthesizer = {
+      name: 'fake',
+      synthesize: (cwd) => cwd === '/scratch/x'
+        ? { kind: 'synthetic', key: 'fake:x', displayName: 'Fake' }
+        : null,
+    }
+    const id = computeIdentity('/scratch/x', noFs, noResolvers, [synth])
+    expect(id.kind).toBe('synthetic')
+    expect(id.key).toBe('fake:x')
+    expect(id.displayName).toBe('Fake')
+  })
+
+  it('prefers a real git identity over a synthesizer match', () => {
+    // Even if cwd matches a synthesizer prefix, an existing git remote wins —
+    // a chat that happens to live inside a real repo groups with that repo.
+    const fs = {
+      exists: (p: string) => p.endsWith('/.git') || p === '/scratch/x',
+      readText: () => null,
+      spawn: (_cmd: string, args: string[]) => {
+        if (args.includes('remote.origin.url'))
+          return { stdout: 'git@github.com:foo/bar.git\n', exitCode: 0 }
+        return { stdout: '', exitCode: 1 }
+      },
+    }
+    const synth: IdentitySynthesizer = {
+      name: 'fake',
+      synthesize: () => ({ kind: 'synthetic', key: 'fake:x', displayName: 'Fake' }),
+    }
+    const id = computeIdentity('/scratch/x', fs, noResolvers, [synth])
+    expect(id.kind).toBe('git_remote')
+  })
+
+  it('falls through to path when no synthesizer claims the cwd', () => {
+    const synth: IdentitySynthesizer = { name: 'fake', synthesize: () => null }
+    const id = computeIdentity('/Users/chen/random/dir', noFs, noResolvers, [synth])
+    expect(id.kind).toBe('path')
+    expect(id.key).toBe('/Users/chen/random/dir')
   })
 })

--- a/packages/core/src/projects/identity.ts
+++ b/packages/core/src/projects/identity.ts
@@ -3,6 +3,7 @@ import { dirname, join, isAbsolute, resolve } from 'node:path'
 import type { ProjectIdentity, ProjectIdentityKind } from '../types.js'
 import { fallbackDisplayName } from './display-name.js'
 import { DEFAULT_RESOLVERS, type WorktreeUpstreamResolver } from './worktree-resolvers.js'
+import { DEFAULT_SYNTHESIZERS, type IdentitySynthesizer } from './identity-synthesizers.js'
 
 export interface IdentityFs {
   exists(path: string): boolean
@@ -40,6 +41,7 @@ export function computeIdentity(
   cwd: string | null,
   fs: IdentityFs,
   resolvers: readonly WorktreeUpstreamResolver[] = DEFAULT_RESOLVERS,
+  synthesizers: readonly IdentitySynthesizer[] = DEFAULT_SYNTHESIZERS,
 ): ProjectIdentity {
   if (!cwd) return loose()
 
@@ -94,14 +96,24 @@ export function computeIdentity(
     for (const r of resolvers) {
       const upstream = r.resolve(cwd)
       if (!upstream || !fs.exists(upstream)) continue
-      const id = computeIdentity(upstream, fs, [])
+      const id = computeIdentity(upstream, fs, [], [])
       if (id.kind === 'git_remote' || id.kind === 'git_common_dir' || id.kind === 'manifest_path') {
         return id
       }
     }
   }
 
-  // 4. path
+  // 4. identity synthesizers — collapse known scratch-workspace patterns
+  // (e.g. Codex desktop's per-chat temp dirs under ~/Documents/Codex/<date>/)
+  // into a single synthetic project. Only runs when no real project signal
+  // was found above; a chat that happens to live inside a real git repo or
+  // manifest still groups under that repo.
+  for (const s of synthesizers) {
+    const id = s.synthesize(cwd)
+    if (id) return id
+  }
+
+  // 5. path
   return {
     kind: 'path',
     key: cwd,

--- a/packages/core/src/sync/syncer.test.ts
+++ b/packages/core/src/sync/syncer.test.ts
@@ -124,6 +124,94 @@ describe('Syncer', () => {
     expect(results).toHaveLength(1)
     expect(results[0]?.snippet).toContain(tailKeyword)
   })
+
+  it('collapses multiple Codex scratch chats into a single project row', async () => {
+    const baseDir = makeTempDir('spool-syncer-codex-')
+    const codexHome = join(baseDir, 'codex-home')
+    const sessionsDir = join(codexHome, '.codex', 'sessions', '2026', '05', '11')
+    const spoolDataDir = join(baseDir, 'spool-data')
+    mkdirSync(sessionsDir, { recursive: true })
+
+    const scratchA = join(baseDir, 'Documents', 'Codex', '2026-05-11', 'codex-project')
+    const scratchB = join(baseDir, 'Documents', 'Codex', '2026-05-11', 'new-chat')
+    mkdirSync(scratchA, { recursive: true })
+    mkdirSync(scratchB, { recursive: true })
+
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDataDir)
+    vi.stubEnv('HOME', baseDir)
+    vi.stubEnv('CODEX_HOME', join(codexHome, '.codex'))
+
+    function writeCodexSession(name: string, sessionId: string, cwd: string): string {
+      const fp = join(sessionsDir, name)
+      writeFileSync(fp, [
+        JSON.stringify({
+          timestamp: '2026-05-11T12:00:00Z',
+          type: 'session_meta',
+          payload: { id: sessionId, cwd },
+        }),
+        JSON.stringify({
+          timestamp: '2026-05-11T12:00:01Z',
+          type: 'turn_context',
+          payload: { model: 'gpt-5.4', cwd },
+        }),
+        JSON.stringify({
+          timestamp: '2026-05-11T12:00:02Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'hello' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-05-11T12:00:03Z',
+          type: 'event_msg',
+          payload: { type: 'agent_message', message: 'hi' },
+        }),
+      ].join('\n'))
+      return fp
+    }
+
+    const fileA = writeCodexSession(
+      'rollout-2026-05-11T12-00-00-019e1559-3c84-7f53-9e3c-850bbb705720.jsonl',
+      '019e1559-3c84-7f53-9e3c-850bbb705720',
+      scratchA,
+    )
+    const fileB = writeCodexSession(
+      'rollout-2026-05-11T12-05-00-019e155c-4a84-7713-9ea4-b83f03f50589.jsonl',
+      '019e155c-4a84-7713-9ea4-b83f03f50589',
+      scratchB,
+    )
+
+    const { getDB, Syncer } = await loadCoreModules()
+    const db = getDB()
+    openDbs.push(db)
+    const syncer = new Syncer(db)
+
+    expect(syncer.syncFile(fileA, 'codex')).toBe('added')
+    expect(syncer.syncFile(fileB, 'codex')).toBe('added')
+
+    const rows = db.prepare(
+      `SELECT id, slug, display_path, display_name, identity_kind, identity_key
+       FROM projects WHERE identity_kind = 'synthetic'`,
+    ).all() as Array<{
+      id: number
+      slug: string
+      display_path: string
+      display_name: string
+      identity_kind: string
+      identity_key: string
+    }>
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      slug: 'codex:scratch',
+      display_path: join(baseDir, 'Documents', 'Codex'),
+      display_name: 'Codex Chats',
+      identity_key: 'codex:scratch',
+    })
+
+    const sessionCount = db.prepare(
+      `SELECT COUNT(*) AS n FROM sessions WHERE project_id = ?`,
+    ).get(rows[0]!.id) as { n: number }
+    expect(sessionCount.n).toBe(2)
+  })
 })
 
 async function loadCoreModules() {

--- a/packages/core/src/sync/syncer.ts
+++ b/packages/core/src/sync/syncer.ts
@@ -171,8 +171,12 @@ export class Syncer {
       }
 
       const sourceId = getSourceId(this.db, source)
-      const { slug, displayPath, displayName } = resolveProject(filePath, source, parsed.cwd)
+      const { slug: rawSlug, displayPath, displayName } = resolveProject(filePath, source, parsed.cwd)
       const identity = computeIdentity(parsed.cwd || null, realFs)
+      // Synthetic identities deduplicate by identity key, not by per-cwd slug,
+      // so every matching session converges to a single project row instead
+      // of accumulating one row per scratch dir.
+      const slug = identity.kind === 'synthetic' ? identity.key : rawSlug
       const projectId = getOrCreateProject(
         this.db, sourceId, slug,
         identity.displayPath ?? displayPath,

--- a/packages/core/src/sync/syncer.ts
+++ b/packages/core/src/sync/syncer.ts
@@ -174,7 +174,8 @@ export class Syncer {
       const { slug, displayPath, displayName } = resolveProject(filePath, source, parsed.cwd)
       const identity = computeIdentity(parsed.cwd || null, realFs)
       const projectId = getOrCreateProject(
-        this.db, sourceId, slug, displayPath,
+        this.db, sourceId, slug,
+        identity.displayPath ?? displayPath,
         identity.displayName || displayName,
         { identityKind: identity.kind, identityKey: identity.key },
       )

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,6 +52,7 @@ export type ProjectIdentityKind =
   | 'git_remote'
   | 'git_common_dir'
   | 'manifest_path'
+  | 'synthetic'
   | 'path'
   | 'loose'
   | 'spool_internal'
@@ -60,6 +61,11 @@ export interface ProjectIdentity {
   kind: ProjectIdentityKind
   key: string                       // normalized origin URL / abs path / 'loose'
   displayName: string
+  // Optional override for the project row's display_path. Used by synthetic
+  // identities to publish a stable header path (e.g. "~/Documents/Codex")
+  // instead of leaking the per-session scratch dir of whichever chat was
+  // synced first.
+  displayPath?: string
 }
 
 export interface ProjectGroup {


### PR DESCRIPTION
## Summary

- Codex desktop creates one disposable workspace per non-project chat under `~/Documents/Codex/<YYYY-MM-DD>/<slug>/`. The dir has no `.git` and no manifest, so every chat used to fall through to a `path`-kind project row and clutter the sidebar.
- Introduces a parallel `identity-synthesizers` chain inside `computeIdentity`, sitting between worktree-resolvers and the path fallback. Each synthesizer matches a known scratch-workspace pattern and returns a stable synthetic identity that collapses every matching cwd into a single sidebar group.
- The first concrete synthesizer, `codexScratchSynthesizer`, matches the Codex scratch prefix and returns `{ kind: 'synthetic', key: 'codex:scratch', displayName: 'Codex Chats', displayPath: ~/Documents/Codex }`. The `displayPath` field is new on `ProjectIdentity` and, when set, overrides the per-session cwd that previously leaked into `projects.display_path` — so the group header now shows a stable root instead of whichever scratch dir was synced first.

## Why a new chain instead of reusing worktree-resolvers

Worktree-resolvers exist to *recover an upstream identity* (returning a real path that gets re-fed through git/manifest detection). They only fire when `!fs.exists(cwd)` and recurse into the upstream. Codex scratch dirs are live, empty, and have no upstream — the contract doesn't fit. A parallel chain keeps each abstraction honest and leaves room for future scratch-pattern matchers (Claude Desktop, Gemini's untitled chats, etc.).

## Notes

- No DB migration. Existing path-kind rows for these chats stay as-is; new syncs land under the synthetic identity, and the next reclassification pass can be added once there's user feedback. (Conscious deferral.)
- `ProjectIdentity.displayPath` is optional; non-synthetic identities are unaffected and the syncer continues to use the per-file `resolveProject` result for them.
- Recursive call inside the worktree-resolver branch now passes empty resolver *and* empty synthesizer chains to avoid double-application on the upstream path.

## Test plan

- [x] `pnpm --filter @spool-lab/core test` — 161/161 passing, including new tests for `codexScratchSynthesizer` (4) and `computeIdentity` chain order (3).
- [x] `tsc --noEmit` clean across core / app / cli.
- [x] Manual smoke: two real Codex scratch jsonl files under `~/.codex/sessions/.../rollout-*.jsonl` re-sync into a single "Codex Chats" sidebar entry with header path `~/Documents/Codex`; per-chat `cwd`s still surface in the existing `directoryGroups` chip strip inside the project view.
- [x] Verified non-scratch identities unchanged: spool repo still resolves to `git_remote`, ad-hoc paths still fall through to `path`-kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)