### PR TITLE
polish(app): unify toast surface and copy

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -230,7 +230,7 @@ export default function App() {
       }, 'shares')
     } catch (err) {
       console.error('Failed to persist imported .spool draft:', err)
-      toast.error(`Couldn't import ${file.name}`, { description: 'Saving the draft failed' })
+      toast.error(`Couldn't import ${file.name}`, { description: 'Saving the draft failed.' })
     }
   }, [openShareEditor])
 
@@ -671,15 +671,14 @@ export default function App() {
   const handleCopySessionId = useCallback((source: FragmentResult['source']) => {
     const command = getSessionResumeCommandPrefix(source)
     if (!command) return
-    toast('Session ID copied', {
+    toast.success('Copied session ID', {
       id: 'resume-command',
       description: (
         <span>
-          Write{' '}
+          Paste after{' '}
           <code className="rounded bg-warm-bg dark:bg-dark-bg px-1.5 py-0.5 font-mono text-[11px]">
             {command}
-          </code>{' '}
-          then paste the id to resume this session
+          </code>
         </span>
       ),
     })

--- a/packages/app/src/renderer/components/AppToaster.tsx
+++ b/packages/app/src/renderer/components/AppToaster.tsx
@@ -48,11 +48,11 @@ export default function AppToaster() {
             'bg-warm-surface dark:bg-dark-surface2',
             'ring-warm-border dark:ring-dark-border',
           ].join(' '),
-          icon: 'flex-none flex items-center justify-center',
+          icon: 'flex-none flex items-center justify-center self-start mt-[2px]',
           content: 'flex flex-col gap-0.5 min-w-0 flex-1',
           title: 'text-[13px] font-normal leading-snug tracking-[-0.005em] truncate',
           description:
-            'text-[12px] leading-snug text-warm-muted dark:text-dark-muted',
+            'text-[12px] leading-snug text-warm-muted dark:text-dark-muted line-clamp-2 break-all',
           actionButton: [
             'shrink-0 self-center',
             'px-2.5 py-1 rounded-md',

--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -148,9 +148,9 @@ export default function ShareEditorPage({
       console.error('Export to PNG failed:', err)
       setSaveState('error')
       if (err instanceof PngTooTallError) {
-        toast.error('Conversation too tall for PNG — try PDF export.')
+        toast.error("Couldn't export PNG", { description: 'Conversation too tall — try PDF instead.' })
       } else {
-        toast.error('Export failed — see console for details')
+        toast.error("Couldn't export PNG", { description: 'See console for details.' })
       }
     }
   }, [beginSaving, conversation, opts.template])
@@ -172,7 +172,7 @@ export default function ShareEditorPage({
     } catch (err) {
       console.error('Export to PDF failed:', err)
       setSaveState('error')
-      toast.error('Export failed — see console for details')
+      toast.error("Couldn't export PDF", { description: 'See console for details.' })
     }
   }, [beginSaving, conversation, opts.template])
 
@@ -184,11 +184,16 @@ export default function ShareEditorPage({
       ext: '.pdf',
     })
     if (slot.kind === 'cancelled') return
-    const res = await fetch(pdfPreview.url)
-    const blob = await res.blob()
-    await writeToSlot(slot, blob, pdfPreview.filename)
-    toast.success(`Saved ${pdfPreview.filename}`)
-    setPdfPreview(null)
+    try {
+      const res = await fetch(pdfPreview.url)
+      const blob = await res.blob()
+      await writeToSlot(slot, blob, pdfPreview.filename)
+      toast.success(`Saved ${pdfPreview.filename}`)
+      setPdfPreview(null)
+    } catch (err) {
+      console.error('Save PDF failed:', err)
+      toast.error("Couldn't save PDF", { description: 'See console for details.' })
+    }
   }, [pdfPreview])
 
   const handleDelete = useCallback(async () => {
@@ -196,7 +201,7 @@ export default function ShareEditorPage({
       await window.spool.shareDraft.delete(draftId)
     } catch (err) {
       console.error('Delete share draft failed:', err)
-      toast.error('Could not delete draft')
+      toast.error("Couldn't delete draft")
       return
     }
     onBack()
@@ -223,7 +228,7 @@ export default function ShareEditorPage({
     } catch (err) {
       console.error('Export to .spool failed:', err)
       setSaveState('error')
-      toast.error('Export failed — see console for details')
+      toast.error("Couldn't export .spool", { description: 'See console for details.' })
     }
   }, [beginSaving, conversation, opts])
 

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -32,9 +32,16 @@ export default function SharesPage({ onOpenDraft, onImportSpool }: Props) {
     (file: File) => onImportSpool?.(file),
     [onImportSpool],
   )
+  const onRejectDrop = useCallback((files: File[]) => {
+    const name = files[0]?.name
+    toast.error(`Couldn't import ${name ?? 'file'}`, {
+      description: 'Only .spool files are supported.',
+    })
+  }, [])
   const { isDragActive, dragHandlers } = useSpoolDrop({
     enabled: Boolean(onImportSpool),
     onImport,
+    onReject: onRejectDrop,
   })
 
   const handleDelete = useCallback(async (draft: ShareDraftListItem) => {
@@ -48,14 +55,14 @@ export default function SharesPage({ onOpenDraft, onImportSpool }: Props) {
           onClick: () => {
             void restoreDraft(full).catch((err) => {
               console.error('Restore share draft failed:', err)
-              toast.error('Could not restore draft')
+              toast.error("Couldn't restore draft")
             })
           },
         },
       })
     } catch (err) {
       console.error('Delete share draft failed:', err)
-      toast.error('Could not delete draft')
+      toast.error("Couldn't delete draft")
     }
   }, [removeDraft, restoreDraft])
 


### PR DESCRIPTION
## What
Every toast in the renderer now follows one shape; the AppToaster surface gets a few visual fixes so multi-line descriptions and single-line actions both read cleanly.

## Why
Toast copy had grown five different patterns over the share work — "Could not …" vs "Couldn't …", "Export failed — see console for details" vs "Conversation too tall for PNG — try PDF export.", plain `toast(...)` for success cases that should have read green, etc. With share entries landing in more surfaces, this would only get worse; locking the shape now is cheap.

The AppToaster tweaks fall out of the same audit: long filenames in `.spool` import descriptions wrapped unbounded (bad), and the icon vertically centered against a multi-line column ended up between lines (bad). Both are surface-level fixes that affect every toast in the app, so they belong in one place.

## How it connects
**Toast copy shape:**
- Success: `toast.success('<verb-past> <subject>')`, single line, no description.
- Destructive + undo: neutral `toast(...)` with `action: { label: 'Undo', onClick }` — neutral so the action button stays the focus.
- Error: `toast.error("Couldn't <verb> [<subject>]", { description: '<reason ending with a period>' })`.

**Sites touched:**
- `App.tsx`: `'Session ID copied'` (plain) → `.success('Copied session ID')`; description trimmed from a 2-line "Write `<cmd>` then paste the id to resume this session" to a 1-line "Paste after `<cmd>`".
- `App.tsx`: `'Saving the draft failed'` → `'Saving the draft failed.'` (period).
- `SharesPage`: wires `useSpoolDrop.onReject` → `toast.error("Couldn't import {name}", { description: 'Only .spool files are supported.' })`. Renames `'Could not restore draft'` / `'Could not delete draft'` to `Couldn't ...`.
- `ShareEditorPage`: PNG / PDF / .spool export errors all become `toast.error("Couldn't export <fmt>", { description: <reason>. })`. `savePdfFromPreview` now has a try/catch so a failed `writeToSlot` toasts an error instead of silently dropping.

**AppToaster:**
- icon: `self-start + mt-[2px]` so it sits next to the first content line even when description wraps; single-line toasts with an action button still center as a row.
- description: `line-clamp-2 + break-all` caps long filenames at two lines instead of unbounded wrap.

## Test plan
- [ ] Export PNG → success toast; cancel save slot → no toast; force a PNG-too-tall → "Couldn't export PNG — Conversation too tall — try PDF instead."
- [ ] Export PDF → preview opens; cancel save slot → no toast; save succeeds → "Saved <filename>"; force a write failure → "Couldn't save PDF"
- [ ] Export .spool → success toast; force a serialize/write failure → "Couldn't export .spool"
- [ ] Copy session ID → "Copied session ID — Paste after `<cmd>`" on one line each
- [ ] Delete draft → neutral toast with Undo; Undo restores; force restore failure → "Couldn't restore draft"
- [ ] Drop non-`.spool` on Shares page → "Couldn't import {name} — Only .spool files are supported."
- [ ] Drop corrupt `.spool` → "Couldn't import {name} — <parse-error message>"
- [ ] All error toasts: icon aligns with first description line, descriptions cap at 2 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
