### PR TITLE
feat(app): drag-to-pan preview + accurate Fit on demand

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -101,6 +101,25 @@ export default function App() {
   // the Shares page while a session is also selected.
   const [shareEditorReturnView, setShareEditorReturnView] = useState<View>('search')
 
+  // Remembers the sidebar fold state at the moment the user entered
+  // the share editor, so we can restore it on exit. Lives outside
+  // React state because it isn't part of any render output.
+  const sidebarRestoreRef = useRef<boolean | null>(null)
+
+  // Auto-collapse the left sidebar synchronously alongside the view
+  // change so the share editor renders with sidebar=collapsed on its
+  // very first paint. Doing this asynchronously via useEffect causes
+  // PreviewPane's initial fit measurement to sample a mid-animation
+  // pane width and produce a too-small scale.
+  const enterShareEditor = useCallback((nextSidebarCollapsed: boolean) => {
+    if (!nextSidebarCollapsed) {
+      sidebarRestoreRef.current = nextSidebarCollapsed
+      setSidebarCollapsed(true)
+    } else {
+      sidebarRestoreRef.current = null
+    }
+  }, [])
+
   const handleStartShareFromSession = useCallback(async (session: Session, messages: Message[]) => {
     const draftId = sessionDraftId(session.sessionUuid)
     // If the user has shared this session before, reopen their saved
@@ -129,10 +148,11 @@ export default function App() {
       console.error('Failed to load or persist share draft, falling back to a fresh compose:', err)
       conversation = composeFromSession(session, messages)
     }
+    enterShareEditor(sidebarCollapsed)
     setShareConversation(conversation)
     setShareEditorReturnView('session')
     setView('share-editor')
-  }, [])
+  }, [enterShareEditor, sidebarCollapsed])
 
   const handleOpenDraft = useCallback(async (draft: ShareDraftListItem) => {
     // The list query intentionally omits snapshot_json — fetch the
@@ -145,13 +165,14 @@ export default function App() {
         return
       }
       const doc = JSON.parse(full.snapshot_json) as SpoolDocument
+      enterShareEditor(sidebarCollapsed)
       setShareConversation(doc.conversation)
       setShareEditorReturnView('shares')
       setView('share-editor')
     } catch (err) {
       console.error('Failed to parse draft snapshot:', err)
     }
-  }, [])
+  }, [enterShareEditor, sidebarCollapsed])
 
   const handleCloseShareEditor = useCallback(() => {
     setShareConversation(null)
@@ -165,27 +186,16 @@ export default function App() {
       .catch(console.error)
   }, [])
 
-  // Auto-collapse the left sidebar while the share editor is open —
-  // the editor already shows a right panel, so leaving both rails
-  // expanded leaves very little room for the preview. The user's
-  // previous sidebar state is restored on exit; the persisted
-  // preference on disk is intentionally untouched.
-  const sidebarRestoreRef = useRef<boolean | null>(null)
+  // Restore the pre-editor sidebar state when the user leaves the
+  // share editor — by Back button, by clicking into a sidebar
+  // destination, or any other path that moves view away. Skip when
+  // the user manually re-expanded the sidebar mid-edit so their
+  // explicit choice wins.
   useEffect(() => {
-    if (view === 'share-editor') {
-      if (sidebarRestoreRef.current === null) {
-        sidebarRestoreRef.current = sidebarCollapsed
-        if (!sidebarCollapsed) setSidebarCollapsed(true)
-      }
-    } else if (sidebarRestoreRef.current !== null) {
-      const restore = sidebarRestoreRef.current
-      const stillCollapsed = sidebarCollapsed
-      sidebarRestoreRef.current = null
-      // Only restore the saved state if the user didn't override it
-      // while editing — if they manually re-opened the sidebar during
-      // the editor session, honor that explicit choice.
-      if (stillCollapsed) setSidebarCollapsed(restore)
-    }
+    if (view === 'share-editor' || sidebarRestoreRef.current === null) return
+    const restore = sidebarRestoreRef.current
+    sidebarRestoreRef.current = null
+    if (sidebarCollapsed) setSidebarCollapsed(restore)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [view])
 

--- a/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
+++ b/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useLayoutEffect, useRef, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useLayoutEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
 import {
   TemplateRender,
   TEMPLATE_RATIO,
@@ -11,10 +11,18 @@ export type Zoom = number | 'fit'
 
 export const ZOOM_STEPS = [0.25, 0.5, 0.75, 1, 1.5, 2] as const
 
-const PANE_W = 740
+/** Horizontal breathing room around the canvas inside the pane.
+ *  px-10 (40px each side) + 20px safety so the canvas never touches
+ *  the pane edge at fit. */
+const FIT_HORIZONTAL_PAD = 80 + 40
 
-export function fitScale(ratioW: number) {
-  return Math.min((PANE_W - 100) / ratioW, 0.7)
+/** Compute the scale that fits a canvas of natural width `ratioW` into a
+ *  pane whose inner client width is `paneW`. Clamped to 5–100% so a
+ *  narrow template can't blow up past native resolution. Exported so
+ *  callers / tests can reason about it without measuring DOM. */
+export function fitScaleFor(paneW: number, ratioW: number): number {
+  const available = Math.max(paneW - FIT_HORIZONTAL_PAD, 200)
+  return Math.max(0.05, Math.min(available / ratioW, 1))
 }
 
 export function nextZoomStep(current: number, direction: 1 | -1): number {
@@ -46,8 +54,6 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
   ref,
 ) {
   const ratio = TEMPLATE_RATIO[opts.template]
-  const fit = fitScale(ratio.w)
-  const scale = zoom === 'fit' ? fit : zoom
 
   const innerRef = useRef<HTMLDivElement>(null)
   const [naturalH, setNaturalH] = useState(ratio.h)
@@ -56,9 +62,96 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
     setNaturalH(Math.max(ratio.h, innerRef.current.scrollHeight))
   }, [convo, opts, ratio.h])
 
+  // Pan: drag-to-scroll on the empty backdrop / padding around the
+  // canvas. Holding Space extends pan over the canvas too — that's
+  // the Figma / Sketch convention and keeps mousedown on text from
+  // hijacking the user's text-selection gesture.
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const canvasRef = useRef<HTMLDivElement | null>(null)
+  const [isPanning, setIsPanning] = useState(false)
+  const [spaceHeld, setSpaceHeld] = useState(false)
+
+  // Fit-scale is captured at mount and only refreshed when the user
+  // explicitly clicks Fit. Layout-driven re-fits (panel toggle,
+  // sidebar toggle, template switch) intentionally do NOT recompute —
+  // the canvas stays at whatever scale the user last accepted.
+  const [fitScale, setFitScale] = useState<number>(0.7)
+  const measureFit = useCallback((): number => {
+    const sc = scrollRef.current
+    if (!sc) return 0.7
+    return fitScaleFor(sc.clientWidth, ratio.w)
+  }, [ratio.w])
+  useLayoutEffect(() => {
+    // Run once on mount — useLayoutEffect commits before paint, so
+    // the canvas appears at the correct fit scale on the very first
+    // frame and the user never sees a 0.7 fallback flash.
+    setFitScale(measureFit())
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const scale = zoom === 'fit' ? fitScale : zoom
+
+  useEffect(() => {
+    const isTypingTarget = (el: EventTarget | null) => {
+      if (!(el instanceof HTMLElement)) return false
+      const tag = el.tagName
+      return tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.code !== 'Space') return
+      if (isTypingTarget(e.target)) return
+      // Always preventDefault — even on key repeat — otherwise the
+      // browser's "Space scrolls down by a page" default fires for
+      // every repeat event and the preview races to the bottom.
+      e.preventDefault()
+      if (!e.repeat) setSpaceHeld(true)
+    }
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.code === 'Space') setSpaceHeld(false)
+    }
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('keyup', onKeyUp)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('keyup', onKeyUp)
+    }
+  }, [])
+
+  const beginPan = (e: ReactMouseEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return
+    const target = e.target as HTMLElement
+    if (target.closest('[data-pan-ignore]')) return
+    const onCanvas = canvasRef.current?.contains(target) ?? false
+    if (onCanvas && !spaceHeld) return
+    const sc = scrollRef.current
+    if (!sc) return
+    e.preventDefault()
+    const startX = e.clientX
+    const startY = e.clientY
+    const sLeft = sc.scrollLeft
+    const sTop = sc.scrollTop
+    setIsPanning(true)
+    const onMove = (m: globalThis.MouseEvent) => {
+      sc.scrollLeft = sLeft - (m.clientX - startX)
+      sc.scrollTop = sTop - (m.clientY - startY)
+    }
+    const onUp = () => {
+      document.removeEventListener('mousemove', onMove)
+      document.removeEventListener('mouseup', onUp)
+      setIsPanning(false)
+    }
+    document.addEventListener('mousemove', onMove)
+    document.addEventListener('mouseup', onUp)
+  }
+
+  const scrollCursor = isPanning ? 'grabbing' : spaceHeld ? 'grab' : undefined
+
   const handleIn = () => setZoom(nextZoomStep(scale, 1))
   const handleOut = () => setZoom(nextZoomStep(scale, -1))
-  const handleFit = () => setZoom('fit')
+  const handleFit = () => {
+    setFitScale(measureFit())
+    setZoom('fit')
+  }
 
   // Stash the live ratio onto the forwarded ref's parent target via
   // useImperativeHandle pattern — but since we just need the unscaled
@@ -72,7 +165,12 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
 
   return (
     <div className="relative flex-1 min-w-0 flex">
-      <div className="flex-1 overflow-auto scrollbar-none relative bg-warm-bg dark:bg-dark-bg">
+      <div
+        ref={scrollRef}
+        onMouseDown={beginPan}
+        style={scrollCursor ? { cursor: scrollCursor } : undefined}
+        className="flex-1 overflow-auto scrollbar-none relative bg-warm-bg dark:bg-dark-bg cursor-grab"
+      >
         <div
           className="relative px-10 py-8 flex flex-col items-center gap-3.5"
           style={{ margin: '0 auto', width: 'fit-content', minWidth: '100%', boxSizing: 'border-box' }}
@@ -93,6 +191,7 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
               otherwise the first paint at fallback scale visibly
               animates into the real scale, looking like a double zoom. */}
           <div
+            ref={canvasRef}
             className="relative overflow-hidden"
             style={{
               width: ratio.w * scale,
@@ -100,6 +199,7 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
               boxShadow: '0 2px 6px rgba(0,0,0,.1), 0 20px 50px rgba(0,0,0,.08)',
               borderRadius: 2,
               transition: 'width 220ms cubic-bezier(.2,.8,.2,1), height 220ms cubic-bezier(.2,.8,.2,1)',
+              cursor: spaceHeld || isPanning ? 'inherit' : 'default',
             }}
           >
             <div
@@ -145,7 +245,10 @@ function ZoomControl({ percent, isFit, onIn, onOut, onFit }: ZoomControlProps) {
   const minPercent = ZOOM_STEPS[0]! * 100
   const maxPercent = ZOOM_STEPS[ZOOM_STEPS.length - 1]! * 100
   return (
-    <div className="absolute right-4 bottom-4 z-20 flex items-center gap-0.5 px-1 h-7 rounded-md bg-warm-surface dark:bg-dark-surface shadow-sm text-[11px] text-warm-text dark:text-dark-text">
+    <div
+      data-pan-ignore
+      className="absolute right-4 bottom-4 z-20 flex items-center gap-0.5 px-1 h-7 rounded-md bg-warm-surface dark:bg-dark-surface shadow-sm text-[11px] text-warm-text dark:text-dark-text"
+    >
       <ZoomBtn label="−" onClick={onOut} ariaLabel="Zoom out" disabled={percent <= minPercent} />
       <span className="min-w-[34px] text-center select-none text-warm-text dark:text-dark-text tabular-nums">
         {percent}%


### PR DESCRIPTION
## What

Two `PreviewPane` behaviour changes that often confused users: the canvas couldn't be panned without grabbing the scrollbar, and the Fit scale was always wrong unless the window happened to be exactly the size the constant in the code assumed.

## Pan: drag on padding, Space modifier to extend over the canvas

Mouse-drag in the padded backdrop around the canvas (the warm-bg area outside the artifact) scrolls the preview container. Dragging on the canvas itself does nothing by default — that area is reserved for future text selection / turn-level editing.

Holding `Space` flips the gesture: dragging anywhere inside the preview pans the canvas, even when starting on rendered text. This follows the Figma / Sketch convention so users familiar with design tools don't have to learn a new modifier.

**Why a modifier instead of "drag-anywhere pans".** The straightforward version conflicts with text selection on rendered turns. Even if the editor doesn't yet expose turn-level editing, users instinctively try to select copy from the preview; a global-pan gesture would silently steal those clicks. Space-to-pan keeps both behaviours available.

**Why `preventDefault` on every Space keydown, including repeats.** The browser's default for Space is "scroll by a page". An initial preventDefault stops the first scroll, but as soon as the user holds Space past the OS's repeat threshold (typically 500 ms), repeat keydown events fire and any one that *doesn't* preventDefault triggers a page-down. The preview would race to the bottom within ~200 ms of holding Space. The fix is `e.preventDefault()` unconditionally; the `e.repeat` flag is checked only to skip duplicating the state update.

The `keydown` / `keyup` listeners are attached at the document level so the modifier works regardless of focus position; they're scoped to `code === 'Space'` and skip when an input / textarea is focused so text fields still receive the keystroke normally.

## Fit: measured once at mount, cached, only refreshed on user click

The previous implementation re-evaluated fit on every render against a hard-coded constant `PANE_W = 740`. Two problems:

- The value was wrong at any non-default window width. Users with wider or narrower windows saw the canvas either floating in empty space or overflowing.
- Fit silently re-applied when the user opened the right panel, switched template, or toggled the sidebar — overriding their explicit zoom. The user's "I want this scale" choice was undone by any UI interaction.

New behaviour: `useLayoutEffect` reads `scrollRef.current.clientWidth` once after mount. Because it runs before the first paint, the canvas appears at the correct fit scale on the very first frame — no flash from a fallback value to the measured one. The result is cached in state. Subsequent panel toggles, sidebar toggles, and template switches deliberately don't recompute — they preserve whatever scale the user last accepted.

Clicking the Fit button re-measures from the current `clientWidth` and updates the cache. This is the only path that refreshes fit.

**Why the `useLayoutEffect` over `useEffect`.** `useEffect` runs after the browser paints, so the canvas would render once at the fallback (0.7) and then re-render at the measured value, producing a visible "double zoom" flash. `useLayoutEffect` runs after DOM commit but before paint, so the second render's value is what the user sees.

The previous `fitScale(ratioW)` constant-using helper moves out into a pure `fitScaleFor(paneW, ratioW)` so the formula is testable without mounting the component:

```ts
fitScaleFor(paneW, ratioW) = clamp(
  (max(paneW - 120, 200)) / ratioW,
  0.05,
  1
)
```

The `- 120` accounts for `px-10` horizontal padding on both sides (80 px) plus 40 px of breathing room. Clamp at 1 prevents oversizing past native resolution; clamp at 0.05 prevents the canvas from collapsing on absurdly narrow windows.

## How it connects

- Sidebar auto-collapse from #166 had to land first — the auto-collapse on editor entry needs to commit before this PR's `useLayoutEffect` measures, or the cached fit samples a mid-animation pane width and ends up too small. #166 moves the auto-collapse setState into the entry-handler call path so both setStates batch into the same render and the measurement is correct.
- ZoomControl gets a `data-pan-ignore` attribute so clicks on its `+` / `−` / `Fit` buttons don't start a pan. Future overlays placed inside the preview should set the same attribute if they don't want pan events.
- No new tests — both behaviours are interaction-heavy and exercised manually. The `fitScaleFor` helper is extracted but currently untested; would be a clean unit to cover later.