### PR TITLE
fix(ci): build share-kit before electron-vite in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build app (arm64 DMG + ZIP)
         run: |
-          pnpm --filter @spool-lab/core build
+          pnpm -F @spool/app build:deps
           cd packages/app
           npx electron-vite build
           npx electron-builder --mac --arm64 --publish never
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build app (AppImage + tar.gz)
         run: |
-          pnpm --filter @spool-lab/core build
+          pnpm -F @spool/app build:deps
           cd packages/app
           npx electron-vite build
           npx electron-builder --linux --publish never


### PR DESCRIPTION
## What

In `.github/workflows/release.yml`, replace the manual `pnpm --filter @spool-lab/core build` step with `pnpm -F @spool/app build:deps` in both the build-mac and build-linux jobs, so that `@spool/share-kit` also gets built before `electron-vite build` runs.

## Why

The v0.4.7 release run failed at electron-vite build with:

```
[commonjs--resolver] Failed to resolve entry for package "@spool/share-kit".
```

`@spool/app` depends on the workspace package `@spool/share-kit`, whose `main` field points at `dist/`. pnpm workspaces don't auto-build deps on install, so when the workflow jumped straight from installing deps to running electron-vite, share-kit's `dist/` didn't exist and the renderer build aborted.

The app already has a `build:deps` script (`build:core && build:share-kit`) that's used by the local `dev`, `build`, and `test:e2e` flows — the release workflow is the only consumer that wasn't using it.

## How it connects

No source changes. Pure CI fix. After this lands, re-cutting a release via `scripts/release.sh` (v0.4.7 → v0.4.8) should produce mac + linux artifacts and a GitHub release.

## Test plan

- [ ] CI passes on this PR (unit + e2e × mac/ubuntu).
- [ ] After merge, the next `scripts/release.sh` run produces a complete release with the DMG, mac zip, and AppImage artifacts attached.