### PR TITLE
fix: stream Codex session parsing

### DIFF
--- a/packages/core/src/parsers/codex.test.ts
+++ b/packages/core/src/parsers/codex.test.ts
@@ -96,7 +96,7 @@ describe('parseCodexSession', () => {
     expect(parseCodexSession(fp)).toBeNull()
   })
 
-  it('parses sessions when whole-file string reads exceed the V8 string limit', async () => {
+  it('streams via readSync without depending on whole-file readFileSync (V8 string-limit safe)', async () => {
     const fp = writeTmpSession([
       {
         timestamp: '2026-04-05T12:30:00Z',
@@ -110,14 +110,19 @@ describe('parseCodexSession', () => {
       },
     ])
 
+    const readFileSyncMock = vi.fn(() => {
+      throw new Error('Cannot create a string longer than 0x1fffffe8 characters')
+    })
+    const readSyncMock = vi.fn<typeof import('node:fs').readSync>()
+
     vi.resetModules()
     vi.doMock('node:fs', async importOriginal => {
       const fs = await importOriginal<typeof import('node:fs')>()
+      readSyncMock.mockImplementation((...args) => fs.readSync(...args))
       return {
         ...fs,
-        readFileSync: vi.fn(() => {
-          throw new Error('Cannot create a string longer than 0x1fffffe8 characters')
-        }),
+        readFileSync: readFileSyncMock,
+        readSync: readSyncMock,
       }
     })
 
@@ -126,6 +131,8 @@ describe('parseCodexSession', () => {
       const parsed = parseWithMockedFs(fp)
       expect(parsed?.title).toBe('Index a very large Codex session.')
       expect(parsed?.messages).toHaveLength(1)
+      expect(readFileSyncMock).not.toHaveBeenCalled()
+      expect(readSyncMock).toHaveBeenCalled()
     } finally {
       vi.doUnmock('node:fs')
       vi.resetModules()

--- a/packages/core/src/parsers/codex.test.ts
+++ b/packages/core/src/parsers/codex.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { writeFileSync, mkdtempSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -94,5 +94,41 @@ describe('parseCodexSession', () => {
     ])
 
     expect(parseCodexSession(fp)).toBeNull()
+  })
+
+  it('parses sessions when whole-file string reads exceed the V8 string limit', async () => {
+    const fp = writeTmpSession([
+      {
+        timestamp: '2026-04-05T12:30:00Z',
+        type: 'session_meta',
+        payload: { id: 'large-session', cwd: '/tmp/project' },
+      },
+      {
+        timestamp: '2026-04-05T12:30:01Z',
+        type: 'event_msg',
+        payload: { type: 'user_message', message: 'Index a very large Codex session.' },
+      },
+    ])
+
+    vi.resetModules()
+    vi.doMock('node:fs', async importOriginal => {
+      const fs = await importOriginal<typeof import('node:fs')>()
+      return {
+        ...fs,
+        readFileSync: vi.fn(() => {
+          throw new Error('Cannot create a string longer than 0x1fffffe8 characters')
+        }),
+      }
+    })
+
+    try {
+      const { parseCodexSession: parseWithMockedFs } = await import('./codex.js')
+      const parsed = parseWithMockedFs(fp)
+      expect(parsed?.title).toBe('Index a very large Codex session.')
+      expect(parsed?.messages).toHaveLength(1)
+    } finally {
+      vi.doUnmock('node:fs')
+      vi.resetModules()
+    }
   })
 })

--- a/packages/core/src/parsers/codex.ts
+++ b/packages/core/src/parsers/codex.ts
@@ -1,5 +1,6 @@
-import { readFileSync } from 'node:fs'
+import { closeSync, openSync, readSync } from 'node:fs'
 import { basename } from 'node:path'
+import { StringDecoder } from 'node:string_decoder'
 import type { ParseSessionResult, ParsedSession, ParsedMessage } from '../types.js'
 import { stripSpoolSystemPrelude } from './spool-prelude.js'
 
@@ -10,6 +11,8 @@ interface CodexRecord {
 }
 
 export const CODEX_INDEX_VERSION = 'codex-v5-filter-internal-assessment-and-approval-session-search-fts'
+
+const READ_CHUNK_SIZE = 1024 * 1024
 
 const INTERNAL_CODEX_SESSION_MARKERS = [
   'The following is the Codex agent history whose request action you are assessing',
@@ -25,8 +28,6 @@ const INTERNAL_CODEX_SESSION_MARKERS = [
 ] as const
 
 export function loadCodexSession(filePath: string): ParseSessionResult {
-  const raw = readFileSync(filePath, 'utf8')
-  const lines = raw.split('\n').filter(l => l.trim().length > 0)
   const eventMessages: ParsedMessage[] = []
   const responseMessages: ParsedMessage[] = []
   let sessionUuid = ''
@@ -38,7 +39,7 @@ export function loadCodexSession(filePath: string): ParseSessionResult {
   const fileMatch = basename(filePath).match(/rollout-.+-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/)
   if (fileMatch?.[1]) sessionUuid = fileMatch[1]
 
-  for (const line of lines) {
+  for (const line of readNonEmptyLines(filePath)) {
     let record: CodexRecord
     try {
       record = JSON.parse(line) as CodexRecord
@@ -176,6 +177,33 @@ export function loadCodexSession(filePath: string): ParseSessionResult {
       endedAt: timestamps[timestamps.length - 1] ?? new Date().toISOString(),
       messages,
     },
+  }
+}
+
+function* readNonEmptyLines(filePath: string): Iterable<string> {
+  const fd = openSync(filePath, 'r')
+  const buffer = Buffer.allocUnsafe(READ_CHUNK_SIZE)
+  const decoder = new StringDecoder('utf8')
+  let pending = ''
+
+  try {
+    while (true) {
+      const bytesRead = readSync(fd, buffer, 0, buffer.length, null)
+      if (bytesRead === 0) break
+
+      pending += decoder.write(buffer.subarray(0, bytesRead))
+      const lines = pending.split('\n')
+      pending = lines.pop() ?? ''
+
+      for (const line of lines) {
+        if (line.trim().length > 0) yield line
+      }
+    }
+
+    pending += decoder.end()
+    if (pending.trim().length > 0) yield pending
+  } finally {
+    closeSync(fd)
   }
 }
 


### PR DESCRIPTION
## Summary

- Stream Codex JSONL session parsing instead of reading the whole file into one string.
- Preserve existing session parsing behavior while avoiding V8 string-size failures on very large Codex sessions.
- Add a regression test that simulates the `Cannot create a string longer than 0x1fffffe8 characters` failure from whole-file reads.

## Root cause

Codex parser used `readFileSync(filePath, "utf8")` and then split the entire JSONL payload. Multi-GB Codex sessions can exceed V8 single-string limits before parsing begins.

## Validation

- `pnpm --filter @spool-lab/cli... build`
- `pnpm --filter @spool-lab/core test -- codex.test.ts` (28 test files, 176 tests passed)
- `spool sync` against local history with previously failing 1.5GB Codex sessions: `Done: +30 added, 5 updated, 0 errors`
