### PR TITLE
feat(app): swap share serif from Instrument to Fraunces

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -21,11 +21,11 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.17.1",
+    "@fontsource-variable/fraunces": "^5.2.9",
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/hanken-grotesk": "^5.2.8",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource/geist-mono": "^5.2.7",
-    "@fontsource/instrument-serif": "^5.2.5",
     "@spool-lab/core": "workspace:*",
     "@spool/share-kit": "workspace:*",
     "@tanstack/react-virtual": "^3.13.6",

--- a/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
+++ b/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
@@ -16,7 +16,7 @@ import { TemplateThumb } from './TemplateThumb.js'
 // hosts that may want broader range.
 const TEMPLATE_IDS = new Set(['chat', 'letter', 'atelier', 'interview'] as const)
 const PAPER_IDS = new Set(['bone', 'snow', 'graphite', 'ink'] as const)
-const TYPEFACE_IDS = new Set(['inter', 'geist', 'instrument-serif', 'hanken-grotesk'] as const)
+const TYPEFACE_IDS = new Set(['inter', 'geist', 'fraunces', 'hanken-grotesk'] as const)
 const COLORWAY_IDS = new Set(['amber', 'iris', 'moss', 'ink'] as const)
 const TEMPLATE_CHOICES = TEMPLATES.filter((t) => (TEMPLATE_IDS as Set<string>).has(t.id))
 const PAPER_CHOICES = PAPERS.filter((p) => (PAPER_IDS as Set<string>).has(p.id))

--- a/packages/app/src/renderer/styles.css
+++ b/packages/app/src/renderer/styles.css
@@ -28,10 +28,16 @@
   src: url('@fontsource-variable/hanken-grotesk/files/hanken-grotesk-latin-wght-normal.woff2') format('woff2-variations');
   unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
 }
+@font-face {
+  font-family: 'Fraunces Variable';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url('@fontsource-variable/fraunces/files/fraunces-latin-wght-normal.woff2') format('woff2-variations');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
 @import "@fontsource/geist-mono/latin-400.css";
 @import "@fontsource/geist-mono/latin-500.css";
-@import "@fontsource/instrument-serif/latin-400.css";
-@import "@fontsource/instrument-serif/latin-400-italic.css";
 @import "tailwindcss";
 
 @theme {

--- a/packages/share-kit/src/lib/types.ts
+++ b/packages/share-kit/src/lib/types.ts
@@ -42,7 +42,7 @@ export interface Conversation {
 
 export type Template = 'atelier' | 'letter' | 'transcript' | 'interview' | 'chat'
 export type Paper = 'bone' | 'snow' | 'linen' | 'graphite' | 'ink'
-export type Typeface = 'inter' | 'geist' | 'instrument-serif' | 'hanken-grotesk'
+export type Typeface = 'inter' | 'geist' | 'fraunces' | 'hanken-grotesk'
 export type Density = 'compact' | 'relaxed'
 
 export interface PaperTokens {
@@ -164,9 +164,9 @@ export const TYPEFACES: TypefaceDef[] = [
     sample: 'Aa',
   },
   {
-    id: 'instrument-serif',
-    name: 'Instrument Serif',
-    family: "'Instrument Serif', 'Georgia', serif",
+    id: 'fraunces',
+    name: 'Fraunces',
+    family: "'Fraunces Variable', 'Fraunces', 'Georgia', serif",
     sample: 'Aa',
   },
   {

--- a/packages/share-kit/src/styles/global.css
+++ b/packages/share-kit/src/styles/global.css
@@ -4,8 +4,7 @@
 @import '@fontsource-variable/geist';
 @import '@fontsource/geist-mono/latin-400.css';
 @import '@fontsource/geist-mono/latin-500.css';
-@import '@fontsource/instrument-serif/400.css';
-@import '@fontsource/instrument-serif/400-italic.css';
+@import '@fontsource-variable/fraunces';
 @import '@fontsource-variable/hanken-grotesk';
 @import './tokens.css';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@agentclientprotocol/sdk':
         specifier: ^0.17.1
         version: 0.17.1(zod@4.3.6)
+      '@fontsource-variable/fraunces':
+        specifier: ^5.2.9
+        version: 5.2.9
       '@fontsource-variable/geist':
         specifier: ^5.2.8
         version: 5.2.8
@@ -37,9 +40,6 @@ importers:
       '@fontsource/geist-mono':
         specifier: ^5.2.7
         version: 5.2.7
-      '@fontsource/instrument-serif':
-        specifier: ^5.2.5
-        version: 5.2.8
       '@spool-lab/core':
         specifier: workspace:*
         version: link:../core
@@ -1073,6 +1073,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fontsource-variable/fraunces@5.2.9':
+    resolution: {integrity: sha512-Y6IjunlN9Ni723np+GIgAaKzCDBrPRrqNi01TZxHs5wtHYROWFM9W6yiT+/gGwSjWIRD18oX17kD/BRWekc/Lw==}
+
   '@fontsource-variable/geist@5.2.8':
     resolution: {integrity: sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==}
 
@@ -1084,9 +1087,6 @@ packages:
 
   '@fontsource/geist-mono@5.2.7':
     resolution: {integrity: sha512-xVPVFISJg/K0VVd+aQN0Y7X/sw9hUcJPyDWFJ5GpyU3bHELhoRsJkPSRSHXW32mOi0xZCUQDOaPj1sqIFJ1FGg==}
-
-  '@fontsource/instrument-serif@5.2.8':
-    resolution: {integrity: sha512-s+bkz+syj2rO00Rmq9g0P+PwuLig33DR1xDR8pTWmovH1pUjwnncrFk++q9mmOex8fUQ7oW80gPpPDaw7V1MMw==}
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
@@ -5934,6 +5934,8 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@fontsource-variable/fraunces@5.2.9': {}
+
   '@fontsource-variable/geist@5.2.8': {}
 
   '@fontsource-variable/hanken-grotesk@5.2.8': {}
@@ -5941,8 +5943,6 @@ snapshots:
   '@fontsource-variable/inter@5.2.8': {}
 
   '@fontsource/geist-mono@5.2.7': {}
-
-  '@fontsource/instrument-serif@5.2.8': {}
 
   '@gar/promisify@1.1.3': {}
 


### PR DESCRIPTION
## What

Replace Instrument Serif with Fraunces in the share-editor typeface picker (the third slot of `TYPEFACES` in `@spool/share-kit`). Adds `@fontsource-variable/fraunces` to the app, drops `@fontsource/instrument-serif`, and updates both the Electron-side `styles.css` (`@font-face` latin-only declaration, matching how Geist/Inter/Hanken are loaded) and the share-kit's `global.css` host stylesheet.

## Why

Instrument Serif renders too thin to be the editorial-serif option in the picker — across the templates' card-title and body sizes, it reads brittle next to Inter/Geist/Hanken. Fraunces is variable with optical sizes (9–144) so it stays substantial at headline scales and warm at body scale, and pairs visually with the other three options.

## How it connects

- `share-kit/TYPEFACES` is the single registry the share-editor pulls from; renaming the slot's `id`/`name`/`family` is enough for ControlPanel previews + every template's body renderer to pick it up.
- `DEFAULT_OPTS.typeface` stays `'inter'`, so no default behavior changes.
- Feature is pre-launch — no migration shim; the slot just swaps.

## Test plan

- [x] `pnpm -C packages/share-kit build` clean
- [x] `pnpm -C packages/app exec tsc --noEmit` clean
- [ ] Open share editor, pick the 3rd typeface slot, see Fraunces render in the canvas at template body and headline scales