### PR TITLE
polish(app): library landing uses FeaturedEmptyState

### DIFF
--- a/packages/app/src/renderer/components/EmptyState.tsx
+++ b/packages/app/src/renderer/components/EmptyState.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react'
+
+export function FeaturedEmptyState({
+  icon,
+  title,
+  hint,
+}: {
+  icon: ReactNode
+  title: string
+  hint: ReactNode
+}) {
+  return (
+    <div className="h-full flex flex-col items-center justify-center text-center px-6">
+      <div
+        className="w-14 h-14 rounded-full flex items-center justify-center mb-5 bg-warm-surface dark:bg-dark-surface text-warm-muted dark:text-dark-muted"
+        aria-hidden="true"
+      >
+        {icon}
+      </div>
+      <h2 className="text-xl font-semibold tracking-[-0.01em] text-warm-text dark:text-dark-text mb-2">
+        {title}
+      </h2>
+      <p className="text-sm leading-relaxed text-warm-muted dark:text-dark-muted max-w-[360px]">
+        {hint}
+      </p>
+    </div>
+  )
+}
+
+export function SmallEmptyState({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex items-center justify-center px-6 py-16 text-sm text-warm-muted dark:text-dark-muted text-center">
+      {children}
+    </div>
+  )
+}

--- a/packages/app/src/renderer/components/LibraryLanding.tsx
+++ b/packages/app/src/renderer/components/LibraryLanding.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { Library as LibraryIcon } from 'lucide-react'
 import type { Session } from '@spool-lab/core'
 import SessionRow from './SessionRow.js'
+import { FeaturedEmptyState } from './EmptyState.js'
 
 type Props = {
   onSelectProject: (identityKey: string) => void
@@ -71,9 +73,15 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId, onShare
         {recentSessions === null ? (
           <SessionRowsSkeleton count={6} />
         ) : totalSessions === 0 ? (
-          <p className="px-6 py-6 text-sm text-warm-faint dark:text-dark-muted">
-            No sessions yet. Run <code className="font-mono bg-warm-surface dark:bg-dark-surface px-1 rounded">spool sync</code> to index your AI sessions.
-          </p>
+          <FeaturedEmptyState
+            icon={<LibraryIcon size={22} strokeWidth={1.5} />}
+            title="No sessions yet"
+            hint={
+              <>
+                Run <code className="font-mono bg-warm-surface dark:bg-dark-surface px-1 rounded">spool sync</code> to index your AI sessions and they'll appear here.
+              </>
+            }
+          />
         ) : (
           <>
             {pinnedSessions.length > 0 && (

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -3,6 +3,7 @@ import { Newspaper, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useShareDrafts } from '../hooks/useShareDrafts'
 import { useSpoolDrop } from '../hooks/useSpoolDrop.js'
+import { FeaturedEmptyState, SmallEmptyState } from './EmptyState.js'
 import type { ShareDraftListItem } from '@spool-lab/core'
 import {
   TemplateRender,
@@ -447,41 +448,6 @@ function CorruptDraftCard({
           }}
         />
       )}
-    </div>
-  )
-}
-
-function FeaturedEmptyState({
-  icon,
-  title,
-  hint,
-}: {
-  icon: ReactNode
-  title: string
-  hint: string
-}) {
-  return (
-    <div className="h-full flex flex-col items-center justify-center text-center px-6">
-      <div
-        className="w-14 h-14 rounded-full flex items-center justify-center mb-5 bg-warm-surface dark:bg-dark-surface text-warm-muted dark:text-dark-muted"
-        aria-hidden="true"
-      >
-        {icon}
-      </div>
-      <h2 className="text-xl font-semibold tracking-[-0.01em] text-warm-text dark:text-dark-text mb-2">
-        {title}
-      </h2>
-      <p className="text-sm leading-relaxed text-warm-muted dark:text-dark-muted max-w-[360px]">
-        {hint}
-      </p>
-    </div>
-  )
-}
-
-function SmallEmptyState({ children }: { children: ReactNode }) {
-  return (
-    <div className="flex items-center justify-center px-6 py-16 text-sm text-warm-muted dark:text-dark-muted text-center">
-      {children}
     </div>
   )
 }


### PR DESCRIPTION
## What
Library landing's empty state ("No sessions yet. Run spool sync …") now uses the same centered, iconified FeaturedEmptyState that Shares uses, so the two pages read as siblings when empty.

## Why
Shares already had a polished empty state — round icon chip, large title, ~360px hint paragraph. Library's empty state was a bare paragraph in the corner. Different visual register for the same shape of moment ("there's nothing here yet because you haven't done X").

## How it connects
- Extracted `FeaturedEmptyState` + `SmallEmptyState` from SharesPage into a new `components/EmptyState.tsx` module so both pages can import the same component.
- LibraryLanding uses it with the Lucide `Library` icon as the chip glyph; copy stays roughly the same ("Run `spool sync` to index your AI sessions and they'll appear here.")
- Hint slot loosened from `string` to `ReactNode` so Library can keep the inline `<code>spool sync</code>` formatting that the old paragraph had.

## Test plan
- [ ] With zero sessions (fresh DB / SPOOL_HOME=/tmp/empty), Library landing centers the empty state and shows the Library icon chip
- [ ] Copy still references `spool sync` in a code chip
- [ ] Shares empty state visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)