### PR TITLE
polish(app): refine session row visuals in Library and Project views

### DIFF
--- a/packages/app/src/renderer/components/Badges.tsx
+++ b/packages/app/src/renderer/components/Badges.tsx
@@ -1,15 +1,24 @@
-import { getSessionSourceColor, getSessionSourceShortLabel } from '../../shared/sessionSources.js'
+import {
+  getSessionSourceColor,
+  getSessionSourceColorDark,
+  getSessionSourceShortLabel,
+} from '../../shared/sessionSources.js'
+import { useIsDark } from '../hooks/useIsDark.js'
 
 export function SourceBadge({ source }: { source: string }) {
+  const isDark = useIsDark()
+  const color = isDark ? getSessionSourceColorDark(source) : getSessionSourceColor(source)
   return (
     <span
       data-testid="source-badge"
       data-source={source}
-      className="text-[10px] font-semibold font-mono px-1.5 py-0.5 rounded text-white"
-      style={{ background: getSessionSourceColor(source) }}
+      className="text-[10px] font-mono font-medium px-1.5 py-0.5 rounded"
+      style={{
+        background: `color-mix(in srgb, ${color} ${isDark ? '16%' : '12%'}, transparent)`,
+        color,
+      }}
     >
       {getSessionSourceShortLabel(source)}
     </span>
   )
 }
-

--- a/packages/app/src/renderer/components/LibraryLanding.tsx
+++ b/packages/app/src/renderer/components/LibraryLanding.tsx
@@ -102,6 +102,7 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId }: Props
                     key={session.sessionUuid}
                     session={session}
                     showProject
+                    bucket={bucket.label}
                     onPinChange={handlePinChange}
                     onOpenSession={onOpenSession}
                     onCopySessionId={onCopySessionId}
