### PR TITLE
feat(app): autosave editor opts back into share_drafts on every change

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -14,7 +14,7 @@ import AppTopBar from './components/AppTopBar.js'
 import SharesPage from './components/SharesPage.js'
 import ShareEditorPage from './components/ShareEditorPage.js'
 import { composeFromSession, sessionDraftId, buildPreviewDocument } from './lib/compose-from-session.js'
-import { buildSpoolDocument, DEFAULT_OPTS, type Conversation, type SpoolDocument } from '@spool/share-kit'
+import { buildSpoolDocument, DEFAULT_OPTS, type Conversation, type EditorOpts, type SpoolDocument } from '@spool/share-kit'
 import type { Message, Session, ShareDraftListItem } from '@spool-lab/core'
 import { getSessionResumeCommandPrefix } from '../shared/resumeCommand.js'
 import { DEFAULT_SEARCH_SORT_ORDER, type SearchSortOrder } from '../shared/searchSort.js'
@@ -95,7 +95,17 @@ export default function App() {
   const [searchScope, setSearchScope] = useState<'all' | 'project'>('all')
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [sharePanelOpen, setSharePanelOpen] = useState(true)
-  const [shareConversation, setShareConversation] = useState<Conversation | null>(null)
+  /** Active share-editor session: conversation, the user's last
+   *  accepted opts, and the draft-row metadata the editor needs to
+   *  upsert autosaves back into share_drafts. Cleared on Back. */
+  type ShareEditorBundle = {
+    draftId: string
+    sourceKind: 'spool-session' | 'pasted-url' | 'imported-file' | 'imported-jsonl'
+    sourceOrigin: string | null
+    conversation: Conversation
+    opts: EditorOpts
+  }
+  const [shareEditor, setShareEditor] = useState<ShareEditorBundle | null>(null)
   // The view the user came from when opening the editor — Back returns
   // here. Captured up front because guessing from current state
   // (selectedSession etc.) misroutes when the user opens a draft from
@@ -128,14 +138,21 @@ export default function App() {
     // the snapshot). Only when no draft exists do we build a fresh
     // one with DEFAULT_OPTS and persist it.
     let conversation: Conversation
+    let opts: EditorOpts
     try {
       const existing = await window.spool?.shareDraft?.get(draftId)
       if (existing) {
         const doc = JSON.parse(existing.snapshot_json) as SpoolDocument
         conversation = doc.conversation
+        // Merge with DEFAULT_OPTS so a snapshot saved before a new
+        // EditorOpts field landed (e.g. colorway, density) doesn't
+        // leave that field undefined and crash TEMPLATE_RATIO lookups
+        // / PreviewPane's TemplateRender downstream.
+        opts = { ...DEFAULT_OPTS, ...(doc.opts ?? {}) }
       } else {
         conversation = composeFromSession(session, messages)
-        const doc = buildSpoolDocument(conversation, DEFAULT_OPTS)
+        opts = DEFAULT_OPTS
+        const doc = buildSpoolDocument(conversation, opts)
         await window.spool?.shareDraft?.upsert({
           draft_id: draftId,
           source_kind: 'spool-session',
@@ -148,9 +165,16 @@ export default function App() {
     } catch (err) {
       console.error('Failed to load or persist share draft, falling back to a fresh compose:', err)
       conversation = composeFromSession(session, messages)
+      opts = DEFAULT_OPTS
     }
     enterShareEditor(sidebarCollapsed)
-    setShareConversation(conversation)
+    setShareEditor({
+      draftId,
+      sourceKind: 'spool-session',
+      sourceOrigin: session.sessionUuid,
+      conversation,
+      opts,
+    })
     setShareEditorReturnView('session')
     setView('share-editor')
   }, [enterShareEditor, sidebarCollapsed])
@@ -167,7 +191,13 @@ export default function App() {
       }
       const doc = JSON.parse(full.snapshot_json) as SpoolDocument
       enterShareEditor(sidebarCollapsed)
-      setShareConversation(doc.conversation)
+      setShareEditor({
+        draftId: draft.draft_id,
+        sourceKind: draft.source_kind,
+        sourceOrigin: draft.source_origin,
+        conversation: doc.conversation,
+        opts: { ...DEFAULT_OPTS, ...(doc.opts ?? {}) },
+      })
       setShareEditorReturnView('shares')
       setView('share-editor')
     } catch (err) {
@@ -176,7 +206,7 @@ export default function App() {
   }, [enterShareEditor, sidebarCollapsed])
 
   const handleCloseShareEditor = useCallback(() => {
-    setShareConversation(null)
+    setShareEditor(null)
     setView(shareEditorReturnView)
   }, [shareEditorReturnView])
 
@@ -633,11 +663,15 @@ export default function App() {
 
   // Share editor owns its own PageLayout (with a right panel) — short-
   // circuit App's regular two-column layout for that view.
-  if (isShareEditorView && shareConversation) {
+  if (isShareEditorView && shareEditor) {
     return (
       <>
         <ShareEditorPage
-          conversation={shareConversation}
+          draftId={shareEditor.draftId}
+          sourceKind={shareEditor.sourceKind}
+          sourceOrigin={shareEditor.sourceOrigin}
+          conversation={shareEditor.conversation}
+          initialOpts={shareEditor.opts}
           onBack={handleCloseShareEditor}
           panelOpen={sharePanelOpen}
           onTogglePanel={() => setSharePanelOpen((v) => !v)}

--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { flushSync } from 'react-dom'
 import { Download, PanelRight } from 'lucide-react'
 import {
-  DEFAULT_OPTS,
   TEMPLATE_RATIO,
   buildSpoolDocument,
   openSaveSlot,
@@ -13,13 +12,22 @@ import {
   type Conversation,
   type EditorOpts,
 } from '@spool/share-kit'
+import type { ShareDraftSourceKind } from '@spool-lab/core'
 import PageLayout from './PageLayout.js'
 import { PreviewPane, type Zoom } from './share-editor/PreviewPane.js'
 import { ControlPanel } from './share-editor/ControlPanel.js'
 import { DownloadButton } from './share-editor/DownloadButton.js'
+import { buildPreviewDocument } from '../lib/compose-from-session.js'
 
 type Props = {
+  /** Stable id of the share_drafts row to autosave into. */
+  draftId: string
+  sourceKind: ShareDraftSourceKind
+  sourceOrigin: string | null
   conversation: Conversation
+  /** Editor opts loaded from the persisted snapshot. The editor takes
+   *  this as its initial state and persists any subsequent change. */
+  initialOpts: EditorOpts
   onBack: () => void
   panelOpen: boolean
   onTogglePanel: () => void
@@ -41,7 +49,11 @@ type SaveState = 'idle' | 'saving' | 'error'
  * follow-up commits.
  */
 export default function ShareEditorPage({
+  draftId,
+  sourceKind,
+  sourceOrigin,
   conversation,
+  initialOpts,
   onBack,
   panelOpen,
   onTogglePanel,
@@ -49,12 +61,40 @@ export default function ShareEditorPage({
   sidebarCollapsed,
   onToggleSidebar,
 }: Props) {
-  const [opts, setOpts] = useState<EditorOpts>(DEFAULT_OPTS)
+  const [opts, setOpts] = useState<EditorOpts>(initialOpts)
   const [zoom, setZoom] = useState<Zoom>('fit')
   const [saveState, setSaveState] = useState<SaveState>('idle')
   const [toast, setToast] = useState<string | null>(null)
   const [pdfPreview, setPdfPreview] = useState<{ url: string; filename: string } | null>(null)
   const previewRef = useRef<HTMLDivElement | null>(null)
+
+  // Autosave opts changes back into share_drafts. Debounced so a
+  // rapid sequence of clicks (e.g. paging through colorways) collapses
+  // into one upsert. We skip the very first effect run — that one
+  // fires on mount with the value we just loaded from disk, no need
+  // to write the same bytes back. Using a didMount ref instead of
+  // identity-checking opts keeps this robust even if a parent re-render
+  // produces a new conversation/opts object reference with no actual
+  // change in content.
+  const didMountRef = useRef(false)
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true
+      return
+    }
+    const handle = window.setTimeout(() => {
+      const doc = buildSpoolDocument(conversation, opts)
+      void window.spool?.shareDraft?.upsert({
+        draft_id: draftId,
+        source_kind: sourceKind,
+        source_origin: sourceOrigin,
+        title: conversation.title,
+        snapshot_json: JSON.stringify(doc),
+        preview_json: JSON.stringify(buildPreviewDocument(doc)),
+      }).catch((err) => console.error('Autosave share draft failed:', err))
+    }, 400)
+    return () => window.clearTimeout(handle)
+  }, [opts, conversation, draftId, sourceKind, sourceOrigin])
 
   // Revoke the in-memory blob: URL when the preview modal closes so we
   // don't leak the PDF buffer for the rest of the session.


### PR DESCRIPTION
## What

Closes a same-session regression that surfaced once the editor in #165 was exercised end-to-end: opening Share on a session you'd previously edited didn't restore your saved opts. The editor was finding the existing draft on disk, reading its `snapshot_json`, but then dropping the `opts` field and remounting with `DEFAULT_OPTS`. The user's choices (template, paper, typeface, colorway, density, masthead/colophon flags) silently vanished every time.

Fixes both halves of that loop: the editor now receives saved opts as a prop and writes opts changes back to disk with debounced autosave.

## Threading initial opts through the prop boundary

The previous boundary between `App.tsx` and `ShareEditorPage` only passed `conversation` — the editor was constructed as if every draft were fresh. `App.tsx` now passes a single `shareEditor` bundle:

```ts
{
  draftId: string
  sourceKind: ShareDraftSourceKind
  sourceOrigin: string | null
  conversation: Conversation
  opts: EditorOpts
}
```

`handleStartShareFromSession` and `handleOpenDraft` both fetch the existing draft (when present), parse the snapshot, and pass the parsed `doc.conversation` and `doc.opts` into the bundle. The editor's `useState<EditorOpts>(initialOpts)` then starts from the saved value.

**Why a bundle instead of separate props.** The four metadata fields (`draftId` / `sourceKind` / `sourceOrigin` / `opts`) are coupled — they all describe the same draft, and any one of them being out of sync with the others would corrupt the autosave path (write to the wrong row, etc.). Bundling them into one nullable state value makes "we have a live editing session" a single React state question rather than four separate ones, and unconditional `setShareEditor(null)` on close clears them all atomically.

## Defensive merge with DEFAULT_OPTS on parse

```ts
opts = { ...DEFAULT_OPTS, ...(doc.opts ?? {}) }
```

Applied at both load sites. A snapshot saved before a new `EditorOpts` field landed (e.g. #170 adds `hideEmptyTurns`) arrives with that field `undefined`. Without the merge, `PreviewPane`'s `TEMPLATE_RATIO[opts.template]` lookup could fail downstream, or — worse — `opts.hideEmptyTurns` would be `undefined` and the template would render with implementation-defined behaviour.

This is the no-migration forward-compat strategy: older drafts get the new defaults on next open. Schema doesn't change, no version pragma bump, no backfill script. The cost is one shallow merge per draft load, which is negligible at the cardinalities we care about.

The same merge applies if a `doc.opts` was somehow corrupt or absent entirely (`?? {}` short-circuits) — the editor falls back to fresh defaults rather than crashing.

## Autosave: debounced effect, didMount guard

In `ShareEditorPage`:

```ts
const didMountRef = useRef(false)
useEffect(() => {
  if (!didMountRef.current) {
    didMountRef.current = true
    return
  }
  const handle = window.setTimeout(() => {
    const doc = buildSpoolDocument(conversation, opts)
    void window.spool?.shareDraft?.upsert({
      draft_id: draftId,
      source_kind: sourceKind,
      source_origin: sourceOrigin,
      title: conversation.title,
      snapshot_json: JSON.stringify(doc),
      preview_json: JSON.stringify(buildPreviewDocument(doc)),
    })
  }, 400)
  return () => window.clearTimeout(handle)
}, [opts, conversation, draftId, sourceKind, sourceOrigin])
```

**Why a `didMount` ref instead of value-equality on opts.** The naive guard `if (opts === initialOpts) return` relies on reference identity, which is fragile under future parent re-renders that create a new `opts` object with the same content. A boolean that flips after the first run is robust regardless of how parents are refactored, and the intent ("don't write on the load-back render") is explicit.

**Why 400 ms debounce.** Long enough to collapse rapid clicks (paging through colorway swatches, scrubbing a slider) into one upsert; short enough that the autosave feels immediate when the user pauses. Tested manually with template switches and feels right; can be tuned if telemetry surfaces a different sweet spot.

**Why upserting writes both columns.** `snapshot_json` is the full doc (for re-opening in the editor later); `preview_json` is the slim version (for the Shares grid card). Both must reflect the current state or the grid drifts from the editor — a user could see "Atelier · ink" in the grid but reopening the draft would show their actual saved template. Computing `preview_json` from the same in-memory `doc` ensures they stay in sync. The cost is one extra `buildPreviewDocument` call (a `slice(0, 6)` plus an object spread) per autosave — bounded.

## How it connects

- Editor + entry wiring came from #165. The bug being fixed here was visible once that wiring was exercised against the schema from #164.
- #170 adds `hideEmptyTurns` to `EditorOpts` — the defensive merge here is what lets older drafts pick up the new field's default without a schema migration.
- No new tests — the bug was caught in integration testing; the fix is small enough that the existing `share-drafts` test suite plus manual verification covers it.