### PR TITLE
feat(app): share entry points + unified ⋯ menu surface

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -181,6 +181,19 @@ export default function App() {
     setView('share-editor')
   }, [enterShareEditor, sidebarCollapsed])
 
+  const handleStartShareFromUuid = useCallback(async (sessionUuid: string) => {
+    try {
+      const result = await window.spool?.getSession(sessionUuid)
+      if (!result) {
+        console.error('Cannot share — session not found:', sessionUuid)
+        return
+      }
+      await handleStartShareFromSession(result.session, result.messages)
+    } catch (err) {
+      console.error('Failed to load session for share:', err)
+    }
+  }, [handleStartShareFromSession])
+
   const handleOpenDraft = useCallback(async (draft: ShareDraftListItem) => {
     // The list query intentionally omits snapshot_json — fetch the
     // full row before parsing so the editor gets the complete
@@ -911,6 +924,7 @@ export default function App() {
                         onOpenSession={handleOpenSession}
                         defaultSortOrder={defaultSearchSort}
                         onCopySessionId={handleCopySessionId}
+                        {...(FEATURES.share ? { onShareSession: handleStartShareFromUuid } : {})}
                       />
                     </div>
                   )}

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -133,7 +133,7 @@ export default function App() {
     }
   }, [])
 
-  const handleStartShareFromSession = useCallback(async (session: Session, messages: Message[]) => {
+  const handleStartShareFromSession = useCallback(async (session: Session, messages: Message[], returnView: View = 'session') => {
     const draftId = sessionDraftId(session.sessionUuid)
     // If the user has shared this session before, reopen their saved
     // draft (their edits to template / paper / typeface / etc. are in
@@ -177,7 +177,7 @@ export default function App() {
       conversation,
       opts,
     })
-    setShareEditorReturnView('session')
+    setShareEditorReturnView(returnView)
     setView('share-editor')
   }, [enterShareEditor, sidebarCollapsed])
 
@@ -188,11 +188,11 @@ export default function App() {
         console.error('Cannot share — session not found:', sessionUuid)
         return
       }
-      await handleStartShareFromSession(result.session, result.messages)
+      await handleStartShareFromSession(result.session, result.messages, view)
     } catch (err) {
       console.error('Failed to load session for share:', err)
     }
