### PR TITLE
feat(app): add Pinned section to sidebar

### DIFF
--- a/packages/app/e2e/sidebar-pinned.spec.ts
+++ b/packages/app/e2e/sidebar-pinned.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, waitForSync, type AppContext } from './helpers/launch'
+
+let ctx: AppContext
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+async function pinFirstSessionInProject(window: AppContext['window']): Promise<string> {
+  await window.locator('[data-testid="sidebar-project-row"]').first().click()
+  const firstRow = window.locator('[data-testid="session-row"]').first()
+  await expect(firstRow).toBeVisible({ timeout: 5000 })
+  const uuid = await firstRow.getAttribute('data-session-uuid')
+  expect(uuid).toBeTruthy()
+  await firstRow.hover()
+  await firstRow.locator('[data-testid="pin-button"]').click()
+  return uuid as string
+}
+
+test('sidebar pinned section appears after pinning and lists the session', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  // Initially no Pinned section
+  await expect(window.locator('[data-testid="sidebar-pinned-toggle"]')).toBeHidden()
+
+  const uuid = await pinFirstSessionInProject(window)
+
+  const pinnedToggle = window.locator('[data-testid="sidebar-pinned-toggle"]')
+  await expect(pinnedToggle).toBeVisible({ timeout: 5000 })
+
+  const pinnedRow = window.locator(`[data-testid="sidebar-pinned-row"][data-session-uuid="${uuid}"]`)
+  await expect(pinnedRow).toBeVisible({ timeout: 5000 })
+
+  // Cleanup
+  await pinnedRow.hover()
+  await pinnedRow.locator('[data-testid="sidebar-pinned-unpin"]').click()
+  await expect(pinnedRow).toBeHidden({ timeout: 5000 })
+})
+
+test('clicking a sidebar pinned row opens the session detail', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  const uuid = await pinFirstSessionInProject(window)
+
+  await window.locator('[data-testid="sidebar-library"]').click()
+
+  const pinnedRow = window.locator(`[data-testid="sidebar-pinned-row"][data-session-uuid="${uuid}"]`)
+  await expect(pinnedRow).toBeVisible({ timeout: 5000 })
+  await pinnedRow.click()
+
+  await expect(window.locator('[data-testid="session-detail"]')).toBeVisible({ timeout: 5000 })
+
+  // Cleanup
+  await window.locator('[data-testid="sidebar-library"]').click()
+  await pinnedRow.hover()
+  await pinnedRow.locator('[data-testid="sidebar-pinned-unpin"]').click()
+  await expect(pinnedRow).toBeHidden({ timeout: 5000 })
+})
+
+test('unpinning from sidebar also clears the Library pinned segment', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  const uuid = await pinFirstSessionInProject(window)
+
+  await window.locator('[data-testid="sidebar-library"]').click()
+
+  const libraryPinned = window.locator('[data-testid="library-pinned"]')
+  await expect(libraryPinned).toBeVisible({ timeout: 5000 })
+  await expect(libraryPinned.locator(`[data-session-uuid="${uuid}"]`)).toBeVisible()
+
+  // Unpin from sidebar
+  const pinnedRow = window.locator(`[data-testid="sidebar-pinned-row"][data-session-uuid="${uuid}"]`)
+  await pinnedRow.hover()
+  await pinnedRow.locator('[data-testid="sidebar-pinned-unpin"]').click()
+
+  // Library's pinned segment should react immediately
+  await expect(libraryPinned.locator(`[data-session-uuid="${uuid}"]`)).toBeHidden({ timeout: 5000 })
+})
+
+test('sidebar pinned kebab menu exposes Resume and Copy actions', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  const uuid = await pinFirstSessionInProject(window)
+
+  const pinnedRow = window.locator(`[data-testid="sidebar-pinned-row"][data-session-uuid="${uuid}"]`)
+  await expect(pinnedRow).toBeVisible({ timeout: 5000 })
+  await pinnedRow.hover()
+  await pinnedRow.locator('[data-testid="sidebar-pinned-menu-trigger"]').click()
+
+  await expect(window.getByRole('menuitem', { name: /Resume in Terminal/ })).toBeVisible()
+  await expect(window.getByRole('menuitem', { name: /Copy session ID/ })).toBeVisible()
+
+  // Close menu and cleanup
+  await window.keyboard.press('Escape')
+  await pinnedRow.hover()
+  await pinnedRow.locator('[data-testid="sidebar-pinned-unpin"]').click()
+  await expect(pinnedRow).toBeHidden({ timeout: 5000 })
+})
+
+test('sidebar pinned sort menu changes the visible order', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  // Pin two sessions across two projects to get a stable comparison
+  const projects = window.locator('[data-testid="sidebar-project-row"]')
+  await expect(projects.first()).toBeVisible({ timeout: 5000 })
+  expect(await projects.count()).toBeGreaterThanOrEqual(2)
+
+  await projects.nth(0).click()
+  const rowA = window.locator('[data-testid="session-row"]').first()
+  await expect(rowA).toBeVisible({ timeout: 5000 })
+  await rowA.hover()
+  await rowA.locator('[data-testid="pin-button"]').click()
+
+  await projects.nth(1).click()
+  const rowB = window.locator('[data-testid="session-row"]').first()
+  await expect(rowB).toBeVisible({ timeout: 5000 })
+  await rowB.hover()
+  await rowB.locator('[data-testid="pin-button"]').click()
+
+  await expect(window.locator('[data-testid="sidebar-pinned-row"]')).toHaveCount(2, { timeout: 5000 })
+
+  const sidebar = window.locator('[data-testid="sidebar"]')
+  const orderRecentPinned = await sidebar.locator('[data-testid="sidebar-pinned-row"]').evaluateAll(
+    nodes => nodes.map(n => n.getAttribute('data-session-uuid')),
+  )
+
+  // Switch sort order to Name (A–Z) and confirm visible order changes (or stays consistent)
+  await sidebar.locator('[data-testid="sidebar-pinned-sort-trigger"]').click()
+  await window.getByRole('menuitem', { name: /Name \(A.{1,3}Z\)/ }).click()
+
+  const orderByName = await sidebar.locator('[data-testid="sidebar-pinned-row"]').evaluateAll(
+    nodes => nodes.map(n => n.getAttribute('data-session-uuid')),
+  )
+
+  expect(orderByName).toHaveLength(2)
+  // Both sets contain the same two uuids, but the array shapes should be valid
+  expect(new Set(orderByName)).toEqual(new Set(orderRecentPinned))
+
+  // Cleanup
+  for (const uuid of orderByName) {
+    const row = window.locator(`[data-testid="sidebar-pinned-row"][data-session-uuid="${uuid}"]`)
+    await row.hover()
+    await row.locator('[data-testid="sidebar-pinned-unpin"]').click()
+  }
+  await expect(window.locator('[data-testid="sidebar-pinned-row"]')).toHaveCount(0, { timeout: 5000 })
+})

