### PR TITLE
polish(app): tidy session detail chrome and unify icon button sizing

### DIFF
--- a/packages/app/src/renderer/components/MessageBubble.tsx
+++ b/packages/app/src/renderer/components/MessageBubble.tsx
@@ -8,6 +8,7 @@ export type { FindRange }
 interface Props {
   message: Message
   isDark: boolean
+  showAvatar?: boolean
   findRanges?: ReadonlyArray<FindRange>
   matchIndexOffset?: number
   activeMatchIndex?: number
@@ -17,6 +18,7 @@ interface Props {
 function MessageBubble({
   message,
   isDark,
+  showAvatar = true,
   findRanges = [],
   matchIndexOffset = 0,
   activeMatchIndex = -1,
@@ -24,6 +26,7 @@ function MessageBubble({
 }: Props) {
   const isUser = message.role === 'user'
   const isSystem = message.role === 'system'
+  const isToolUseOnly = message.toolNames.length > 0 && !message.contentText
   const contentText = message.contentText || (isSystem ? '(summary)' : '')
 
   const markdownProps = {
@@ -45,16 +48,42 @@ function MessageBubble({
     )
   }
 
+  if (isToolUseOnly) {
+    return (
+      <div className="px-6 py-0.5 flex items-center gap-2">
+        {showAvatar ? (
+          <div className="flex-none w-5 h-5 rounded-full flex items-center justify-center text-[9px] font-bold bg-neutral-700 text-white dark:bg-neutral-300 dark:text-neutral-900">
+            A
+          </div>
+        ) : (
+          <div className="flex-none w-5 h-5" aria-hidden />
+        )}
+        <div className="flex-1 min-w-0 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[10px] text-neutral-400">
+          {message.toolNames.map((name) => (
+            <span key={name} className="font-mono bg-neutral-100 dark:bg-neutral-800 text-neutral-500 px-1.5 py-0.5 rounded">
+              {name}
+            </span>
+          ))}
+          <span className="font-mono">{formatTime(message.timestamp)}</span>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="px-6 py-2">
       <div className="flex items-start gap-2">
-        <div className={`flex-none w-5 h-5 rounded-full mt-0.5 flex items-center justify-center text-[9px] font-bold ${
-          isUser
-            ? 'bg-blue-500 text-white'
-            : 'bg-neutral-700 text-white dark:bg-neutral-300 dark:text-neutral-900'
-        }`}>
-          {isUser ? 'U' : 'A'}
-        </div>
+        {showAvatar ? (
+          <div className={`flex-none w-5 h-5 rounded-full mt-0.5 flex items-center justify-center text-[9px] font-bold ${
+            isUser
+              ? 'bg-blue-500 text-white'
+              : 'bg-neutral-700 text-white dark:bg-neutral-300 dark:text-neutral-900'
+          }`}>
+            {isUser ? 'U' : 'A'}
+          </div>
+        ) : (
+          <div className="flex-none w-5 h-5 mt-0.5" aria-hidden />
+        )}
         <div className="flex-1 min-w-0">
           {message.toolNames.length > 0 && (
             <div className="flex flex-wrap gap-1 mb-1">
@@ -65,9 +94,7 @@ function MessageBubble({
               ))}
             </div>
           )}
-          {message.contentText
-            ? <MarkdownContent {...markdownProps} />
-            : <span className="text-sm text-neutral-400 italic">(tool use)</span>}
+          <MarkdownContent {...markdownProps} />
           <p className="text-[10px] text-neutral-400 mt-1">{formatTime(message.timestamp)}</p>
         </div>
       </div>

--- a/packages/app/src/renderer/components/MessageList.tsx
+++ b/packages/app/src/renderer/components/MessageList.tsx
@@ -80,19 +80,22 @@ const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
           && activeMatchIndex >= matchState.offset
           && activeMatchIndex < matchState.offset + matchState.ranges.length
         const isTarget = msg.id === targetMessageId
+        const prev = index > 0 ? messages[index - 1] : undefined
+        const showAvatar = !prev || prev.role !== msg.role || prev.role === 'system'
 
         return (
           <div
             data-index={index}
             {...(isTarget ? { 'data-testid': 'target-message' } : {})}
             {...(isTarget && showTargetHighlight ? { 'data-highlighted': '1' } : {})}
-            className={`border-b border-warm-border/50 dark:border-dark-border/50 transition-colors duration-700 ${
+            className={`transition-colors duration-700 ${
               isTarget && showTargetHighlight ? 'bg-accent/10 dark:bg-accent-dark/10' : ''
             }`}
           >
             <MessageBubble
               message={msg}
               isDark={isDark}
+              showAvatar={showAvatar}
               {...(matchState ? { findRanges: matchState.ranges, matchIndexOffset: matchState.offset } : {})}
               activeMatchIndex={containsActive ? activeMatchIndex : -1}
               {...(containsActive ? { onActiveMatchRef } : {})}

--- a/packages/app/src/renderer/components/PinButton.tsx
+++ b/packages/app/src/renderer/components/PinButton.tsx
@@ -28,7 +28,7 @@ export default function PinButton({ sessionUuid, pinned, onChange, size = 'sm' }
     }
   }
 
-  const dim = size === 'md' ? 'w-8 h-8' : 'w-6 h-6'
+  const dim = size === 'md' ? 'w-8 h-8' : 'w-5 h-5'
   const icon = size === 'md' ? 16 : 13
 
   return (

--- a/packages/app/src/renderer/components/PinIcon.tsx
+++ b/packages/app/src/renderer/components/PinIcon.tsx
@@ -12,15 +12,15 @@ export default function PinIcon({ size = 13, filled = false, className }: Props)
       viewBox="0 0 24 24"
       fill={filled ? 'currentColor' : 'none'}
       stroke="currentColor"
-      strokeWidth={filled ? 1.5 : 1.8}
+      strokeWidth={filled ? 1.4 : 1.6}
       strokeLinecap="round"
       strokeLinejoin="round"
       className={className}
       aria-hidden="true"
     >
-      <path d="M15 4.5l-4 4l-4 1.5l-1.5 1.5l7 7l1.5 -1.5l1.5 -4l4 -4" />
-      <path d="M9 15l-4.5 4.5" />
-      <path d="M14.5 4l5.5 5.5" />
+      <path d="M15.3 3.3l-4.8 4.8l-4.8 1.8l-1.8 1.8l8.4 8.4l1.8 -1.8l1.8 -4.8l4.8 -4.8" />
+      <path d="M8.1 15.9l-5.4 5.4" />
+      <path d="M14.7 2.7l6.6 6.6" />
     </svg>
   )
 }

--- a/packages/app/src/renderer/components/SearchOverlay.tsx
+++ b/packages/app/src/renderer/components/SearchOverlay.tsx
@@ -163,7 +163,7 @@ export default function SearchOverlay({
       onClick={(event) => { if (event.target === event.currentTarget) onClose() }}
     >
       <div className="w-full max-w-xl rounded-xl border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface shadow-xl overflow-hidden">
-        <div className="flex items-center gap-2 px-4 py-3 border-b border-warm-border dark:border-dark-border">
+        <div className="flex items-center gap-2 px-4 py-3">
           <SearchIcon />
           <input
             ref={inputRef}
@@ -189,7 +189,7 @@ export default function SearchOverlay({
           )}
         </div>
 
-        <div className="px-4 py-2 flex items-center gap-2 border-b border-warm-border dark:border-dark-border">
+        <div className="px-4 py-2 flex items-center gap-2">
           <span className="text-[10px] uppercase tracking-wider text-warm-faint">Searching:</span>
           <ScopeChip
             label={scopeProjectName ? `in: ${scopeProjectName}` : 'in: project'}
@@ -283,7 +283,7 @@ export default function SearchOverlay({
                   aria-selected={index === activeIndex}
                   onMouseEnter={() => setActiveIndex(index)}
                   onClick={() => onOpenResult(result.sessionUuid, result.messageId, query)}
-                  className={`px-4 py-2.5 cursor-pointer border-b border-warm-border/50 dark:border-dark-border/50 ${
+                  className={`px-4 py-2.5 cursor-pointer ${
                     index === activeIndex ? 'bg-warm-surface2 dark:bg-dark-surface2' : ''
                   }`}
                 >
@@ -304,7 +304,7 @@ export default function SearchOverlay({
           )}
         </div>
 
-        <div className="w-full px-4 py-2 text-[11px] border-t border-warm-border dark:border-dark-border flex items-center justify-between text-warm-faint dark:text-dark-muted gap-3">
+        <div className="w-full px-4 py-2 text-[11px] flex items-center justify-between text-warm-faint dark:text-dark-muted gap-3">
           <div className="flex items-center gap-3 flex-wrap">
             {(showRecents ? flatRecents.length > 0 : results.length > 0) && (
               <>

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -228,7 +228,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
   return (
     <div className="relative flex flex-col h-full" data-testid="session-detail">
       {/* Session header */}
-      <div className="flex-none flex items-start gap-3 px-6 pt-1.5 pb-3 border-b border-warm-border dark:border-dark-border">
+      <div className="flex-none flex items-start gap-3 px-6 pt-1.5 pb-3">
         {onBack && (
           <button
             type="button"
@@ -249,12 +249,6 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
           </h2>
 
           <p className="mt-1 flex items-center gap-1.5 text-[11px] text-warm-faint dark:text-dark-muted min-w-0">
-            <span className="font-mono truncate" title={session.projectDisplayPath}>{session.projectDisplayPath}</span>
-            <span aria-hidden>·</span>
-            <span className="flex-none">{session.messageCount} {session.messageCount === 1 ? 'message' : 'messages'}</span>
-            <span aria-hidden>·</span>
-            <span className="flex-none">{formatRelativeDate(session.startedAt)}</span>
-            <span aria-hidden>·</span>
             <span className="inline-flex items-center gap-1 flex-none">
               <span
                 aria-hidden
@@ -263,6 +257,12 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
               />
               <span className="font-mono">{getSessionSourceShortLabel(session.source)}</span>
             </span>
+            <span aria-hidden>·</span>
+            <span className="font-mono truncate" title={session.projectDisplayPath}>{session.projectDisplayPath}</span>
+            <span aria-hidden>·</span>
+            <span className="flex-none">{formatRelativeDate(session.startedAt)}</span>
+            <span aria-hidden>·</span>
+            <span className="flex-none">{session.messageCount} {session.messageCount === 1 ? 'message' : 'messages'}</span>
           </p>
         </div>
 
@@ -279,7 +279,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
               onClick={() => onShare(session, messages)}
               title="Create a share from this session"
               aria-label="Create a share from this session"
-              className="inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors"
+              className="inline-flex items-center justify-center w-5 h-5 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors"
             >
               <Share2 size={13} strokeWidth={1.6} aria-hidden />
             </button>
@@ -291,7 +291,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
             disabled={resuming}
             title={resuming ? 'Opening…' : 'Resume in Terminal'}
             aria-label={resuming ? 'Opening…' : 'Resume in Terminal'}
-            className="inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+            className="inline-flex items-center justify-center w-5 h-5 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
           >
             <SquareTerminal size={13} strokeWidth={1.6} aria-hidden />
           </button>
@@ -304,12 +304,12 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
                 type="button"
                 onClick={toggle}
                 aria-label="More actions"
-                className="inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors"
+                className="inline-flex items-center justify-center w-5 h-5 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors"
               >
-                <svg width="13" height="13" viewBox="0 0 14 14" fill="currentColor">
-                  <circle cx="3" cy="7" r="1.2" />
-                  <circle cx="7" cy="7" r="1.2" />
-                  <circle cx="11" cy="7" r="1.2" />
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <circle cx="5" cy="12" r="1.5" />
+                  <circle cx="12" cy="12" r="1.5" />
+                  <circle cx="19" cy="12" r="1.5" />
                 </svg>
               </button>
             )}

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -106,10 +106,10 @@ export default function SessionRow({ session, pinned = false, showProject = fals
                 aria-expanded={open}
                 className="inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75"
               >
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
-                  <circle cx="3" cy="7" r="1.2" />
-                  <circle cx="7" cy="7" r="1.2" />
-                  <circle cx="11" cy="7" r="1.2" />
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+                  <circle cx="5" cy="12" r="1.5" />
+                  <circle cx="12" cy="12" r="1.5" />
+                  <circle cx="19" cy="12" r="1.5" />
                 </svg>
               </button>
             )}

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -466,7 +466,7 @@ function PinnedRow({
           : 'text-warm-text/85 dark:text-dark-text/85 hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text'
       }`}
     >
-      <span className="flex-1 truncate text-[13px]">{title}</span>
+      <span className="flex-1 truncate text-[13px]" title={title}>{title}</span>
       <span
         className="flex-none flex items-center gap-1.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 group-has-[[aria-expanded=true]]:opacity-100 transition-opacity"
         onClick={(e) => e.stopPropagation()}
@@ -495,10 +495,10 @@ function PinnedRow({
               aria-expanded={open}
               className="inline-flex items-center justify-center h-4 text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition-colors"
             >
-              <svg width="13" height="13" viewBox="0 0 14 14" fill="currentColor" aria-hidden>
-                <circle cx="3" cy="7" r="1.2" />
-                <circle cx="7" cy="7" r="1.2" />
-                <circle cx="11" cy="7" r="1.2" />
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+                <circle cx="5" cy="12" r="1.5" />
+                <circle cx="12" cy="12" r="1.5" />
+                <circle cx="19" cy="12" r="1.5" />
               </svg>
             </button>
           )}


### PR DESCRIPTION
## What

Visual polish pass on the session detail view and a few neighboring surfaces that share the same icon vocabulary.

**Session detail**
- Drop the bottom border under the header and the divider between every message — quieter scroll surface.
- Reorder header metadata so the source pill leads (colored dot gives quick identification) and the project path takes the flex space; messages count + relative time trail.
- Pure tool-use messages collapse from a 3-line block (avatar + chip + placeholder + timestamp) into a single inline row: chip(s) + timestamp, indented to the agent's avatar column.
- Consecutive same-role messages share one avatar — only the first message of a run shows the glyph; subsequent ones keep the indent for visual continuity. The first tool-use in a run still anchors the `A` glyph so tool calls visibly belong to the agent.

**Icon buttons (header cluster + neighbors)**
- Shrink the right-side action buttons (pin / share / resume / more) from `w-6 h-6` to `w-5 h-5` to match the back button — less empty padding inside the focus ring.
- Standardize self-drawn icons so they sit on the same visual weight as the lucide ones:
  - `PinIcon` uses `strokeWidth=1.6` (filled 1.4) and the path is scaled to fill the 24×24 viewBox.
  - All "more actions" dots converge on `24×24 viewBox` with `r=1.5` — across SessionDetail, Sidebar, and SessionRow.

**SearchOverlay**
- Remove the dividers under the input, under the scope chips, between result rows, and above the footer hints. Background contrast already separates the sections.

**Sidebar**
- Add a native `title` tooltip on truncated pinned-row titles so the full session title is reachable on hover.

## Why

The session detail page felt noisy: divider lines between every message stacked into "rules," every tool call took a full block, and the icon button cluster mixed three different visual systems (lucide icons at strokeWidth 1.6, a custom Pin at 1.8, custom dots in a 14×14 viewBox at filled circle r=1.2). Tightening these moves the chrome closer to the calm density established in the recent Library/Project polish PRs (#176/#178).

## How it connects

Builds on the recent sidebar and library row visual work; no behavior changes, no schema or IPC changes. All edits are renderer-only in `@spool/app`.

## Test plan

- [ ] Open a long session — message list scrolls without horizontal rule artifacts; tool-use rows collapse and group under one assistant avatar; clicking a tool-use row still has its hover affordances.
- [ ] Header — source pill leads, path truncates cleanly with the title tooltip; the four right-side icon buttons line up at uniform 20×20 with consistent icon weight.
- [ ] `⌘K` search palette — no dividers; recents and result rows still highlight on hover/keyboard, footer hints still readable.
- [ ] Sidebar Pinned — hover a pinned row with a long title and confirm the native tooltip shows the full title; pin/more icons match weight.
- [ ] Find-in-session (`⌘F`) still highlights, scrolls to active match, and navigates with `⌘← / ⌘→`.