### PR TITLE
polish(app): smarter loading skeleton for Shares page

### DIFF
--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { Newspaper } from 'lucide-react'
 import { useShareDrafts } from '../hooks/useShareDrafts'
 import type { ShareDraftListItem } from '@spool-lab/core'
@@ -50,8 +50,32 @@ function DraftsList({
   error: string | null
   onOpenDraft?: ((draft: ShareDraftListItem) => void) | undefined
 }) {
+  const [skeletonCount] = useState(readSkeletonCount)
+  // Defer skeleton render by 150ms so sub-threshold loads (local sqlite is
+  // usually <50ms) don't flash a meaningless placeholder. The same gate
+  // applies to the screen-reader announcement: if loading is imperceptible
+  // visually, there's no value announcing it either.
+  const [showLoadingHint, setShowLoadingHint] = useState(false)
+  useEffect(() => {
+    if (!loading || drafts.length > 0) {
+      setShowLoadingHint(false)
+      return
+    }
+    const t = setTimeout(() => setShowLoadingHint(true), 150)
+    return () => clearTimeout(t)
+  }, [loading, drafts.length])
+  useEffect(() => {
+    if (!loading && !error) writeSkeletonCount(drafts.length)
+  }, [loading, error, drafts.length])
+
   if (loading && drafts.length === 0) {
-    return <SmallEmptyState>Loading drafts…</SmallEmptyState>
+    if (!showLoadingHint) return null
+    return (
+      <>
+        <span className="sr-only" role="status">Loading drafts…</span>
+        {skeletonCount > 0 && <DraftsSkeleton count={skeletonCount} />}
+      </>
+    )
   }
   if (error) {
     return <SmallEmptyState>Couldn't load drafts: {error}</SmallEmptyState>
@@ -194,6 +218,53 @@ function DraftCard({
         </span>
       </span>
     </button>
+  )
+}
+
+const SKELETON_COUNT_KEY = 'spool.shares.skeletonCount'
+const SKELETON_COUNT_DEFAULT = 4
+const SKELETON_COUNT_MAX = 24
+
+function readSkeletonCount(): number {
+  try {
+    const raw = localStorage.getItem(SKELETON_COUNT_KEY)
+    if (raw === null) return SKELETON_COUNT_DEFAULT
+    const n = Number(raw)
+    if (!Number.isFinite(n) || n < 0) return SKELETON_COUNT_DEFAULT
+    return Math.min(Math.floor(n), SKELETON_COUNT_MAX)
+  } catch {
+    return SKELETON_COUNT_DEFAULT
+  }
+}
+
+function writeSkeletonCount(n: number): void {
+  try {
+    const clamped = Math.min(Math.max(0, Math.floor(n)), SKELETON_COUNT_MAX)
+    localStorage.setItem(SKELETON_COUNT_KEY, String(clamped))
+  } catch {
+    // localStorage can throw (private mode, quota); skeleton just falls
+    // back to the default count on the next mount.
+  }
+}
+
+function DraftsSkeleton({ count }: { count: number }) {
+  const cardH = Math.round(CARD_W * (FALLBACK_RATIO.h / FALLBACK_RATIO.w))
+  return (
+    <ul
+      aria-hidden
+      data-testid="shares-skeleton"
+      className="grid gap-5 px-6 pt-3 pb-6"
+      style={{ gridTemplateColumns: `repeat(auto-fill, ${CARD_W}px)` }}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <li key={i}>
+          <div
+            className="rounded-md bg-warm-surface2 dark:bg-dark-surface2 border border-warm-border dark:border-dark-border opacity-60 animate-pulse"
+            style={{ width: CARD_W, height: cardH }}
+          />
+        </li>
+      ))}
+    </ul>
   )
 }
 


### PR DESCRIPTION
## What

Replaces the small `Loading drafts…` text on the Shares page with a card-shaped skeleton grid that mirrors the real draft layout.

## Why

Phase 0 Shares ships a small-text loading state that doesn't look related to the grid it's about to become — a brief visual flicker that reads as "something is broken" before content lands. A skeleton matching the final layout removes the layout shift and looks intentional.

## How it works

- Skeleton uses the same `auto-fill` grid + 158px card size as real drafts, with the codebase's existing `bg-warm-surface2 / animate-pulse / opacity-60` pattern from `SessionRowsSkeleton`.
- Count is seeded from the user's last observed draft count, persisted in `localStorage` (`spool.shares.skeletonCount`, clamped 0–24). New users get a conservative default of 4; repeat users see a skeleton shaped like what they actually have, which keeps the skeleton → real-data transition nearly shift-free.
- Render is deferred by **150ms** so sub-threshold loads (local sqlite is usually <50ms) don't flash a meaningless placeholder. The same gate covers an `sr-only` `role="status"` "Loading drafts…" announcement, so AT users hear it exactly when it's perceptible — preserving the original announcement behavior without spamming on fast loads.
- If the user has zero drafts, the previously stored 0 makes the next mount skip the skeleton entirely and go straight to the empty state.
- `localStorage` errors (private mode / quota) silently fall back to the default count.

## Test plan

- [ ] Sidebar → Shares with existing drafts: no perceptible flicker; content appears without layout jump
- [ ] Sidebar → Shares with zero drafts: empty state appears without a skeleton flash
- [ ] DevTools: set `localStorage.setItem('spool.shares.skeletonCount', '12')` and reload; confirm skeleton shape on slow disk / artificial delay
- [ ] Refresh while drafts are visible: existing cards stay rendered (no flash back to skeleton)
- [ ] Toggle dark mode: skeleton tones swap correctly via `bg-warm-surface2 dark:bg-dark-surface2`
- [ ] Screen reader: "Loading drafts…" is announced when loading exceeds 150ms

cc @graydawnc