@@ -118,14 +119,12 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId }: Props
 
 export function CollapsibleSection({
   label,
-  accent = false,
   children,
   testId,
   dataAttr,
   defaultOpen = true,
 }: {
   label: string
-  accent?: boolean
   children: ReactNode
   testId?: string
   dataAttr?: Record<string, string>
@@ -138,9 +137,7 @@ export function CollapsibleSection({
         type="button"
         onClick={() => setOpen(o => !o)}
         aria-expanded={open}
-        className={`group w-full flex items-center gap-1.5 px-6 pt-3 pb-1 text-[10px] font-semibold tracking-[0.08em] text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75 select-none ${
-          accent ? 'bg-accent/[0.04] dark:bg-accent-dark/[0.04]' : ''
-        }`}
+        className="group w-full flex items-center gap-1.5 px-6 pt-3 pb-1 text-[10px] font-semibold tracking-[0.08em] text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75 select-none"
       >
         <span>{label}</span>
         <svg

--- a/packages/app/src/renderer/components/ProjectView.tsx
+++ b/packages/app/src/renderer/components/ProjectView.tsx
@@ -171,7 +171,7 @@ export default function ProjectView({
 
   return (
     <div data-testid="project-view" className="flex flex-col h-full overflow-hidden">
-      <div className="flex-none px-6 pt-1.5 pb-3 border-b border-warm-border dark:border-dark-border">
+      <div className="flex-none px-6 pt-1.5 pb-3">
         <div className="flex items-baseline gap-3 flex-wrap">
           <h1 className="text-xl font-semibold tracking-tight text-warm-text dark:text-dark-text">
             {group?.displayName ?? identityKey}
@@ -314,10 +314,9 @@ export default function ProjectView({
             {visiblePinned.length > 0 && (
               <CollapsibleSection
                 label={`PINNED · ${visiblePinned.length} ${visiblePinned.length === 1 ? 'session' : 'sessions'}`}
-                accent
                 testId="project-view-pinned"
               >
-                <div className="bg-accent/[0.02] dark:bg-accent-dark/[0.02]">
+                <div>
                   {visiblePinned.map(session => (
                     <SessionRow
                       key={session.sessionUuid}
@@ -434,23 +433,21 @@ function DirectoryGroupSection({
         <span className="font-mono text-[11px] font-medium truncate">
           {name}
         </span>
-        <span className="ml-auto flex items-center gap-2 flex-none self-center">
-          {count > 1 && (
-            <span className="font-mono text-[10px] tabular-nums">
-              {count}
-            </span>
-          )}
-          <svg
-            width="9"
-            height="9"
-            viewBox="0 0 9 9"
-            fill="none"
-            aria-hidden
-            className={`flex-none transition-all opacity-30 group-hover:opacity-100 ${open ? 'rotate-90' : ''}`}
-          >
-            <path d="M3 1.5L6 4.5L3 7.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        </span>
+        {count > 1 && (
+          <span className="font-mono text-[10px] tabular-nums flex-none">
+            {count}
+          </span>
+        )}
+        <svg
+          width="9"
+          height="9"
+          viewBox="0 0 9 9"
+          fill="none"
+          aria-hidden
+          className={`flex-none transition-all opacity-30 group-hover:opacity-100 ${open ? 'rotate-90' : ''}`}
+        >
+          <path d="M3 1.5L6 4.5L3 7.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
       </button>
       {open && (
         <div>

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -11,16 +11,18 @@ type Props = {
   session: Session
   pinned?: boolean
   showProject?: boolean
+  bucket?: string
   onPinChange?: (uuid: string, pinned: boolean) => void
   onOpenSession: (uuid: string) => void
   onCopySessionId: (source: Session['source']) => void
 }
 
-export default function SessionRow({ session, pinned = false, showProject = false, onPinChange, onOpenSession, onCopySessionId }: Props) {
+export default function SessionRow({ session, pinned = false, showProject = false, bucket, onPinChange, onOpenSession, onCopySessionId }: Props) {
   const [resuming, setResuming] = useState(false)
 
   const title = session.title?.trim() || '(no title)'
-  const date = formatRelativeDate(session.startedAt)
+  const date = formatRelativeDate(session.startedAt, { bucket })
+  const model = compactModel(session.model)
 
   function handleOpen() {
     onOpenSession(session.sessionUuid)
@@ -56,7 +58,7 @@ export default function SessionRow({ session, pinned = false, showProject = fals
           handleOpen()
         }
       }}
-      className="group flex items-start gap-3 px-5 py-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors duration-75 border-b border-warm-border dark:border-dark-border cursor-pointer focus:outline-none focus:bg-warm-surface dark:focus:bg-dark-surface"
+      className="group flex items-start gap-3 px-5 py-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors duration-75 cursor-pointer focus:outline-none focus:bg-warm-surface dark:focus:bg-dark-surface"
     >
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2 mb-0.5">
@@ -66,14 +68,25 @@ export default function SessionRow({ session, pinned = false, showProject = fals
           </span>
         </div>
         <p className="text-xs text-warm-faint dark:text-dark-muted truncate">
-          {showProject && <span className="text-warm-muted dark:text-dark-muted">{session.projectDisplayName} · </span>}
-          {date} · {session.messageCount} {session.messageCount === 1 ? 'message' : 'messages'}
-          {session.model && ` · ${session.model}`}
+          {showProject && (
+            <>
+              <span className="text-warm-muted dark:text-dark-muted">{session.projectDisplayName}</span>
+              {' · '}
+            </>
+          )}
+          {date} · {session.messageCount} {session.messageCount === 1 ? 'msg' : 'msgs'}
+          {model && ` · ${model}`}
         </p>
       </div>
 
       <div className="flex-none flex items-center gap-1 -mt-0.5" onClick={(e) => e.stopPropagation()}>
-        <span className={pinned ? '' : 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity'}>
+        <span
+          className={
+            pinned
+              ? 'opacity-70 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity'
+              : 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity'
+          }
+        >
           <PinButton
             sessionUuid={session.sessionUuid}
             pinned={pinned}
@@ -122,6 +135,18 @@ export default function SessionRow({ session, pinned = false, showProject = fals
       </div>
     </div>
   )
+}
+
+function compactModel(model: string | null | undefined): string {
+  if (!model) return ''
+  const m = model.match(/^claude-(opus|sonnet|haiku)(?:-(\d+))?(?:-(\d+))?$/)
+  if (!m) return model
+  const name = m[1]!
+  const major = m[2]
+  const minor = m[3]
+  if (minor) return `${name} ${major}.${minor}`
+  if (major) return `${name} ${major}`
+  return name
 }
 
 function PlayIcon() {

--- a/packages/app/src/renderer/styles.css
+++ b/packages/app/src/renderer/styles.css
@@ -39,7 +39,7 @@
 
   /* Source badges */
   --color-src-claude: #6B5B8A;
-  --color-src-codex: #1A6B3C;
+  --color-src-codex: #2F7A4A;
   --color-src-gemini: #4285F4;
 
   /* Typography */

--- a/packages/app/src/shared/formatDate.ts
+++ b/packages/app/src/shared/formatDate.ts
@@ -1,13 +1,27 @@
-export function formatRelativeDate(iso: string): string {
+export function formatRelativeDate(iso: string, opts?: { bucket?: string | undefined }): string {
   try {
     const d = new Date(iso)
     const now = new Date()
-    const diffDays = Math.floor((now.getTime() - d.getTime()) / 86400000)
-    if (diffDays === 0) return 'today'
-    if (diffDays === 1) return 'yesterday'
-    if (diffDays < 7) return `${diffDays}d ago`
-    return d.toLocaleDateString()
+    const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
+    const startOfSessionDay = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
+    const dayDiff = Math.round((startOfToday - startOfSessionDay) / 86400000)
+    if (dayDiff <= 0) {
+      const time = formatTime(d)
+      return opts?.bucket === 'TODAY' ? time : `today, ${time}`
+    }
+    if (dayDiff === 1) {
+      const time = formatTime(d)
+      return opts?.bucket === 'YESTERDAY' ? time : `yesterday, ${time}`
+    }
+    if (d.getFullYear() === now.getFullYear()) {
+      return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' }).format(d)
+    }
+    return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(d)
   } catch {
     return iso.slice(0, 10)
   }
+}
+
+function formatTime(d: Date): string {
+  return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`
 }

--- a/packages/app/src/shared/sessionSources.ts
+++ b/packages/app/src/shared/sessionSources.ts
@@ -3,21 +3,28 @@ const SESSION_SOURCE_META = {
     label: 'Claude Code',
     shortLabel: 'claude',
     color: '#6B5B8A',
+    colorDark: '#9B8BBF',
   },
   codex: {
     label: 'Codex CLI',
     shortLabel: 'codex',
-    color: '#1A6B3C',
+    color: '#2F7A4A',
+    colorDark: '#7AC78F',
   },
   gemini: {
     label: 'Gemini CLI',
     shortLabel: 'gemini',
     color: '#4285F4',
+    colorDark: '#7AA8E0',
   },
 } as const
 
 export function getSessionSourceColor(source: string): string {
   return SESSION_SOURCE_META[source as keyof typeof SESSION_SOURCE_META]?.color ?? '#888888'
+}
+
+export function getSessionSourceColorDark(source: string): string {
+  return SESSION_SOURCE_META[source as keyof typeof SESSION_SOURCE_META]?.colorDark ?? '#A8A8A0'
 }
 
 export function getSessionSourceLabel(source: string): string {


### PR DESCRIPTION
## What

Polish pass over the session row component used in Library home and Project detail.

- **Source badges** — switched from solid color + white text to a 12–16% tinted background with same-color text (font weight 600 → 500). Added dark-mode source colors that were missing per `DESIGN.md`; also softened codex green so claude/codex/gemini sit in the same lightness family on dark.
- **Date display** — formatter is now context-aware:
  - Library, in `TODAY` bucket: `14:32`
  - Library, in `YESTERDAY` bucket: `23:47`
  - Library, 2 days–same year: `Apr 28`
  - Library, cross year: `Apr 28, 2025`
  - Project view (no bucket): same shape but with `today, ` / `yesterday, ` prefix to disambiguate the bare time.
- **Bucketing bug fix** — `formatRelativeDate` used a rolling 24-hour window while `bucketByDate` uses calendar-day boundaries, so a session started at 23:00 yesterday could be bucketed under `YESTERDAY` while the row still rendered `today`. Both now share the same calendar-day math.
- **Meta line tightening** — `claude-opus-4-7` → `opus 4.7`, `messages` → `msgs`.
- **Quiet rhythm** — removed per-row bottom dividers, the project header's bottom border, and the pinned section's accent wash. Section labels + hover state carry the structure.
- **Directory group header** — count + chevron now sit next to the directory name on the left instead of floating to the far right.
- **Pin icon** — pinned state is `opacity-70` at rest, lifts to 100 on hover.

## Why

The session row was the most-repeated element in the app but several details drifted from `DESIGN.md`'s "warm index" direction:

- Solid-fill badges with white text shouted in a list of dozens; the spec describes badges as supporting identifiers, not loud chrome.
- The `today` / `yesterday` strings were redundant once the user had already entered a `TODAY` bucket — but completely hiding the time also threw away useful "morning vs late night" signal. The new format keeps the precision without the redundancy.
- The pinned section background tint, per-row dividers, and project-header border were all line-art that compounded with the badge density to make the surface feel busier than its low-key competitors (Linear, Notion, Apple Mail).

## How it connects

- `SessionRow` gains an optional `bucket` prop, threaded from `LibraryLanding` so the formatter can drop the redundant date prefix.
- `formatRelativeDate` keeps the same signature for existing callers (`SearchOverlay`, `SessionDetail`, `ProjectView` header, `FragmentResults`) — they get the unbucketed format (`today, 14:32` etc.), which is strictly more informative than the previous `today`.
- `SourceBadge` consumes a new `useIsDark`-driven dark color from `sessionSources.ts`; the colors there now match `DESIGN.md`'s source-badge table (with the codex tweak called out above).

## Test plan

- [ ] Library home: `TODAY` rows show only `HH:MM`, `YESTERDAY` rows show only `HH:MM`, `EARLIER THIS WEEK / MONTH` rows show `Mon DD`, older rows show `Mon DD, YYYY`.
- [ ] Project view: today/yesterday rows show `today, HH:MM` / `yesterday, HH:MM`; older rows show `Mon DD` / `Mon DD, YYYY`.
- [ ] A session started yesterday at 23:00 is bucketed under `YESTERDAY` and its row renders `23:00`, not `today`.
- [ ] Source badges read clearly in both light and dark mode with no white-on-color chips.
- [ ] Pinned section in Project view has no orange wash; project-header has no bottom border.
- [ ] Directory group header shows `name <count> <chevron>` clustered on the left.