### PR TITLE
feat(core): add v11 schema for share_drafts table

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -6,8 +6,12 @@ import {
   searchFragments, searchSessionPreview, listRecentSessions, getSessionWithMessages, getStatus,
   pinSession, unpinSession, getPinnedUuids, listPinnedSessions,
   listProjectGroups, listSessionsByIdentity, listPinnedSessionsByIdentity,
+  listShareDrafts, getShareDraft, upsertShareDraft, deleteShareDraft, countDraftsBySession,
 } from '@spool-lab/core'
-import type { FragmentResult, SessionSource, ListSessionsByIdentityOptions } from '@spool-lab/core'
+import type {
+  FragmentResult, SessionSource, ListSessionsByIdentityOptions,
+  ShareDraftRow, UpsertShareDraftInput,
+} from '@spool-lab/core'
 import { setupTray } from './tray.js'
 import { AcpManager } from './acp.js'
 import { setupAutoUpdater, downloadUpdate, quitAndInstall } from './updater.js'
@@ -321,6 +325,30 @@ ipcMain.handle('spool:list-pinned-sessions', () => {
 
 ipcMain.handle('spool:list-pinned-sessions-by-identity', (_e, { identityKey }: { identityKey: string }) => {
   return listPinnedSessionsByIdentity(db, identityKey)
+})
+
+ipcMain.handle('spool:list-share-drafts', (_e, { limit }: { limit?: number } = {}) => {
+  const opts: { limit?: number } = {}
+  if (limit !== undefined) opts.limit = limit
+  return listShareDrafts(db, opts)
+})
+
+ipcMain.handle('spool:get-share-draft', (_e, { draftId }: { draftId: string }) => {
+  return getShareDraft(db, draftId)
+})
+
+ipcMain.handle('spool:upsert-share-draft', (_e, { input }: { input: UpsertShareDraftInput }) => {
+  upsertShareDraft(db, input)
+  return { ok: true }
+})
+
+ipcMain.handle('spool:delete-share-draft', (_e, { draftId }: { draftId: string }) => {
+  deleteShareDraft(db, draftId)
+  return { ok: true }
+})
+
+ipcMain.handle('spool:count-drafts-by-session', (_e, { sessionUuid }: { sessionUuid: string }) => {
+  return countDraftsBySession(db, sessionUuid)
 })
 
 ipcMain.handle('spool:get-runtime-info', () => {

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -1,5 +1,9 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import type { FragmentResult, Session, Message, StatusInfo, SyncResult, SearchResult, ProjectGroup, ListSessionsByIdentityOptions, ProjectSessionSortOrder } from '@spool-lab/core'
+import type {
+  FragmentResult, Session, Message, StatusInfo, SyncResult, SearchResult, ProjectGroup,
+  ListSessionsByIdentityOptions, ProjectSessionSortOrder,
+  ShareDraftRow, UpsertShareDraftInput,
+} from '@spool-lab/core'
 import type { SearchSortOrder } from '../shared/searchSort.js'
 import type { SidebarSortOrder } from '../shared/sidebarSort.js'
 import type { ThemeEditorStateV1 } from '../renderer/theme/editorTypes.js'
@@ -92,6 +96,19 @@ const api = {
 
   setSidebarCollapsed: (collapsed: boolean): Promise<{ ok: boolean }> =>
     ipcRenderer.invoke('spool:set-sidebar-collapsed', { collapsed }),
+
+  shareDraft: {
+    list: (limit?: number): Promise<ShareDraftRow[]> =>
+      ipcRenderer.invoke('spool:list-share-drafts', { limit }),
+    get: (draftId: string): Promise<ShareDraftRow | null> =>
+      ipcRenderer.invoke('spool:get-share-draft', { draftId }),
+    upsert: (input: UpsertShareDraftInput): Promise<{ ok: boolean }> =>
+      ipcRenderer.invoke('spool:upsert-share-draft', { input }),
+    delete: (draftId: string): Promise<{ ok: boolean }> =>
+      ipcRenderer.invoke('spool:delete-share-draft', { draftId }),
+    countBySession: (sessionUuid: string): Promise<number> =>
+      ipcRenderer.invoke('spool:count-drafts-by-session', { sessionUuid }),
+  },
 
   // AI / ACP
   getAiAgents: (): Promise<AgentInfo[]> =>

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -2,7 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 import type {
   FragmentResult, Session, Message, StatusInfo, SyncResult, SearchResult, ProjectGroup,
   ListSessionsByIdentityOptions, ProjectSessionSortOrder,
-  ShareDraftRow, UpsertShareDraftInput,
+  ShareDraftRow, ShareDraftListItem, UpsertShareDraftInput,
 } from '@spool-lab/core'
 import type { SearchSortOrder } from '../shared/searchSort.js'
 import type { SidebarSortOrder } from '../shared/sidebarSort.js'
@@ -98,7 +98,7 @@ const api = {
     ipcRenderer.invoke('spool:set-sidebar-collapsed', { collapsed }),
 
   shareDraft: {
-    list: (limit?: number): Promise<ShareDraftRow[]> =>
+    list: (limit?: number): Promise<ShareDraftListItem[]> =>
       ipcRenderer.invoke('spool:list-share-drafts', { limit }),
     get: (draftId: string): Promise<ShareDraftRow | null> =>
       ipcRenderer.invoke('spool:get-share-draft', { draftId }),

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -11,6 +11,7 @@ import ProjectView from './components/ProjectView.js'
 import LibraryLanding from './components/LibraryLanding.js'
 import SearchOverlay from './components/SearchOverlay.js'
 import AppTopBar from './components/AppTopBar.js'
+import SharesPage from './components/SharesPage.js'
 import { getSessionResumeCommandPrefix } from '../shared/resumeCommand.js'
 import { DEFAULT_SEARCH_SORT_ORDER, type SearchSortOrder } from '../shared/searchSort.js'
 import { DEFAULT_SIDEBAR_SORT_ORDER, type SidebarSortOrder } from '../shared/sidebarSort.js'
@@ -21,7 +22,7 @@ import { applyEditorTheme } from './theme/applyEditorTheme.js'
 import { loadThemeEditorState, saveThemeEditorState } from './theme/persist.js'
 import { useHotkeys } from './hooks/useHotkeys.js'
 
-type View = 'search' | 'session'
+type View = 'search' | 'session' | 'shares'
 type SettingsTab = 'general' | 'appearance' | 'sources' | 'agent'
 
 type FragmentSearchResult = FragmentResult & { kind: 'fragment' }
@@ -107,6 +108,7 @@ export default function App() {
   const showProjectView = activeProjectKey !== null && view === 'search' && !selectedSession && !query.trim()
   const showSearchResults = view === 'search' && !selectedSession && !!query.trim()
   const isHomeMode = homeMode && view === 'search' && !selectedSession && !showProjectView && !showSearchResults
+  const isSharesView = view === 'shares'
 
   useEffect(() => {
     loadThemeEditorState()
@@ -513,6 +515,15 @@ export default function App() {
           setView('search')
           setQuery('')
         }}
+        onSelectShares={() => {
+          setActiveProjectKey(null)
+          setHomeMode(false)
+          setSelectedSession(null)
+          setTargetMessageId(null)
+          setView('shares')
+          setQuery('')
+        }}
+        isSharesActive={isSharesView}
         onOpenSearch={handleSearchOpen}
         syncStatus={syncStatus}
         status={status}
@@ -525,7 +536,9 @@ export default function App() {
       </div>
       <div className="relative flex flex-col flex-1 min-w-0">
       <div className="flex flex-col flex-1 min-h-0 relative">
-        {isHomeMode ? (
+        {isSharesView ? (
+          <SharesPage />
+        ) : isHomeMode ? (
           <LibraryLanding
             onSelectProject={(key) => {
               setActiveProjectKey(key)

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -1,0 +1,167 @@
+import { useState } from 'react'
+import { useShareDrafts } from '../hooks/useShareDrafts'
+import type { ShareDraftRow } from '@spool-lab/core'
+
+type Tab = 'drafts' | 'published'
+
+export default function SharesPage() {
+  const [tab, setTab] = useState<Tab>('drafts')
+  const { drafts, loading, error } = useShareDrafts()
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <header className="flex-none px-6 pt-6 pb-3">
+        <h1 className="text-lg font-semibold tracking-[-0.02em] text-warm-text dark:text-dark-text">
+          Shares
+        </h1>
+      </header>
+
+      <div className="flex-none px-6 border-b border-warm-border dark:border-dark-border">
+        <div className="flex gap-1" role="tablist">
+          <TabButton
+            label="Drafts"
+            count={drafts.length}
+            active={tab === 'drafts'}
+            onClick={() => setTab('drafts')}
+          />
+          <TabButton
+            label="Published"
+            active={tab === 'published'}
+            onClick={() => setTab('published')}
+          />
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {tab === 'drafts' ? (
+          <DraftsTab drafts={drafts} loading={loading} error={error} />
+        ) : (
+          <PublishedTab />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function TabButton({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  label: string
+  count?: number
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={[
+        'flex items-center gap-1.5 px-3 py-2 text-sm border-b-2 transition-colors',
+        active
+          ? 'border-accent text-warm-text dark:text-dark-text'
+          : 'border-transparent text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text',
+      ].join(' ')}
+    >
+      <span>{label}</span>
+      {count !== undefined && count > 0 && (
+        <span className="text-xs text-warm-faint dark:text-dark-muted">({count})</span>
+      )}
+    </button>
+  )
+}
+
+function DraftsTab({
+  drafts,
+  loading,
+  error,
+}: {
+  drafts: ShareDraftRow[]
+  loading: boolean
+  error: string | null
+}) {
+  if (loading && drafts.length === 0) {
+    return <EmptyState label="Loading drafts…" />
+  }
+  if (error) {
+    return <EmptyState label={`Couldn't load drafts: ${error}`} />
+  }
+  if (drafts.length === 0) {
+    return (
+      <EmptyState
+        label="No drafts yet"
+        hint="Create a share from a session, search result, or AI answer to start a draft."
+      />
+    )
+  }
+  return (
+    <ul className="px-6 py-4 flex flex-col gap-2">
+      {drafts.map((draft) => (
+        <li
+          key={draft.draft_id}
+          className="px-3 py-2 rounded-md border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface"
+        >
+          <div className="text-sm text-warm-text dark:text-dark-text">
+            {draft.title || 'untitled'}
+          </div>
+          <div className="text-xs text-warm-muted dark:text-dark-muted">
+            edited {formatRelative(draft.updated_at)}
+            {draft.source_origin ? ` · from ${describeSource(draft)}` : ''}
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function PublishedTab() {
+  return (
+    <EmptyState
+      label="Coming in a future update"
+      hint="Once Spool Share supports hosted permalinks, your published shares will appear here."
+    />
+  )
+}
+
+function EmptyState({ label, hint }: { label: string; hint?: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center px-6 py-16 text-center text-warm-muted dark:text-dark-muted">
+      <p className="text-sm">{label}</p>
+      {hint && <p className="text-xs mt-1.5 max-w-md">{hint}</p>}
+    </div>
+  )
+}
+
+function describeSource(draft: ShareDraftRow): string {
+  switch (draft.source_kind) {
+    case 'spool-session':
+      return `session ${draft.source_origin}`
+    case 'pasted-url':
+      return draft.source_origin ?? 'pasted link'
+    case 'imported-file':
+      return draft.source_origin ?? 'imported file'
+    case 'imported-jsonl':
+      return draft.source_origin ?? 'imported transcript'
+  }
+}
+
+function formatRelative(iso: string): string {
+  // SQLite datetime('now') yields 'YYYY-MM-DD HH:MM:SS' in UTC; parse
+  // explicitly so we don't fall back to local-time interpretation.
+  const parsed = Date.parse(iso.replace(' ', 'T') + 'Z')
+  if (Number.isNaN(parsed)) return iso
+  const now = Date.now()
+  const diffSec = Math.max(0, Math.round((now - parsed) / 1000))
+  if (diffSec < 60) return 'just now'
+  const diffMin = Math.round(diffSec / 60)
+  if (diffMin < 60) return `${diffMin} min ago`
+  const diffHr = Math.round(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+  const diffDay = Math.round(diffHr / 24)
+  if (diffDay < 30) return `${diffDay}d ago`
+  return new Date(parsed).toLocaleDateString()
+}

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -146,6 +146,8 @@ function describeSource(draft: ShareDraftRow): string {
       return draft.source_origin ?? 'imported file'
     case 'imported-jsonl':
       return draft.source_origin ?? 'imported transcript'
+    default:
+      return draft.source_origin ?? 'unknown source'
   }
 }
 

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -1,81 +1,27 @@
-import { useState } from 'react'
+import { type ReactNode } from 'react'
+import { Newspaper } from 'lucide-react'
 import { useShareDrafts } from '../hooks/useShareDrafts'
 import type { ShareDraftRow } from '@spool-lab/core'
 
-type Tab = 'drafts' | 'published'
-
+/**
+ * The Drafts / Published tab strip is intentionally not rendered yet:
+ * Phase 0 only has Drafts, and showing a Published tab that maps to a
+ * "Coming in a future update" placeholder reads as a broken promise.
+ * The tab strip lands in Phase 2 alongside the actual publish flow.
+ */
 export default function SharesPage() {
-  const [tab, setTab] = useState<Tab>('drafts')
   const { drafts, loading, error } = useShareDrafts()
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <header className="flex-none px-6 pt-6 pb-3">
-        <h1 className="text-lg font-semibold tracking-[-0.02em] text-warm-text dark:text-dark-text">
-          Shares
-        </h1>
-      </header>
-
-      <div className="flex-none px-6 border-b border-warm-border dark:border-dark-border">
-        <div className="flex gap-1" role="tablist">
-          <TabButton
-            label="Drafts"
-            count={drafts.length}
-            active={tab === 'drafts'}
-            onClick={() => setTab('drafts')}
-          />
-          <TabButton
-            label="Published"
-            active={tab === 'published'}
-            onClick={() => setTab('published')}
-          />
-        </div>
-      </div>
-
       <div className="flex-1 min-h-0 overflow-y-auto">
-        {tab === 'drafts' ? (
-          <DraftsTab drafts={drafts} loading={loading} error={error} />
-        ) : (
-          <PublishedTab />
-        )}
+        <DraftsList drafts={drafts} loading={loading} error={error} />
       </div>
     </div>
   )
 }
 
-function TabButton({
-  label,
-  count,
-  active,
-  onClick,
-}: {
-  label: string
-  count?: number
-  active: boolean
-  onClick: () => void
-}) {
-  return (
-    <button
-      type="button"
-      role="tab"
-      aria-selected={active}
-      onClick={onClick}
-      className={[
-        'flex items-center gap-1.5 px-3 py-2 text-sm border-b-2 transition-colors',
-        active
-          ? 'border-accent text-warm-text dark:text-dark-text'
-          : 'border-transparent text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text',
-      ].join(' ')}
-    >
-      <span>{label}</span>
-      {count !== undefined && count > 0 && (
-        <span className="text-xs text-warm-faint dark:text-dark-muted">({count})</span>
-      )}
-    </button>
-  )
-}
-
-function DraftsTab({
+function DraftsList({
   drafts,
   loading,
   error,
@@ -85,16 +31,17 @@ function DraftsTab({
   error: string | null
 }) {
   if (loading && drafts.length === 0) {
-    return <EmptyState label="Loading drafts…" />
+    return <SmallEmptyState>Loading drafts…</SmallEmptyState>
   }
   if (error) {
-    return <EmptyState label={`Couldn't load drafts: ${error}`} />
+    return <SmallEmptyState>Couldn't load drafts: {error}</SmallEmptyState>
   }
   if (drafts.length === 0) {
     return (
-      <EmptyState
-        label="No drafts yet"
-        hint="Create a share from a session, search result, or AI answer to start a draft."
+      <FeaturedEmptyState
+        icon={<Newspaper size={22} strokeWidth={1.5} />}
+        title="No shares yet"
+        hint="Start a share from a session, a search result, or an AI answer — drafts you create land here, ready to keep editing."
       />
     )
   }
@@ -118,20 +65,37 @@ function DraftsTab({
   )
 }
 
-function PublishedTab() {
+function FeaturedEmptyState({
+  icon,
+  title,
+  hint,
+}: {
+  icon: ReactNode
+  title: string
+  hint: string
+}) {
   return (
-    <EmptyState
-      label="Coming in a future update"
-      hint="Once Spool Share supports hosted permalinks, your published shares will appear here."
-    />
+    <div className="h-full flex flex-col items-center justify-center text-center px-6">
+      <div
+        className="w-14 h-14 rounded-full flex items-center justify-center mb-5 bg-warm-surface dark:bg-dark-surface text-warm-muted dark:text-dark-muted"
+        aria-hidden="true"
+      >
+        {icon}
+      </div>
+      <h2 className="text-xl font-semibold tracking-[-0.01em] text-warm-text dark:text-dark-text mb-2">
+        {title}
+      </h2>
+      <p className="text-sm leading-relaxed text-warm-muted dark:text-dark-muted max-w-[360px]">
+        {hint}
+      </p>
+    </div>
   )
 }
 
-function EmptyState({ label, hint }: { label: string; hint?: string }) {
+function SmallEmptyState({ children }: { children: ReactNode }) {
   return (
-    <div className="flex flex-col items-center justify-center px-6 py-16 text-center text-warm-muted dark:text-dark-muted">
-      <p className="text-sm">{label}</p>
-      {hint && <p className="text-xs mt-1.5 max-w-md">{hint}</p>}
+    <div className="flex items-center justify-center px-6 py-16 text-sm text-warm-muted dark:text-dark-muted text-center">
+      {children}
     </div>
   )
 }

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react'
 import { Newspaper } from 'lucide-react'
 import { useShareDrafts } from '../hooks/useShareDrafts'
-import type { ShareDraftRow } from '@spool-lab/core'
+import type { ShareDraftListItem } from '@spool-lab/core'
 
 /**
  * The Drafts / Published tab strip is intentionally not rendered yet:
@@ -26,7 +26,7 @@ function DraftsList({
   loading,
   error,
 }: {
-  drafts: ShareDraftRow[]
+  drafts: ShareDraftListItem[]
   loading: boolean
   error: string | null
 }) {
@@ -100,7 +100,7 @@ function SmallEmptyState({ children }: { children: ReactNode }) {
   )
 }
 
-function describeSource(draft: ShareDraftRow): string {
+function describeSource(draft: ShareDraftListItem): string {
   switch (draft.source_kind) {
     case 'spool-session':
       return `session ${draft.source_origin}`

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import type { ProjectGroup, SessionSource, StatusInfo } from '@spool-lab/core'
-import { Library as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon } from 'lucide-react'
+import { Library as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Share2 as SharesIcon } from 'lucide-react'
 import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
 import {
   DEFAULT_SIDEBAR_SORT_ORDER,
@@ -14,6 +14,8 @@ type Props = {
   onSelectProject: (identityKey: string) => void
   onSelectHome?: () => void
   isLibraryActive?: boolean
+  onSelectShares?: () => void
+  isSharesActive?: boolean
   onOpenSearch?: () => void
   syncStatus?: { phase: string; count: number; total: number } | null
   status?: StatusInfo | null
@@ -24,7 +26,7 @@ type Props = {
   onSortOrderChange?: (next: SidebarSortOrder) => void
 }
 
-export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHome, isLibraryActive = false, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true, sortOrder = DEFAULT_SIDEBAR_SORT_ORDER, onSortOrderChange }: Props) {
+export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHome, isLibraryActive = false, onSelectShares, isSharesActive = false, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true, sortOrder = DEFAULT_SIDEBAR_SORT_ORDER, onSortOrderChange }: Props) {
   const [groups, setGroups] = useState<ProjectGroup[] | null>(null)
   const [projectsOpen, setProjectsOpen] = useState(true)
 
@@ -56,6 +58,15 @@ export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHo
             label="Library"
             active={isLibraryActive}
             onClick={onSelectHome}
+          />
+        )}
+        {onSelectShares && (
+          <NavRow
+            testId="sidebar-shares"
+            icon={<SharesIcon size={14} strokeWidth={1.75} />}
+            label="Shares"
+            active={isSharesActive}
+            onClick={onSelectShares}
           />
         )}
         {onOpenSearch && (

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import type { ProjectGroup, SessionSource, StatusInfo } from '@spool-lab/core'
-import { Library as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Share2 as SharesIcon } from 'lucide-react'
+import { Library as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon } from 'lucide-react'
 import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
 import {
   DEFAULT_SIDEBAR_SORT_ORDER,

--- a/packages/app/src/renderer/hooks/useShareDrafts.ts
+++ b/packages/app/src/renderer/hooks/useShareDrafts.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
-import type { ShareDraftRow } from '@spool-lab/core'
+import type { ShareDraftListItem } from '@spool-lab/core'
 
 interface UseShareDraftsResult {
-  drafts: ShareDraftRow[]
+  drafts: ShareDraftListItem[]
   loading: boolean
   error: string | null
   refresh: () => Promise<void>
@@ -16,7 +16,7 @@ interface UseShareDraftsResult {
  * IPC event vs. just refetch on focus.
  */
 export function useShareDrafts(opts: { limit?: number } = {}): UseShareDraftsResult {
-  const [drafts, setDrafts] = useState<ShareDraftRow[]>([])
+  const [drafts, setDrafts] = useState<ShareDraftListItem[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 

--- a/packages/app/src/renderer/hooks/useShareDrafts.ts
+++ b/packages/app/src/renderer/hooks/useShareDrafts.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { ShareDraftRow } from '@spool-lab/core'
+
+interface UseShareDraftsResult {
+  drafts: ShareDraftRow[]
+  loading: boolean
+  error: string | null
+  refresh: () => Promise<void>
+}
+
+/**
+ * Reads the local share_drafts table via the preload bridge. Light: no
+ * push notification yet, so callers refresh after a known-to-mutate
+ * action (editor autosave, delete, etc.). PR 3 will revisit this once
+ * the editor exists and we can decide whether to push a "draft changed"
+ * IPC event vs. just refetch on focus.
+ */
+export function useShareDrafts(opts: { limit?: number } = {}): UseShareDraftsResult {
+  const [drafts, setDrafts] = useState<ShareDraftRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const rows = await window.spool.shareDraft.list(opts.limit)
+      setDrafts(rows)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [opts.limit])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  return { drafts, loading, error, refresh }
+}

--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -427,6 +427,31 @@ export function runMigrations(db: Database.Database): void {
     db.pragma('user_version = 10')
   }
 
+  if (version < 11) {
+    // v11: share_drafts table — locally-persisted in-progress shares
+    // managed by Spool Share's editor. Independent of the sessions index;
+    // a draft can survive its source session being deleted because the
+    // full snapshot is captured at compose time and stored as JSON.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS share_drafts (
+        draft_id        TEXT PRIMARY KEY,
+        source_kind     TEXT NOT NULL CHECK (source_kind IN (
+          'spool-session', 'pasted-url', 'imported-file', 'imported-jsonl'
+        )),
+        source_origin   TEXT,
+        title           TEXT NOT NULL DEFAULT '',
+        snapshot_json   TEXT NOT NULL,
+        created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE INDEX IF NOT EXISTS idx_share_drafts_updated_at
+        ON share_drafts(updated_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_share_drafts_source_origin
+        ON share_drafts(source_origin);
+    `)
+    db.pragma('user_version = 11')
+  }
+
   rebuildFtsTableIfEmpty(db, 'messages', 'messages_fts_trigram')
   rebuildFtsTableIfEmpty(db, 'session_search', 'session_search_fts')
   rebuildFtsTableIfEmpty(db, 'session_search', 'session_search_fts_trigram')

--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -432,6 +432,16 @@ export function runMigrations(db: Database.Database): void {
     // managed by Spool Share's editor. Independent of the sessions index;
     // a draft can survive its source session being deleted because the
     // full snapshot is captured at compose time and stored as JSON.
+    //
+    // Two JSON payloads per row:
+    //   - snapshot_json: the complete SpoolDocument (full conversation +
+    //     opts). Used when opening the editor. Can be hundreds of KB on
+    //     long sessions.
+    //   - preview_json: a slim subset used by the Shares grid card —
+    //     opts + title + source + word count + the first handful of
+    //     turns. Kept under a few KB so listShareDrafts can SELECT it
+    //     across hundreds of rows without shipping multi-MB IPC payloads
+    //     to the renderer.
     db.exec(`
       CREATE TABLE IF NOT EXISTS share_drafts (
         draft_id        TEXT PRIMARY KEY,
@@ -441,6 +451,7 @@ export function runMigrations(db: Database.Database): void {
         source_origin   TEXT,
         title           TEXT NOT NULL DEFAULT '',
         snapshot_json   TEXT NOT NULL,
+        preview_json    TEXT NOT NULL DEFAULT '{}',
         created_at      TEXT NOT NULL DEFAULT (datetime('now')),
         updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
       );

--- a/packages/core/src/db/share-drafts.test.ts
+++ b/packages/core/src/db/share-drafts.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const tempDirs: string[] = []
+const openDbs: Array<{ close: () => void }> = []
+
+afterEach(() => {
+  while (openDbs.length > 0) openDbs.pop()?.close()
+  vi.unstubAllEnvs()
+  vi.resetModules()
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('share_drafts schema (v11)', () => {
+  it('creates the table with expected columns and indexes', async () => {
+    const { db } = await load()
+
+    const columns = db
+      .prepare('PRAGMA table_info(share_drafts)')
+      .all() as Array<{ name: string; type: string; notnull: number; pk: number }>
+
+    const byName = new Map(columns.map((c) => [c.name, c]))
+    expect(byName.get('draft_id')?.pk).toBe(1)
+    expect(byName.get('source_kind')?.notnull).toBe(1)
+    expect(byName.get('source_origin')?.notnull).toBe(0)
+    expect(byName.get('title')?.notnull).toBe(1)
+    expect(byName.get('snapshot_json')?.notnull).toBe(1)
+    expect(byName.get('created_at')?.notnull).toBe(1)
+    expect(byName.get('updated_at')?.notnull).toBe(1)
+
+    const indexes = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='share_drafts'`)
+      .all() as Array<{ name: string }>
+    const names = indexes.map((i) => i.name)
+    expect(names).toContain('idx_share_drafts_updated_at')
+    expect(names).toContain('idx_share_drafts_source_origin')
+  })
+
+  it('accepts inserts with each valid source_kind', async () => {
+    const { db } = await load()
+    const kinds = ['spool-session', 'pasted-url', 'imported-file', 'imported-jsonl']
+    for (const k of kinds) {
+      db.prepare(
+        `INSERT INTO share_drafts (draft_id, source_kind, snapshot_json) VALUES (?, ?, ?)`,
+      ).run(`d-${k}`, k, '{}')
+    }
+    const count = (
+      db.prepare('SELECT COUNT(*) AS n FROM share_drafts').get() as { n: number }
+    ).n
+    expect(count).toBe(4)
+  })
+
+  it('rejects an unknown source_kind via CHECK constraint', async () => {
+    const { db } = await load()
+    expect(() =>
+      db
+        .prepare(`INSERT INTO share_drafts (draft_id, source_kind, snapshot_json) VALUES (?, ?, ?)`)
+        .run('bad', 'not-a-kind', '{}'),
+    ).toThrow(/CHECK constraint/)
+  })
+
+  it('defaults title to empty string and stamps timestamps', async () => {
+    const { db } = await load()
+    db.prepare(
+      `INSERT INTO share_drafts (draft_id, source_kind, snapshot_json) VALUES (?, ?, ?)`,
+    ).run('d1', 'spool-session', '{}')
+    const row = db
+      .prepare('SELECT title, created_at, updated_at FROM share_drafts WHERE draft_id=?')
+      .get('d1') as { title: string; created_at: string; updated_at: string }
+    expect(row.title).toBe('')
+    expect(row.created_at).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
+    expect(row.updated_at).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
+  })
+
+  it('user_version reaches 11 after migration', async () => {
+    const { db } = await load()
+    const v = (db.pragma('user_version') as Array<{ user_version: number }>)[0]?.user_version
+    expect(v).toBe(11)
+  })
+
+  it('migration is idempotent across re-open', async () => {
+    const spoolDir = makeTempDir('spool-share-drafts-reopen-')
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDir)
+
+    const first = await loadInto(spoolDir)
+    first.db.prepare(
+      `INSERT INTO share_drafts (draft_id, source_kind, title, snapshot_json) VALUES (?, ?, ?, ?)`,
+    ).run('keep-me', 'pasted-url', 'persisted draft', '{"v":1}')
+    first.db.close()
+    openDbs.length = 0
+
+    vi.resetModules()
+    const second = await loadInto(spoolDir)
+    const row = second.db
+      .prepare('SELECT title FROM share_drafts WHERE draft_id=?')
+      .get('keep-me') as { title: string }
+    expect(row.title).toBe('persisted draft')
+  })
+})
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+async function load() {
+  const spoolDir = makeTempDir('spool-share-drafts-')
+  vi.stubEnv('SPOOL_DATA_DIR', spoolDir)
+  return loadInto(spoolDir)
+}
+
+async function loadInto(_spoolDir: string) {
+  vi.resetModules()
+  const dbModule = await import('./db.js')
+  const db = dbModule.getDB()
+  openDbs.push(db)
+  return { db }
+}

--- a/packages/core/src/db/share-drafts.test.ts
+++ b/packages/core/src/db/share-drafts.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import type { ShareDraftRow } from './share-drafts.js'
+import type { ShareDraftListItem } from './share-drafts.js'
 
 const tempDirs: string[] = []
 const openDbs: Array<{ close: () => void }> = []
@@ -31,6 +31,7 @@ describe('share_drafts schema (v11)', () => {
     expect(byName.get('source_origin')?.notnull).toBe(0)
     expect(byName.get('title')?.notnull).toBe(1)
     expect(byName.get('snapshot_json')?.notnull).toBe(1)
+    expect(byName.get('preview_json')?.notnull).toBe(1)
     expect(byName.get('created_at')?.notnull).toBe(1)
     expect(byName.get('updated_at')?.notnull).toBe(1)
 
@@ -92,6 +93,7 @@ describe('share_drafts schema (v11)', () => {
       source_origin: 'sess-uuid',
       title: 'first',
       snapshot_json: '{"v":1}',
+      preview_json: '{"v":1}',
     })
     const row = mod.getShareDraft(db, 'd-1')
     expect(row?.title).toBe('first')
@@ -108,6 +110,7 @@ describe('share_drafts schema (v11)', () => {
       source_origin: 'sess-uuid',
       title: 'first',
       snapshot_json: '{"v":1}',
+      preview_json: '{"v":1}',
     })
     const first = mod.getShareDraft(db, 'd-1')
 
@@ -123,6 +126,7 @@ describe('share_drafts schema (v11)', () => {
       source_origin: 'sess-uuid',
       title: 'second',
       snapshot_json: '{"v":2}',
+      preview_json: '{"v":2}',
     })
     const second = mod.getShareDraft(db, 'd-1')
     expect(second?.title).toBe('second')
@@ -140,6 +144,7 @@ describe('share_drafts schema (v11)', () => {
         source_origin: `https://example.com/${id}`,
         title: id,
         snapshot_json: '{}',
+        preview_json: '{}',
       })
     }
     // Force a predictable order by stamping updated_at in reverse.
@@ -148,7 +153,11 @@ describe('share_drafts schema (v11)', () => {
     db.prepare(`UPDATE share_drafts SET updated_at = ? WHERE draft_id = ?`).run('2026-01-03 00:00:00', 'c')
 
     const rows = mod.listShareDrafts(db)
-    expect(rows.map((r: ShareDraftRow) => r.draft_id)).toEqual(['c', 'b', 'a'])
+    expect(rows.map((r: ShareDraftListItem) => r.draft_id)).toEqual(['c', 'b', 'a'])
+    // List query must not haul snapshot_json across the IPC boundary —
+    // that's the whole point of the slim SELECT.
+    expect(rows[0]).not.toHaveProperty('snapshot_json')
+    expect(rows[0]).toHaveProperty('preview_json')
   })
 
   it('listShareDrafts respects the limit option', async () => {
@@ -160,6 +169,7 @@ describe('share_drafts schema (v11)', () => {
         source_origin: `sess-${i}`,
         title: '',
         snapshot_json: '{}',
+        preview_json: '{}',
       })
     }
     expect(mod.listShareDrafts(db, { limit: 2 })).toHaveLength(2)
@@ -178,6 +188,7 @@ describe('share_drafts schema (v11)', () => {
       source_origin: 'foo.spool',
       title: '',
       snapshot_json: '{}',
+      preview_json: '{}',
     })
     mod.deleteShareDraft(db, 'gone')
     expect(mod.getShareDraft(db, 'gone')).toBeNull()
@@ -191,6 +202,7 @@ describe('share_drafts schema (v11)', () => {
       source_origin: 'sess-X',
       title: '',
       snapshot_json: '{}',
+      preview_json: '{}',
     })
     mod.upsertShareDraft(db, {
       draft_id: 'b',
@@ -198,6 +210,7 @@ describe('share_drafts schema (v11)', () => {
       source_origin: 'sess-X',
       title: '',
       snapshot_json: '{}',
+      preview_json: '{}',
     })
     mod.upsertShareDraft(db, {
       draft_id: 'c',
@@ -205,6 +218,7 @@ describe('share_drafts schema (v11)', () => {
       source_origin: 'sess-Y',
       title: '',
       snapshot_json: '{}',
+      preview_json: '{}',
     })
     // A pasted-url draft whose origin happens to match a session uuid
     // should not be counted as a spool-session.
@@ -214,6 +228,7 @@ describe('share_drafts schema (v11)', () => {
       source_origin: 'sess-X',
       title: '',
       snapshot_json: '{}',
+      preview_json: '{}',
     })
     expect(mod.countDraftsBySession(db, 'sess-X')).toBe(2)
     expect(mod.countDraftsBySession(db, 'sess-Y')).toBe(1)

--- a/packages/core/src/db/share-drafts.test.ts
+++ b/packages/core/src/db/share-drafts.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import type { ShareDraftRow } from './share-drafts.js'
 
 const tempDirs: string[] = []
 const openDbs: Array<{ close: () => void }> = []
@@ -83,6 +84,142 @@ describe('share_drafts schema (v11)', () => {
     expect(v).toBe(11)
   })
 
+  it('upsertShareDraft inserts a new row with timestamps', async () => {
+    const { db, mod } = await load()
+    mod.upsertShareDraft(db, {
+      draft_id: 'd-1',
+      source_kind: 'spool-session',
+      source_origin: 'sess-uuid',
+      title: 'first',
+      snapshot_json: '{"v":1}',
+    })
+    const row = mod.getShareDraft(db, 'd-1')
+    expect(row?.title).toBe('first')
+    expect(row?.snapshot_json).toBe('{"v":1}')
+    expect(row?.created_at).toBeTruthy()
+    expect(row?.updated_at).toBe(row?.created_at)
+  })
+
+  it('upsertShareDraft updates in place and bumps updated_at', async () => {
+    const { db, mod } = await load()
+    mod.upsertShareDraft(db, {
+      draft_id: 'd-1',
+      source_kind: 'spool-session',
+      source_origin: 'sess-uuid',
+      title: 'first',
+      snapshot_json: '{"v":1}',
+    })
+    const first = mod.getShareDraft(db, 'd-1')
+
+    // SQLite datetime('now') has 1-second granularity, so we have to
+    // shift the row's created_at backward to observe the timestamp
+    // movement in a sub-second test.
+    db.prepare(`UPDATE share_drafts SET updated_at = datetime('now', '-2 seconds') WHERE draft_id = ?`)
+      .run('d-1')
+
+    mod.upsertShareDraft(db, {
+      draft_id: 'd-1',
+      source_kind: 'spool-session',
+      source_origin: 'sess-uuid',
+      title: 'second',
+      snapshot_json: '{"v":2}',
+    })
+    const second = mod.getShareDraft(db, 'd-1')
+    expect(second?.title).toBe('second')
+    expect(second?.snapshot_json).toBe('{"v":2}')
+    expect(second!.updated_at >= first!.updated_at).toBe(true)
+  })
+
+  it('listShareDrafts returns rows in updated_at DESC order', async () => {
+    const { db, mod } = await load()
+    const ids = ['a', 'b', 'c']
+    for (const id of ids) {
+      mod.upsertShareDraft(db, {
+        draft_id: id,
+        source_kind: 'pasted-url',
+        source_origin: `https://example.com/${id}`,
+        title: id,
+        snapshot_json: '{}',
+      })
+    }
+    // Force a predictable order by stamping updated_at in reverse.
+    db.prepare(`UPDATE share_drafts SET updated_at = ? WHERE draft_id = ?`).run('2026-01-01 00:00:00', 'a')
+    db.prepare(`UPDATE share_drafts SET updated_at = ? WHERE draft_id = ?`).run('2026-01-02 00:00:00', 'b')
+    db.prepare(`UPDATE share_drafts SET updated_at = ? WHERE draft_id = ?`).run('2026-01-03 00:00:00', 'c')
+
+    const rows = mod.listShareDrafts(db)
+    expect(rows.map((r: ShareDraftRow) => r.draft_id)).toEqual(['c', 'b', 'a'])
+  })
+
+  it('listShareDrafts respects the limit option', async () => {
+    const { db, mod } = await load()
+    for (let i = 0; i < 5; i++) {
+      mod.upsertShareDraft(db, {
+        draft_id: `d-${i}`,
+        source_kind: 'spool-session',
+        source_origin: `sess-${i}`,
+        title: '',
+        snapshot_json: '{}',
+      })
+    }
+    expect(mod.listShareDrafts(db, { limit: 2 })).toHaveLength(2)
+  })
+
+  it('getShareDraft returns null for unknown id', async () => {
+    const { db, mod } = await load()
+    expect(mod.getShareDraft(db, 'nope')).toBeNull()
+  })
+
+  it('deleteShareDraft removes the row', async () => {
+    const { db, mod } = await load()
+    mod.upsertShareDraft(db, {
+      draft_id: 'gone',
+      source_kind: 'imported-file',
+      source_origin: 'foo.spool',
+      title: '',
+      snapshot_json: '{}',
+    })
+    mod.deleteShareDraft(db, 'gone')
+    expect(mod.getShareDraft(db, 'gone')).toBeNull()
+  })
+
+  it('countDraftsBySession counts only spool-session drafts with matching origin', async () => {
+    const { db, mod } = await load()
+    mod.upsertShareDraft(db, {
+      draft_id: 'a',
+      source_kind: 'spool-session',
+      source_origin: 'sess-X',
+      title: '',
+      snapshot_json: '{}',
+    })
+    mod.upsertShareDraft(db, {
+      draft_id: 'b',
+      source_kind: 'spool-session',
+      source_origin: 'sess-X',
+      title: '',
+      snapshot_json: '{}',
+    })
+    mod.upsertShareDraft(db, {
+      draft_id: 'c',
+      source_kind: 'spool-session',
+      source_origin: 'sess-Y',
+      title: '',
+      snapshot_json: '{}',
+    })
+    // A pasted-url draft whose origin happens to match a session uuid
+    // should not be counted as a spool-session.
+    mod.upsertShareDraft(db, {
+      draft_id: 'd',
+      source_kind: 'pasted-url',
+      source_origin: 'sess-X',
+      title: '',
+      snapshot_json: '{}',
+    })
+    expect(mod.countDraftsBySession(db, 'sess-X')).toBe(2)
+    expect(mod.countDraftsBySession(db, 'sess-Y')).toBe(1)
+    expect(mod.countDraftsBySession(db, 'sess-Z')).toBe(0)
+  })
+
   it('migration is idempotent across re-open', async () => {
     const spoolDir = makeTempDir('spool-share-drafts-reopen-')
     vi.stubEnv('SPOOL_DATA_DIR', spoolDir)
@@ -118,7 +255,8 @@ async function load() {
 async function loadInto(_spoolDir: string) {
   vi.resetModules()
   const dbModule = await import('./db.js')
+  const mod = await import('./share-drafts.js')
   const db = dbModule.getDB()
   openDbs.push(db)
-  return { db }
+  return { db, mod }
 }

--- a/packages/core/src/db/share-drafts.ts
+++ b/packages/core/src/db/share-drafts.ts
@@ -10,14 +10,23 @@ export type ShareDraftSourceKind =
   | 'imported-file'
   | 'imported-jsonl'
 
-export interface ShareDraftRow {
+/** Row shape for the Shares grid: full metadata plus the slim
+ *  `preview_json` blob. Excludes `snapshot_json` so list queries don't
+ *  haul hundreds of KB per row over IPC. */
+export interface ShareDraftListItem {
   draft_id: string
   source_kind: ShareDraftSourceKind
   source_origin: string | null
   title: string
-  snapshot_json: string
+  preview_json: string
   created_at: string
   updated_at: string
+}
+
+/** Row shape for the editor: ShareDraftListItem + the full document
+ *  blob. Returned by getShareDraft, never by listShareDrafts. */
+export interface ShareDraftRow extends ShareDraftListItem {
+  snapshot_json: string
 }
 
 export interface UpsertShareDraftInput {
@@ -26,43 +35,57 @@ export interface UpsertShareDraftInput {
   source_origin: string | null
   title: string
   snapshot_json: string
+  preview_json: string
 }
 
-const SELECT_COLS = 'draft_id, source_kind, source_origin, title, snapshot_json, created_at, updated_at'
+const LIST_COLS = 'draft_id, source_kind, source_origin, title, preview_json, created_at, updated_at'
+const FULL_COLS = `${LIST_COLS}, snapshot_json`
 
+/** Lists drafts for the Shares grid. Intentionally omits `snapshot_json`
+ *  so the IPC payload stays small even when the user has hundreds of
+ *  drafts. The editor fetches the full row via getShareDraft. */
 export function listShareDrafts(
   db: Database.Database,
   opts: { limit?: number } = {},
-): ShareDraftRow[] {
+): ShareDraftListItem[] {
   const limit = opts.limit ?? 200
   return db
-    .prepare(`SELECT ${SELECT_COLS} FROM share_drafts ORDER BY updated_at DESC LIMIT ?`)
-    .all(limit) as ShareDraftRow[]
+    .prepare(`SELECT ${LIST_COLS} FROM share_drafts ORDER BY updated_at DESC LIMIT ?`)
+    .all(limit) as ShareDraftListItem[]
 }
 
 export function getShareDraft(db: Database.Database, draftId: string): ShareDraftRow | null {
   return (
     (db
-      .prepare(`SELECT ${SELECT_COLS} FROM share_drafts WHERE draft_id = ?`)
+      .prepare(`SELECT ${FULL_COLS} FROM share_drafts WHERE draft_id = ?`)
       .get(draftId) as ShareDraftRow | undefined) ?? null
   )
 }
 
 /**
  * Insert a new draft or update an existing one in place. Touches
- * updated_at on every call; preserves created_at on update.
+ * updated_at on every call; preserves created_at on update. Both JSON
+ * blobs are written together — callers must keep them in sync.
  */
 export function upsertShareDraft(db: Database.Database, input: UpsertShareDraftInput): void {
   db.prepare(
-    `INSERT INTO share_drafts (draft_id, source_kind, source_origin, title, snapshot_json, updated_at)
-     VALUES (?, ?, ?, ?, ?, datetime('now'))
+    `INSERT INTO share_drafts (draft_id, source_kind, source_origin, title, snapshot_json, preview_json, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
      ON CONFLICT(draft_id) DO UPDATE SET
        source_kind   = excluded.source_kind,
        source_origin = excluded.source_origin,
        title         = excluded.title,
        snapshot_json = excluded.snapshot_json,
+       preview_json  = excluded.preview_json,
        updated_at    = excluded.updated_at`,
-  ).run(input.draft_id, input.source_kind, input.source_origin, input.title, input.snapshot_json)
+  ).run(
+    input.draft_id,
+    input.source_kind,
+    input.source_origin,
+    input.title,
+    input.snapshot_json,
+    input.preview_json,
+  )
 }
 
 export function deleteShareDraft(db: Database.Database, draftId: string): void {

--- a/packages/core/src/db/share-drafts.ts
+++ b/packages/core/src/db/share-drafts.ts
@@ -1,0 +1,84 @@
+import type Database from 'better-sqlite3'
+
+/** Mirrors the CHECK constraint in the v11 migration. Kept as a local
+ *  string union so @spool/core stays free of any @spool/share-kit
+ *  dependency; the app layer reconciles this with share-kit's Snapshot
+ *  type when it parses snapshot_json. */
+export type ShareDraftSourceKind =
+  | 'spool-session'
+  | 'pasted-url'
+  | 'imported-file'
+  | 'imported-jsonl'
+
+export interface ShareDraftRow {
+  draft_id: string
+  source_kind: ShareDraftSourceKind
+  source_origin: string | null
+  title: string
+  snapshot_json: string
+  created_at: string
+  updated_at: string
+}
+
+export interface UpsertShareDraftInput {
+  draft_id: string
+  source_kind: ShareDraftSourceKind
+  source_origin: string | null
+  title: string
+  snapshot_json: string
+}
+
+const SELECT_COLS = 'draft_id, source_kind, source_origin, title, snapshot_json, created_at, updated_at'
+
+export function listShareDrafts(
+  db: Database.Database,
+  opts: { limit?: number } = {},
+): ShareDraftRow[] {
+  const limit = opts.limit ?? 200
+  return db
+    .prepare(`SELECT ${SELECT_COLS} FROM share_drafts ORDER BY updated_at DESC LIMIT ?`)
+    .all(limit) as ShareDraftRow[]
+}
+
+export function getShareDraft(db: Database.Database, draftId: string): ShareDraftRow | null {
+  return (
+    (db
+      .prepare(`SELECT ${SELECT_COLS} FROM share_drafts WHERE draft_id = ?`)
+      .get(draftId) as ShareDraftRow | undefined) ?? null
+  )
+}
+
+/**
+ * Insert a new draft or update an existing one in place. Touches
+ * updated_at on every call; preserves created_at on update.
+ */
+export function upsertShareDraft(db: Database.Database, input: UpsertShareDraftInput): void {
+  db.prepare(
+    `INSERT INTO share_drafts (draft_id, source_kind, source_origin, title, snapshot_json, updated_at)
+     VALUES (?, ?, ?, ?, ?, datetime('now'))
+     ON CONFLICT(draft_id) DO UPDATE SET
+       source_kind   = excluded.source_kind,
+       source_origin = excluded.source_origin,
+       title         = excluded.title,
+       snapshot_json = excluded.snapshot_json,
+       updated_at    = excluded.updated_at`,
+  ).run(input.draft_id, input.source_kind, input.source_origin, input.title, input.snapshot_json)
+}
+
+export function deleteShareDraft(db: Database.Database, draftId: string): void {
+  db.prepare('DELETE FROM share_drafts WHERE draft_id = ?').run(draftId)
+}
+
+/**
+ * Count drafts that originated from a given Spool session. Drives the
+ * "N shares from this session" chip on SessionDetail (PR 4).
+ */
+export function countDraftsBySession(db: Database.Database, sessionUuid: string): number {
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) AS n FROM share_drafts
+       WHERE source_kind = 'spool-session' AND source_origin = ?`,
+    )
+    .get(sessionUuid) as { n: number }
+  return row.n
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from './types.js'
 export * from './db/db.js'
 export * from './db/queries.js'
+export * from './db/share-drafts.js'
 export * from './parsers/claude.js'
 export * from './parsers/codex.js'
 export * from './parsers/gemini.js'


### PR DESCRIPTION
## What

Introduces `share_drafts`, the local table that stores in-progress shares for the editor, plus the CRUD API + IPC bridge + Sidebar entry that consumes it. The editor itself doesn't ship here — #165 wires it up — so this PR is the foundation: the schema lands ahead of any code that writes to it.

## Schema (v11 migration)

```sql
CREATE TABLE share_drafts (
  draft_id      TEXT PRIMARY KEY,
  source_kind   TEXT NOT NULL CHECK (source_kind IN (
                  'spool-session', 'pasted-url', 'imported-file', 'imported-jsonl'
                )),
  source_origin TEXT,
  title         TEXT NOT NULL DEFAULT '',
  snapshot_json TEXT NOT NULL,
  preview_json  TEXT NOT NULL DEFAULT '{}',
  created_at    TEXT NOT NULL DEFAULT (datetime('now')),
  updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
);
CREATE INDEX idx_share_drafts_updated_at ON share_drafts(updated_at DESC);
CREATE INDEX idx_share_drafts_source_origin ON share_drafts(source_origin);
```

Migration is wrapped in the existing `if (version < 11)` guard in `migrateUpToCurrent` and bumps `user_version` to 11 only after the table is created. `CREATE TABLE IF NOT EXISTS` keeps re-runs idempotent.

## Schema decisions

**Why two JSON columns instead of one.** A draft's full snapshot is the entire conversation plus editor opts. On long sessions (480 messages, 8 K words) this serializes to 150–300 KB; pathological cases (multi-thousand-message agent sessions) push 1 MB+. The Shares grid only needs opts + a handful of turns to render a thumbnail. If the list query selects `snapshot_json`, a 100-draft grid mount ships 15–30 MB over IPC for content the cards won't render. Splitting into `snapshot_json` (full document, fetched by the editor) and `preview_json` (slim subset — opts + first ~6 turns, kept under a few KB) makes list payloads sub-MB regardless of session size, while preserving the full document for the editor.

The slim preview is computed at write time, not lazily — keeps the read path simple at the cost of one extra column on every upsert.

**Why JSON columns instead of normalized tables for opts / turns.** The shape evolves (Phase 0 adds `hideEmptyTurns` in #170; future phases may add per-turn redaction, voiceover annotations, etc.). A normalized schema would require a migration for every shape change. JSON in TEXT columns means the schema is stable across shape changes and `JSON.parse` / `JSON.stringify` on the renderer side is fast enough for the cardinalities we expect (single drafts, not bulk queries). Defensive merge with `DEFAULT_OPTS` on parse (added in #169) handles forward-compat without migrations.

**Why `source_kind` is a CHECK-constrained enum, not an integer FK.** Four values, no plans to grow, and the constraint lets SQLite reject bad inserts at write time. A separate `sources` reference table would just add a join with no benefit.

**Why `source_origin` is nullable / free-form text.** Drafts can originate from a Spool session (UUID), a pasted URL, an imported file (filename), or an imported JSONL — different namespaces, none worth normalizing. A draft survives its source session being deleted because the snapshot is captured at compose time; the column is hint-only, not a FK.

**Why two indexes.**
- `idx_share_drafts_updated_at` (DESC) is the primary query — the Shares grid lists by recency.
- `idx_share_drafts_source_origin` accelerates the `countDraftsBySession` query that drives the "N shares from this session" chip on `SessionDetail` (PR 4 scope, not in this stack yet but the index is already paid for here).

## CRUD API

`packages/core/src/db/share-drafts.ts` exposes:

- `listShareDrafts(db, { limit }) → ShareDraftListItem[]` — SELECT excludes `snapshot_json`, used by Shares grid.
- `getShareDraft(db, draftId) → ShareDraftRow | null` — SELECT includes everything, used by the editor.
- `upsertShareDraft(db, input)` — single `INSERT ... ON CONFLICT(draft_id) DO UPDATE` that writes both JSON columns and bumps `updated_at`. `created_at` is preserved on update.
- `deleteShareDraft(db, draftId)` — straight delete by id.
- `countDraftsBySession(db, sessionUuid) → number` — count of `'spool-session'` drafts originating from a given session.

Types split: `ShareDraftListItem` (no `snapshot_json`), `ShareDraftRow extends ShareDraftListItem` (adds `snapshot_json`). Consumers in #165 are TypeScript-checked to use the right one — the editor never gets a `ShareDraftListItem` it can't open, the grid never gets a `ShareDraftRow` it doesn't need.

## IPC + app surface

- `spool:list-share-drafts`, `spool:get-share-draft`, `spool:upsert-share-draft`, `spool:delete-share-draft`, `spool:count-drafts-by-session` handlers in the main process.
- `window.spool.shareDraft.*` exposed via preload.
- Sidebar gains a Shares nav-row (icon: Newspaper). Empty `SharesPage` with a featured empty-state (no shares yet → hint about how to create one). The Drafts / Published tab strip is intentionally absent until Phase 2 lands the publish flow — a tab pointing at a "coming soon" placeholder reads as a broken promise.

## Tests

Thirteen tests in `share-drafts.test.ts` cover: schema columns, indexes, CHECK constraint, default values, timestamp stamping, version pragma, upsert insert-then-update with `updated_at` bump, list ordering, list limit, `getShareDraft` miss returns null, delete, `countDraftsBySession` correctness, migration idempotence across reopen. The list test also asserts the row shape — explicit `not.toHaveProperty('snapshot_json')` and `toHaveProperty('preview_json')` — so a future change that accidentally re-adds the heavy column to the slim query fails CI.

## How it connects

- #165 wires the editor against this schema (`handleStartShareFromSession`, `handleOpenDraft`, `SharesPage` thumbnail gallery).
- #169 adds the autosave path and the defensive merge with `DEFAULT_OPTS` on parse.
- The codex-aggregate migration (`#161`, on `main`) lands before this; both are version-gated and don't interact.