### PR TITLE
polish(app): use Copy icon for both copy-to-clipboard menu items

### DIFF
--- a/packages/app/src/renderer/components/ContinueActions.tsx
+++ b/packages/app/src/renderer/components/ContinueActions.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { MoreHorizontal, Eye, SquareTerminal, Share2, Copy, ChevronRight, Loader2 } from 'lucide-react'
+import { MoreHorizontal, Eye, SquareTerminal, Share2, Copy, Loader2 } from 'lucide-react'
 import type { FragmentResult } from '@spool-lab/core'
 import Menu from './Menu.js'
 import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
@@ -61,7 +61,7 @@ export default function ContinueActions({ result, onOpenSession, onCopySessionId
     }] : []),
     ...(resumeCommand ? [{
       label: copiedCommand ? 'Copied resume command' : 'Copy resume command',
-      icon: <ChevronRight size={ICON_SIZE} strokeWidth={ICON_STROKE} aria-hidden />,
+      icon: <Copy size={ICON_SIZE} strokeWidth={ICON_STROKE} aria-hidden />,
       onSelect: () => { void handleCopyCommand() },
     }] : []),
     {

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { SquareTerminal, Share2, MoreHorizontal, ChevronRight, Copy } from 'lucide-react'
+import { SquareTerminal, Share2, MoreHorizontal, Copy } from 'lucide-react'
 import type { Session, Message } from '@spool-lab/core'
 import { type FindRange } from './MessageBubble.js'
 import MessageList, { type MessageListHandle } from './MessageList.js'
@@ -317,7 +317,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
               },
               ...(resumeCommandAvailable ? [{
                 label: commandCopied ? 'Copied!' : 'Copy resume command',
-                icon: <ChevronRight size={14} strokeWidth={1.6} aria-hidden />,
+                icon: <Copy size={14} strokeWidth={1.6} aria-hidden />,
                 onSelect: () => { void handleCopyCommand() },
               }] : []),
             ]}

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { SquareTerminal, MoreHorizontal, ChevronRight, Copy, Loader2, Share2 } from 'lucide-react'
+import { SquareTerminal, MoreHorizontal, Copy, Loader2, Share2 } from 'lucide-react'
 import type { Session } from '@spool-lab/core'
 import { SourceBadge } from './Badges.js'
 import PinButton from './PinButton.js'
@@ -126,7 +126,7 @@ export default function SessionRow({ session, pinned = false, showProject = fals
               },
               ...(resumeCommand ? [{
                 label: 'Copy resume command',
-                icon: <ChevronRight size={14} strokeWidth={1.6} aria-hidden />,
+                icon: <Copy size={14} strokeWidth={1.6} aria-hidden />,
                 onSelect: () => { void handleCopyCommand() },
               }] : []),
               {

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import type { ProjectGroup, Session, SessionSource, StatusInfo } from '@spool-lab/core'
-import { Library as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, SquareTerminal, MoreHorizontal, ChevronRight, Copy, Loader2, Share2 } from 'lucide-react'
+import { Library as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, SquareTerminal, MoreHorizontal, Copy, Loader2, Share2 } from 'lucide-react'
 import PinIcon from './PinIcon.js'
 import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
 import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
@@ -518,7 +518,7 @@ function PinnedRow({
             },
             ...(resumeCommand ? [{
               label: 'Copy resume command',
-              icon: <ChevronRight size={14} strokeWidth={1.6} aria-hidden />,
+              icon: <Copy size={14} strokeWidth={1.6} aria-hidden />,
               onSelect: () => { void handleCopyCommand() },
             }] : []),
             {


### PR DESCRIPTION
## What
Both Copy resume command and Copy session ID now use Lucide Copy as their menu icon, replacing the ChevronRight glyph on the resume-command item.

## Why
Different glyphs implied different action kinds, but both items perform the same thing — write text to the clipboard. The labels stay distinct, which is enough to tell them apart; the icons shouldn't have to do that work too.

## How it connects
Four menu surfaces use ContinueActions / SessionRow / Sidebar.PinnedRow / SessionDetail respectively — all four had the same ChevronRight on the resume-command item from the icon-unification round. Swapped in place; ChevronRight import dropped from each file.

## Test plan
- [ ] FragmentResults row ⋯ menu: both copy items show the same Copy icon
- [ ] Library / Project SessionRow ⋯: same
- [ ] Sidebar pinned row ⋯: same
- [ ] SessionDetail header ⋯: same
- [ ] Both items still copy the right thing (resume command vs uuid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)