### PR TITLE
polish(app): align row line 2 with badge text

### DIFF
--- a/packages/app/src/renderer/components/FragmentResults.tsx
+++ b/packages/app/src/renderer/components/FragmentResults.tsx
@@ -162,19 +162,21 @@ function FragmentRow({
         />
       </div>
 
-      <div className="text-xs text-warm-muted dark:text-dark-muted mb-1.5 truncate">
-        {project}
-        {result.profileLabel && <span> · {result.profileLabel}</span>}
-        {result.matchCount > 1 && (
-          <span data-testid="match-count"> · {result.matchCount} matches</span>
-        )}
-      </div>
+      <div className="pl-1.5">
+        <div className="text-xs text-warm-muted dark:text-dark-muted mb-1.5 truncate">
+          {project}
+          {result.profileLabel && <span> · {result.profileLabel}</span>}
+          {result.matchCount > 1 && (
+            <span data-testid="match-count"> · {result.matchCount} matches</span>
+          )}
+        </div>
 
-      <p
-        className="font-mono text-xs text-warm-text dark:text-dark-text leading-relaxed [&>strong]:font-semibold [&>strong]:text-accent dark:[&>strong]:text-accent-dark select-text cursor-text"
-        onClick={(e) => e.stopPropagation()}
-        dangerouslySetInnerHTML={{ __html: snippet }}
-      />
+        <p
+          className="font-mono text-xs text-warm-text dark:text-dark-text leading-relaxed [&>strong]:font-semibold [&>strong]:text-accent dark:[&>strong]:text-accent-dark select-text cursor-text"
+          onClick={(e) => e.stopPropagation()}
+          dangerouslySetInnerHTML={{ __html: snippet }}
+        />
+      </div>
     </div>
   )
 }

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -68,7 +68,7 @@ export default function SessionRow({ session, pinned = false, showProject = fals
             {title}
           </span>
         </div>
-        <p className="text-xs text-warm-faint dark:text-dark-muted truncate">
+        <p className="pl-1.5 text-xs text-warm-faint dark:text-dark-muted truncate">
           {showProject && (
             <>
               <span className="text-warm-muted dark:text-dark-muted">{session.projectDisplayName}</span>


### PR DESCRIPTION
## What
On rows that show `[badge] Title` on line 1 and `project · date · …` (or a snippet) on line 2, line 2 now indents by 6px so it lines up with the badge's text content (the start of "claude" / "codex" / etc.), not with the badge's left edge.

Applies to:
- SessionRow — Library landing (pinned + buckets) and ProjectView
- FragmentRow — search results (meta line + snippet)

## Why
Line 1 starts at the badge background's left edge; line 2 started at the same x. Visually that read as "line 2 sticks out under the badge" because the badge has 6px of internal left padding before its text begins. Nudging line 2 6px right makes line 2's text glyphs line up with the badge's text glyphs.

## How it connects
`SourceBadge` uses `px-1.5` (6px each side). The fix is a single `pl-1.5` on line 2 — no structural changes to line 1 layout, no badge width assumptions.

For FragmentRow, line 2 + snippet are wrapped in one `<div className="pl-1.5">` so both indent together.

## Test plan
- [ ] Library landing: meta line under each session row starts at the badge's text x, not the badge's background x
- [ ] ProjectView: same
- [ ] Search results: project meta + mono snippet both indent to badge text x
- [ ] Title still truncates with ellipsis at long widths; date/actions still right-justify

🤖 Generated with [Claude Code](https://claude.com/claude-code)
