### PR TITLE
feat(app): delete share drafts with click-twice confirm

### DIFF
--- a/packages/app/src/renderer/components/AppToaster.tsx
+++ b/packages/app/src/renderer/components/AppToaster.tsx
@@ -20,8 +20,8 @@ export default function AppToaster() {
         classNames: {
           toast: [
             'group/toast pointer-events-auto',
-            'flex items-start gap-2.5',
-            'w-[340px] px-3.5 py-3',
+            'flex items-center gap-3',
+            'min-w-[260px] max-w-[380px] w-max px-3.5 py-2.5',
             'rounded-[10px]',
             // Default (neutral / non-typed) — elevated white card.
             'bg-white dark:bg-[#2A2A24]',
@@ -48,9 +48,9 @@ export default function AppToaster() {
             'bg-warm-surface dark:bg-dark-surface2',
             'ring-warm-border dark:ring-dark-border',
           ].join(' '),
-          icon: 'flex-none mt-px',
+          icon: 'flex-none flex items-center justify-center',
           content: 'flex flex-col gap-0.5 min-w-0 flex-1',
-          title: 'text-[13px] font-medium leading-snug tracking-[-0.005em]',
+          title: 'text-[13px] font-normal leading-snug tracking-[-0.005em] truncate',
           description:
             'text-[12px] leading-snug text-warm-muted dark:text-dark-muted',
           actionButton: [

--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { flushSync } from 'react-dom'
-import { Download, PanelRight } from 'lucide-react'
+import { Download, PanelRight, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import {
   TEMPLATE_RATIO,
@@ -66,6 +66,7 @@ export default function ShareEditorPage({
   const [zoom, setZoom] = useState<Zoom>('fit')
   const [saveState, setSaveState] = useState<SaveState>('idle')
   const [pdfPreview, setPdfPreview] = useState<{ url: string; filename: string } | null>(null)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
   const previewRef = useRef<HTMLDivElement | null>(null)
 
   // Autosave opts changes back into share_drafts. Debounced so a
@@ -190,6 +191,17 @@ export default function ShareEditorPage({
     setPdfPreview(null)
   }, [pdfPreview])
 
+  const handleDelete = useCallback(async () => {
+    try {
+      await window.spool.shareDraft.delete(draftId)
+    } catch (err) {
+      console.error('Delete share draft failed:', err)
+      toast.error('Could not delete draft')
+      return
+    }
+    onBack()
+  }, [draftId, onBack])
+
   const exportSpoolFile = useCallback(async () => {
     // Same pre-pick discipline as PNG; JSON.stringify is fast but
     // saveBlob's picker call still needs the user gesture.
@@ -216,7 +228,7 @@ export default function ShareEditorPage({
   }, [beginSaving, conversation, opts])
 
   const topBarContent = (
-    <div className="flex-1 min-w-0 flex items-center gap-3 px-3">
+    <div className="flex-1 min-w-0 flex items-center gap-2 px-3">
       <button
         type="button"
         onClick={onBack}
@@ -228,7 +240,7 @@ export default function ShareEditorPage({
           <path d="M8 3L4 6.5L8 10" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
         </svg>
       </button>
-      <div className="flex-1 min-w-0 flex items-baseline gap-2">
+      <div className="min-w-0 flex items-baseline gap-2">
         <h1
           className="min-w-0 text-[13px] font-medium text-warm-text dark:text-dark-text truncate"
           title={conversation.title}
@@ -236,12 +248,25 @@ export default function ShareEditorPage({
           {conversation.title}
         </h1>
         <span
-          className="min-w-0 text-[11px] text-warm-faint dark:text-dark-muted truncate"
+          className="min-w-0 text-[11px] text-warm-faint dark:text-dark-muted truncate whitespace-nowrap"
           title={meta}
         >
           {meta}
         </span>
       </div>
+      <EditorDeleteChip
+        confirming={confirmingDelete}
+        onClick={() => {
+          if (confirmingDelete) {
+            setConfirmingDelete(false)
+            void handleDelete()
+          } else {
+            setConfirmingDelete(true)
+          }
+        }}
+        onCancel={() => setConfirmingDelete(false)}
+      />
+      <div className="flex-1" />
       <DownloadButton
         saving={saveState === 'saving'}
         onPng={() => { void exportPng() }}
@@ -317,5 +342,74 @@ export default function ShareEditorPage({
         </div>
       </div>
     </PageLayout>
+  )
+}
+
+/**
+ * Click-twice delete affordance in the editor top bar. Resting: a small
+ * trash button. First click expands it into a "Delete?" pill with
+ * destructive color. Second click fires onClick. Escape, mouse-leave,
+ * or clicking outside cancels the primed state.
+ */
+/**
+ * Click-twice delete affordance in the editor top bar. The outer wrapper
+ * reserves a fixed 24×24 slot so neighbouring elements never move. When
+ * primed, the inner span absolutely-positions itself and grows
+ * rightward into a "Delete?" pill that overlays whatever sits beside it
+ * — temporary visual occlusion is acceptable here; layout reflow is not.
+ */
+function EditorDeleteChip({
+  confirming,
+  onClick,
+  onCancel,
+}: {
+  confirming: boolean
+  onClick: () => void
+  onCancel: () => void
+}) {
+  const wrapRef = useRef<HTMLButtonElement | null>(null)
+
+  useEffect(() => {
+    if (!confirming) return
+    function onDown(e: MouseEvent) {
+      if (!wrapRef.current?.contains(e.target as Node)) onCancel()
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onCancel()
+    }
+    window.addEventListener('mousedown', onDown)
+    window.addEventListener('keydown', onKey)
+    return () => {
+      window.removeEventListener('mousedown', onDown)
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [confirming, onCancel])
+
+  return (
+    <button
+      ref={wrapRef}
+      type="button"
+      data-testid="share-editor-delete"
+      data-confirming={confirming ? '' : undefined}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick()
+        }
+      }}
+      onMouseLeave={() => {
+        if (confirming) onCancel()
+      }}
+      aria-label={confirming ? 'Click again to confirm delete' : 'Delete draft'}
+      title={confirming ? 'Click again to confirm' : 'Delete draft'}
+      className={`flex-none inline-flex items-center justify-center h-6 rounded cursor-pointer select-none transition-[width,padding,background-color,color] duration-150 text-[11.5px] font-medium tracking-[-0.005em] whitespace-nowrap overflow-hidden ${
+        confirming
+          ? 'w-[60px] px-2.5 bg-[color:var(--color-status-error)] dark:bg-[color:var(--color-status-error-dark)] text-white shadow-[0_1px_3px_rgba(0,0,0,0.18)]'
+          : 'w-6 text-warm-faint dark:text-dark-muted hover:text-[color:var(--color-status-error)] dark:hover:text-[color:var(--color-status-error-dark)] hover:bg-[color:var(--color-status-error)]/8 dark:hover:bg-[color:var(--color-status-error-dark)]/12'
+      }`}
+    >
+      {confirming ? 'Delete' : <Trash2 size={13} strokeWidth={1.75} />}
+    </button>
   )
 }

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
-import { Newspaper } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { Newspaper, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
 import { useShareDrafts } from '../hooks/useShareDrafts'
 import type { ShareDraftListItem } from '@spool-lab/core'
 import {
@@ -22,8 +23,30 @@ type Props = {
  * The tab strip lands in Phase 2 alongside the actual publish flow.
  */
 export default function SharesPage({ onOpenDraft }: Props) {
-  const { drafts, loading, error } = useShareDrafts()
+  const { drafts, loading, error, removeDraft, restoreDraft } = useShareDrafts()
   const hasDrafts = drafts.length > 0
+
+  const handleDelete = useCallback(async (draft: ShareDraftListItem) => {
+    try {
+      const full = await removeDraft(draft.draft_id)
+      if (!full) return
+      const title = draft.title || 'Untitled'
+      toast(`Deleted “${title}”`, {
+        action: {
+          label: 'Undo',
+          onClick: () => {
+            void restoreDraft(full).catch((err) => {
+              console.error('Restore share draft failed:', err)
+              toast.error('Could not restore draft')
+            })
+          },
+        },
+      })
+    } catch (err) {
+      console.error('Delete share draft failed:', err)
+      toast.error('Could not delete draft')
+    }
+  }, [removeDraft, restoreDraft])
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -33,7 +56,13 @@ export default function SharesPage({ onOpenDraft }: Props) {
         </div>
       )}
       <div className="flex-1 min-h-0 overflow-y-auto">
-        <DraftsList drafts={drafts} loading={loading} error={error} onOpenDraft={onOpenDraft} />
+        <DraftsList
+          drafts={drafts}
+          loading={loading}
+          error={error}
+          onOpenDraft={onOpenDraft}
+          onDeleteDraft={handleDelete}
+        />
       </div>
     </div>
   )
@@ -44,11 +73,13 @@ function DraftsList({
   loading,
   error,
   onOpenDraft,
+  onDeleteDraft,
 }: {
   drafts: ShareDraftListItem[]
   loading: boolean
   error: string | null
   onOpenDraft?: ((draft: ShareDraftListItem) => void) | undefined
+  onDeleteDraft: (draft: ShareDraftListItem) => void
 }) {
   const [skeletonCount] = useState(readSkeletonCount)
   // Defer skeleton render by 150ms so sub-threshold loads (local sqlite is
@@ -96,7 +127,7 @@ function DraftsList({
     >
       {drafts.map((draft) => (
         <li key={draft.draft_id}>
-          <DraftCard draft={draft} onClick={onOpenDraft} />
+          <DraftCard draft={draft} onClick={onOpenDraft} onDelete={onDeleteDraft} />
         </li>
       ))}
     </ul>
@@ -109,9 +140,11 @@ const FALLBACK_RATIO = { w: 720, h: 960 }
 function DraftCard({
   draft,
   onClick,
+  onDelete,
 }: {
   draft: ShareDraftListItem
   onClick?: ((draft: ShareDraftListItem) => void) | undefined
+  onDelete: (draft: ShareDraftListItem) => void
 }) {
   // The preview blob is a SpoolDocument-shaped subset: full opts +
   // conversation metadata + first ~6 turns. Card rendering only ever
@@ -126,7 +159,7 @@ function DraftCard({
   }, [draft.preview_json])
 
   if (!doc) {
-    return <CorruptDraftCard draft={draft} onClick={onClick} />
+    return <CorruptDraftCard draft={draft} onClick={onClick} onDelete={onDelete} />
   }
 
   const ratio = TEMPLATE_RATIO[doc.opts.template] ?? FALLBACK_RATIO
@@ -145,8 +178,19 @@ function DraftCard({
   )
 
   const title = doc.conversation.title || 'Untitled'
+  const [hover, setHover] = useState(false)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
 
   return (
+    <div
+      className="relative inline-block"
+      style={{ width: CARD_W, height: cardH }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => {
+        setHover(false)
+        setConfirmingDelete(false)
+      }}
+    >
     <button
       type="button"
       data-testid="shares-draft-row"
@@ -218,6 +262,64 @@ function DraftCard({
         </span>
       </span>
     </button>
+      {hover && (
+        <DeleteChip
+          confirming={confirmingDelete}
+          onClick={() => {
+            if (confirmingDelete) {
+              onDelete(draft)
+              setConfirmingDelete(false)
+            } else {
+              setConfirmingDelete(true)
+            }
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Quilt-style click-twice delete affordance. Resting state is a small
+ * X-chip in the top-right corner; first click expands it to a "Delete?"
+ * pill with inverted colors; second click fires onClick. The parent
+ * resets confirming state on mouse-leave so the pill never lingers in
+ * its primed state after the user has moved on.
+ */
+function DeleteChip({ confirming, onClick }: { confirming: boolean; onClick: () => void }) {
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      data-testid="shares-draft-delete"
+      data-confirming={confirming ? '' : undefined}
+      onClick={(e) => {
+        e.stopPropagation()
+        onClick()
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.stopPropagation()
+          e.preventDefault()
+          onClick()
+        }
+      }}
+      aria-label={confirming ? 'Click again to confirm delete' : 'Delete draft'}
+      title={confirming ? 'Click again to confirm' : 'Delete draft'}
+      className={`absolute top-1.5 right-1.5 z-10 h-5 min-w-5 inline-flex items-center justify-center rounded-full cursor-pointer select-none transition-[padding,background,color,border-color] duration-150 shadow-[0_1px_3px_rgba(0,0,0,0.12)] font-sans text-[10.5px] font-medium tracking-[0.02em] whitespace-nowrap ${
+        confirming
+          ? 'bg-warm-text dark:bg-dark-text text-warm-bg dark:text-dark-bg border border-warm-text dark:border-dark-text px-2'
+          : 'bg-warm-bg dark:bg-dark-bg text-warm-muted dark:text-dark-muted border border-warm-border dark:border-dark-border'
+      }`}
+    >
+      {confirming ? (
+        'Delete'
+      ) : (
+        <svg width="9" height="9" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden>
+          <path d="M2 2l6 6M8 2l-6 6" />
+        </svg>
+      )}
+    </span>
   )
 }
 
@@ -268,19 +370,50 @@ function DraftsSkeleton({ count }: { count: number }) {
   )
 }
 
-function CorruptDraftCard({ draft }: { draft: ShareDraftListItem; onClick?: unknown }) {
+function CorruptDraftCard({
+  draft,
+  onDelete,
+}: {
+  draft: ShareDraftListItem
+  onClick?: unknown
+  onDelete: (draft: ShareDraftListItem) => void
+}) {
   const ratio = FALLBACK_RATIO
   const cardH = Math.round(CARD_W * (ratio.h / ratio.w))
+  const title = draft.title || 'Untitled'
+  const [hover, setHover] = useState(false)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
   return (
     <div
-      className="block rounded-md border border-dashed border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface text-warm-faint dark:text-dark-muted text-xs flex flex-col items-center justify-center gap-1 px-3 text-center"
+      className="relative inline-block"
       style={{ width: CARD_W, height: cardH }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => {
+        setHover(false)
+        setConfirmingDelete(false)
+      }}
     >
-      <span className="font-medium text-warm-text dark:text-dark-text line-clamp-2">
-        {draft.title || 'Untitled'}
-      </span>
-      <span>snapshot unreadable</span>
-      <span>edited {formatRelative(draft.updated_at)}</span>
+      <div
+        className="block rounded-md border border-dashed border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface text-warm-faint dark:text-dark-muted text-xs flex flex-col items-center justify-center gap-1 px-3 text-center"
+        style={{ width: CARD_W, height: cardH }}
+      >
+        <span className="font-medium text-warm-text dark:text-dark-text line-clamp-2">{title}</span>
+        <span>snapshot unreadable</span>
+        <span>edited {formatRelative(draft.updated_at)}</span>
+      </div>
+      {hover && (
+        <DeleteChip
+          confirming={confirmingDelete}
+          onClick={() => {
+            if (confirmingDelete) {
+              onDelete(draft)
+              setConfirmingDelete(false)
+            } else {
+              setConfirmingDelete(true)
+            }
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/packages/app/src/renderer/components/share-editor/DownloadButton.tsx
+++ b/packages/app/src/renderer/components/share-editor/DownloadButton.tsx
@@ -70,7 +70,7 @@ export function DownloadButton({ saving, onPng, onPdf, onSpool }: Props) {
   }
 
   return (
-    <div ref={rootRef} className="relative flex" data-testid="share-editor-download">
+    <div ref={rootRef} className="relative flex flex-none" data-testid="share-editor-download">
       <button
         type="button"
         onClick={trigger}

--- a/packages/app/src/renderer/hooks/useShareDrafts.ts
+++ b/packages/app/src/renderer/hooks/useShareDrafts.ts
@@ -1,11 +1,17 @@
 import { useCallback, useEffect, useState } from 'react'
-import type { ShareDraftListItem } from '@spool-lab/core'
+import type { ShareDraftListItem, ShareDraftRow } from '@spool-lab/core'
 
 interface UseShareDraftsResult {
   drafts: ShareDraftListItem[]
   loading: boolean
   error: string | null
   refresh: () => Promise<void>
+  /** Delete a draft. Optimistically drops it from the local list, then
+   *  asks main to DELETE from the share_drafts table. Returns the full
+   *  row that was deleted so callers can offer Undo. */
+  removeDraft: (draftId: string) => Promise<ShareDraftRow | null>
+  /** Re-insert a previously-deleted draft via upsert. Used by Undo. */
+  restoreDraft: (row: ShareDraftRow) => Promise<void>
 }
 
 /**
@@ -37,5 +43,33 @@ export function useShareDrafts(opts: { limit?: number } = {}): UseShareDraftsRes
     void refresh()
   }, [refresh])
 
-  return { drafts, loading, error, refresh }
+  const removeDraft = useCallback(async (draftId: string): Promise<ShareDraftRow | null> => {
+    // Fetch the full row first so the caller can offer Undo with the
+    // snapshot intact. listShareDrafts omits snapshot_json on purpose.
+    const full = await window.spool.shareDraft.get(draftId)
+    if (!full) return null
+    setDrafts(prev => prev.filter(d => d.draft_id !== draftId))
+    try {
+      await window.spool.shareDraft.delete(draftId)
+      return full
+    } catch (err) {
+      // Roll back the optimistic remove if the delete itself failed.
+      void refresh()
+      throw err
+    }
+  }, [refresh])
+
+  const restoreDraft = useCallback(async (row: ShareDraftRow): Promise<void> => {
+    await window.spool.shareDraft.upsert({
+      draft_id: row.draft_id,
+      source_kind: row.source_kind,
+      source_origin: row.source_origin,
+      title: row.title,
+      snapshot_json: row.snapshot_json,
+      preview_json: row.preview_json,
+    })
+    await refresh()
+  }, [refresh])
+
+  return { drafts, loading, error, refresh, removeDraft, restoreDraft }
 }


### PR DESCRIPTION
Adds a destructive-action affordance for share drafts in two surfaces:
a chip on hover for each Shares card, and an inline pill in the editor
top bar. Both follow a click-twice pattern — the first click primes the
button into a red "Delete" pill; the second click commits. Mouse-leave,
click-outside, or Escape resets the primed state so the affordance
never lingers once the user has moved on.

Storage is "immediate delete, restore via Undo". The hook now exposes
`removeDraft` (which fetches the full row before optimistically dropping
it from the list, then issues IPC DELETE) and `restoreDraft` (re-upserts
the captured row). Sharespage uses both for an Undo toast that runs for
4s on the existing AppToaster surface. Editor-side delete navigates back
to the previous view on confirm and does not surface Undo — the user
has already left the draft, so a "find it in Shares" Undo path is more
confusing than helpful; the click-twice pill is the only confirmation
surface there.

The editor pill expands in place (24px → 60px). When the title row is
short, the empty flex spacer absorbs the size change; when it's long,
title/meta truncate to make room. DownloadButton is now flex-none so it
never wraps under any title length. Toast width is min/max instead of
fixed so short messages don't look sparse.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>