### PR TITLE
feat(app): replace ad-hoc toasts with sonner

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -42,6 +42,7 @@
     "remark": "^15",
     "remark-gfm": "^4",
     "shiki": "^1",
+    "sonner": "^2.0.7",
     "ws": "^8.20.0",
     "zustand": "^5.0.3"
   },

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useRef, memo, startTransition, useDeferredValue } from 'react'
+import { toast } from 'sonner'
 import type { FragmentResult, SearchResult, StatusInfo } from '@spool-lab/core'
 import { type SearchMode } from './components/SearchBar.js'
 import FragmentResults from './components/FragmentResults.js'
@@ -11,6 +12,7 @@ import ProjectView from './components/ProjectView.js'
 import LibraryLanding from './components/LibraryLanding.js'
 import SearchOverlay from './components/SearchOverlay.js'
 import AppTopBar from './components/AppTopBar.js'
+import AppToaster from './components/AppToaster.js'
 import SharesPage from './components/SharesPage.js'
 import ShareEditorPage from './components/ShareEditorPage.js'
 import { composeFromSession, sessionDraftId, buildPreviewDocument } from './lib/compose-from-session.js'
@@ -60,7 +62,6 @@ export default function App() {
   const [status, setStatus] = useState<StatusInfo | null>(null)
   const [runtimeInfo, setRuntimeInfo] = useState<RuntimeInfo | null>(null)
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const syncRefreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const searchRequestSeq = useRef(0)
   const previewRequestSeq = useRef(0)
@@ -86,7 +87,6 @@ export default function App() {
   const [sidebarSortOrder, setSidebarSortOrder] = useState<SidebarSortOrder>(DEFAULT_SIDEBAR_SORT_ORDER)
   const [pinnedSortOrder, setPinnedSortOrder] = useState<PinnedSortOrder>(DEFAULT_PINNED_SORT_ORDER)
   const [projectSortOrder, setProjectSortOrder] = useState<ProjectSessionSortOrder>(DEFAULT_PROJECT_SORT_ORDER)
-  const [resumeToastCommand, setResumeToastCommand] = useState<string | null>(null)
   const [themeEditor, setThemeEditor] = useState<ThemeEditorStateV1>(() => defaultThemeEditorState())
   const themeHydrated = useRef(false)
   const deferredResults = useDeferredValue(results)
@@ -344,7 +344,6 @@ export default function App() {
   useEffect(() => {
     return () => {
       if (searchTimer.current) clearTimeout(searchTimer.current)
-      if (toastTimer.current) clearTimeout(toastTimer.current)
       if (syncRefreshTimer.current) clearTimeout(syncRefreshTimer.current)
     }
   }, [])
@@ -622,9 +621,18 @@ export default function App() {
   const handleCopySessionId = useCallback((source: FragmentResult['source']) => {
     const command = getSessionResumeCommandPrefix(source)
     if (!command) return
-    setResumeToastCommand(command)
-    if (toastTimer.current) clearTimeout(toastTimer.current)
-    toastTimer.current = setTimeout(() => setResumeToastCommand(null), 3200)
+    toast('Session ID copied', {
+      id: 'resume-command',
+      description: (
+        <span>
+          Write{' '}
+          <code className="rounded bg-warm-bg dark:bg-dark-bg px-1.5 py-0.5 font-mono text-[11px]">
+            {command}
+          </code>{' '}
+          then paste the id to resume this session
+        </span>
+      ),
+    })
   }, [])
 
   const activeAgentInfo = availableAgents.find(a => a.id === aiAgent) ?? availableAgents[0]
@@ -698,6 +706,7 @@ export default function App() {
           sidebarCollapsed={sidebarCollapsed}
           onToggleSidebar={toggleSidebar}
         />
+        <AppToaster />
         {/* App-level overlays (settings, search) still mount above the
             share editor's PageLayout. */}
         {showSettings && (
@@ -915,9 +924,7 @@ export default function App() {
       </div>
       </div>
 
-      {resumeToastCommand && (
-        <ResumeToast command={resumeToastCommand} />
-      )}
+      <AppToaster />
 
       {showSettings && (
         <SettingsPanel
@@ -958,20 +965,6 @@ export default function App() {
         onCommit={handleSearchCommit}
         onOpenResult={handleOpenResultFromOverlay}
       />
-    </div>
-  )
-}
-
-function ResumeToast({ command }: { command: string }) {
-  const suffix = 'then paste the id to resume this session'
-
-  return (
-    <div className="pointer-events-none absolute bottom-10 left-1/2 z-40 -translate-x-1/2 animate-in fade-in duration-150 px-4">
-      <div className="rounded-full border border-warm-border dark:border-dark-border bg-warm-surface2/95 dark:bg-dark-surface2/95 px-4 py-2 shadow-lg backdrop-blur-sm">
-        <p className="whitespace-nowrap text-xs text-warm-text dark:text-dark-text">
-          Write <code className="rounded bg-warm-bg dark:bg-dark-bg px-1.5 py-0.5 font-mono text-[11px]">{command}</code> {suffix}
-        </p>
-      </div>
     </div>
   )
 }

--- a/packages/app/src/renderer/components/AppToaster.tsx
+++ b/packages/app/src/renderer/components/AppToaster.tsx
@@ -1,0 +1,106 @@
+import { CircleCheck, CircleAlert, TriangleAlert, Info } from 'lucide-react'
+import { Toaster } from 'sonner'
+
+/**
+ * App-wide toast surface. Wraps sonner's <Toaster /> with DESIGN.md tokens:
+ * elevated warm card, type-specific tints + Lucide icons so status reads
+ * at a glance, amber accent only on the action button.
+ */
+export default function AppToaster() {
+  return (
+    <Toaster
+      position="bottom-right"
+      theme="system"
+      duration={4000}
+      visibleToasts={3}
+      gap={10}
+      offset={20}
+      toastOptions={{
+        unstyled: true,
+        classNames: {
+          toast: [
+            'group/toast pointer-events-auto',
+            'flex items-start gap-2.5',
+            'w-[340px] px-3.5 py-3',
+            'rounded-[10px]',
+            // Default (neutral / non-typed) — elevated white card.
+            'bg-white dark:bg-[#2A2A24]',
+            'ring-1 ring-warm-border/70 dark:ring-white/[0.06]',
+            'shadow-[0_1px_2px_rgba(20,20,16,0.04),0_8px_28px_rgba(20,20,16,0.10)]',
+            'dark:shadow-[0_2px_8px_rgba(0,0,0,0.35),0_16px_40px_rgba(0,0,0,0.45)]',
+            'font-sans text-warm-text dark:text-dark-text',
+          ].join(' '),
+          // Per-type tints: light wash + tinted ring. Subtle enough to
+          // sit alongside warm palette, strong enough to read as status.
+          success: [
+            'bg-[#F1F8F1] dark:bg-[#1F2A1F]',
+            'ring-[color:var(--color-status-success)]/30 dark:ring-[color:var(--color-status-success-dark)]/30',
+          ].join(' '),
+          error: [
+            'bg-[#FDF1EE] dark:bg-[#2E1F1B]',
+            'ring-[color:var(--color-status-error)]/35 dark:ring-[color:var(--color-status-error-dark)]/35',
+          ].join(' '),
+          warning: [
+            'bg-[#FBF4E5] dark:bg-[#2E261B]',
+            'ring-[color:var(--color-status-warning)]/35 dark:ring-[color:var(--color-status-warning-dark)]/35',
+          ].join(' '),
+          info: [
+            'bg-warm-surface dark:bg-dark-surface2',
+            'ring-warm-border dark:ring-dark-border',
+          ].join(' '),
+          icon: 'flex-none mt-px',
+          content: 'flex flex-col gap-0.5 min-w-0 flex-1',
+          title: 'text-[13px] font-medium leading-snug tracking-[-0.005em]',
+          description:
+            'text-[12px] leading-snug text-warm-muted dark:text-dark-muted',
+          actionButton: [
+            'shrink-0 self-center',
+            'px-2.5 py-1 rounded-md',
+            'text-[12px] font-medium',
+            'text-accent dark:text-accent-dark',
+            'hover:bg-accent-bg dark:hover:bg-accent-bg-dark',
+            'transition-colors',
+          ].join(' '),
+          cancelButton: [
+            'shrink-0 self-center',
+            'px-2.5 py-1 rounded-md',
+            'text-[12px]',
+            'text-warm-muted dark:text-dark-muted',
+            'hover:bg-warm-surface dark:hover:bg-dark-surface',
+            'transition-colors',
+          ].join(' '),
+        },
+      }}
+      icons={{
+        success: (
+          <CircleCheck
+            size={16}
+            strokeWidth={2}
+            className="text-[color:var(--color-status-success)] dark:text-[color:var(--color-status-success-dark)]"
+          />
+        ),
+        error: (
+          <CircleAlert
+            size={16}
+            strokeWidth={2}
+            className="text-[color:var(--color-status-error)] dark:text-[color:var(--color-status-error-dark)]"
+          />
+        ),
+        warning: (
+          <TriangleAlert
+            size={16}
+            strokeWidth={2}
+            className="text-[color:var(--color-status-warning)] dark:text-[color:var(--color-status-warning-dark)]"
+          />
+        ),
+        info: (
+          <Info
+            size={16}
+            strokeWidth={2}
+            className="text-warm-muted dark:text-dark-muted"
+          />
+        ),
+      }}
+    />
+  )
+}

--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { flushSync } from 'react-dom'
 import { Download, PanelRight } from 'lucide-react'
+import { toast } from 'sonner'
 import {
   TEMPLATE_RATIO,
   buildSpoolDocument,
@@ -64,7 +65,6 @@ export default function ShareEditorPage({
   const [opts, setOpts] = useState<EditorOpts>(initialOpts)
   const [zoom, setZoom] = useState<Zoom>('fit')
   const [saveState, setSaveState] = useState<SaveState>('idle')
-  const [toast, setToast] = useState<string | null>(null)
   const [pdfPreview, setPdfPreview] = useState<{ url: string; filename: string } | null>(null)
   const previewRef = useRef<HTMLDivElement | null>(null)
 
@@ -108,13 +108,6 @@ export default function ShareEditorPage({
     return `${conversation.createdAt} · ${wordLabel}`
   }, [conversation])
 
-  // Auto-dismiss the toast after a few seconds.
-  useEffect(() => {
-    if (!toast) return
-    const id = window.setTimeout(() => setToast(null), 3200)
-    return () => window.clearTimeout(id)
-  }, [toast])
-
   // Force React to commit the "Exporting…" state and let the browser
   // paint before kicking off rasterization. Without this, batched
   // updates + a blocking main thread keep the button at "Export" until
@@ -149,14 +142,14 @@ export default function ShareEditorPage({
       const blob = await rasterizeToPngBlob(node, { width, height })
       await writeToSlot(slot, blob, filename)
       setSaveState('idle')
-      setToast(`Saved ${filename}`)
+      toast.success(`Saved ${filename}`)
     } catch (err) {
       console.error('Export to PNG failed:', err)
       setSaveState('error')
       if (err instanceof PngTooTallError) {
-        setToast('Conversation too tall for PNG — try PDF export.')
+        toast.error('Conversation too tall for PNG — try PDF export.')
       } else {
-        setToast('Export failed — see console for details')
+        toast.error('Export failed — see console for details')
       }
     }
   }, [beginSaving, conversation, opts.template])
@@ -178,7 +171,7 @@ export default function ShareEditorPage({
     } catch (err) {
       console.error('Export to PDF failed:', err)
       setSaveState('error')
-      setToast('Export failed — see console for details')
+      toast.error('Export failed — see console for details')
     }
   }, [beginSaving, conversation, opts.template])
 
@@ -193,7 +186,7 @@ export default function ShareEditorPage({
     const res = await fetch(pdfPreview.url)
     const blob = await res.blob()
     await writeToSlot(slot, blob, pdfPreview.filename)
-    setToast(`Saved ${pdfPreview.filename}`)
+    toast.success(`Saved ${pdfPreview.filename}`)
     setPdfPreview(null)
   }, [pdfPreview])
 
@@ -214,11 +207,11 @@ export default function ShareEditorPage({
       const blob = new Blob([JSON.stringify(doc, null, 2)], { type: 'application/spool+json' })
       await writeToSlot(slot, blob, filename)
       setSaveState('idle')
-      setToast(`Saved ${filename}`)
+      toast.success(`Saved ${filename}`)
     } catch (err) {
       console.error('Export to .spool failed:', err)
       setSaveState('error')
-      setToast('Export failed — see console for details')
+      toast.error('Export failed — see console for details')
     }
   }, [beginSaving, conversation, opts])
 
@@ -278,15 +271,6 @@ export default function ShareEditorPage({
       rightPanelOpen={panelOpen}
     >
       <div className="flex flex-col h-full" data-testid="share-editor-page">
-        {toast && (
-          <div
-            role="status"
-            className="pointer-events-none fixed bottom-5 left-1/2 -translate-x-1/2 z-40 px-3 py-1.5 rounded-md text-[12px] text-white bg-warm-text/95 dark:bg-dark-surface2/95 shadow-lg backdrop-blur-sm"
-          >
-            {toast}
-          </div>
-        )}
-
         {pdfPreview && (
           <div
             className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       shiki:
         specifier: ^1
         version: 1.29.2
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ws:
         specifier: ^8.20.0
         version: 8.20.0
@@ -4660,6 +4663,12 @@ packages:
   socks@2.8.7:
     resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -9716,6 +9725,11 @@ snapshots:
     dependencies:
       ip-address: 10.1.0
       smart-buffer: 4.2.0
+
+  sonner@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
Two hand-rolled toast surfaces — the share-editor export feedback and the
fragment-result resume-command hint — were independent <div>s with no
stacking, no hover-pause, no action support, and visuals that didn't sit
flush with the warm palette. Both are now sonner calls behind a single
themed Toaster mount.

The Toaster wrapper runs sonner unstyled and provides the chrome itself:
elevated white card in light / warm dark surface in dark, ring border,
layered shadow for real elevation, Lucide status icons (16px) with
type-tinted backgrounds and ring colors so success/error/warning read at
a glance without shouting. Amber accent is reserved for the action
button, matching DESIGN.md.

The share-editor view returns early from App's main render, so the
Toaster is mounted in both branches. ResumeToast keeps its <code> tag
via sonner's ReactNode description.

This sets up the undo-toast surface for the upcoming delete-draft work.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>