### PR TITLE
feat(app): full-width top bar + floating style-panel card

### DIFF
--- a/packages/app/src/renderer/components/AppTopBar.tsx
+++ b/packages/app/src/renderer/components/AppTopBar.tsx
@@ -22,7 +22,9 @@ export default function AppTopBar({ sidebarCollapsed, onToggleSidebar, children 
 
   return (
     <div data-testid="app-top-bar" className="relative flex-none min-h-9 select-none" style={dragStyle}>
-      {/* Background: animated sidebar/content split, behind the button. */}
+      {/* Background: animated sidebar split + content bg flooding the
+          rest of the bar (including over the right rail). The rail
+          itself gets its surface tint only BELOW the bar. */}
       <div className="absolute inset-0 flex pointer-events-none" aria-hidden="true">
         <div
           className={[

--- a/packages/app/src/renderer/components/PageLayout.tsx
+++ b/packages/app/src/renderer/components/PageLayout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from 'react'
 import AppTopBar from './AppTopBar.js'
 
+const RIGHT_PANEL_WIDTH = 280
+
 type Props = {
   /** Left sidebar (Library / Shares / Projects rail). The caller
    *  owns this so each page can pass the same Sidebar instance with
@@ -12,10 +14,9 @@ type Props = {
    *  (back arrow, title, primary action buttons). Pass null on pages
    *  that don't need any. */
   topBar?: ReactNode
-  /** Page-level right column (e.g. share editor's style picker). Lives
-   *  as a full-height sibling of the (sidebar + content) sub-tree, so
-   *  its top edge sits at the window top rather than below AppTopBar.
-   *  Pass null when the page doesn't want a right column. */
+  /** Page-level right column (e.g. share editor's style picker).
+   *  Sits below the AppTopBar so the bar spans the full window width
+   *  and its primary actions stay reachable while the panel scrolls. */
   rightPanel?: ReactNode
   /** Controls the right column's animated width. */
   rightPanelOpen?: boolean
@@ -24,10 +25,10 @@ type Props = {
 }
 
 /**
- * Three-column layout shell: [sidebar | content | rightPanel]. The
- * AppTopBar sits on top of (sidebar + content) only, so the right
- * column extends from window top to bottom and its first content row
- * can align vertically with the top bar's row.
+ * Three-column layout shell. AppTopBar sits at the top and spans the
+ * full window width (sidebar + content + rightPanel are all sibling
+ * columns BELOW it). The bar paints a matching surface-coloured
+ * segment over the right column so the top edge reads as one band.
  *
  * Slot prop pattern — callers pass JSX nodes for each slot instead of
  * portaling content via DOM ids. Keeps the layout's contract typed
@@ -43,44 +44,37 @@ export default function PageLayout({
   children,
 }: Props) {
   return (
-    <div className="relative flex h-screen bg-warm-bg dark:bg-dark-bg text-warm-text dark:text-dark-text">
-      {/* Main column: AppTopBar over (sidebar + content). Shrinks
-          horizontally when the right column is open. */}
-      <div className="flex flex-col flex-1 min-w-0">
-        <AppTopBar sidebarCollapsed={sidebarCollapsed} onToggleSidebar={onToggleSidebar}>
-          {topBar}
-        </AppTopBar>
-        <div className="flex flex-1 min-h-0">
-          <div
-            className="flex-none overflow-hidden"
-            style={{
-              width: sidebarCollapsed ? 0 : 240,
-              transition: 'width 200ms ease-out',
-            }}
-            aria-hidden={sidebarCollapsed}
-          >
-            {sidebar}
-          </div>
-          <div className="relative flex flex-col flex-1 min-w-0">
-            {children}
-          </div>
-        </div>
-      </div>
-
-      {/* Right column — full-height sibling of the main column.
-          Width animates to 0 when collapsed so it slides out cleanly.
-          Inline style transition (rather than Tailwind's
-          transition-[width]) is the only one that reliably animates
-          across all React/Tailwind v4 builds. */}
-      <div
-        className="flex-none overflow-hidden"
-        style={{
-          width: rightPanelOpen ? 280 : 0,
-          transition: 'width 200ms ease-out',
-        }}
-        aria-hidden={!rightPanelOpen}
+    <div className="relative flex flex-col h-screen bg-warm-bg dark:bg-dark-bg text-warm-text dark:text-dark-text">
+      <AppTopBar
+        sidebarCollapsed={sidebarCollapsed}
+        onToggleSidebar={onToggleSidebar}
       >
-        {rightPanel}
+        {topBar}
+      </AppTopBar>
+      <div className="flex flex-1 min-h-0">
+        <div
+          className="flex-none overflow-hidden"
+          style={{
+            width: sidebarCollapsed ? 0 : 240,
+            transition: 'width 200ms ease-out',
+          }}
+          aria-hidden={sidebarCollapsed}
+        >
+          {sidebar}
+        </div>
+        <div className="relative flex flex-col flex-1 min-w-0">
+          {children}
+        </div>
+        <div
+          className="flex-none overflow-hidden"
+          style={{
+            width: rightPanelOpen ? RIGHT_PANEL_WIDTH : 0,
+            transition: 'width 200ms ease-out',
+          }}
+          aria-hidden={!rightPanelOpen}
+        >
+          {rightPanel}
+        </div>
       </div>
     </div>
   )

--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -255,27 +255,13 @@ export default function ShareEditorPage({
         onPdf={() => { void exportPdf() }}
         onSpool={() => { void exportSpoolFile() }}
       />
-      {/* Always mounted so toggling panelOpen doesn't snap-shift the
-          Download button. The button's width, leading margin, and
-          opacity all animate in sync with the right panel's 200ms
-          width transition. When the panel is open the button shrinks
-          to zero width and the negative margin absorbs the parent's
-          gap-3 so Download sits flush against the right column. */}
       <button
         type="button"
         onClick={onTogglePanel}
-        title="Show style panel"
-        aria-label="Show style panel"
-        aria-pressed={false}
-        aria-hidden={panelOpen}
-        tabIndex={panelOpen ? -1 : 0}
-        style={{
-          width: panelOpen ? 0 : 28,
-          marginLeft: panelOpen ? -12 : 0,
-          opacity: panelOpen ? 0 : 1,
-          transition: 'width 200ms ease-out, margin-left 200ms ease-out, opacity 200ms ease-out',
-        }}
-        className="flex-none inline-flex items-center justify-center h-7 overflow-hidden rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text"
+        title={panelOpen ? 'Hide style panel' : 'Show style panel'}
+        aria-label={panelOpen ? 'Hide style panel' : 'Show style panel'}
+        aria-pressed={panelOpen}
+        className="flex-none inline-flex items-center justify-center w-7 h-7 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
       >
         <PanelRight size={15} strokeWidth={1.75} />
       </button>
@@ -288,7 +274,7 @@ export default function ShareEditorPage({
       sidebarCollapsed={sidebarCollapsed}
       onToggleSidebar={onToggleSidebar}
       topBar={topBarContent}
-      rightPanel={<ControlPanel opts={opts} setOpts={setOpts} onClose={onTogglePanel} />}
+      rightPanel={<ControlPanel opts={opts} setOpts={setOpts} />}
       rightPanelOpen={panelOpen}
     >
       <div className="flex flex-col h-full" data-testid="share-editor-page">

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -61,7 +61,7 @@ function DraftsList({
   }
   return (
     <ul
-      className="grid gap-5 px-6 pt-3 pb-6"
+      className="grid gap-5 px-6 pt-3 pb-6 justify-center"
       style={{ gridTemplateColumns: `repeat(auto-fill, ${CARD_W}px)` }}
     >
       {drafts.map((draft) => (
@@ -73,7 +73,7 @@ function DraftsList({
   )
 }
 
-const CARD_W = 170
+const CARD_W = 150
 const FALLBACK_RATIO = { w: 720, h: 960 }
 
 function DraftCard({

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -23,9 +23,15 @@ type Props = {
  */
 export default function SharesPage({ onOpenDraft }: Props) {
   const { drafts, loading, error } = useShareDrafts()
+  const hasDrafts = drafts.length > 0
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
+      {hasDrafts && (
+        <div className="flex-none px-6 pt-1.5 pb-3 font-mono text-[11px] text-warm-faint dark:text-dark-muted tabular-nums">
+          Drafts · {drafts.length}
+        </div>
+      )}
       <div className="flex-1 min-h-0 overflow-y-auto">
         <DraftsList drafts={drafts} loading={loading} error={error} onOpenDraft={onOpenDraft} />
       </div>
@@ -61,7 +67,7 @@ function DraftsList({
   }
   return (
     <ul
-      className="grid gap-5 px-6 pt-3 pb-6 justify-center"
+      className="grid gap-5 px-6 pb-6"
       style={{ gridTemplateColumns: `repeat(auto-fill, ${CARD_W}px)` }}
     >
       {drafts.map((draft) => (
@@ -73,7 +79,7 @@ function DraftsList({
   )
 }
 
-const CARD_W = 150
+const CARD_W = 158
 const FALLBACK_RATIO = { w: 720, h: 960 }
 
 function DraftCard({

--- a/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
+++ b/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { PanelRight } from 'lucide-react'
 import {
   COLORWAYS,
   PAPERS,
@@ -27,39 +26,29 @@ const COLORWAY_CHOICES = COLORWAYS.filter((c) => (COLORWAY_IDS as Set<string>).h
 type Props = {
   opts: EditorOpts
   setOpts: (next: EditorOpts) => void
-  onClose: () => void
 }
 
-export function ControlPanel({ opts, setOpts, onClose }: Props) {
+export function ControlPanel({ opts, setOpts }: Props) {
   const [advancedOpen, setAdvancedOpen] = useState(true)
   const currentColor = COLORWAY_CHOICES.find((c) => c.id === opts.colorway) ?? COLORWAY_CHOICES[0]!
   const currentPaper = PAPER_CHOICES.find((p) => p.id === opts.paper) ?? PAPER_CHOICES[0]!
   const currentTypeface = TYPEFACE_CHOICES.find((t) => t.id === opts.typeface) ?? TYPEFACE_CHOICES[0]!
 
   return (
+    <div className="w-full h-full p-2 pt-0">
     <aside
       data-testid="share-editor-style-panel"
-      className="w-full h-full bg-warm-surface dark:bg-dark-surface overflow-y-auto scrollbar-none flex flex-col"
+      className="w-full h-full bg-warm-bg dark:bg-dark-bg overflow-y-auto scrollbar-none flex flex-col rounded-[10px] border border-warm-border dark:border-dark-border"
     >
-      {/* First section's header lives in an h-9 row so it sits in the
-          same vertical band as the AppTopBar to the left — TEMPLATE
-          label visually aligns with the Download button. The panel
-          fold toggle occupies the right edge of this row. */}
-      <div className="flex-none h-9 pl-4 pr-2 flex items-center justify-between">
-        <div className="text-[11px] font-medium tracking-[0.08em] uppercase text-warm-muted dark:text-dark-muted leading-none">
-          Template
+      <div className="px-4 pt-3 pb-4">
+        <div className="flex items-baseline justify-between mb-3">
+          <div className="text-[11px] font-medium tracking-[0.08em] uppercase text-warm-muted dark:text-dark-muted leading-none">
+            Template
+          </div>
+          <div className="text-[11px] text-warm-faint dark:text-dark-muted leading-none">
+            {TEMPLATE_CHOICES.length} looks
+          </div>
         </div>
-        <button
-          type="button"
-          onClick={onClose}
-          title="Hide style panel"
-          aria-label="Hide style panel"
-          className="flex-none inline-flex items-center justify-center w-7 h-7 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
-        >
-          <PanelRight size={15} strokeWidth={1.75} />
-        </button>
-      </div>
-      <div className="px-4 pb-4">
         <div className="flex flex-col gap-1.5">
           {TEMPLATE_CHOICES.map((tpl) => {
             const active = opts.template === tpl.id
@@ -182,6 +171,7 @@ export function ControlPanel({ opts, setOpts, onClose }: Props) {
         />
       </Collapsible>
     </aside>
+    </div>
   )
 }
 


### PR DESCRIPTION
## What

The right-panel fold toggle, which lived inside `ControlPanel`'s first section header, scrolled out of reach the moment the user moved past the template cards. Three coordinated layout changes fix that and tidy the editor's shell.

The fold toggle moves back to the app top bar (always visible). The page layout flattens so the top bar spans the full window. The right panel itself stops being an edge-to-edge rail and becomes a floating card inset on three sides — matching the design-system "card" radius and border, with the canvas's warm-bg showing through around it.

## Why the layout flattens

Previously `PageLayout` was structured so the right column was a sibling of `[sidebar + (top bar + content)]`. The column extended from window top to bottom, and its first row could align vertically with the bar's row. That arrangement made sense when the fold toggle lived *inside* the panel — the bar was visually a property of the left-and-centre columns, and the right panel was its own self-contained vertical strip.

With the fold toggle back in the bar, the bar now logically governs all three columns. The natural shape is `flex-col` root, bar on top spanning the full width, then a `flex-row` below for `[sidebar | content | rightPanel]`. The right column starts below the bar instead of climbing past it.

The AppTopBar keeps its existing two-segment background (sidebar surface + content bg). The content-bg segment floods the area above the right rail too — so visually the bar reads as one continuous strip with the rail's surface tint appearing only below it. An earlier iteration painted a third surface-coloured segment over the right rail to match the panel; removing it (per feedback) makes the bar read cleaner and gives the floating-card panel its own visual identity.

## Why the panel becomes a floating card

A floor-to-ceiling rail with `bg-warm-surface` competes visually with the sidebar (also `bg-warm-surface`) — the page reads as two navigation columns flanking the content, which under-sells what the right panel actually is (a tool palette for editing the artifact).

The card treatment — `bg-warm-bg`, 1px `border-warm-border`, 10px `rounded-[10px]` (per DESIGN.md's card spec), inset 8px on left / right / bottom — sits on the canvas the way a tool palette would in Figma / Sketch / AFFiNE. It also lets the bar above read as one band: surface-colour on the left, content-colour everywhere else, with the card hovering below.

The inner sections (Template / Paper / Typeface / Colorway / More options) no longer rely on the rail's surface tint as negative space — each section's own widgets (template cards, paper swatches, typeface tiles, colorway swatches, chips, toggles) carry their own backgrounds, so flattening the panel doesn't make them disappear.

## Why the fold toggle is plain again

An earlier iteration of the panel toggle animated `width` / `margin-left` / `opacity` in sync with the right column's 200 ms width transition to avoid the Download button snapping left / right during toggle. With the toggle now living in the bar — whose width doesn't change with the panel — none of that machinery is needed. The button is a plain always-mounted control that flips its title between Show / Hide. The hack and its 25-line inline-style block come out.

## Why `ControlPanel`'s special TEMPLATE header goes away

The TEMPLATE row used to be an `h-9` band with the section label on the left and the close button on the right, sized to vertically align with the bar's traffic-light row across the layout boundary. That alignment was the *only* reason the row was special. With the close button gone from the panel (now in the bar) and the panel no longer needing to align with the bar (now sitting below it), the TEMPLATE row converts to a regular `Section` — same shape as Paper / Typeface / Colorway, consistent visual rhythm.

## Two small Shares polish commits also in this PR

Bundled because they touch the same layout / chrome area:

- **Card width.** Shrunk from 170 px to 158 px so four cards fit per row at default window width (~980 px usable after sidebar + paddings). Aspect ratio (3:4) and thumbnail scaling unchanged.
- **`Drafts · N` label.** Replaces the earlier "Shares" + count title above the grid. The sidebar already tells the user the page is Shares; this row's job is just "what kind of share, how many" — a faint mono `Drafts · 4` does that with less duplication. When Phase 2 lands Published, a second row can sit next to or below it.

## How it connects

- The fold-toggle hack this PR removes was introduced in #166 to mitigate the same problem from the wrong angle (try to make the in-panel toggle feel like it animated with the layout). The proper fix was always to move the toggle, but it required the layout flatten that lands here.
- `PageLayout`'s API doesn't change — `topBar` / `sidebar` / `rightPanel` / `children` slots stay the same. The internal restructure is invisible to callers other than `ShareEditorPage`.
- No schema, IPC, or persistence changes — pure shell rework.