-  }, [handleStartShareFromSession])
+  }, [handleStartShareFromSession, view])
 
   const handleOpenDraft = useCallback(async (draft: ShareDraftListItem) => {
     // The list query intentionally omits snapshot_json — fetch the
@@ -697,6 +697,7 @@ export default function App() {
       pinnedSortOrder={pinnedSortOrder}
       onPinnedSortOrderChange={handlePinnedSortChange}
       onCopySessionId={handleCopySessionId}
+      {...(FEATURES.share ? { onShareSession: handleStartShareFromUuid } : {})}
       onSettingsClick={() => { setSettingsTab('general'); setShowSettings(true) }}
     />
   )
@@ -816,6 +817,7 @@ export default function App() {
         pinnedSortOrder={pinnedSortOrder}
         onPinnedSortOrderChange={handlePinnedSortChange}
         onCopySessionId={handleCopySessionId}
+        {...(FEATURES.share ? { onShareSession: handleStartShareFromUuid } : {})}
         onSettingsClick={() => { setSettingsTab('general'); setShowSettings(true) }}
       />
       </div>
@@ -835,11 +837,12 @@ export default function App() {
             }}
             onOpenSession={handleOpenSession}
             onCopySessionId={handleCopySessionId}
+            {...(FEATURES.share ? { onShare: handleStartShareFromUuid } : {})}
           />
         ) : (
           <>
             {!showProjectView && view !== 'session' && !!query.trim() && (
-              <div className="flex items-center gap-3 px-6 pt-6 pb-3 flex-none">
+              <div className="flex items-center gap-3 px-6 pt-1.5 pb-3 flex-none">
                 <button
                   type="button"
                   onClick={handleClearResults}
@@ -886,6 +889,7 @@ export default function App() {
                   onSortOrderChange={handleProjectSortChange}
                   onOpenSession={handleOpenSession}
                   onCopySessionId={handleCopySessionId}
+                  {...(FEATURES.share ? { onShare: handleStartShareFromUuid } : {})}
                 />
               ) : (
                 <div className="h-full flex flex-col overflow-hidden">

--- a/packages/app/src/renderer/components/ContinueActions.tsx
+++ b/packages/app/src/renderer/components/ContinueActions.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { MoreHorizontal, Eye, SquareTerminal } from 'lucide-react'
+import { MoreHorizontal, Eye, SquareTerminal, Share2, Copy, ChevronRight, Loader2 } from 'lucide-react'
 import type { FragmentResult } from '@spool-lab/core'
 import Menu from './Menu.js'
 import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
@@ -8,9 +8,13 @@ type Props = {
   result: FragmentResult
   onOpenSession: (uuid: string, messageId?: number) => void
   onCopySessionId: (source: FragmentResult['source']) => void
+  onShare?: () => void
 }
 
-export default function ContinueActions({ result, onOpenSession, onCopySessionId }: Props) {
+const ICON_SIZE = 14
+const ICON_STROKE = 1.6
+
+export default function ContinueActions({ result, onOpenSession, onCopySessionId, onShare }: Props) {
   const [copiedId, setCopiedId] = useState(false)
   const [copiedCommand, setCopiedCommand] = useState(false)
   const [resuming, setResuming] = useState(false)
@@ -39,23 +43,30 @@ export default function ContinueActions({ result, onOpenSession, onCopySessionId
   const menuItems = [
     {
       label: 'View session',
-      icon: <EyeIcon />,
+      icon: <Eye size={ICON_SIZE} strokeWidth={ICON_STROKE} aria-hidden />,
       onSelect: () => onOpenSession(result.sessionUuid, result.messageId),
     },
+    ...(onShare ? [{
+      label: 'Share session',
+      icon: <Share2 size={ICON_SIZE} strokeWidth={ICON_STROKE} aria-hidden />,
+      onSelect: onShare,
+    }] : []),
     ...(resumeCommand ? [{
       label: resuming ? 'Opening Terminal…' : 'Open in Terminal',
-      icon: resuming ? <SpinnerIcon /> : <TerminalIcon />,
+      icon: resuming
+        ? <Loader2 size={ICON_SIZE} strokeWidth={ICON_STROKE} className="animate-spin" aria-hidden />
+        : <SquareTerminal size={ICON_SIZE} strokeWidth={ICON_STROKE} aria-hidden />,
       onSelect: () => { void handleResume() },
       disabled: resuming,
     }] : []),
     ...(resumeCommand ? [{
       label: copiedCommand ? 'Copied resume command' : 'Copy resume command',
-      icon: <CommandIcon />,
+      icon: <ChevronRight size={ICON_SIZE} strokeWidth={ICON_STROKE} aria-hidden />,
       onSelect: () => { void handleCopyCommand() },
     }] : []),
     {
       label: copiedId ? 'Copied session ID' : 'Copy session ID',
-      icon: <CopyIcon />,
+      icon: <Copy size={ICON_SIZE} strokeWidth={ICON_STROKE} aria-hidden />,
       onSelect: () => { void handleCopyId() },
     },
   ]
@@ -73,47 +84,12 @@ export default function ContinueActions({ result, onOpenSession, onCopySessionId
             event.stopPropagation()
             toggle()
           }}
-          className="flex-none self-center inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text hover:bg-warm-surface2 dark:hover:bg-dark-surface2 transition-colors"
+          className="flex-none self-center inline-flex items-center justify-center w-5 h-5 rounded text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text hover:bg-warm-surface2 dark:hover:bg-dark-surface2 transition-colors"
         >
-          <MoreHorizontal size={14} strokeWidth={1.8} aria-hidden />
+          <MoreHorizontal size={13} strokeWidth={ICON_STROKE} aria-hidden />
         </button>
       )}
       items={menuItems}
     />
-  )
-}
-
-function EyeIcon() {
-  return <Eye size={14} strokeWidth={1.5} aria-hidden />
-}
-
-function TerminalIcon() {
-  return <SquareTerminal size={14} strokeWidth={1.5} aria-hidden />
-}
-
-function CommandIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M3 4.5L5 7L3 9.5" />
-      <path d="M6.5 10H11.5" />
-    </svg>
-  )
-}
-
-function CopyIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-      <rect x="5" y="5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.5" />
-      <path d="M9 5V3.5C9 2.67 8.33 2 7.5 2H3.5C2.67 2 2 2.67 2 3.5V7.5C2 8.33 2.67 9 3.5 9H5" stroke="currentColor" strokeWidth="1.5" />
-    </svg>
-  )
-}
-
-function SpinnerIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" className="animate-spin">
-      <circle cx="7" cy="7" r="5.25" stroke="currentColor" strokeWidth="1.5" fill="none" strokeOpacity="0.3" />
-      <path d="M7 1.75A5.25 5.25 0 0112.25 7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" fill="none" />
-    </svg>
   )
 }

