### PR TITLE
feat(app): codesign + notarize macOS, surface auto-update banner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,11 @@ jobs:
           npx electron-vite build
           npx electron-builder --mac --arm64 --publish never
         env:
-          CSC_IDENTITY_AUTO_DISCOVERY: false
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Get version
         id: version

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ dist-electron/
 
 # Native binaries (rebuilt per-platform via electron-rebuild)
 build/
+!packages/app/build/
+packages/app/build/*
+!packages/app/build/entitlements.mac.plist
 *.node
 
 # Compiled artifacts that may end up in src/ by mistake

--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,6 @@ dist-electron/
 # Native binaries (rebuilt per-platform via electron-rebuild)
 build/
 !packages/app/build/
-packages/app/build/*
-!packages/app/build/entitlements.mac.plist
 *.node
 
 # Compiled artifacts that may end up in src/ by mistake

--- a/packages/app/build/entitlements.mac.plist
+++ b/packages/app/build/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+</dict>
+</plist>

--- a/packages/app/build/notarize-dmg.js
+++ b/packages/app/build/notarize-dmg.js
@@ -1,0 +1,55 @@
+// electron-builder hook: notarize + staple the DMG itself so first-launch
+// works fully offline. The .app inside is already notarized + stapled by
+// electron-builder's default mac.notarize flow, but the .dmg container is
+// not — without this, Gatekeeper has to fetch the ticket from CloudKit on
+// the user's first DMG double-click.
+//
+// Skips gracefully when notarize env isn't set (e.g. local dev/CI without
+// secrets) so unsigned builds still complete.
+'use strict'
+
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = async (context) => {
+  const { artifactPaths, platformToTargets } = context
+
+  const isMacBuild = [...platformToTargets.keys()].some(
+    (p) => p.name === 'mac' || p.nodeName === 'darwin',
+  )
+  if (!isMacBuild) return
+
+  const dmgs = (artifactPaths || []).filter((p) => p.endsWith('.dmg'))
+  if (dmgs.length === 0) return
+
+  const appleId = process.env['APPLE_ID']
+  const password = process.env['APPLE_APP_SPECIFIC_PASSWORD']
+  const teamId = process.env['APPLE_TEAM_ID']
+  if (!appleId || !password || !teamId) {
+    console.log('[notarize-dmg] APPLE_* env not set — skipping DMG notarize/staple')
+    return
+  }
+
+  for (const dmg of dmgs) {
+    console.log(`[notarize-dmg] submitting ${dmg}`)
+    await execFileAsync('xcrun', [
+      'notarytool', 'submit', dmg,
+      '--apple-id', appleId,
+      '--password', password,
+      '--team-id', teamId,
+      '--wait',
+    ], { maxBuffer: 32 * 1024 * 1024 })
+
+    console.log(`[notarize-dmg] stapling ${dmg}`)
+    await execFileAsync('xcrun', ['stapler', 'staple', dmg], {
+      maxBuffer: 4 * 1024 * 1024,
+    })
+
+    await execFileAsync('xcrun', ['stapler', 'validate', dmg], {
+      maxBuffer: 4 * 1024 * 1024,
+    })
+    console.log(`[notarize-dmg] ${dmg} stapled OK`)
+  }
+}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -75,6 +75,11 @@
     "mac": {
       "category": "public.app-category.developer-tools",
       "icon": "resources/icon.icns",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
+      "notarize": true,
       "target": [
         {
           "target": "dmg",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -104,7 +104,9 @@
         }
       ]
     },
+    "afterAllArtifactBuild": "build/notarize-dmg.js",
     "dmg": {
+      "sign": true,
       "title": "Spool",
       "iconSize": 80,
       "contents": [

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -244,6 +244,7 @@ export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, o
         )}
       </div>
 
+      <UpdateBanner />
       <SidebarStatus
         syncStatus={syncStatus ?? null}
         status={status ?? null}
@@ -330,6 +331,83 @@ function SidebarStatus({
         </button>
       )}
     </div>
+  )
+}
+
+type UpdateStatus = {
+  status: 'available' | 'downloading' | 'ready' | 'error'
+  version?: string | undefined
+  percent?: number | undefined
+}
+
+function UpdateBanner() {
+  const [update, setUpdate] = useState<UpdateStatus | null>(null)
+
+  useEffect(() => {
+    if (!window.spool?.onUpdateStatus) return
+    const off = window.spool.onUpdateStatus((data) => {
+      if (data.status === 'error') setUpdate(null)
+      else setUpdate(data)
+    })
+    return () => { off() }
+  }, [])
+
+  if (!update) return null
+
+  const isDownloading = update.status === 'downloading'
+  const isAction = update.status === 'available' || update.status === 'ready'
+
+  const onClick = () => {
+    if (update.status === 'available') void window.spool?.downloadUpdate()
+    else if (update.status === 'ready') void window.spool?.installUpdate()
+  }
+
+  const label =
+    update.status === 'available' ? `Update available${update.version ? ` · v${update.version}` : ''}` :
+    update.status === 'ready' ? 'Restart to update' :
+    update.percent != null ? `Downloading update… ${update.percent}%` : 'Downloading update…'
+
+  const baseRow = 'flex-none mx-2 mb-2 h-9 px-3 rounded-md flex items-center gap-2 text-[12px] bg-warm-surface2 dark:bg-dark-surface2 text-warm-text dark:text-dark-text'
+
+  const icon =
+    update.status === 'available' ? (
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="flex-none">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+        <polyline points="7 10 12 15 17 10" />
+        <line x1="12" y1="15" x2="12" y2="3" />
+      </svg>
+    ) : update.status === 'ready' ? (
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="flex-none">
+        <polyline points="23 4 23 10 17 10" />
+        <polyline points="1 20 1 14 7 14" />
+        <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+      </svg>
+    ) : (
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="flex-none animate-spin">
+        <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+      </svg>
+    )
+
+  if (isDownloading || !isAction) {
+    return (
+      <div data-testid={`update-banner-${update.status}`} className={`${baseRow} text-warm-muted dark:text-dark-muted`}>
+        {icon}
+        <span className="flex-1 min-w-0 truncate">{label}</span>
+      </div>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid={`update-banner-${update.status}`}
+      onClick={onClick}
+      title={label}
+      className={`${baseRow} text-left w-auto hover:brightness-95 dark:hover:brightness-110 transition-[filter]`}
+    >
+      {icon}
+      <span className="flex-1 min-w-0 truncate">{label}</span>
+    </button>
   )
 }
 

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import type { ProjectGroup, Session, SessionSource, StatusInfo } from '@spool-lab/core'
 import { Library as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, SquareTerminal, MoreHorizontal, Copy, Loader2, Share2 } from 'lucide-react'
 import PinIcon from './PinIcon.js'
@@ -342,29 +342,49 @@ type UpdateStatus = {
 
 function UpdateBanner() {
   const [update, setUpdate] = useState<UpdateStatus | null>(null)
+  // Tracks the last status that wasn't 'error' so we can decide whether
+  // an error event interrupted a user-visible action (download in
+  // progress) — silent failures during background checks shouldn't
+  // surface a banner from nowhere.
+  const lastStatusRef = useRef<UpdateStatus['status'] | null>(null)
+  const [errorDismissed, setErrorDismissed] = useState(false)
 
   useEffect(() => {
     if (!window.spool?.onUpdateStatus) return
     const off = window.spool.onUpdateStatus((data) => {
-      if (data.status === 'error') setUpdate(null)
-      else setUpdate(data)
+      if (data.status === 'error') {
+        if (lastStatusRef.current === 'downloading') {
+          setUpdate({ status: 'error' })
+        } else {
+          setUpdate(null)
+        }
+        return
+      }
+      lastStatusRef.current = data.status
+      setErrorDismissed(false)
+      setUpdate(data)
     })
     return () => { off() }
   }, [])
 
   if (!update) return null
+  if (update.status === 'error' && errorDismissed) return null
 
   const isDownloading = update.status === 'downloading'
-  const isAction = update.status === 'available' || update.status === 'ready'
+  const isError = update.status === 'error'
+  const isAction = update.status === 'available' || update.status === 'ready' || isError
 
-  const onClick = () => {
+  const onClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
     if (update.status === 'available') void window.spool?.downloadUpdate()
     else if (update.status === 'ready') void window.spool?.installUpdate()
+    else if (isError) void window.spool?.downloadUpdate()
   }
 
   const label =
     update.status === 'available' ? `Update available${update.version ? ` · v${update.version}` : ''}` :
     update.status === 'ready' ? 'Restart to update' :
+    isError ? 'Update failed — retry' :
     update.percent != null ? `Downloading update… ${update.percent}%` : 'Downloading update…'
 
   const baseRow = 'flex-none mx-2 mb-2 h-9 px-3 rounded-md flex items-center gap-2 text-[12px] bg-warm-surface2 dark:bg-dark-surface2 text-warm-text dark:text-dark-text'
@@ -382,17 +402,54 @@ function UpdateBanner() {
         <polyline points="1 20 1 14 7 14" />
         <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
       </svg>
+    ) : isError ? (
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="flex-none">
+        <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+        <line x1="12" y1="9" x2="12" y2="13" />
+        <line x1="12" y1="17" x2="12.01" y2="17" />
+      </svg>
     ) : (
       <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="flex-none animate-spin">
         <path d="M21 12a9 9 0 1 1-6.219-8.56" />
       </svg>
     )
 
-  if (isDownloading || !isAction) {
+  if (isDownloading) {
     return (
       <div data-testid={`update-banner-${update.status}`} className={`${baseRow} text-warm-muted dark:text-dark-muted`}>
         {icon}
         <span className="flex-1 min-w-0 truncate">{label}</span>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div data-testid="update-banner-error" className={`${baseRow} pr-1 text-warm-muted dark:text-dark-muted`}>
+        <button
+          type="button"
+          data-testid="update-banner-error-retry"
+          onClick={onClick}
+          title="Retry download"
+          aria-label="Retry update download"
+          className="flex-1 min-w-0 flex items-center gap-2 -mx-1 px-1 rounded hover:bg-black/[0.04] dark:hover:bg-white/[0.04] transition-colors"
+        >
+          {icon}
+          <span className="flex-1 min-w-0 truncate text-left">{label}</span>
+        </button>
+        <button
+          type="button"
+          data-testid="update-banner-error-dismiss"
+          onClick={(e) => { e.stopPropagation(); setErrorDismissed(true) }}
+          title="Dismiss"
+          aria-label="Dismiss update error"
+          className="flex-none inline-flex items-center justify-center w-6 h-6 rounded text-warm-faint dark:text-dark-muted hover:bg-black/[0.06] dark:hover:bg-white/[0.06] hover:text-warm-text dark:hover:text-dark-text transition-colors"
+        >
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
       </div>
     )
   }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,9 +2,10 @@
 set -euo pipefail
 
 # Bumps version, tags, pushes, and dispatches the CI Release workflow.
-# Build + artifact upload happen in GitHub Actions so the release is never
-# signed with a local Apple Development cert (which is tied to specific
-# device UDIDs and would crash for everyone else). See .github/workflows/release.yml.
+# Build + sign + notarize + artifact upload run in GitHub Actions using the
+# Developer ID Application cert and app-specific password stored as repo
+# secrets (CSC_LINK, CSC_KEY_PASSWORD, APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD,
+# APPLE_TEAM_ID). See .github/workflows/release.yml.
 #
 # Usage:
 #   ./scripts/release.sh              # patch bump (0.3.8 → 0.3.9)


### PR DESCRIPTION
## Summary

Auto-update was completely broken on macOS in 0.4.x:

1. **No-op installs.** CI built unsigned `.dmg`/`.zip` (`CSC_IDENTITY_AUTO_DISCOVERY=false`), so Squirrel.Mac refused to swap the bundle in `quitAndInstall()`. Users saw "Restart to update" but the restart did nothing.
2. **No UI to click.** PR #128's library-shell refactor removed `StatusBar`, which owned the only auto-update entry point — the renderer kept sending `spool:update-status` events to dead listeners.

This PR fixes both, and adds error handling + DMG stapling along the way.

## What this PR does

**Signing pipeline**
- `release.yml` injects `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` into the mac build step.
- `build.mac` in `packages/app/package.json` gains `hardenedRuntime`, `entitlements`, `entitlementsInherit`, `notarize: true`.
- `build/entitlements.mac.plist` carries the entitlements Electron's V8 needs (`allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation`, `allow-dyld-environment-variables`).
- `dmg.sign: true` and a new `afterAllArtifactBuild` hook (`build/notarize-dmg.js`) submit the `.dmg` itself to notarytool and staple the ticket, so first install works **fully offline** — Gatekeeper does not have to query CloudKit on the user's first double-click. Hook skips when `APPLE_*` env is absent so unsigned local builds still finish.
- `scripts/release.sh` comment updated to reflect the new secret layout.

**UI**
- New `UpdateBanner` inside `Sidebar` shows above `SidebarStatus`, Claude-desktop-style pill (subtle surface tone, 36px tall, full sidebar width). Three primary states: `Update available · vX.Y.Z` (download), `Downloading update… NN%` (passive, spinner), `Restart to update` (install).
- Available/ready icons inherit `currentColor`; downloading is rendered with `text-warm-muted`/`dark-muted` for both icon and label.
- Error handling: an `error` event mid-download produces a dismissible "Update failed — retry" pill. The retry click re-triggers `downloadUpdate()`; the explicit × button hides the banner for this session. Background-check failures (no preceding `downloading`) stay silent so we never spawn a banner from nothing. Dismissal resets on the next non-error event so a fresh release can still promote the user.

**Hygiene**
- `.gitignore` simplified — anything under `packages/app/build/` is tracked, instead of allow-listing each config file.

## Verified locally

End-to-end on Apple Silicon with the Developer ID Application cert for `TypeSafe Limited`:

| | `codesign --verify` | `spctl --assess` | `xcrun stapler validate` |
|---|---|---|---|
| `Spool.app` | valid + DR satisfied | accepted, source=Notarized Developer ID | The validate action worked |
| `Spool-0.4.9-arm64.dmg` | valid + DR satisfied | accepted (`--type open`) | The validate action worked |

Three Apple notarize submissions across two builds — all `Accepted`. UI smoke-tested in dev with all banner states (available → downloading → error → retry → ready) plus the × dismiss path.

## Test plan

- [ ] CI release workflow succeeds with the new secrets
- [ ] Resulting `.dmg` opens on a clean Mac without Gatekeeper warning
- [ ] After install, sidebar shows "Update available · v…" when a newer release is published
- [ ] Clicking through Available → Downloading → Restart actually replaces the running app
- [ ] Manually killing network mid-download surfaces "Update failed — retry"; × dismisses for the session