### PR TITLE
feat(share-kit,app): hide empty turns by default

### DIFF
--- a/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
+++ b/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
@@ -151,6 +151,12 @@ export function ControlPanel({ opts, setOpts, onClose }: Props) {
           </div>
         </div>
         <Toggle
+          label="Hide empty turns"
+          sub="Skip role headers with no content (tool-only assistant turns)"
+          value={opts.hideEmptyTurns}
+          onChange={(v) => setOpts({ ...opts, hideEmptyTurns: v })}
+        />
+        <Toggle
           label="Gap markers"
           sub="Show ⋯ where turns are skipped"
           value={opts.showGaps}

--- a/packages/share-kit/src/lib/types.ts
+++ b/packages/share-kit/src/lib/types.ts
@@ -217,6 +217,12 @@ export interface EditorOpts {
   /** Bottom chrome — "Stitched on Spool" + page marker. Turn off for
    *  social-ready outputs where branding would read as clutter. */
   showColophon: boolean
+  /** Skip turns whose body is empty or whitespace-only. Tool-only
+   *  assistant turns (status updates, sub-conversation noise that
+   *  upstream parsers couldn't drop) otherwise show up as bare role
+   *  headers with no content. On by default; users can flip it off
+   *  to expose every turn explicitly. */
+  hideEmptyTurns: boolean
 }
 
 /** The on-disk .spool file format. Version-stamped for forward compat. */
@@ -271,6 +277,7 @@ export const DEFAULT_OPTS: EditorOpts = {
   showGaps: true,
   showMasthead: true,
   showColophon: true,
+  hideEmptyTurns: true,
 }
 
 /** Fill in any missing fields on stored opts with defaults. We're

--- a/packages/share-kit/src/templates/selection.ts
+++ b/packages/share-kit/src/templates/selection.ts
@@ -32,6 +32,7 @@ export function selectSegments(convo: Conversation, opts: EditorOpts): SelectedS
   const all = convo.turns
   const sel = opts.selected
   const keep = sel ? new Set(sel) : null
+  const hideEmpty = opts.hideEmptyTurns
 
   const turns: KeptTurn[] = []
   const gapBefore: number[] = []
@@ -39,6 +40,10 @@ export function selectSegments(convo: Conversation, opts: EditorOpts): SelectedS
 
   for (let i = 0; i < all.length; i++) {
     if (keep !== null && !keep.has(i)) {
+      gap++
+      continue
+    }
+    if (hideEmpty && all[i]!.body.trim() === '') {
       gap++
       continue
     }
@@ -52,6 +57,6 @@ export function selectSegments(convo: Conversation, opts: EditorOpts): SelectedS
     gapBefore,
     kept: turns.length,
     total: all.length,
-    isExcerpt: keep !== null && turns.length !== all.length,
+    isExcerpt: turns.length !== all.length,
   }
 }


### PR DESCRIPTION
## What

Tool-only assistant turns — status updates, ACP heartbeats, and other sub-conversation noise that the upstream parsers in #162 couldn't drop without violating the "faithful to the source" contract — render as bare role headers with no body. In the preview, they appear as a column of CLAUDE / CODEX badges separated by gaps; in the export they're worse, since there's no hover affordance to suggest they're empty by design.

This PR hides them by default. Adds `EditorOpts.hideEmptyTurns: boolean` (default `true`), filters them out at render time in `selectSegments`, and exposes the toggle in `ControlPanel`'s More options.

## Why filter at render time rather than at parse time

Two layers in the share-kit pipeline could host this filter:

1. **Parser layer** (`packages/share-kit/src/lib/parsers/*`) — drop the turn before it ever reaches the `Conversation` object.
2. **Render layer** (`selectSegments` in `templates/selection.ts`) — keep the turn in the data, skip it when assembling the visible segments.

Parser-layer filtering is destructive: the turn is gone from the snapshot, and a future user setting "show me everything" couldn't bring it back. It also breaks any future turn-level editing UI (selection by original index, etc.) because the index space would silently differ from the source JSONL.

Render-layer filtering keeps the data intact. The full turn list lives in `conversation.turns`, the snapshot on disk includes all of them, and `selectSegments` is the single place that decides what's visible. Adding a "show everything" toggle later is one boolean — no data recovery needed.

## Why empty turns count as gaps

`selectSegments` returns a `gapBefore[i]` array parallel to the kept turns; templates render a "⋯ N turns skipped" marker between non-adjacent kept turns when `opts.showGaps` is on. An empty turn that simply disappears from both would silently misrepresent the conversation's flow — a reader looking at the artifact would have no signal that something was elided.

The implementation treats an empty turn the same as a non-selected turn: it doesn't appear in `turns`, and it contributes `+1` to the next kept turn's `gapBefore`. With `showGaps` on, the user sees an honest "⋯ 1 turn skipped" marker; with `showGaps` off, the elision is silent — but in that mode the user has already opted into silent elisions across the board (e.g. their selected-passage gaps were already silent).

## Why default `true`

Two factors:

- The empty-turn pollution comes from a parsing limitation, not user content. Showing it by default privileges the parser's view of the source over what a reader would expect.
- The Shares feature's primary use is publishing — the user is producing an artifact for someone else to read. Defaulting to the cleaner output makes the first-time experience match user intent. Anyone who wants the full source can flip the toggle off in More options.

## How "empty" is defined

`all[i].body.trim() === ''`. Whitespace-only counts as empty. The check runs on the raw `body` string, before the templates apply their own per-turn rendering — so a turn that's `"\n\n\n"` is treated the same as `""`.

This catches the common case (turns with no body) and the slightly-less-common case (turns with only whitespace from a parser bug). It doesn't catch turns whose body is "just an emoji" or "just `[redacted]`" — those would need a richer definition. For now, the simple trim-empty check matches the noise pattern observed in real Claude / Codex sessions.

## UI placement

The toggle lives in `ControlPanel`'s More options section, immediately above "Gap markers". The two interact: Hide-empty on + Gap markers on → empty turns collapse into a visible "⋯ N skipped" marker. Hide-empty on + Gap markers off → silent elision. Hide-empty off → every turn renders, regardless of body. Placing them adjacent makes the interaction discoverable.

## Forward compat

Drafts saved before this PR don't have `hideEmptyTurns` in their snapshot. #169's defensive merge with `DEFAULT_OPTS` on parse gives them the new default (`true`) on next open without a schema migration. The autosave (also #169) then writes the field on the user's next change.

## How it connects

- Builds on the parser pipeline from #162 and the editor's options system from #165.
- Depends on #169's defensive merge for clean forward-compat with existing drafts.
- The "show everything" inverse is not implemented in this PR — the toggle is enough for Phase 0; a richer "view all turns including hidden" mode can layer on later.