--- a/packages/app/src/renderer/components/FragmentResults.tsx
+++ b/packages/app/src/renderer/components/FragmentResults.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import { Share2 } from 'lucide-react'
 import type { FragmentResult } from '@spool-lab/core'
 import ContinueActions from './ContinueActions.js'
 import { SourceBadge } from './Badges.js'
@@ -155,22 +154,12 @@ function FragmentRow({
           {title}
         </h3>
         <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
-        {onShareSession && (
-          <button
-            type="button"
-            aria-label="Share session"
-            title="Share session"
-            onClick={(event) => {
-              event.stopPropagation()
-              onShareSession(result.sessionUuid)
-            }}
-            className="flex-none self-center inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text hover:bg-warm-surface2 dark:hover:bg-dark-surface2 transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-            data-testid="fragment-share"
-          >
-            <Share2 size={14} strokeWidth={1.5} aria-hidden />
-          </button>
-        )}
-        <ContinueActions result={result} onOpenSession={onOpenSession} onCopySessionId={onCopySessionId} />
+        <ContinueActions
+          result={result}
+          onOpenSession={onOpenSession}
+          onCopySessionId={onCopySessionId}
+          {...(onShareSession ? { onShare: () => onShareSession(result.sessionUuid) } : {})}
+        />
       </div>
 
       <div className="text-xs text-warm-muted dark:text-dark-muted mb-1.5 truncate">

--- a/packages/app/src/renderer/components/FragmentResults.tsx
+++ b/packages/app/src/renderer/components/FragmentResults.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Share2 } from 'lucide-react'
 import type { FragmentResult } from '@spool-lab/core'
 import ContinueActions from './ContinueActions.js'
 import { SourceBadge } from './Badges.js'
@@ -15,9 +16,10 @@ type Props = {
   onOpenSession: (uuid: string, messageId?: number) => void
   defaultSortOrder: SearchSortOrder
   onCopySessionId: (source: FragmentResult['source']) => void
+  onShareSession?: (uuid: string) => void
 }
 
-export default function FragmentResults({ results, query, onOpenSession, defaultSortOrder, onCopySessionId }: Props) {
+export default function FragmentResults({ results, query, onOpenSession, defaultSortOrder, onCopySessionId, onShareSession }: Props) {
   const [activeFilter, setActiveFilter] = useState('all')
   const [sortOrder, setSortOrder] = useState<SearchSortOrder>(defaultSortOrder)
 
@@ -109,6 +111,7 @@ export default function FragmentResults({ results, query, onOpenSession, default
               result={result}
               onOpenSession={onOpenSession}
               onCopySessionId={onCopySessionId}
+              {...(onShareSession ? { onShareSession } : {})}
             />
           ))}
         </div>
@@ -128,10 +131,12 @@ function FragmentRow({
   result,
   onOpenSession,
   onCopySessionId,
+  onShareSession,
 }: {
   result: FragmentRowResult
   onOpenSession: (uuid: string, messageId?: number) => void
   onCopySessionId: (source: FragmentResult['source']) => void
+  onShareSession?: (uuid: string) => void
 }) {
   const snippet = result.snippet.replace(/<mark>/g, '<strong>').replace(/<\/mark>/g, '</strong>')
   const date = formatRelativeDate(result.startedAt)
@@ -150,6 +155,21 @@ function FragmentRow({
           {title}
         </h3>
         <span className="text-xs text-warm-faint dark:text-dark-muted flex-none">{date}</span>
+        {onShareSession && (
+          <button
+            type="button"
+            aria-label="Share session"
+            title="Share session"
+            onClick={(event) => {
+              event.stopPropagation()
+              onShareSession(result.sessionUuid)
+            }}
+            className="flex-none self-center inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text hover:bg-warm-surface2 dark:hover:bg-dark-surface2 transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+            data-testid="fragment-share"
+          >
+            <Share2 size={14} strokeWidth={1.5} aria-hidden />
+          </button>
+        )}
         <ContinueActions result={result} onOpenSession={onOpenSession} onCopySessionId={onCopySessionId} />
       </div>
 

--- a/packages/app/src/renderer/components/LibraryLanding.tsx
+++ b/packages/app/src/renderer/components/LibraryLanding.tsx
@@ -6,6 +6,7 @@ type Props = {
   onSelectProject: (identityKey: string) => void
   onOpenSession: (uuid: string) => void
   onCopySessionId: (source: Session['source']) => void
+  onShare?: (uuid: string) => void
 }
 
 type DateBucket = {
@@ -13,7 +14,7 @@ type DateBucket = {
   sessions: Session[]
 }
 
-export default function LibraryLanding({ onOpenSession, onCopySessionId }: Props) {
+export default function LibraryLanding({ onOpenSession, onCopySessionId, onShare }: Props) {
   const [pinnedSessions, setPinnedSessions] = useState<Session[]>([])
   const [recentSessions, setRecentSessions] = useState<Session[] | null>(null)
   const [reloadKey, setReloadKey] = useState(0)
@@ -90,6 +91,7 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId }: Props
                       onPinChange={handlePinChange}
                       onOpenSession={onOpenSession}
                       onCopySessionId={onCopySessionId}
+                      {...(onShare ? { onShare } : {})}
                     />
                   ))}
                 </div>
@@ -112,6 +114,7 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId }: Props
                     onPinChange={handlePinChange}
                     onOpenSession={onOpenSession}
                     onCopySessionId={onCopySessionId}
+                    {...(onShare ? { onShare } : {})}
                   />
                 ))}
               </CollapsibleSection>

