### PR TITLE
polish(app): selectable preview text, accurate PDF copy, tidy template cards

### DIFF
--- a/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
+++ b/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
@@ -74,13 +74,13 @@ export function ControlPanel({ opts, setOpts }: Props) {
                 />
                 <div className="flex-1 min-w-0">
                   <div
-                    className={`text-[13px] font-medium ${
+                    className={`text-xs font-medium leading-tight ${
                       active ? 'text-accent dark:text-accent-dark' : 'text-warm-text dark:text-dark-text'
                     }`}
                   >
                     {tpl.name}
                   </div>
-                  <div className="text-[10.5px] text-warm-muted dark:text-dark-muted font-mono leading-snug mt-0.5 truncate">
+                  <div className="text-[10px] text-warm-muted dark:text-dark-muted font-mono leading-tight line-clamp-2">
                     {tpl.blurb}
                   </div>
                 </div>

--- a/packages/app/src/renderer/components/share-editor/DownloadButton.tsx
+++ b/packages/app/src/renderer/components/share-editor/DownloadButton.tsx
@@ -15,7 +15,7 @@ type FormatDef = {
 
 const FORMATS: FormatDef[] = [
   { k: 'png', l: 'PNG image', b: 'Download PNG', s: '3× pixel ratio · social-feed friendly' },
-  { k: 'pdf', l: 'PDF', b: 'Download PDF', s: 'Single page · print-ready' },
+  { k: 'pdf', l: 'PDF', b: 'Download PDF', s: 'A4 paginated · print-ready' },
   { k: 'spool', l: 'Spool file', b: 'Download .spool', s: 'Editable in Spool · keeps your styling' },
 ]
 

--- a/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
+++ b/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
@@ -211,7 +211,7 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
                 willChange: 'transform',
               }}
             >
-              <div ref={setRefs} style={{ width: ratio.w }}>
+              <div ref={setRefs} style={{ width: ratio.w, userSelect: 'text' }}>
                 <TemplateRender template={opts.template} convo={convo} opts={opts} />
               </div>
             </div>

--- a/packages/app/src/renderer/components/share-editor/TemplateThumb.tsx
+++ b/packages/app/src/renderer/components/share-editor/TemplateThumb.tsx
@@ -13,7 +13,7 @@ type Props = {
 export function TemplateThumb({ id, accent, paper, border, text, muted, surface }: Props) {
   const baseStyle: React.CSSProperties = {
     width: 48,
-    height: 38,
+    height: 44,
     borderRadius: 2,
     background: paper,
     border: `1px solid ${border}`,


### PR DESCRIPTION
Four small fixes that surfaced once Phase 0 was in the user's hands. None of them touch schema, IPC, or persistence — pure renderer-side polish.

**Preview text was unselectable.** The app sets `body { user-select: none }` to keep the sidebar / top bar / nav rows from being accidentally selected during normal click-around. The rendered conversation in the share editor inherits that rule, so users couldn't copy a quote out of the preview into a chat or doc. Scoping a `user-select: text` override onto the TemplateRender wrapper enables selection inside the artifact while leaving the chrome guard intact everywhere else.

**The PDF download menu lied.** The subtitle said "Single page · print-ready" — but PDF export prints at A4 and Chromium paginates vertically as content runs, which means anything longer than ~30 turns produces multiple pages. The pagination is the right behaviour (forcing a single page would mean printing a 1-meter-tall artifact, which no reader / printer handles well). Fix the copy instead: "A4 paginated · print-ready".

**Template cards read loose after the blurb wrap landed.** A prior PR (#171) let the blurb wrap to two lines via `line-clamp-2` because the one-line version truncated mid-word at default panel width. With two lines visible, the original `13px` name + `mt-0.5` gap + `leading-snug` blurb spread the right column out vertically. Tightened to `12px` name, no gap, `leading-tight` on both — the card stops feeling top-heavy without losing legibility (12px is still on the DESIGN.md body scale).

**Template thumbnail was visually floating** at the old 38px height against the new 2-line right column. Bumped to 44px so the icon's vertical center sits roughly where the right column's center sits, without stretching all the way to floor-to-ceiling (which made the icon read square and lose its document-like proportion).