### PR TITLE
feat(app): polish share editor chrome and tighten page top padding

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -165,6 +165,30 @@ export default function App() {
       .catch(console.error)
   }, [])
 
+  // Auto-collapse the left sidebar while the share editor is open —
+  // the editor already shows a right panel, so leaving both rails
+  // expanded leaves very little room for the preview. The user's
+  // previous sidebar state is restored on exit; the persisted
+  // preference on disk is intentionally untouched.
+  const sidebarRestoreRef = useRef<boolean | null>(null)
+  useEffect(() => {
+    if (view === 'share-editor') {
+      if (sidebarRestoreRef.current === null) {
+        sidebarRestoreRef.current = sidebarCollapsed
+        if (!sidebarCollapsed) setSidebarCollapsed(true)
+      }
+    } else if (sidebarRestoreRef.current !== null) {
+      const restore = sidebarRestoreRef.current
+      const stillCollapsed = sidebarCollapsed
+      sidebarRestoreRef.current = null
+      // Only restore the saved state if the user didn't override it
+      // while editing — if they manually re-opened the sidebar during
+      // the editor session, honor that explicit choice.
+      if (stillCollapsed) setSidebarCollapsed(restore)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [view])
+
   const toggleSidebar = useCallback(() => {
     setSidebarCollapsed((prev) => {
       const next = !prev

--- a/packages/app/src/renderer/components/LibraryLanding.tsx
+++ b/packages/app/src/renderer/components/LibraryLanding.tsx
@@ -60,7 +60,7 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId }: Props
 
   return (
     <div data-testid="library-landing" className="flex flex-col h-full overflow-hidden">
-      <div className="flex-1 overflow-y-auto pt-3 pb-12 [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]">
+      <div className="flex-1 overflow-y-auto pb-12 [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]">
         {recentSessions === null ? (
           <SessionRowsSkeleton count={6} />
         ) : totalSessions === 0 ? (
@@ -72,10 +72,9 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId }: Props
             {pinnedSessions.length > 0 && (
               <CollapsibleSection
                 label={`PINNED · ${pinnedSessions.length} ${pinnedSessions.length === 1 ? 'session' : 'sessions'}`}
-                accent
                 testId="library-pinned"
               >
-                <div className="bg-accent/[0.02] dark:bg-accent-dark/[0.02]">
+                <div>
                   {pinnedSessions.map(session => (
                     <SessionRow
                       key={session.sessionUuid}

--- a/packages/app/src/renderer/components/ProjectView.tsx
+++ b/packages/app/src/renderer/components/ProjectView.tsx
@@ -171,7 +171,7 @@ export default function ProjectView({
 
   return (
     <div data-testid="project-view" className="flex flex-col h-full overflow-hidden">
-      <div className="flex-none px-6 pt-3 pb-3 border-b border-warm-border dark:border-dark-border">
+      <div className="flex-none px-6 pt-1.5 pb-3 border-b border-warm-border dark:border-dark-border">
         <div className="flex items-baseline gap-3 flex-wrap">
           <h1 className="text-xl font-semibold tracking-tight text-warm-text dark:text-dark-text">
             {group?.displayName ?? identityKey}

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -221,7 +221,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
   return (
     <div className="relative flex flex-col h-full" data-testid="session-detail">
       {/* Session header */}
-      <div className="flex-none flex items-start gap-3 px-6 pt-3 pb-3 border-b border-warm-border dark:border-dark-border">
+      <div className="flex-none flex items-start gap-3 px-6 pt-1.5 pb-3 border-b border-warm-border dark:border-dark-border">
         {onBack && (
           <button
             type="button"

--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -13,10 +13,10 @@ import {
   type Conversation,
   type EditorOpts,
 } from '@spool/share-kit'
-import Menu from './Menu.js'
 import PageLayout from './PageLayout.js'
 import { PreviewPane, type Zoom } from './share-editor/PreviewPane.js'
 import { ControlPanel } from './share-editor/ControlPanel.js'
+import { DownloadButton } from './share-editor/DownloadButton.js'
 
 type Props = {
   conversation: Conversation
@@ -183,7 +183,7 @@ export default function ShareEditorPage({
   }, [beginSaving, conversation, opts])
 
   const topBarContent = (
-    <div className="flex-1 min-w-0 flex items-center gap-3 px-3 py-1.5">
+    <div className="flex-1 min-w-0 flex items-center gap-3 px-3">
       <button
         type="button"
         onClick={onBack}
@@ -209,40 +209,33 @@ export default function ShareEditorPage({
           {meta}
         </span>
       </div>
-      <Menu
-        align="right"
-        testId="share-editor-export"
-        trigger={({ open, toggle }) => (
-          <button
-            type="button"
-            onClick={toggle}
-            title="Export"
-            aria-label="Export"
-            aria-haspopup="menu"
-            aria-expanded={open}
-            disabled={saveState === 'saving'}
-            className="flex-none inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md text-[12px] font-medium text-warm-text dark:text-dark-text bg-warm-surface dark:bg-dark-surface hover:bg-warm-surface2 dark:hover:bg-dark-surface2 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
-          >
-            <Download size={12} strokeWidth={1.8} />
-            <span>{saveState === 'saving' ? 'Exporting…' : 'Export'}</span>
-            <svg width="8" height="8" viewBox="0 0 8 8" fill="none" aria-hidden>
-              <path d="M1.5 3L4 5.5L6.5 3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
-          </button>
-        )}
-        items={[
-          { label: 'Save as image (PNG)', onSelect: () => { void exportPng() } },
-          { label: 'Save as PDF', onSelect: () => { void exportPdf() } },
-          { label: 'Save as .spool file', onSelect: () => { void exportSpoolFile() } },
-        ]}
+      <DownloadButton
+        saving={saveState === 'saving'}
+        onPng={() => { void exportPng() }}
+        onPdf={() => { void exportPdf() }}
+        onSpool={() => { void exportSpoolFile() }}
       />
+      {/* Always mounted so toggling panelOpen doesn't snap-shift the
+          Download button. The button's width, leading margin, and
+          opacity all animate in sync with the right panel's 200ms
+          width transition. When the panel is open the button shrinks
+          to zero width and the negative margin absorbs the parent's
+          gap-3 so Download sits flush against the right column. */}
       <button
         type="button"
         onClick={onTogglePanel}
-        title={panelOpen ? 'Hide style panel' : 'Show style panel'}
-        aria-label={panelOpen ? 'Hide style panel' : 'Show style panel'}
-        aria-pressed={!panelOpen}
-        className="flex-none inline-flex items-center justify-center w-7 h-7 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
+        title="Show style panel"
+        aria-label="Show style panel"
+        aria-pressed={false}
+        aria-hidden={panelOpen}
+        tabIndex={panelOpen ? -1 : 0}
+        style={{
+          width: panelOpen ? 0 : 28,
+          marginLeft: panelOpen ? -12 : 0,
+          opacity: panelOpen ? 0 : 1,
+          transition: 'width 200ms ease-out, margin-left 200ms ease-out, opacity 200ms ease-out',
+        }}
+        className="flex-none inline-flex items-center justify-center h-7 overflow-hidden rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text"
       >
         <PanelRight size={15} strokeWidth={1.75} />
       </button>
@@ -255,7 +248,7 @@ export default function ShareEditorPage({
       sidebarCollapsed={sidebarCollapsed}
       onToggleSidebar={onToggleSidebar}
       topBar={topBarContent}
-      rightPanel={<ControlPanel opts={opts} setOpts={setOpts} />}
+      rightPanel={<ControlPanel opts={opts} setOpts={setOpts} onClose={onTogglePanel} />}
       rightPanelOpen={panelOpen}
     >
       <div className="flex flex-col h-full" data-testid="share-editor-page">

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -61,7 +61,7 @@ function DraftsList({
   }
   return (
     <ul
-      className="grid gap-5 px-6 py-6"
+      className="grid gap-5 px-6 pt-3 pb-6"
       style={{ gridTemplateColumns: `repeat(auto-fill, ${CARD_W}px)` }}
     >
       {drafts.map((draft) => (

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -50,7 +50,7 @@ export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHo
       data-testid="sidebar"
       className="w-60 flex-none bg-warm-surface dark:bg-dark-surface flex flex-col h-full overflow-hidden"
     >
-      <nav className="px-2 pt-3 pb-2 flex-none flex flex-col gap-0.5" aria-label="Primary">
+      <nav className="px-2 pt-1 pb-2 flex-none flex flex-col gap-0.5" aria-label="Primary">
         {onSelectHome && (
           <NavRow
             testId="sidebar-library"

--- a/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
+++ b/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { PanelRight } from 'lucide-react'
 import {
   COLORWAYS,
   PAPERS,
@@ -26,9 +27,10 @@ const COLORWAY_CHOICES = COLORWAYS.filter((c) => (COLORWAY_IDS as Set<string>).h
 type Props = {
   opts: EditorOpts
   setOpts: (next: EditorOpts) => void
+  onClose: () => void
 }
 
-export function ControlPanel({ opts, setOpts }: Props) {
+export function ControlPanel({ opts, setOpts, onClose }: Props) {
   const [advancedOpen, setAdvancedOpen] = useState(true)
   const currentColor = COLORWAY_CHOICES.find((c) => c.id === opts.colorway) ?? COLORWAY_CHOICES[0]!
   const currentPaper = PAPER_CHOICES.find((p) => p.id === opts.paper) ?? PAPER_CHOICES[0]!
@@ -41,14 +43,21 @@ export function ControlPanel({ opts, setOpts }: Props) {
     >
       {/* First section's header lives in an h-9 row so it sits in the
           same vertical band as the AppTopBar to the left — TEMPLATE
-          label visually aligns with Export. */}
-      <div className="flex-none h-9 px-4 flex items-center justify-between">
+          label visually aligns with the Download button. The panel
+          fold toggle occupies the right edge of this row. */}
+      <div className="flex-none h-9 pl-4 pr-2 flex items-center justify-between">
         <div className="text-[11px] font-medium tracking-[0.08em] uppercase text-warm-muted dark:text-dark-muted leading-none">
           Template
         </div>
-        <div className="text-[11px] text-warm-faint dark:text-dark-muted leading-none">
-          {TEMPLATE_CHOICES.length} looks
-        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          title="Hide style panel"
+          aria-label="Hide style panel"
+          className="flex-none inline-flex items-center justify-center w-7 h-7 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
+        >
+          <PanelRight size={15} strokeWidth={1.75} />
+        </button>
       </div>
       <div className="px-4 pb-4">
         <div className="flex flex-col gap-1.5">
@@ -173,7 +182,7 @@ export function ControlPanel({ opts, setOpts }: Props) {
 function Section({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
   return (
     <div className="px-4 pt-3 pb-4">
-      <div className="flex items-baseline justify-between mb-2">
+      <div className="flex items-baseline justify-between mb-3">
         <div className="text-[11px] font-medium tracking-[0.08em] uppercase text-warm-muted dark:text-dark-muted leading-none">
           {label}
         </div>

--- a/packages/app/src/renderer/components/share-editor/DownloadButton.tsx
+++ b/packages/app/src/renderer/components/share-editor/DownloadButton.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useRef, useState } from 'react'
+import { Download } from 'lucide-react'
+
+export type ExportFormat = 'png' | 'pdf' | 'spool'
+
+type FormatDef = {
+  k: ExportFormat
+  /** Dropdown menu label. */
+  l: string
+  /** Primary button label when this format is selected. */
+  b: string
+  /** Dropdown sub-copy (mono). */
+  s: string
+}
+
+const FORMATS: FormatDef[] = [
+  { k: 'png', l: 'PNG image', b: 'Download PNG', s: '3× pixel ratio · social-feed friendly' },
+  { k: 'pdf', l: 'PDF', b: 'Download PDF', s: 'Single page · print-ready' },
+  { k: 'spool', l: 'Spool file', b: 'Download .spool', s: 'Editable in Spool · keeps your styling' },
+]
+
+const STORAGE_KEY = 'spool:share:lastFormat'
+
+function loadInitial(): ExportFormat {
+  if (typeof window === 'undefined') return 'pdf'
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (raw === 'png' || raw === 'pdf' || raw === 'spool') return raw
+  return 'pdf'
+}
+
+type Props = {
+  saving: boolean
+  onPng: () => void
+  onPdf: () => void
+  onSpool: () => void
+}
+
+export function DownloadButton({ saving, onPng, onPdf, onSpool }: Props) {
+  const [format, setFormat] = useState<ExportFormat>(loadInitial)
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, format)
+  }, [format])
+
+  useEffect(() => {
+    if (!open) return
+    const onDocClick = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const current = FORMATS.find(f => f.k === format) ?? FORMATS[0]!
+
+  const trigger = () => {
+    if (saving) return
+    if (format === 'png') onPng()
+    else if (format === 'pdf') onPdf()
+    else onSpool()
+  }
+
+  return (
+    <div ref={rootRef} className="relative flex" data-testid="share-editor-download">
+      <button
+        type="button"
+        onClick={trigger}
+        disabled={saving}
+        title={`${current.b}  ⌘S`}
+        className="inline-flex items-center gap-1.5 h-6 px-2 rounded-l text-xs font-medium text-white bg-accent dark:bg-accent-dark hover:opacity-90 transition-opacity disabled:opacity-60 disabled:cursor-not-allowed"
+      >
+        <Download size={11} strokeWidth={1.8} />
+        <span>{saving ? 'Exporting…' : current.b}</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        aria-label="Choose format"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        disabled={saving}
+        className="inline-flex items-center justify-center h-6 w-5 rounded-r text-white bg-accent dark:bg-accent-dark border-l border-white/25 hover:opacity-90 transition-opacity disabled:opacity-60 disabled:cursor-not-allowed"
+      >
+        <svg width="8" height="8" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <path d="M2 4l3 3 3-3" />
+        </svg>
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-1.5 w-[260px] rounded-md bg-warm-bg dark:bg-dark-bg border border-warm-border dark:border-dark-border shadow-lg p-1 z-20"
+        >
+          {FORMATS.map(f => {
+            const active = f.k === format
+            return (
+              <button
+                key={f.k}
+                type="button"
+                role="menuitemradio"
+                aria-checked={active}
+                onClick={() => { setFormat(f.k); setOpen(false) }}
+                className={`w-full flex items-start gap-2 text-left px-2.5 py-2 rounded-[5px] transition-colors ${
+                  active
+                    ? 'bg-accent-bg dark:bg-accent-bg-dark'
+                    : 'hover:bg-warm-surface dark:hover:bg-dark-surface'
+                }`}
+              >
+                <span className="w-3 h-3 inline-flex items-center justify-center flex-none mt-[3px]">
+                  {active && (
+                    <svg
+                      width="11"
+                      height="11"
+                      viewBox="0 0 12 12"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="text-accent dark:text-accent-dark"
+                    >
+                      <path d="M2 6l3 3 5-6" />
+                    </svg>
+                  )}
+                </span>
+                <span className="min-w-0 flex flex-col gap-0.5">
+                  <span
+                    className={`text-xs font-medium leading-none whitespace-nowrap ${
+                      active ? 'text-accent dark:text-accent-dark' : 'text-warm-text dark:text-dark-text'
+                    }`}
+                  >
+                    {f.l}
+                  </span>
+                  <span className="font-mono text-[11px] text-warm-muted dark:text-dark-muted leading-snug">
+                    {f.s}
+                  </span>
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export { FORMATS as DOWNLOAD_FORMATS }


### PR DESCRIPTION
## What

Polish layer on top of the editor PR (#165). Three coordinated changes plus several small fixes: the editor's export menu becomes a split Download button, page-top padding pulls in across the app so content sits closer to the title-bar row, and the share editor auto-collapses the left sidebar on entry (with smart restore on exit). No data-layer or IPC changes; pure UI.

## Why the page-top padding pull-in

Each page introduced over the past few PRs settled on a slightly different top-spacing scale — `pt-3` here, `pt-4` there, `py-6` somewhere else. Navigating between Library / Project / Session / Shares produced a visible vertical jump as the content's first line drifted up and down. Unifying around a tighter scale (`pt-1` on Sidebar's nav, `pt-1.5` on Session / Project headers, `pt-3 pb-6` on Shares' grid, no top padding on Library's container) accomplishes two things: navigation feels stable, and content is closer to the macOS traffic-light row, which previously read as visually disconnected.

`ShareEditorPage`'s top-bar slot also drops a stray `py-1.5` that was making the bar exceed `min-h-9` and shoving the buttons below the traffic-light centre line. Removing it brings the buttons back into vertical alignment with the lights.

## Why the sidebar auto-collapse, and why it conditionally restores

The share editor needs the right rail (style panel) open by default, the centre column for the preview, and ideally the left sidebar folded — three columns at default window width is too cramped. So entering the editor folds the sidebar; exiting restores it.

The restore is conditional: if the user manually re-expanded the sidebar during editing — say, to click into another project from the project list — that's an explicit override and we honour it on exit. The mechanism is a ref that captures the pre-entry value, and a guard that only restores if `sidebarCollapsed === true` at exit time. A manually-expanded sidebar fails that check and stays open.

The setState path used to live in a `useEffect` watching the view change; the editor would briefly render with the sidebar still open, the autosave window-width measurement (#167's `useLayoutEffect` Fit) would sample mid-animation, and the cached fit ended up too small. The PR moves the setState into the same call path as the view transition (`handleStartShareFromSession`, `handleOpenDraft`), where it batches into the same render that mounts `ShareEditorPage`. The editor mounts with the sidebar already collapsed, no animation race, no mis-measured fit.

## Why the Download split button

The previous Export menu required the user to re-pick the format every time. Most users settle on one format (PDF or PNG) and don't switch. A split button with the primary action set to the last chosen format collapses the common case into a single click while keeping the caret for switching.

The choice persists to `localStorage` under `spool:share:lastFormat`. Three options: `PNG image` (3× pixel ratio · social-feed friendly), `PDF` (single page · print-ready), `Spool file` (editable in Spool · keeps your styling).

Sub-copy lives in Geist Mono per the design system's "badges / paths" scale; the primary label uses Geist Sans `text-xs` to match the existing `Menu` component's item style.

## Half-pixel cleanup

The Download dropdown had two off-scale sizes: `12.5px` on the main label and `10.5px` on the sub-copy. DESIGN.md explicitly forbids half-pixel sizes — they fight sub-pixel rendering. Snapped onto the scale: `12px / font-medium` for the main label, `11px / font-mono` for the sub-copy.

## How it connects

- Builds on the editor + entry wiring from #165.
- #167 lands the pan / Fit changes that build on top of this PR's `useLayoutEffect` mount-measurement work.
- #169 closes a same-session "options reset" regression that's visible once you can fluently re-enter the editor from a session — this PR makes that re-entry path painless enough to notice the regression.