--- a/packages/app/src/renderer/components/ProjectView.tsx
+++ b/packages/app/src/renderer/components/ProjectView.tsx
@@ -14,6 +14,7 @@ type Props = {
   onSortOrderChange: (next: ProjectSessionSortOrder) => void
   onOpenSession: (uuid: string) => void
   onCopySessionId: (source: Session['source']) => void
+  onShare?: (uuid: string) => void
 }
 
 export default function ProjectView({
@@ -22,6 +23,7 @@ export default function ProjectView({
   onSortOrderChange,
   onOpenSession,
   onCopySessionId,
+  onShare,
 }: Props) {
   const [group, setGroup] = useState<ProjectGroup | null>(null)
   const [sessions, setSessions] = useState<Session[] | null>(null)
@@ -331,6 +333,7 @@ export default function ProjectView({
                       onPinChange={handlePinChange}
                       onOpenSession={onOpenSession}
                       onCopySessionId={onCopySessionId}
+                      {...(onShare ? { onShare } : {})}
                     />
                   ))}
                 </div>
@@ -356,6 +359,7 @@ export default function ProjectView({
                     onPinChange={handlePinChange}
                     onOpenSession={onOpenSession}
                     onCopySessionId={onCopySessionId}
+                    {...(onShare ? { onShare } : {})}
                   />
                 ))}
               </div>
@@ -368,6 +372,7 @@ export default function ProjectView({
                     onPinChange={handlePinChange}
                     onOpenSession={onOpenSession}
                     onCopySessionId={onCopySessionId}
+                    {...(onShare ? { onShare } : {})}
                   />
                 ))}
               </div>
@@ -380,6 +385,7 @@ export default function ProjectView({
                     onPinChange={handlePinChange}
                     onOpenSession={onOpenSession}
                     onCopySessionId={onCopySessionId}
+                    {...(onShare ? { onShare } : {})}
                   />
                 ))}
               </CollapsibleSection>
@@ -392,6 +398,7 @@ export default function ProjectView({
                     onPinChange={handlePinChange}
                     onOpenSession={onOpenSession}
                     onCopySessionId={onCopySessionId}
+                    {...(onShare ? { onShare } : {})}
                   />
                 ))}
               </div>
