### PR TITLE
fix(app): open external links in default browser

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -113,6 +113,26 @@ function createWindow(): BrowserWindow {
     win.loadFile(join(__dirname, '../renderer/index.html'))
   }
 
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    if (/^https?:/i.test(url) || /^mailto:/i.test(url)) {
+      void shell.openExternal(url)
+    }
+    return { action: 'deny' }
+  })
+
+  win.webContents.on('will-navigate', (event, url) => {
+    const current = win.webContents.getURL()
+    const isInternal =
+      url === current ||
+      url.startsWith('file://') ||
+      (!!process.env['ELECTRON_RENDERER_URL'] && url.startsWith(process.env['ELECTRON_RENDERER_URL']))
+    if (isInternal) return
+    if (/^https?:/i.test(url) || /^mailto:/i.test(url)) {
+      event.preventDefault()
+      void shell.openExternal(url)
+    }
+  })
+
   win.on('closed', () => {
     mainWindow = null
     if (!isDevMode) app.dock?.hide()


### PR DESCRIPTION
## Summary
- External links (e.g. `<a target="_blank">` from rendered markdown) currently spawn a bare Electron BrowserWindow — no toolbar, no address bar, no profile, no extensions. Route them to the OS default browser instead.
- Added `setWindowOpenHandler` and a `will-navigate` guard in `createWindow()`. Both forward `http(s)`/`mailto` URLs to `shell.openExternal` and block in-app navigation; internal navigation (file://, dev renderer URL) is untouched.

## Test plan
- [x] Click a markdown link in an AI answer → opens in default browser, no Electron popup
- [x] `tsc --noEmit` clean
- [ ] Verify links in non-markdown surfaces (Settings, about box, etc.) still behave

🤖 Generated with [Claude Code](https://claude.com/claude-code)