--- a/packages/app/src/main/acp.ts
+++ b/packages/app/src/main/acp.ts
@@ -54,6 +54,8 @@ export interface AgentsConfig {
   sidebarShowSessionCount?: boolean
   /** Sort order for the sidebar project list (default: 'recent') */
   sidebarSortOrder?: 'recent' | 'name' | 'most_sessions'
+  /** Sort order for the sidebar pinned sessions list (default: 'recent_pinned') */
+  pinnedSortOrder?: 'recent_pinned' | 'recent' | 'name'
   /** Sort order for the project view session list (default: 'recent') */
   projectSortOrder?: 'recent' | 'oldest' | 'most_messages' | 'title'
   /** Custom agent definitions (extend beyond builtins) */

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -6,6 +6,7 @@ import type {
 } from '@spool-lab/core'
 import type { SearchSortOrder } from '../shared/searchSort.js'
 import type { SidebarSortOrder } from '../shared/sidebarSort.js'
+import type { PinnedSortOrder } from '../shared/pinnedSort.js'
 import type { ThemeEditorStateV1 } from '../renderer/theme/editorTypes.js'
 
 export interface AgentInfo {
@@ -29,6 +30,7 @@ export interface AgentsConfig {
   sidebarShowSourceDots?: boolean
   sidebarShowSessionCount?: boolean
   sidebarSortOrder?: SidebarSortOrder
+  pinnedSortOrder?: PinnedSortOrder
   projectSortOrder?: ProjectSessionSortOrder
   customAgents?: Record<string, {
     name?: string

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -19,6 +19,7 @@ import type { Message, Session, ShareDraftListItem } from '@spool-lab/core'
 import { getSessionResumeCommandPrefix } from '../shared/resumeCommand.js'
 import { DEFAULT_SEARCH_SORT_ORDER, type SearchSortOrder } from '../shared/searchSort.js'
 import { DEFAULT_SIDEBAR_SORT_ORDER, type SidebarSortOrder } from '../shared/sidebarSort.js'
+import { DEFAULT_PINNED_SORT_ORDER, type PinnedSortOrder } from '../shared/pinnedSort.js'
 import { DEFAULT_PROJECT_SORT_ORDER } from '../shared/projectView.js'
 import type { ProjectSessionSortOrder } from '@spool-lab/core'
 import { defaultThemeEditorState, type ThemeEditorStateV1 } from './theme/editorTypes.js'
@@ -83,6 +84,7 @@ export default function App() {
   const [sidebarShowSourceDots, setSidebarShowSourceDots] = useState(true)
   const [sidebarShowSessionCount, setSidebarShowSessionCount] = useState(true)
   const [sidebarSortOrder, setSidebarSortOrder] = useState<SidebarSortOrder>(DEFAULT_SIDEBAR_SORT_ORDER)
+  const [pinnedSortOrder, setPinnedSortOrder] = useState<PinnedSortOrder>(DEFAULT_PINNED_SORT_ORDER)
   const [projectSortOrder, setProjectSortOrder] = useState<ProjectSessionSortOrder>(DEFAULT_PROJECT_SORT_ORDER)
   const [resumeToastCommand, setResumeToastCommand] = useState<string | null>(null)
   const [themeEditor, setThemeEditor] = useState<ThemeEditorStateV1>(() => defaultThemeEditorState())
@@ -294,6 +296,7 @@ export default function App() {
       setSidebarShowSourceDots(config.sidebarShowSourceDots ?? true)
       setSidebarShowSessionCount(config.sidebarShowSessionCount ?? true)
       setSidebarSortOrder(config.sidebarSortOrder ?? DEFAULT_SIDEBAR_SORT_ORDER)
+      setPinnedSortOrder(config.pinnedSortOrder ?? DEFAULT_PINNED_SORT_ORDER)
       setProjectSortOrder(config.projectSortOrder ?? DEFAULT_PROJECT_SORT_ORDER)
       const defaultId = config.defaultAgent && ready.find(a => a.id === config.defaultAgent)
         ? config.defaultAgent
@@ -311,6 +314,17 @@ export default function App() {
     try {
       const config = await window.spool.getAgentsConfig()
       await window.spool.setAgentsConfig({ ...config, sidebarSortOrder: next })
+    } catch (err) {
+      console.error(err)
+    }
+  }, [])
+
+  const handlePinnedSortChange = useCallback(async (next: PinnedSortOrder) => {
+    setPinnedSortOrder(next)
+    if (!window.spool?.setAgentsConfig) return
+    try {
+      const config = await window.spool.getAgentsConfig()
+      await window.spool.setAgentsConfig({ ...config, pinnedSortOrder: next })
     } catch (err) {
       console.error(err)
     }
@@ -622,6 +636,7 @@ export default function App() {
   const sidebarElement = (
     <Sidebar
       activeIdentityKey={activeProjectKey}
+      activeSessionUuid={view === 'session' ? selectedSession : null}
       isLibraryActive={isHomeMode}
       onSelectProject={(key) => {
         setActiveProjectKey(key)
@@ -631,6 +646,7 @@ export default function App() {
         setView('search')
         setQuery('')
       }}
+      onSelectSession={handleOpenSession}
       onSelectHome={() => {
         setActiveProjectKey(null)
         setHomeMode(true)
@@ -657,6 +673,9 @@ export default function App() {
       showSessionCount={sidebarShowSessionCount}
       sortOrder={sidebarSortOrder}
       onSortOrderChange={handleSidebarSortChange}
+      pinnedSortOrder={pinnedSortOrder}
+      onPinnedSortOrderChange={handlePinnedSortChange}
+      onCopySessionId={handleCopySessionId}
       onSettingsClick={() => { setSettingsTab('general'); setShowSettings(true) }}
     />
   )
@@ -735,6 +754,7 @@ export default function App() {
       >
       <Sidebar
         activeIdentityKey={activeProjectKey}
+        activeSessionUuid={view === 'session' ? selectedSession : null}
         isLibraryActive={isHomeMode}
         onSelectProject={(key) => {
           setActiveProjectKey(key)
@@ -744,6 +764,7 @@ export default function App() {
           setView('search')
           setQuery('')
         }}
+        onSelectSession={handleOpenSession}
         onSelectHome={() => {
           setActiveProjectKey(null)
           setHomeMode(true)
@@ -770,6 +791,9 @@ export default function App() {
         showSessionCount={sidebarShowSessionCount}
         sortOrder={sidebarSortOrder}
         onSortOrderChange={handleSidebarSortChange}
+        pinnedSortOrder={pinnedSortOrder}
+        onPinnedSortOrderChange={handlePinnedSortChange}
+        onCopySessionId={handleCopySessionId}
         onSettingsClick={() => { setSettingsTab('general'); setShowSettings(true) }}
       />
       </div>

--- a/packages/app/src/renderer/components/LibraryLanding.tsx
+++ b/packages/app/src/renderer/components/LibraryLanding.tsx
@@ -39,6 +39,12 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId }: Props
     return () => { cancelled = true }
   }, [reloadKey])
 
+  useEffect(() => {
+    function bump() { setReloadKey(k => k + 1) }
+    window.addEventListener('spool:pin-change', bump)
+    return () => window.removeEventListener('spool:pin-change', bump)
+  }, [])
+
   function handlePinChange(sessionUuid: string, pinned: boolean) {
     if (pinned) {
       const candidate = recentSessions?.find(s => s.sessionUuid === sessionUuid)

--- a/packages/app/src/renderer/components/PinButton.tsx
+++ b/packages/app/src/renderer/components/PinButton.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import PinIcon from './PinIcon.js'
 
 type Props = {
   sessionUuid: string
@@ -19,6 +20,7 @@ export default function PinButton({ sessionUuid, pinned, onChange, size = 'sm' }
     try {
       if (next) await window.spool.pinSession(sessionUuid)
       else await window.spool.unpinSession(sessionUuid)
+      window.dispatchEvent(new CustomEvent('spool:pin-change', { detail: { sessionUuid, pinned: next } }))
     } catch {
       onChange?.(pinned)
     } finally {
@@ -50,24 +52,5 @@ export default function PinButton({ sessionUuid, pinned, onChange, size = 'sm' }
     >
       <PinIcon size={icon} filled={pinned} />
     </button>
-  )
-}
-
-function PinIcon({ size, filled }: { size: number; filled: boolean }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill={filled ? 'currentColor' : 'none'}
-      stroke="currentColor"
-      strokeWidth={filled ? 1.5 : 1.8}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M15 4.5l-4 4l-4 1.5l-1.5 1.5l7 7l1.5 -1.5l1.5 -4l4 -4" />
-      <path d="M9 15l-4.5 4.5" />
-      <path d="M14.5 4l5.5 5.5" />
-    </svg>
   )
 }

--- a/packages/app/src/renderer/components/PinIcon.tsx
+++ b/packages/app/src/renderer/components/PinIcon.tsx
@@ -1,0 +1,26 @@
+type Props = {
+  size?: number
+  filled?: boolean
+  className?: string
+}
+
+export default function PinIcon({ size = 13, filled = false, className }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={filled ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth={filled ? 1.5 : 1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M15 4.5l-4 4l-4 1.5l-1.5 1.5l7 7l1.5 -1.5l1.5 -4l4 -4" />
+      <path d="M9 15l-4.5 4.5" />
+      <path d="M14.5 4l5.5 5.5" />
+    </svg>
+  )
+}

--- a/packages/app/src/renderer/components/ProjectView.tsx
+++ b/packages/app/src/renderer/components/ProjectView.tsx
@@ -83,6 +83,12 @@ export default function ProjectView({
     return () => { cancelled = true }
   }, [identityKey, sortOrder, activeSources, reloadKey])
 
+  useEffect(() => {
+    function bump() { setReloadKey(k => k + 1) }
+    window.addEventListener('spool:pin-change', bump)
+    return () => window.removeEventListener('spool:pin-change', bump)
+  }, [])
+
   function handlePinChange(sessionUuid: string, pinned: boolean) {
     if (pinned) {
       const candidate = sessions?.find(s => s.sessionUuid === sessionUuid)

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -107,10 +107,17 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
 
   useEffect(() => {
     let cancelled = false
-    window.spool.getPinnedUuids()
-      .then(uuids => { if (!cancelled) setPinned(uuids.includes(sessionUuid)) })
-      .catch(() => { if (!cancelled) setPinned(false) })
-    return () => { cancelled = true }
+    function refresh() {
+      window.spool.getPinnedUuids()
+        .then(uuids => { if (!cancelled) setPinned(uuids.includes(sessionUuid)) })
+        .catch(() => { if (!cancelled) setPinned(false) })
+    }
+    refresh()
+    window.addEventListener('spool:pin-change', refresh)
+    return () => {
+      cancelled = true
+      window.removeEventListener('spool:pin-change', refresh)
+    }
   }, [sessionUuid])
 
   useEffect(() => {

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -1,17 +1,26 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
-import type { ProjectGroup, SessionSource, StatusInfo } from '@spool-lab/core'
-import { Library as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon } from 'lucide-react'
+import type { ProjectGroup, Session, SessionSource, StatusInfo } from '@spool-lab/core'
+import { Library as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, SquareTerminal } from 'lucide-react'
+import PinIcon from './PinIcon.js'
 import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
+import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
 import {
   DEFAULT_SIDEBAR_SORT_ORDER,
   SIDEBAR_SORT_OPTIONS,
   type SidebarSortOrder,
 } from '../../shared/sidebarSort.js'
+import {
+  DEFAULT_PINNED_SORT_ORDER,
+  PINNED_SORT_OPTIONS,
+  type PinnedSortOrder,
+} from '../../shared/pinnedSort.js'
 import Menu from './Menu.js'
 
 type Props = {
   activeIdentityKey: string | null
+  activeSessionUuid?: string | null
   onSelectProject: (identityKey: string) => void
+  onSelectSession?: (sessionUuid: string) => void
   onSelectHome?: () => void
   isLibraryActive?: boolean
   onSelectShares?: () => void
@@ -24,11 +33,16 @@ type Props = {
   showSessionCount?: boolean
   sortOrder?: SidebarSortOrder
   onSortOrderChange?: (next: SidebarSortOrder) => void
+  pinnedSortOrder?: PinnedSortOrder
+  onPinnedSortOrderChange?: (next: PinnedSortOrder) => void
+  onCopySessionId?: (source: SessionSource) => void
 }
 
-export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHome, isLibraryActive = false, onSelectShares, isSharesActive = false, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true, sortOrder = DEFAULT_SIDEBAR_SORT_ORDER, onSortOrderChange }: Props) {
+export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, onSelectProject, onSelectSession, onSelectHome, isLibraryActive = false, onSelectShares, isSharesActive = false, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true, sortOrder = DEFAULT_SIDEBAR_SORT_ORDER, onSortOrderChange, pinnedSortOrder = DEFAULT_PINNED_SORT_ORDER, onPinnedSortOrderChange, onCopySessionId }: Props) {
   const [groups, setGroups] = useState<ProjectGroup[] | null>(null)
   const [projectsOpen, setProjectsOpen] = useState(true)
+  const [pinned, setPinned] = useState<Session[] | null>(null)
+  const [pinnedOpen, setPinnedOpen] = useState(true)
 
   useEffect(() => {
     let cancelled = false
@@ -38,6 +52,25 @@ export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHo
     return () => { cancelled = true }
   }, [status?.totalSessions])
 
+  useEffect(() => {
+    let cancelled = false
+    function refresh() {
+      window.spool.listPinnedSessions()
+        .then(result => { if (!cancelled) setPinned(result) })
+        .catch(() => { if (!cancelled) setPinned([]) })
+    }
+    refresh()
+    window.addEventListener('spool:pin-change', refresh)
+    return () => {
+      cancelled = true
+      window.removeEventListener('spool:pin-change', refresh)
+    }
+  }, [status?.totalSessions])
+
+  const sortedPinned = useMemo(
+    () => (pinned ? sortPinnedSessions(pinned, pinnedSortOrder) : null),
+    [pinned, pinnedSortOrder],
+  )
   const visibleGroups = (groups ?? []).filter(g => g.sessionCount > 0)
   const projectGroups = useMemo(
     () => sortProjectGroups(visibleGroups.filter(g => g.identityKind !== 'loose'), sortOrder),
@@ -80,92 +113,138 @@ export default function Sidebar({ activeIdentityKey, onSelectProject, onSelectHo
         )}
       </nav>
 
-      <div className="group mx-2 mt-1 px-2 py-1 flex-none flex items-center gap-1">
-        <button
-          type="button"
-          data-testid="sidebar-projects-toggle"
-          aria-expanded={projectsOpen}
-          onClick={() => setProjectsOpen(open => !open)}
-          className="flex-1 flex items-center gap-1.5 text-left text-[11px] font-medium text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text rounded-md select-none"
-        >
-          <span>Projects</span>
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill="none"
-            aria-hidden="true"
-            className={`flex-none transition-all opacity-30 group-hover:opacity-100 ${projectsOpen ? 'rotate-90' : ''}`}
-          >
-            <path d="M4 2L8 6L4 10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        </button>
-        {onSortOrderChange && (
-          <Menu
-            align="right"
-            testId="sidebar-sort-menu"
-            trigger={({ open, toggle }) => (
-              <button
-                type="button"
-                data-testid="sidebar-sort-trigger"
-                onClick={toggle}
-                title="Sort projects"
-                aria-label="Sort projects"
-                aria-haspopup="menu"
-                aria-expanded={open}
-                className={`flex-none inline-flex items-center justify-end h-4 transition-opacity text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text ${
-                  open ? 'opacity-100' : 'opacity-30 group-hover:opacity-100'
-                }`}
-              >
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
-                  <path d="M1 3.5h12M2.5 7h9M5 10.5h4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-                </svg>
-              </button>
-            )}
-            items={SIDEBAR_SORT_OPTIONS.map(option => ({
-              label: option.label,
-              active: sortOrder === option.value,
-              onSelect: () => onSortOrderChange(option.value),
-            }))}
-          />
-        )}
-      </div>
-
-      <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-3 scrollbar-none [mask-image:linear-gradient(to_bottom,black_calc(100%_-_20px),transparent)]">
-        {projectsOpen && (
-          groups === null ? (
-            <SidebarSkeleton />
-          ) : projectGroups.length === 0 && !looseGroup ? (
-            <p className="px-2 py-3 text-xs text-warm-faint dark:text-dark-muted">
-              No sessions yet
-            </p>
-          ) : (
-            <>
-              {projectGroups.map(group => (
-                <ProjectRow
-                  key={group.identityKey}
-                  group={group}
-                  active={group.identityKey === activeIdentityKey}
-                  showSourceDots={showSourceDots}
-                  showSessionCount={showSessionCount}
-                  onClick={() => onSelectProject(group.identityKey)}
+      <div className="flex-1 min-h-0 overflow-y-auto pb-3 scrollbar-none [mask-image:linear-gradient(to_bottom,black_calc(100%_-_20px),transparent)]">
+        {sortedPinned && sortedPinned.length > 0 && onSelectSession && (
+          <>
+            <SectionHeader
+              label="Pinned"
+              open={pinnedOpen}
+              onToggle={() => setPinnedOpen(open => !open)}
+              testId="sidebar-pinned-toggle"
+              trailing={onPinnedSortOrderChange ? (
+                <Menu
+                  align="right"
+                  testId="sidebar-pinned-sort-menu"
+                  trigger={({ open, toggle }) => (
+                    <button
+                      type="button"
+                      data-testid="sidebar-pinned-sort-trigger"
+                      onClick={toggle}
+                      title="Sort pinned"
+                      aria-label="Sort pinned"
+                      aria-haspopup="menu"
+                      aria-expanded={open}
+                      className={`flex-none inline-flex items-center justify-end h-4 transition-opacity text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text ${
+                        open ? 'opacity-100' : 'opacity-30 group-hover:opacity-100'
+                      }`}
+                    >
+                      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+                        <path d="M1 3.5h12M2.5 7h9M5 10.5h4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                      </svg>
+                    </button>
+                  )}
+                  items={PINNED_SORT_OPTIONS.map(option => ({
+                    label: option.label,
+                    active: pinnedSortOrder === option.value,
+                    onSelect: () => onPinnedSortOrderChange(option.value),
+                  }))}
                 />
-              ))}
+              ) : null}
+            />
+            {pinnedOpen && (
+              <div
+                className={
+                  sortedPinned.length > 8
+                    ? 'px-2 max-h-64 overflow-y-auto scrollbar-none'
+                    : 'px-2'
+                }
+              >
+                {sortedPinned.map(session => (
+                  <PinnedRow
+                    key={session.sessionUuid}
+                    session={session}
+                    active={session.sessionUuid === activeSessionUuid}
+                    onClick={() => onSelectSession(session.sessionUuid)}
+                    {...(onCopySessionId ? { onCopySessionId } : {})}
+                  />
+                ))}
+              </div>
+            )}
+          </>
+        )}
 
-              {looseGroup && (
-                <>
-                  <div className="my-2 mx-2 border-t border-warm-border dark:border-dark-border" />
+        <SectionHeader
+          label="Projects"
+          open={projectsOpen}
+          onToggle={() => setProjectsOpen(open => !open)}
+          testId="sidebar-projects-toggle"
+          trailing={onSortOrderChange ? (
+            <Menu
+              align="right"
+              testId="sidebar-sort-menu"
+              trigger={({ open, toggle }) => (
+                <button
+                  type="button"
+                  data-testid="sidebar-sort-trigger"
+                  onClick={toggle}
+                  title="Sort projects"
+                  aria-label="Sort projects"
+                  aria-haspopup="menu"
+                  aria-expanded={open}
+                  className={`flex-none inline-flex items-center justify-end h-4 transition-opacity text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text ${
+                    open ? 'opacity-100' : 'opacity-30 group-hover:opacity-100'
+                  }`}
+                >
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+                    <path d="M1 3.5h12M2.5 7h9M5 10.5h4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                  </svg>
+                </button>
+              )}
+              items={SIDEBAR_SORT_OPTIONS.map(option => ({
+                label: option.label,
+                active: sortOrder === option.value,
+                onSelect: () => onSortOrderChange(option.value),
+              }))}
+            />
+          ) : null}
+        />
+
+        {projectsOpen && (
+          <div className="px-2">
+            {groups === null ? (
+              <SidebarSkeleton />
+            ) : projectGroups.length === 0 && !looseGroup ? (
+              <p className="px-2 py-3 text-xs text-warm-faint dark:text-dark-muted">
+                No sessions yet
+              </p>
+            ) : (
+              <>
+                {projectGroups.map(group => (
                   <ProjectRow
-                    group={looseGroup}
-                    active={looseGroup.identityKey === activeIdentityKey}
+                    key={group.identityKey}
+                    group={group}
+                    active={group.identityKey === activeIdentityKey}
                     showSourceDots={showSourceDots}
                     showSessionCount={showSessionCount}
-                    onClick={() => onSelectProject(looseGroup.identityKey)}
+                    onClick={() => onSelectProject(group.identityKey)}
                   />
-                </>
-              )}
-            </>
-          )
+                ))}
+
+                {looseGroup && (
+                  <>
+                    <div className="my-2 mx-2 border-t border-warm-border dark:border-dark-border" />
+                    <ProjectRow
+                      group={looseGroup}
+                      active={looseGroup.identityKey === activeIdentityKey}
+                      showSourceDots={showSourceDots}
+                      showSessionCount={showSessionCount}
+                      onClick={() => onSelectProject(looseGroup.identityKey)}
+                    />
+                  </>
+                )}
+              </>
+            )}
+          </div>
         )}
       </div>
 
@@ -235,7 +314,7 @@ function SidebarStatus({
   const isOk = !syncStatus || syncStatus.phase === 'done'
 
   return (
-    <div className="flex-none h-[30px] pl-4 pr-2 flex items-center gap-2">
+    <div className="flex-none h-[30px] pl-4 pr-4 flex items-center gap-2">
       <div className="flex-1 min-w-0 flex items-center gap-2">
         <span className={`w-1.5 h-1.5 rounded-full flex-none ${isOk ? 'bg-status-success dark:bg-status-success-dark' : 'bg-status-warning dark:bg-status-warning-dark animate-pulse'}`} />
         <span data-testid="status-text" className="text-[11px] font-mono text-warm-faint dark:text-dark-muted truncate" title={text}>
@@ -249,9 +328,9 @@ function SidebarStatus({
           onClick={onSettingsClick}
           title="Settings"
           aria-label="Settings"
-          className="flex-none inline-flex items-center justify-center w-6 h-6 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75"
+          className="flex-none inline-flex items-center justify-center h-4 text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition-colors"
         >
-          <SettingsIcon size={12} strokeWidth={1.75} />
+          <SettingsIcon size={13} strokeWidth={1.75} />
         </button>
       )}
     </div>
@@ -288,6 +367,194 @@ function formatShortTimeAgo(iso: string): string {
   } catch {
     return iso
   }
+}
+
+function SectionHeader({
+  label,
+  open,
+  onToggle,
+  testId,
+  trailing,
+}: {
+  label: string
+  open: boolean
+  onToggle: () => void
+  testId?: string
+  trailing?: ReactNode
+}) {
+  return (
+    <div className="group mx-2 mt-1 px-2 py-1 flex items-center gap-1">
+      <button
+        type="button"
+        data-testid={testId}
+        aria-expanded={open}
+        onClick={onToggle}
+        className="flex-1 flex items-center gap-1.5 text-left text-[11px] font-medium text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text rounded-md select-none"
+      >
+        <span>{label}</span>
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          aria-hidden="true"
+          className={`flex-none transition-all opacity-30 group-hover:opacity-100 ${open ? 'rotate-90' : ''}`}
+        >
+          <path d="M4 2L8 6L4 10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+      {trailing}
+    </div>
+  )
+}
+
+function PinnedRow({
+  session,
+  active,
+  onClick,
+  onCopySessionId,
+}: {
+  session: Session
+  active: boolean
+  onClick: () => void
+  onCopySessionId?: (source: SessionSource) => void
+}) {
+  const [resuming, setResuming] = useState(false)
+  const [unpinning, setUnpinning] = useState(false)
+  const title = session.title?.trim() || '(no title)'
+  const projectName = session.projectDisplayName || session.projectDisplayPath
+  const resumeCommand = getSessionResumeCommand(session.source, session.sessionUuid)
+
+  async function handleResume() {
+    setResuming(true)
+    await window.spool.resumeCLI(session.sessionUuid, session.source, session.cwd ?? undefined)
+    setTimeout(() => setResuming(false), 1000)
+  }
+
+  async function handleCopyCommand() {
+    if (!resumeCommand) return
+    await navigator.clipboard.writeText(resumeCommand)
+  }
+
+  async function handleCopyId() {
+    await navigator.clipboard.writeText(session.sessionUuid)
+    onCopySessionId?.(session.source)
+  }
+
+  async function handleUnpin() {
+    if (unpinning) return
+    setUnpinning(true)
+    try {
+      await window.spool.unpinSession(session.sessionUuid)
+      window.dispatchEvent(new CustomEvent('spool:pin-change', { detail: { sessionUuid: session.sessionUuid, pinned: false } }))
+    } finally {
+      setUnpinning(false)
+    }
+  }
+
+  return (
+    <div
+      data-testid="sidebar-pinned-row"
+      data-session-uuid={session.sessionUuid}
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onClick()
+        }
+      }}
+      aria-label={projectName ? `${title}, ${projectName}` : title}
+      className={`group w-full text-left flex items-center gap-1 px-2 py-1 rounded-md transition-colors duration-75 cursor-pointer focus:outline-none ${
+        active
+          ? 'bg-warm-surface2 dark:bg-dark-surface2 text-warm-text dark:text-dark-text'
+          : 'text-warm-text/85 dark:text-dark-text/85 hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text'
+      }`}
+    >
+      <span className="flex-1 truncate text-[13px]">{title}</span>
+      <span
+        className="flex-none flex items-center gap-1.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          data-testid="sidebar-pinned-unpin"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => { void handleUnpin() }}
+          aria-label="Unpin"
+          disabled={unpinning}
+          className="inline-flex items-center justify-center h-4 text-accent/80 dark:text-accent-dark/80 hover:text-accent dark:hover:text-accent-dark transition-colors disabled:opacity-50"
+        >
+          <PinIcon size={13} filled />
+        </button>
+        <Menu
+          align="right"
+          trigger={({ toggle }) => (
+            <button
+              type="button"
+              data-testid="sidebar-pinned-menu-trigger"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={toggle}
+              aria-label="More actions"
+              className="inline-flex items-center justify-center h-4 text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition-colors"
+            >
+              <svg width="13" height="13" viewBox="0 0 14 14" fill="currentColor" aria-hidden>
+                <circle cx="3" cy="7" r="1.2" />
+                <circle cx="7" cy="7" r="1.2" />
+                <circle cx="11" cy="7" r="1.2" />
+              </svg>
+            </button>
+          )}
+          items={[
+            {
+              label: resuming ? 'Opening…' : 'Resume in Terminal',
+              icon: resuming ? <SpinnerIcon /> : <SquareTerminal size={14} strokeWidth={1.5} aria-hidden />,
+              onSelect: () => { void handleResume() },
+              disabled: resuming,
+            },
+            ...(resumeCommand ? [{
+              label: 'Copy resume command',
+              icon: <TerminalGlyph />,
+              onSelect: () => { void handleCopyCommand() },
+            }] : []),
+            {
+              label: 'Copy session ID',
+              icon: <CopyGlyph />,
+              onSelect: () => { void handleCopyId() },
+            },
+          ]}
+        />
+      </span>
+    </div>
+  )
+}
+
+function TerminalGlyph() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 4.5L5 7L3 9.5" />
+      <path d="M6.5 10H11.5" />
+    </svg>
+  )
+}
+
+function CopyGlyph() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <rect x="5" y="5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M9 5V3.5C9 2.67 8.33 2 7.5 2H3.5C2.67 2 2 2.67 2 3.5V7.5C2 8.33 2.67 9 3.5 9H5" stroke="currentColor" strokeWidth="1.5" />
+    </svg>
+  )
+}
+
+function SpinnerIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" className="animate-spin" aria-hidden>
+      <circle cx="7" cy="7" r="5.25" stroke="currentColor" strokeWidth="1.5" fill="none" strokeOpacity="0.3" />
+      <path d="M7 1.75A5.25 5.25 0 0112.25 7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" fill="none" />
+    </svg>
+  )
 }
 
 function ProjectRow({
@@ -397,6 +664,29 @@ function sortProjectGroups(groups: ProjectGroup[], order: SidebarSortOrder): Pro
     case 'recent':
     default:
       sorted.sort(compareLastSessionAtDesc)
+      return sorted
+  }
+}
+
+function sortPinnedSessions(sessions: Session[], order: PinnedSortOrder): Session[] {
+  const sorted = [...sessions]
+  switch (order) {
+    case 'name':
+      sorted.sort((a, b) => {
+        const at = (a.title ?? '').trim()
+        const bt = (b.title ?? '').trim()
+        return at.localeCompare(bt, undefined, { sensitivity: 'base' })
+      })
+      return sorted
+    case 'recent':
+      sorted.sort((a, b) => {
+        const ae = a.endedAt ?? ''
+        const be = b.endedAt ?? ''
+        return be.localeCompare(ae)
+      })
+      return sorted
+    case 'recent_pinned':
+    default:
       return sorted
   }
 }

--- a/packages/app/src/shared/pinnedSort.ts
+++ b/packages/app/src/shared/pinnedSort.ts
@@ -1,0 +1,9 @@
+export type PinnedSortOrder = 'recent_pinned' | 'recent' | 'name'
+
+export const DEFAULT_PINNED_SORT_ORDER: PinnedSortOrder = 'recent_pinned'
+
+export const PINNED_SORT_OPTIONS: Array<{ value: PinnedSortOrder; label: string }> = [
+  { value: 'recent_pinned', label: 'Recently pinned' },
+  { value: 'recent', label: 'Recent activity' },
+  { value: 'name', label: 'Name (A–Z)' },
+]


### PR DESCRIPTION
## Summary

Surfaces pinned sessions at the top of the sidebar (between the main nav and the Projects tree) so frequently-revisited sessions are one click away — no longer requires going through Library or a Project view.

## What it adds

- **Pinned group** above Projects: collapsible header, single-line title rows sorted by `pinned_at` desc by default.
- **Sort menu** in the section header (Recently pinned / Recent activity / Name A–Z), persisted to `agentsConfig.pinnedSortOrder` alongside the existing sidebar/project sort settings.
- **Per-row hover actions** matching `SessionRow`'s vocabulary: unpin (📌) + kebab `⋯` with **Resume in Terminal**, **Copy resume command**, **Copy session ID**.
- **Cross-view sync** via a `spool:pin-change` window event. `PinButton` dispatches the event after toggling; `Sidebar`, `LibraryLanding`, `ProjectView`, and `SessionDetail` all listen and refresh so pinning anywhere updates everywhere instantly.
- **Soft cap** at 8 visible rows with internal scroll beyond, so a 30-pin list never pushes Projects offscreen. Overflow only kicks in past the threshold, keeping the kebab menu unclipped in the common case.
- **Icon style harmonised**: settings gear, filter triggers, and the new row actions all share the same "no chrome, color-only hover" treatment.

## Why

Pinning already exists end-to-end (`pins` table + `PinButton` + Library / Project pinned segments), but the sessions were buried two clicks deep. Putting them in the sidebar matches the Notion / Linear / Slack favorites pattern and turns pinning into a true quick-access surface.

## How it connects

- New `packages/app/src/shared/pinnedSort.ts` mirrors `sidebarSort.ts` / `projectView.ts` patterns.
- `Sidebar.tsx` gains the Pinned group above the existing Projects scroll area; both share one scroll container.
- `PinIcon.tsx` is extracted so `PinButton` and the new `PinnedRow` use the exact same SVG drawing — fixes the previous lucide / custom-SVG inconsistency.
- New `agentsConfig.pinnedSortOrder` field, wired through `preload/index.ts` and `main/acp.ts`.

## Follow-up

The kebab menu is positioned with `position: absolute` inside the scrollable container. For the rare case of >8 pinned sessions, the menu on the very bottom row can still be clipped by the scroll context. Tracking a follow-up PR to portal the shared `Menu` component via `createPortal`.

## Test plan

- [x] `pnpm --filter @spool/app test:e2e -- e2e/sidebar-pinned.spec.ts` — 5 new specs all pass
- [x] Existing `pin.spec.ts` / `sidebar.spec.ts` / `project-view.spec.ts` still green (no regressions)
- [x] Manual: pin from `SessionDetail`, `SessionRow` (Library + ProjectView), and the sidebar's own unpin — all three propagate live across views
- [x] Manual: sort menu toggles persist across app restart
- [x] Manual: ≤8 pins shows no scrollbar / dropdown unclipped; >8 pins scrolls inside the section, Projects stays reachable