@@ -412,6 +419,7 @@ function DirectoryGroupSection({
   onPinChange,
   onOpenSession,
   onCopySessionId,
+  onShare,
 }: {
   cwd: string
   projectDisplayPath: string | null
@@ -421,6 +429,7 @@ function DirectoryGroupSection({
   onPinChange: (uuid: string, pinned: boolean) => void
   onOpenSession: (uuid: string) => void
   onCopySessionId: (source: Session['source']) => void
+  onShare?: (uuid: string) => void
 }) {
   const { name } = formatCwdLabel(cwd, projectDisplayPath)
   const count = sessions.length
@@ -464,6 +473,7 @@ function DirectoryGroupSection({
               onPinChange={onPinChange}
               onOpenSession={onOpenSession}
               onCopySessionId={onCopySessionId}
+              {...(onShare ? { onShare } : {})}
             />
           ))}
         </div>

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { SquareTerminal, Share2 } from 'lucide-react'
+import { SquareTerminal, Share2, MoreHorizontal, ChevronRight, Copy } from 'lucide-react'
 import type { Session, Message } from '@spool-lab/core'
 import { type FindRange } from './MessageBubble.js'
 import MessageList, { type MessageListHandle } from './MessageList.js'
@@ -306,20 +306,18 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
                 aria-label="More actions"
                 className="inline-flex items-center justify-center w-5 h-5 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors"
               >
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                  <circle cx="5" cy="12" r="1.5" />
-                  <circle cx="12" cy="12" r="1.5" />
-                  <circle cx="19" cy="12" r="1.5" />
-                </svg>
+                <MoreHorizontal size={13} strokeWidth={1.6} aria-hidden />
               </button>
             )}
             items={[
               {
                 label: 'Copy session ID',
+                icon: <Copy size={14} strokeWidth={1.6} aria-hidden />,
                 onSelect: () => { void handleCopySessionId() },
               },
               ...(resumeCommandAvailable ? [{
                 label: commandCopied ? 'Copied!' : 'Copy resume command',
+                icon: <ChevronRight size={14} strokeWidth={1.6} aria-hidden />,
                 onSelect: () => { void handleCopyCommand() },
               }] : []),
             ]}

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { SquareTerminal } from 'lucide-react'
+import { SquareTerminal, MoreHorizontal, ChevronRight, Copy, Loader2, Share2 } from 'lucide-react'
 import type { Session } from '@spool-lab/core'
 import { SourceBadge } from './Badges.js'
 import PinButton from './PinButton.js'
@@ -15,9 +15,10 @@ type Props = {
   onPinChange?: (uuid: string, pinned: boolean) => void
   onOpenSession: (uuid: string) => void
   onCopySessionId: (source: Session['source']) => void
+  onShare?: (uuid: string) => void
 }
 
-export default function SessionRow({ session, pinned = false, showProject = false, bucket, onPinChange, onOpenSession, onCopySessionId }: Props) {
+export default function SessionRow({ session, pinned = false, showProject = false, bucket, onPinChange, onOpenSession, onCopySessionId, onShare }: Props) {
   const [resuming, setResuming] = useState(false)
 
   const title = session.title?.trim() || '(no title)'
@@ -104,30 +105,33 @@ export default function SessionRow({ session, pinned = false, showProject = fals
                 aria-label="More actions"
                 aria-haspopup="menu"
                 aria-expanded={open}
-                className="inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75"
+                className="inline-flex items-center justify-center w-5 h-5 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75"
               >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-                  <circle cx="5" cy="12" r="1.5" />
-                  <circle cx="12" cy="12" r="1.5" />
-                  <circle cx="19" cy="12" r="1.5" />
-                </svg>
+                <MoreHorizontal size={13} strokeWidth={1.6} aria-hidden />
               </button>
             )}
             items={[
+              ...(onShare ? [{
+                label: 'Share session',
+                icon: <Share2 size={14} strokeWidth={1.6} aria-hidden />,
+                onSelect: () => onShare(session.sessionUuid),
+              }] : []),
               {
                 label: resuming ? 'Opening…' : 'Resume in Terminal',
-                icon: resuming ? <SpinnerIcon /> : <PlayIcon />,
+                icon: resuming
+                  ? <Loader2 size={14} strokeWidth={1.6} className="animate-spin" aria-hidden />
+                  : <SquareTerminal size={14} strokeWidth={1.6} aria-hidden />,
                 onSelect: () => { void handleResume() },
                 disabled: resuming,
               },
               ...(resumeCommand ? [{
                 label: 'Copy resume command',
-                icon: <TerminalIcon />,
+                icon: <ChevronRight size={14} strokeWidth={1.6} aria-hidden />,
                 onSelect: () => { void handleCopyCommand() },
               }] : []),
               {
                 label: 'Copy session ID',
-                icon: <CopyIcon />,
+                icon: <Copy size={14} strokeWidth={1.6} aria-hidden />,
                 onSelect: () => { void handleCopyId() },
               },
             ]}
@@ -150,33 +154,3 @@ function compactModel(model: string | null | undefined): string {
   return name
 }
 
-function PlayIcon() {
-  return <SquareTerminal size={14} strokeWidth={1.5} aria-hidden />
-}
-
-function TerminalIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M3 4.5L5 7L3 9.5" />
-      <path d="M6.5 10H11.5" />
-    </svg>
-  )
-}
-
-function CopyIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-      <rect x="5" y="5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.5" />
-      <path d="M9 5V3.5C9 2.67 8.33 2 7.5 2H3.5C2.67 2 2 2.67 2 3.5V7.5C2 8.33 2.67 9 3.5 9H5" stroke="currentColor" strokeWidth="1.5" />
-    </svg>
-  )
-}
-
-function SpinnerIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" className="animate-spin">
-      <circle cx="7" cy="7" r="5.25" stroke="currentColor" strokeWidth="1.5" fill="none" strokeOpacity="0.3" />
-      <path d="M7 1.75A5.25 5.25 0 0112.25 7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" fill="none" />
-    </svg>
-  )
-}

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import type { ProjectGroup, Session, SessionSource, StatusInfo } from '@spool-lab/core'
-import { Library as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, SquareTerminal } from 'lucide-react'
+import { Library as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, SquareTerminal, MoreHorizontal, ChevronRight, Copy, Loader2, Share2 } from 'lucide-react'
 import PinIcon from './PinIcon.js'
 import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
 import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
