### PR TITLE
feat(app): gate share surfaces behind VITE_FEATURE_SHARE

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -25,6 +25,7 @@ import { defaultThemeEditorState, type ThemeEditorStateV1 } from './theme/editor
 import { applyEditorTheme } from './theme/applyEditorTheme.js'
 import { loadThemeEditorState, saveThemeEditorState } from './theme/persist.js'
 import { useHotkeys } from './hooks/useHotkeys.js'
+import { FEATURES } from './featureFlags.js'
 
 type View = 'search' | 'session' | 'shares' | 'share-editor'
 type SettingsTab = 'general' | 'appearance' | 'sources' | 'agent'
@@ -210,8 +211,8 @@ export default function App() {
   const showProjectView = activeProjectKey !== null && view === 'search' && !selectedSession && !query.trim()
   const showSearchResults = view === 'search' && !selectedSession && !!query.trim()
   const isHomeMode = homeMode && view === 'search' && !selectedSession && !showProjectView && !showSearchResults
-  const isSharesView = view === 'shares'
-  const isShareEditorView = view === 'share-editor'
+  const isSharesView = FEATURES.share && view === 'shares'
+  const isShareEditorView = FEATURES.share && view === 'share-editor'
 
   useEffect(() => {
     loadThemeEditorState()
@@ -608,14 +609,16 @@ export default function App() {
         setView('search')
         setQuery('')
       }}
-      onSelectShares={() => {
-        setActiveProjectKey(null)
-        setHomeMode(false)
-        setSelectedSession(null)
-        setTargetMessageId(null)
-        setView('shares')
-        setQuery('')
-      }}
+      {...(FEATURES.share ? {
+        onSelectShares: () => {
+          setActiveProjectKey(null)
+          setHomeMode(false)
+          setSelectedSession(null)
+          setTargetMessageId(null)
+          setView('shares')
+          setQuery('')
+        },
+      } : {})}
       isSharesActive={isSharesView}
       onOpenSearch={handleSearchOpen}
       syncStatus={syncStatus}
@@ -715,14 +718,16 @@ export default function App() {
           setView('search')
           setQuery('')
         }}
-        onSelectShares={() => {
-          setActiveProjectKey(null)
-          setHomeMode(false)
-          setSelectedSession(null)
-          setTargetMessageId(null)
-          setView('shares')
-          setQuery('')
-        }}
+        {...(FEATURES.share ? {
+          onSelectShares: () => {
+            setActiveProjectKey(null)
+            setHomeMode(false)
+            setSelectedSession(null)
+            setTargetMessageId(null)
+            setView('shares')
+            setQuery('')
+          },
+        } : {})}
         isSharesActive={isSharesView}
         onOpenSearch={handleSearchOpen}
         syncStatus={syncStatus}
@@ -792,7 +797,7 @@ export default function App() {
                   targetMessageId={targetMessageId}
                   onCopySessionId={handleCopySessionId}
                   onBack={handleBack}
-                  onShare={handleStartShareFromSession}
+                  {...(FEATURES.share ? { onShare: handleStartShareFromSession } : {})}
                 />
               ) : showProjectView && activeProjectKey ? (
                 <ProjectView

--- a/packages/app/src/renderer/featureFlags.ts
+++ b/packages/app/src/renderer/featureFlags.ts
@@ -1,0 +1,14 @@
+/// <reference types="vite/client" />
+
+// Build-time feature flags for renderer surfaces. Default to OFF in
+// production so a half-finished feature can be merged to main without
+// exposing it to users; flip on for local dev (vite's import.meta.env.DEV)
+// and for explicit prod overrides via VITE_FEATURE_<NAME>=1.
+
+const envFlag = (key: string): boolean =>
+  ((import.meta.env as Record<string, string | undefined>)[`VITE_FEATURE_${key}`]) === '1'
+
+export const FEATURES = {
+  /** Share editor + Shares page + Share-from-session entry points. */
+  share: import.meta.env.DEV || envFlag('SHARE'),
+} as const


### PR DESCRIPTION
## What

Build-time gate so the in-flight share feature can land on `main` and ship in release builds without users seeing it. New module `featureFlags.ts` exports a single `FEATURES.share` boolean that all share entry points check; the value resolves to `true` in development (Vite's `import.meta.env.DEV`) and in production builds that pass `VITE_FEATURE_SHARE=1`, otherwise `false`.

## Why a build-time flag instead of a runtime one

Two alternatives considered:

1. **Runtime toggle** (settings panel switch, env var read at startup, remote flag service).
2. **Build-time flag** (Vite static replacement at compile time).

Runtime is more flexible — you can flip it post-ship without a rebuild, A/B test, etc. But it also means the share entry points (Sidebar nav-row, Session-detail Share button, the share / share-editor view branches) and all of their dependencies remain in the bundle of every release build. Users on the public release would have the share code shipped to their machines and only the *UI* hidden — which is awkward when the feature isn't ready for any audience.

Build-time gating runs the flag through Vite's static replacement so production builds without `VITE_FEATURE_SHARE=1` have the share branches dead-code-eliminated. Bundle stays smaller, the unfinished code is invisible to users in every meaningful sense, and the development experience is unchanged (the flag is statically `true` in dev).

The tradeoff: flipping it on requires a rebuild. That's acceptable for Phase 0 where there's exactly one decision point ("we're ready to ship to users") and no per-user variation.

## Why gate at every entry rather than one chokepoint

There are four ways into the share surface:

- Sidebar Shares nav-row
- `SessionDetail` Share button
- `view === 'shares'` (renders `SharesPage`)
- `view === 'share-editor'` (renders `ShareEditorPage`)

Gating only at the sidebar would still leave the view branches renderable if any future code path sets `view` to one of those (e.g. an `⌘K` command). Gating only at the views would leave the sidebar row clickable but inert. Gating each independently means a future caller can't accidentally bypass the flag, and removal of the gating later is a search-and-delete pass rather than a redesign.

The two `App.tsx` Sidebar renderings each conditionally spread their `onSelectShares` prop. The conditional spread (vs. passing `undefined`) is required because Sidebar's prop type is `onSelectShares?: () => void` and the monorepo's `exactOptionalPropertyTypes: true` treats those as "may be absent" rather than "may be undefined". Same pattern for `SessionDetail.onShare`. The `isShareEditorView` and `isSharesView` computations both `&&` against `FEATURES.share`, so even if `view` is somehow set to a share value, the render falls through.

## How to flip on for a prod build

```
VITE_FEATURE_SHARE=1 pnpm build
```

The env helper accepts any `VITE_FEATURE_<NAME>=1` so future features can reuse the same convention.

## How it connects

- Lives on top of every share PR in the stack, so the gating is the last thing applied before merge to `main`. Once the feature is ready, the flag flips to `true` unconditionally (or comes out entirely) in a follow-up.
- No tests — Vite's static replacement is well-trodden, and the gating is a pure boolean check at each call site.