### PR TITLE
feat(app): import .spool drafts via drag-and-drop on Shares

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -16,6 +16,7 @@ import AppToaster from './components/AppToaster.js'
 import SharesPage from './components/SharesPage.js'
 import ShareEditorPage from './components/ShareEditorPage.js'
 import { composeFromSession, sessionDraftId, buildPreviewDocument } from './lib/compose-from-session.js'
+import { parseSpoolFile, draftIdForImport, SpoolImportError } from './lib/import-spool.js'
 import { buildSpoolDocument, DEFAULT_OPTS, type Conversation, type EditorOpts, type SpoolDocument } from '@spool/share-kit'
 import type { Message, Session, ShareDraftListItem } from '@spool-lab/core'
 import { getSessionResumeCommandPrefix } from '../shared/resumeCommand.js'
@@ -193,6 +194,46 @@ export default function App() {
       console.error('Failed to load session for share:', err)
     }
   }, [handleStartShareFromSession, view])
+
+  const handleImportSpoolFile = useCallback(async (file: File) => {
+    let snapshotJson: string
+    let doc: SpoolDocument
+    try {
+      snapshotJson = await file.text()
+      doc = parseSpoolFile(snapshotJson)
+    } catch (err) {
+      const message = err instanceof SpoolImportError ? err.message : 'Could not read file'
+      toast.error(`Couldn't import ${file.name}`, { description: message })
+      return
+    }
+    try {
+      const draftId = await draftIdForImport(snapshotJson)
+      const opts: EditorOpts = { ...DEFAULT_OPTS, ...(doc.opts ?? {}) }
+      const normalized: SpoolDocument = { ...doc, opts }
+      const normalizedJson = JSON.stringify(normalized)
+      await window.spool?.shareDraft?.upsert({
+        draft_id: draftId,
+        source_kind: 'imported-file',
+        source_origin: file.name,
+        title: normalized.conversation.title,
+        snapshot_json: normalizedJson,
+        preview_json: JSON.stringify(buildPreviewDocument(normalized)),
+      })
+      enterShareEditor(sidebarCollapsed)
+      setShareEditor({
+        draftId,
+        sourceKind: 'imported-file',
+        sourceOrigin: file.name,
+        conversation: normalized.conversation,
+        opts,
+      })
+      setShareEditorReturnView('shares')
+      setView('share-editor')
+    } catch (err) {
+      console.error('Failed to persist imported .spool draft:', err)
+      toast.error(`Couldn't import ${file.name}`, { description: 'Saving the draft failed' })
+    }
+  }, [enterShareEditor, sidebarCollapsed])
 
   const handleOpenDraft = useCallback(async (draft: ShareDraftListItem) => {
     // The list query intentionally omits snapshot_json — fetch the
@@ -838,6 +879,7 @@ export default function App() {
             onOpenSession={handleOpenSession}
             onCopySessionId={handleCopySessionId}
             {...(FEATURES.share ? { onShare: handleStartShareFromUuid } : {})}
+            {...(FEATURES.share ? { onImportSpool: handleImportSpoolFile } : {})}
           />
         ) : (
           <>

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -16,9 +16,9 @@ import AppToaster from './components/AppToaster.js'
 import SharesPage from './components/SharesPage.js'
 import ShareEditorPage from './components/ShareEditorPage.js'
 import { composeFromSession, sessionDraftId, buildPreviewDocument } from './lib/compose-from-session.js'
-import { parseSpoolFile, draftIdForImport, SpoolImportError } from './lib/import-spool.js'
-import { buildSpoolDocument, DEFAULT_OPTS, type Conversation, type EditorOpts, type SpoolDocument } from '@spool/share-kit'
-import type { Message, Session, ShareDraftListItem } from '@spool-lab/core'
+import { draftIdForImport } from './lib/import-spool.js'
+import { buildSpoolDocument, DEFAULT_OPTS, readSpoolFile, type Conversation, type EditorOpts, type SpoolDocument } from '@spool/share-kit'
+import type { Message, Session, ShareDraftListItem, ShareDraftSourceKind } from '@spool-lab/core'
 import { getSessionResumeCommandPrefix } from '../shared/resumeCommand.js'
 import { DEFAULT_SEARCH_SORT_ORDER, type SearchSortOrder } from '../shared/searchSort.js'
 import { DEFAULT_SIDEBAR_SORT_ORDER, type SidebarSortOrder } from '../shared/sidebarSort.js'
@@ -103,7 +103,7 @@ export default function App() {
    *  upsert autosaves back into share_drafts. Cleared on Back. */
   type ShareEditorBundle = {
     draftId: string
-    sourceKind: 'spool-session' | 'pasted-url' | 'imported-file' | 'imported-jsonl'
+    sourceKind: ShareDraftSourceKind
     sourceOrigin: string | null
     conversation: Conversation
     opts: EditorOpts
@@ -133,6 +133,13 @@ export default function App() {
       sidebarRestoreRef.current = null
     }
   }, [])
+
+  const openShareEditor = useCallback((bundle: ShareEditorBundle, returnView: View) => {
+    enterShareEditor(sidebarCollapsed)
+    setShareEditor(bundle)
+    setShareEditorReturnView(returnView)
+    setView('share-editor')
+  }, [enterShareEditor, sidebarCollapsed])
 
   const handleStartShareFromSession = useCallback(async (session: Session, messages: Message[], returnView: View = 'session') => {
     const draftId = sessionDraftId(session.sessionUuid)
@@ -170,17 +177,14 @@ export default function App() {
       conversation = composeFromSession(session, messages)
       opts = DEFAULT_OPTS
     }
-    enterShareEditor(sidebarCollapsed)
-    setShareEditor({
+    openShareEditor({
       draftId,
       sourceKind: 'spool-session',
       sourceOrigin: session.sessionUuid,
       conversation,
       opts,
-    })
-    setShareEditorReturnView(returnView)
-    setView('share-editor')
-  }, [enterShareEditor, sidebarCollapsed])
+    }, returnView)
+  }, [openShareEditor])
 
   const handleStartShareFromUuid = useCallback(async (sessionUuid: string) => {
     try {
@@ -196,21 +200,19 @@ export default function App() {
   }, [handleStartShareFromSession, view])
 
   const handleImportSpoolFile = useCallback(async (file: File) => {
-    let snapshotJson: string
     let doc: SpoolDocument
     try {
-      snapshotJson = await file.text()
-      doc = parseSpoolFile(snapshotJson)
+      doc = await readSpoolFile(file)
     } catch (err) {
-      const message = err instanceof SpoolImportError ? err.message : 'Could not read file'
+      const message = err instanceof Error ? err.message : 'Could not read file'
       toast.error(`Couldn't import ${file.name}`, { description: message })
       return
     }
     try {
-      const draftId = await draftIdForImport(snapshotJson)
       const opts: EditorOpts = { ...DEFAULT_OPTS, ...(doc.opts ?? {}) }
       const normalized: SpoolDocument = { ...doc, opts }
       const normalizedJson = JSON.stringify(normalized)
+      const draftId = await draftIdForImport(normalizedJson)
       await window.spool?.shareDraft?.upsert({
         draft_id: draftId,
         source_kind: 'imported-file',
@@ -219,21 +221,18 @@ export default function App() {
         snapshot_json: normalizedJson,
         preview_json: JSON.stringify(buildPreviewDocument(normalized)),
       })
-      enterShareEditor(sidebarCollapsed)
-      setShareEditor({
+      openShareEditor({
         draftId,
         sourceKind: 'imported-file',
         sourceOrigin: file.name,
         conversation: normalized.conversation,
         opts,
-      })
-      setShareEditorReturnView('shares')
-      setView('share-editor')
+      }, 'shares')
     } catch (err) {
       console.error('Failed to persist imported .spool draft:', err)
       toast.error(`Couldn't import ${file.name}`, { description: 'Saving the draft failed' })
     }
-  }, [enterShareEditor, sidebarCollapsed])
+  }, [openShareEditor])
 
   const handleOpenDraft = useCallback(async (draft: ShareDraftListItem) => {
     // The list query intentionally omits snapshot_json — fetch the
@@ -246,20 +245,17 @@ export default function App() {
         return
       }
       const doc = JSON.parse(full.snapshot_json) as SpoolDocument
-      enterShareEditor(sidebarCollapsed)
-      setShareEditor({
+      openShareEditor({
         draftId: draft.draft_id,
         sourceKind: draft.source_kind,
         sourceOrigin: draft.source_origin,
         conversation: doc.conversation,
         opts: { ...DEFAULT_OPTS, ...(doc.opts ?? {}) },
-      })
-      setShareEditorReturnView('shares')
-      setView('share-editor')
+      }, 'shares')
     } catch (err) {
       console.error('Failed to parse draft snapshot:', err)
     }
-  }, [enterShareEditor, sidebarCollapsed])
+  }, [openShareEditor])
 
   const handleCloseShareEditor = useCallback(() => {
     setShareEditor(null)

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -861,7 +861,10 @@ export default function App() {
       <div className="relative flex flex-col flex-1 min-w-0">
       <div className="flex flex-col flex-1 min-h-0 relative">
         {isSharesView ? (
-          <SharesPage onOpenDraft={handleOpenDraft} />
+          <SharesPage
+            onOpenDraft={handleOpenDraft}
+            {...(FEATURES.share ? { onImportSpool: handleImportSpoolFile } : {})}
+          />
         ) : isHomeMode ? (
           <LibraryLanding
             onSelectProject={(key) => {
@@ -875,7 +878,6 @@ export default function App() {
             onOpenSession={handleOpenSession}
             onCopySessionId={handleCopySessionId}
             {...(FEATURES.share ? { onShare: handleStartShareFromUuid } : {})}
-            {...(FEATURES.share ? { onImportSpool: handleImportSpoolFile } : {})}
           />
         ) : (
           <>

--- a/packages/app/src/renderer/components/LibraryLanding.tsx
+++ b/packages/app/src/renderer/components/LibraryLanding.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
 import type { Session } from '@spool-lab/core'
 import SessionRow from './SessionRow.js'
 import { useSpoolDrop } from '../hooks/useSpoolDrop.js'
@@ -17,9 +17,13 @@ type DateBucket = {
 }
 
 export default function LibraryLanding({ onOpenSession, onCopySessionId, onShare, onImportSpool }: Props) {
+  const onImport = useCallback(
+    (file: File) => onImportSpool?.(file),
+    [onImportSpool],
+  )
   const { isDragActive, dragHandlers } = useSpoolDrop({
     enabled: Boolean(onImportSpool),
-    onImport: (file) => onImportSpool?.(file),
+    onImport,
   })
   const [pinnedSessions, setPinnedSessions] = useState<Session[]>([])
   const [recentSessions, setRecentSessions] = useState<Session[] | null>(null)

--- a/packages/app/src/renderer/components/LibraryLanding.tsx
+++ b/packages/app/src/renderer/components/LibraryLanding.tsx
@@ -1,14 +1,12 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import type { Session } from '@spool-lab/core'
 import SessionRow from './SessionRow.js'
-import { useSpoolDrop } from '../hooks/useSpoolDrop.js'
 
 type Props = {
   onSelectProject: (identityKey: string) => void
   onOpenSession: (uuid: string) => void
   onCopySessionId: (source: Session['source']) => void
   onShare?: (uuid: string) => void
-  onImportSpool?: (file: File) => void | Promise<void>
 }
 
 type DateBucket = {
@@ -16,15 +14,7 @@ type DateBucket = {
   sessions: Session[]
 }
 
-export default function LibraryLanding({ onOpenSession, onCopySessionId, onShare, onImportSpool }: Props) {
-  const onImport = useCallback(
-    (file: File) => onImportSpool?.(file),
-    [onImportSpool],
-  )
-  const { isDragActive, dragHandlers } = useSpoolDrop({
-    enabled: Boolean(onImportSpool),
-    onImport,
-  })
+export default function LibraryLanding({ onOpenSession, onCopySessionId, onShare }: Props) {
   const [pinnedSessions, setPinnedSessions] = useState<Session[]>([])
   const [recentSessions, setRecentSessions] = useState<Session[] | null>(null)
   const [reloadKey, setReloadKey] = useState(0)
@@ -76,12 +66,7 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId, onShare
   const totalSessions = (pinnedSessions.length) + (recentSessions?.length ?? 0)
 
   return (
-    <div
-      data-testid="library-landing"
-      className="relative flex flex-col h-full overflow-hidden"
-      {...dragHandlers}
-    >
-      {isDragActive && <SpoolDropOverlay />}
+    <div data-testid="library-landing" className="flex flex-col h-full overflow-hidden">
       <div className="flex-1 overflow-y-auto pb-12 [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]">
         {recentSessions === null ? (
           <SessionRowsSkeleton count={6} />
@@ -176,20 +161,6 @@ export function CollapsibleSection({
         </svg>
       </button>
       {open && children}
-    </div>
-  )
-}
-
-function SpoolDropOverlay() {
-  return (
-    <div
-      data-testid="library-spool-drop-overlay"
-      aria-hidden
-      className="absolute inset-2 z-20 pointer-events-none flex items-center justify-center rounded-[10px] border-2 border-dashed border-accent dark:border-accent-dark bg-accent-bg/70 dark:bg-accent-bg-dark/70 backdrop-blur-[1px]"
-    >
-      <p className="text-sm font-medium text-accent dark:text-accent-dark">
-        Drop <span className="font-mono">.spool</span> to import
-      </p>
     </div>
   )
 }

--- a/packages/app/src/renderer/components/LibraryLanding.tsx
+++ b/packages/app/src/renderer/components/LibraryLanding.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import type { Session } from '@spool-lab/core'
 import SessionRow from './SessionRow.js'
+import { useSpoolDrop } from '../hooks/useSpoolDrop.js'
 
 type Props = {
   onSelectProject: (identityKey: string) => void
   onOpenSession: (uuid: string) => void
   onCopySessionId: (source: Session['source']) => void
   onShare?: (uuid: string) => void
+  onImportSpool?: (file: File) => void | Promise<void>
 }
 
 type DateBucket = {
@@ -14,7 +16,11 @@ type DateBucket = {
   sessions: Session[]
 }
 
-export default function LibraryLanding({ onOpenSession, onCopySessionId, onShare }: Props) {
+export default function LibraryLanding({ onOpenSession, onCopySessionId, onShare, onImportSpool }: Props) {
+  const { isDragActive, dragHandlers } = useSpoolDrop({
+    enabled: Boolean(onImportSpool),
+    onImport: (file) => onImportSpool?.(file),
+  })
   const [pinnedSessions, setPinnedSessions] = useState<Session[]>([])
   const [recentSessions, setRecentSessions] = useState<Session[] | null>(null)
   const [reloadKey, setReloadKey] = useState(0)
@@ -66,7 +72,12 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId, onShare
   const totalSessions = (pinnedSessions.length) + (recentSessions?.length ?? 0)
 
   return (
-    <div data-testid="library-landing" className="flex flex-col h-full overflow-hidden">
+    <div
+      data-testid="library-landing"
+      className="relative flex flex-col h-full overflow-hidden"
+      {...dragHandlers}
+    >
+      {isDragActive && <SpoolDropOverlay />}
       <div className="flex-1 overflow-y-auto pb-12 [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]">
         {recentSessions === null ? (
           <SessionRowsSkeleton count={6} />
@@ -161,6 +172,20 @@ export function CollapsibleSection({
         </svg>
       </button>
       {open && children}
+    </div>
+  )
+}
+
+function SpoolDropOverlay() {
+  return (
+    <div
+      data-testid="library-spool-drop-overlay"
+      aria-hidden
+      className="absolute inset-2 z-20 pointer-events-none flex items-center justify-center rounded-[10px] border-2 border-dashed border-accent dark:border-accent-dark bg-accent-bg/70 dark:bg-accent-bg-dark/70 backdrop-blur-[1px]"
+    >
+      <p className="text-sm font-medium text-accent dark:text-accent-dark">
+        Drop <span className="font-mono">.spool</span> to import
+      </p>
     </div>
   )
 }

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react
 import { Newspaper, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useShareDrafts } from '../hooks/useShareDrafts'
+import { useSpoolDrop } from '../hooks/useSpoolDrop.js'
 import type { ShareDraftListItem } from '@spool-lab/core'
 import {
   TemplateRender,
@@ -14,6 +15,7 @@ import { getSessionSourceColor } from '../../shared/sessionSources.js'
 
 type Props = {
   onOpenDraft?: ((draft: ShareDraftListItem) => void) | undefined
+  onImportSpool?: ((file: File) => void | Promise<void>) | undefined
 }
 
 /**
@@ -22,9 +24,18 @@ type Props = {
  * "Coming in a future update" placeholder reads as a broken promise.
  * The tab strip lands in Phase 2 alongside the actual publish flow.
  */
-export default function SharesPage({ onOpenDraft }: Props) {
+export default function SharesPage({ onOpenDraft, onImportSpool }: Props) {
   const { drafts, loading, error, removeDraft, restoreDraft } = useShareDrafts()
   const hasDrafts = drafts.length > 0
+
+  const onImport = useCallback(
+    (file: File) => onImportSpool?.(file),
+    [onImportSpool],
+  )
+  const { isDragActive, dragHandlers } = useSpoolDrop({
+    enabled: Boolean(onImportSpool),
+    onImport,
+  })
 
   const handleDelete = useCallback(async (draft: ShareDraftListItem) => {
     try {
@@ -49,7 +60,8 @@ export default function SharesPage({ onOpenDraft }: Props) {
   }, [removeDraft, restoreDraft])
 
   return (
-    <div className="flex flex-col flex-1 min-h-0">
+    <div className="relative flex flex-col flex-1 min-h-0" {...dragHandlers}>
+      {isDragActive && <SpoolDropOverlay />}
       {hasDrafts && (
         <div className="flex-none px-6 pt-1.5 pb-3 font-mono text-[11px] text-warm-faint dark:text-dark-muted tabular-nums">
           Drafts · {drafts.length}
@@ -64,6 +76,20 @@ export default function SharesPage({ onOpenDraft }: Props) {
           onDeleteDraft={handleDelete}
         />
       </div>
+    </div>
+  )
+}
+
+function SpoolDropOverlay() {
+  return (
+    <div
+      data-testid="shares-spool-drop-overlay"
+      aria-hidden
+      className="absolute inset-2 z-20 pointer-events-none flex items-center justify-center rounded-[10px] border border-dashed border-accent/70 dark:border-accent-dark/70 bg-accent-bg/60 dark:bg-accent-bg-dark/60 backdrop-blur-[1px]"
+    >
+      <p className="text-sm font-medium text-accent dark:text-accent-dark">
+        Drop <span className="font-mono">.spool</span> to import
+      </p>
     </div>
   )
 }

--- a/packages/app/src/renderer/hooks/useSpoolDrop.ts
+++ b/packages/app/src/renderer/hooks/useSpoolDrop.ts
@@ -1,0 +1,67 @@
+import { useCallback, useRef, useState, type DragEvent } from 'react'
+
+type Options = {
+  enabled: boolean
+  onImport: (file: File) => void | Promise<void>
+}
+
+/** Drag-and-drop intake for `.spool` files. Tracks an isDragActive flag
+ *  that flips on only when the user is dragging files (not in-document
+ *  drags), so the consumer can show a drop overlay without false
+ *  positives from text/element dragging. */
+export function useSpoolDrop({ enabled, onImport }: Options) {
+  const [isDragActive, setIsDragActive] = useState(false)
+  // dragenter / dragleave fire per nested element, so a depth counter
+  // is needed to know when the drag has truly left the target.
+  const depthRef = useRef(0)
+
+  const isFileDrag = (event: DragEvent) =>
+    Array.from(event.dataTransfer?.types ?? []).includes('Files')
+
+  const onDragEnter = useCallback(
+    (event: DragEvent) => {
+      if (!enabled || !isFileDrag(event)) return
+      event.preventDefault()
+      depthRef.current += 1
+      setIsDragActive(true)
+    },
+    [enabled],
+  )
+
+  const onDragOver = useCallback(
+    (event: DragEvent) => {
+      if (!enabled || !isFileDrag(event)) return
+      event.preventDefault()
+      event.dataTransfer.dropEffect = 'copy'
+    },
+    [enabled],
+  )
+
+  const onDragLeave = useCallback(
+    (event: DragEvent) => {
+      if (!enabled || !isFileDrag(event)) return
+      event.preventDefault()
+      depthRef.current = Math.max(0, depthRef.current - 1)
+      if (depthRef.current === 0) setIsDragActive(false)
+    },
+    [enabled],
+  )
+
+  const onDrop = useCallback(
+    (event: DragEvent) => {
+      if (!enabled || !isFileDrag(event)) return
+      event.preventDefault()
+      depthRef.current = 0
+      setIsDragActive(false)
+      const files = Array.from(event.dataTransfer?.files ?? [])
+      const spool = files.find((f) => f.name.toLowerCase().endsWith('.spool'))
+      if (spool) void onImport(spool)
+    },
+    [enabled, onImport],
+  )
+
+  return {
+    isDragActive,
+    dragHandlers: { onDragEnter, onDragOver, onDragLeave, onDrop },
+  }
+}

--- a/packages/app/src/renderer/hooks/useSpoolDrop.ts
+++ b/packages/app/src/renderer/hooks/useSpoolDrop.ts
@@ -3,9 +3,10 @@ import { useCallback, useRef, useState, type DragEvent } from 'react'
 type Options = {
   enabled: boolean
   onImport: (file: File) => void | Promise<void>
+  onReject?: (files: File[]) => void
 }
 
-export function useSpoolDrop({ enabled, onImport }: Options) {
+export function useSpoolDrop({ enabled, onImport, onReject }: Options) {
   const [isDragActive, setIsDragActive] = useState(false)
   // dragenter / dragleave fire per nested element; depth counter tells
   // us when the drag has truly left the target.
@@ -52,8 +53,9 @@ export function useSpoolDrop({ enabled, onImport }: Options) {
       const files = Array.from(event.dataTransfer?.files ?? [])
       const spool = files.find((f) => f.name.toLowerCase().endsWith('.spool'))
       if (spool) void onImport(spool)
+      else if (files.length > 0) onReject?.(files)
     },
-    [enabled, onImport],
+    [enabled, onImport, onReject],
   )
 
   return {

--- a/packages/app/src/renderer/hooks/useSpoolDrop.ts
+++ b/packages/app/src/renderer/hooks/useSpoolDrop.ts
@@ -5,14 +5,10 @@ type Options = {
   onImport: (file: File) => void | Promise<void>
 }
 
-/** Drag-and-drop intake for `.spool` files. Tracks an isDragActive flag
- *  that flips on only when the user is dragging files (not in-document
- *  drags), so the consumer can show a drop overlay without false
- *  positives from text/element dragging. */
 export function useSpoolDrop({ enabled, onImport }: Options) {
   const [isDragActive, setIsDragActive] = useState(false)
-  // dragenter / dragleave fire per nested element, so a depth counter
-  // is needed to know when the drag has truly left the target.
+  // dragenter / dragleave fire per nested element; depth counter tells
+  // us when the drag has truly left the target.
   const depthRef = useRef(0)
 
   const isFileDrag = (event: DragEvent) =>

--- a/packages/app/src/renderer/lib/import-spool.test.ts
+++ b/packages/app/src/renderer/lib/import-spool.test.ts
@@ -1,56 +1,17 @@
 import { describe, it, expect } from 'vitest'
-import { draftIdForImport, parseSpoolFile, SpoolImportError } from './import-spool'
-
-const validDoc = {
-  version: 1,
-  conversation: {
-    title: 'Hello',
-    turns: [{ id: 't1', role: 'user', body: 'hi' }],
-  },
-  opts: { template: 'classic' },
-}
-
-describe('parseSpoolFile', () => {
-  it('returns the parsed document when shape is valid', () => {
-    const doc = parseSpoolFile(JSON.stringify(validDoc))
-    expect(doc.conversation.turns).toHaveLength(1)
-  })
-
-  it('rejects non-JSON', () => {
-    expect(() => parseSpoolFile('{not json')).toThrow(SpoolImportError)
-  })
-
-  it('rejects non-object root', () => {
-    expect(() => parseSpoolFile('[]')).toThrow(SpoolImportError)
-    expect(() => parseSpoolFile('42')).toThrow(SpoolImportError)
-  })
-
-  it('rejects missing conversation.turns', () => {
-    expect(() => parseSpoolFile(JSON.stringify({ ...validDoc, conversation: {} }))).toThrow(
-      SpoolImportError,
-    )
-  })
-
-  it('rejects missing opts', () => {
-    const { opts: _opts, ...without } = validDoc
-    expect(() => parseSpoolFile(JSON.stringify(without))).toThrow(SpoolImportError)
-  })
-})
+import { draftIdForImport } from './import-spool'
 
 describe('draftIdForImport', () => {
   it('is deterministic for the same snapshot', async () => {
-    const json = JSON.stringify(validDoc)
-    const a = await draftIdForImport(json)
-    const b = await draftIdForImport(json)
+    const a = await draftIdForImport('{"hello":1}')
+    const b = await draftIdForImport('{"hello":1}')
     expect(a).toBe(b)
     expect(a.startsWith('imported:')).toBe(true)
   })
 
   it('differs across distinct snapshots', async () => {
-    const a = await draftIdForImport(JSON.stringify(validDoc))
-    const b = await draftIdForImport(
-      JSON.stringify({ ...validDoc, conversation: { ...validDoc.conversation, title: 'Other' } }),
-    )
+    const a = await draftIdForImport('{"hello":1}')
+    const b = await draftIdForImport('{"hello":2}')
     expect(a).not.toBe(b)
   })
 })

--- a/packages/app/src/renderer/lib/import-spool.test.ts
+++ b/packages/app/src/renderer/lib/import-spool.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { draftIdForImport, parseSpoolFile, SpoolImportError } from './import-spool'
+
+const validDoc = {
+  version: 1,
+  conversation: {
+    title: 'Hello',
+    turns: [{ id: 't1', role: 'user', body: 'hi' }],
+  },
+  opts: { template: 'classic' },
+}
+
+describe('parseSpoolFile', () => {
+  it('returns the parsed document when shape is valid', () => {
+    const doc = parseSpoolFile(JSON.stringify(validDoc))
+    expect(doc.conversation.turns).toHaveLength(1)
+  })
+
+  it('rejects non-JSON', () => {
+    expect(() => parseSpoolFile('{not json')).toThrow(SpoolImportError)
+  })
+
+  it('rejects non-object root', () => {
+    expect(() => parseSpoolFile('[]')).toThrow(SpoolImportError)
+    expect(() => parseSpoolFile('42')).toThrow(SpoolImportError)
+  })
+
+  it('rejects missing conversation.turns', () => {
+    expect(() => parseSpoolFile(JSON.stringify({ ...validDoc, conversation: {} }))).toThrow(
+      SpoolImportError,
+    )
+  })
+
+  it('rejects missing opts', () => {
+    const { opts: _opts, ...without } = validDoc
+    expect(() => parseSpoolFile(JSON.stringify(without))).toThrow(SpoolImportError)
+  })
+})
+
+describe('draftIdForImport', () => {
+  it('is deterministic for the same snapshot', async () => {
+    const json = JSON.stringify(validDoc)
+    const a = await draftIdForImport(json)
+    const b = await draftIdForImport(json)
+    expect(a).toBe(b)
+    expect(a.startsWith('imported:')).toBe(true)
+  })
+
+  it('differs across distinct snapshots', async () => {
+    const a = await draftIdForImport(JSON.stringify(validDoc))
+    const b = await draftIdForImport(
+      JSON.stringify({ ...validDoc, conversation: { ...validDoc.conversation, title: 'Other' } }),
+    )
+    expect(a).not.toBe(b)
+  })
+})

--- a/packages/app/src/renderer/lib/import-spool.ts
+++ b/packages/app/src/renderer/lib/import-spool.ts
@@ -1,40 +1,5 @@
-import type { SpoolDocument } from '@spool/share-kit'
-
-export class SpoolImportError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'SpoolImportError'
-  }
-}
-
-/** Parse a .spool file's text and validate that it's a SpoolDocument shape
- *  we recognize. Throws SpoolImportError on any mismatch so callers can
- *  surface a single toast without inspecting the failure kind. */
-export function parseSpoolFile(text: string): SpoolDocument {
-  let raw: unknown
-  try {
-    raw = JSON.parse(text)
-  } catch {
-    throw new SpoolImportError('File is not valid JSON')
-  }
-  if (!raw || typeof raw !== 'object') {
-    throw new SpoolImportError('Top-level JSON must be an object')
-  }
-  const obj = raw as Record<string, unknown>
-  const conversation = obj.conversation as Record<string, unknown> | undefined
-  if (!conversation || !Array.isArray(conversation.turns)) {
-    throw new SpoolImportError('Missing conversation.turns')
-  }
-  if (!obj.opts || typeof obj.opts !== 'object' || Array.isArray(obj.opts)) {
-    throw new SpoolImportError('Missing opts')
-  }
-  return obj as unknown as SpoolDocument
-}
-
-/** Stable draft id for an imported .spool — same snapshot text always
- *  collapses onto the same draft row, so re-importing reopens the
- *  existing draft instead of forking it. Hash is SHA-1/8 (good enough
- *  for collision avoidance across a single user's local library). */
+/** Content-hash draft id for an imported .spool, so re-importing the
+ *  same file collapses onto the same draft row instead of forking. */
 export async function draftIdForImport(snapshotJson: string): Promise<string> {
   const buf = new TextEncoder().encode(snapshotJson)
   const hash = await crypto.subtle.digest('SHA-1', buf)

--- a/packages/app/src/renderer/lib/import-spool.ts
+++ b/packages/app/src/renderer/lib/import-spool.ts
@@ -1,0 +1,46 @@
+import type { SpoolDocument } from '@spool/share-kit'
+
+export class SpoolImportError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SpoolImportError'
+  }
+}
+
+/** Parse a .spool file's text and validate that it's a SpoolDocument shape
+ *  we recognize. Throws SpoolImportError on any mismatch so callers can
+ *  surface a single toast without inspecting the failure kind. */
+export function parseSpoolFile(text: string): SpoolDocument {
+  let raw: unknown
+  try {
+    raw = JSON.parse(text)
+  } catch {
+    throw new SpoolImportError('File is not valid JSON')
+  }
+  if (!raw || typeof raw !== 'object') {
+    throw new SpoolImportError('Top-level JSON must be an object')
+  }
+  const obj = raw as Record<string, unknown>
+  const conversation = obj.conversation as Record<string, unknown> | undefined
+  if (!conversation || !Array.isArray(conversation.turns)) {
+    throw new SpoolImportError('Missing conversation.turns')
+  }
+  if (!obj.opts || typeof obj.opts !== 'object' || Array.isArray(obj.opts)) {
+    throw new SpoolImportError('Missing opts')
+  }
+  return obj as unknown as SpoolDocument
+}
+
+/** Stable draft id for an imported .spool — same snapshot text always
+ *  collapses onto the same draft row, so re-importing reopens the
+ *  existing draft instead of forking it. Hash is SHA-1/8 (good enough
+ *  for collision avoidance across a single user's local library). */
+export async function draftIdForImport(snapshotJson: string): Promise<string> {
+  const buf = new TextEncoder().encode(snapshotJson)
+  const hash = await crypto.subtle.digest('SHA-1', buf)
+  const hex = [...new Uint8Array(hash)]
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 8)
+  return `imported:${hex}`
+}


### PR DESCRIPTION
## What
Drop a `.spool` file onto the Shares page and it becomes an editable draft — the editor opens on the imported document and the row is persisted to `share_drafts` so it shows up in the grid next time. Reuses share-kit's `readSpoolFile` for parse + validation, so any file the kit emits round-trips cleanly.

## Why
`.spool` was an export-only artifact in Phase 0. The two-way flow (export → share/edit → re-import) is the load-bearing piece of "shares as portable drafts": anyone you sent a `.spool` to can drop it back, tweak it, and re-export. Phase 0 plan §PR4 listed this; this PR closes that item.

## How it connects
- `useSpoolDrop` hook owns drag-active state + file filtering. Uses a depth counter for the nested dragenter/dragleave problem. Filters on `dataTransfer.types.includes('Files')` so in-document text drags don't trip the overlay.
- `draftIdForImport(snapshotJson)` content-hashes the normalized JSON (SHA-1/8) so re-importing the same file collapses onto the same draft instead of forking.
- `handleImportSpoolFile` (App.tsx) reads → validates via `readSpoolFile` → merges with `DEFAULT_OPTS` (for forward-compat with snapshots saved before later EditorOpts fields) → upserts under `source_kind='imported-file'` (already valid in the v11 CHECK enum, no schema bump needed) → routes to share editor.
- Drop target lives on `SharesPage`, not LibraryLanding — imports become drafts, so the affordance sits next to the drafts list. Overlay is a 1px accent/70 dashed border + bg/60, intentionally a hint not a wall.
- Shared `openShareEditor(bundle, returnView)` helper deduplicates the `setShareEditor` / `setShareEditorReturnView` / `setView` tail across the three handlers that open the editor (start-share-from-session, open-draft, import).
- `useSpoolDrop.onReject(files)` signature added so the Shares page can surface a toast when the user drops something that isn't a `.spool`. (Wiring + toast copy land in the follow-up toast unification PR.)

## Risk
Medium. No schema migration (the `imported-file` enum value was already in v11). Forward-compat handled by the existing `{...DEFAULT_OPTS, ...doc.opts}` merge. `readSpoolFile` is already shipped in @spool/share-kit, no new public surface there.

## Test plan
- [ ] Open Shares page → drag a `.spool` over the area → overlay appears
- [ ] Drop a real `.spool` → editor opens on the imported document; Back returns to Shares
- [ ] Re-import the same file → opens the same draft (idempotent draftId)
- [ ] Drop a non-`.spool` file → no editor; the next PR adds the toast (silent for now)
- [ ] Drop a malformed `.spool` (manually corrupted JSON) → toast surfaces the parse error
- [ ] LibraryLanding has no drop overlay anymore (drop moved to SharesPage)
- [ ] vitest `import-spool.test.ts` passes: `draftIdForImport` deterministic + distinct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