@@ -36,9 +36,10 @@ type Props = {
   pinnedSortOrder?: PinnedSortOrder
   onPinnedSortOrderChange?: (next: PinnedSortOrder) => void
   onCopySessionId?: (source: SessionSource) => void
+  onShareSession?: (uuid: string) => void
 }
 
-export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, onSelectProject, onSelectSession, onSelectHome, isLibraryActive = false, onSelectShares, isSharesActive = false, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true, sortOrder = DEFAULT_SIDEBAR_SORT_ORDER, onSortOrderChange, pinnedSortOrder = DEFAULT_PINNED_SORT_ORDER, onPinnedSortOrderChange, onCopySessionId }: Props) {
+export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, onSelectProject, onSelectSession, onSelectHome, isLibraryActive = false, onSelectShares, isSharesActive = false, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true, sortOrder = DEFAULT_SIDEBAR_SORT_ORDER, onSortOrderChange, pinnedSortOrder = DEFAULT_PINNED_SORT_ORDER, onPinnedSortOrderChange, onCopySessionId, onShareSession }: Props) {
   const [groups, setGroups] = useState<ProjectGroup[] | null>(null)
   const [projectsOpen, setProjectsOpen] = useState(true)
   const [pinned, setPinned] = useState<Session[] | null>(null)
@@ -160,6 +161,7 @@ export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, o
                     active={session.sessionUuid === activeSessionUuid}
                     onClick={() => onSelectSession(session.sessionUuid)}
                     {...(onCopySessionId ? { onCopySessionId } : {})}
+                    {...(onShareSession ? { onShare: onShareSession } : {})}
                   />
                 ))}
               </div>
@@ -407,11 +409,13 @@ function PinnedRow({
   active,
   onClick,
   onCopySessionId,
+  onShare,
 }: {
   session: Session
   active: boolean
   onClick: () => void
   onCopySessionId?: (source: SessionSource) => void
+  onShare?: (uuid: string) => void
 }) {
   const [resuming, setResuming] = useState(false)
   const [unpinning, setUnpinning] = useState(false)
@@ -495,61 +499,37 @@ function PinnedRow({
               aria-expanded={open}
               className="inline-flex items-center justify-center h-4 text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition-colors"
             >
-              <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-                <circle cx="5" cy="12" r="1.5" />
-                <circle cx="12" cy="12" r="1.5" />
-                <circle cx="19" cy="12" r="1.5" />
-              </svg>
+              <MoreHorizontal size={13} strokeWidth={1.6} aria-hidden />
             </button>
           )}
           items={[
+            ...(onShare ? [{
+              label: 'Share session',
+              icon: <Share2 size={14} strokeWidth={1.6} aria-hidden />,
+              onSelect: () => onShare(session.sessionUuid),
+            }] : []),
             {
               label: resuming ? 'Opening…' : 'Resume in Terminal',
-              icon: resuming ? <SpinnerIcon /> : <SquareTerminal size={14} strokeWidth={1.5} aria-hidden />,
+              icon: resuming
+                ? <Loader2 size={14} strokeWidth={1.6} className="animate-spin" aria-hidden />
+                : <SquareTerminal size={14} strokeWidth={1.6} aria-hidden />,
               onSelect: () => { void handleResume() },
               disabled: resuming,
             },
             ...(resumeCommand ? [{
               label: 'Copy resume command',
-              icon: <TerminalGlyph />,
+              icon: <ChevronRight size={14} strokeWidth={1.6} aria-hidden />,
               onSelect: () => { void handleCopyCommand() },
             }] : []),
             {
               label: 'Copy session ID',
-              icon: <CopyGlyph />,
+              icon: <Copy size={14} strokeWidth={1.6} aria-hidden />,
               onSelect: () => { void handleCopyId() },
             },
           ]}
         />
       </span>
     </div>
-  )
-}
-
-function TerminalGlyph() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M3 4.5L5 7L3 9.5" />
-      <path d="M6.5 10H11.5" />
-    </svg>
-  )
-}
-
-function CopyGlyph() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-      <rect x="5" y="5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.5" />
-      <path d="M9 5V3.5C9 2.67 8.33 2 7.5 2H3.5C2.67 2 2 2.67 2 3.5V7.5C2 8.33 2.67 9 3.5 9H5" stroke="currentColor" strokeWidth="1.5" />
-    </svg>
-  )
-}
-
-function SpinnerIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" className="animate-spin" aria-hidden>
-      <circle cx="7" cy="7" r="5.25" stroke="currentColor" strokeWidth="1.5" fill="none" strokeOpacity="0.3" />
-      <path d="M7 1.75A5.25 5.25 0 0112.25 7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" fill="none" />
-    </svg>
   )
 }
 


### PR DESCRIPTION
## What
Surface Share from every place a user sees a session list — search-result rows (FragmentResults), Library / Project rows (SessionRow), sidebar Pinned rows (PinnedRow), plus the existing SessionDetail header button. While here, harmonize all four ⋯ menus so they share one trigger glyph and one set of menu icons.

## Why
Share's only entry was the SessionDetail header. Every other touchpoint where users live (search, library home, project view, pinned sidebar) had no way to start a share without first opening the session. The Phase 0 plan §PR4 secondary-entries item.

The menu cleanup is opportunistic but earned: putting Share into four separate menus made the existing inconsistencies (hand-rolled SVG icons, mismatched 3-dot glyphs at 13 vs 14 px, mixed strokes) visible side-by-side, so unifying them now keeps each menu honest as more items land later.

## How it connects
- `handleStartShareFromUuid` (new) fetches `session + messages` and routes to the existing `handleStartShareFromSession`, threading the live `view` as the editor's return view. Without this, Back from a list-triggered share fell into the empty 'session' fallback when no `selectedSession` was set.
- All entries gated by `FEATURES.share` (`VITE_FEATURE_SHARE`), same as Phase 0.
- Menu triggers: hand-rolled 3-circle SVGs across `ContinueActions` / `SessionRow` / `Sidebar.PinnedRow` / `SessionDetail` replaced with Lucide `MoreHorizontal` at `size=13 strokeWidth=1.6`, matching `PinIcon` next to it.
- Menu items: `CommandIcon` / `CopyIcon` / `SpinnerIcon` helpers (hand-rolled SVGs) replaced with Lucide `ChevronRight` / `Copy` / `Loader2`. SessionDetail's previously icon-less menu picks up the same set.
- Search-results header padding `pt-6` → `pt-1.5` so the "Results for X" bar matches SessionDetail's top bar instead of dropping ~18px lower.

## Test plan
- [ ] Library → row ⋯: Share session item visible (dev), opens editor, Back returns to Library
- [ ] Project view → row ⋯: same, Back returns to project
- [ ] Sidebar pinned row ⋯: same, Back returns to whatever view was active
- [ ] Search results row ⋯: same, Back returns to search results
- [ ] SessionDetail header Share button still works, Back returns to session
- [ ] All four ⋯ trigger glyphs visually match in size + stroke
- [ ] Menu items in all four surfaces share the same icon style
- [ ] `FEATURES.share = false` (prod build without flag) hides every Share menu item

🤖 Generated with [Claude Code](https://claude.com/claude-code)
