### PR TITLE
feat(app): share affordance with BookText icon and state-aware tooltip

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -919,7 +919,9 @@ export default function App() {
                   targetMessageId={targetMessageId}
                   onCopySessionId={handleCopySessionId}
                   onBack={handleBack}
-                  {...(FEATURES.share ? { onShare: handleStartShareFromSession } : {})}
+                  {...(FEATURES.share ? {
+                    onShare: handleStartShareFromSession,
+                  } : {})}
                 />
               ) : showProjectView && activeProjectKey ? (
                 <ProjectView

--- a/packages/app/src/renderer/components/ContinueActions.tsx
+++ b/packages/app/src/renderer/components/ContinueActions.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { MoreHorizontal, Eye, SquareTerminal, Share2, Copy, Loader2 } from 'lucide-react'
+import { MoreHorizontal, Eye, SquareTerminal, BookText, Copy, Loader2 } from 'lucide-react'
 import type { FragmentResult } from '@spool-lab/core'
 import Menu from './Menu.js'
 import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
@@ -47,8 +47,8 @@ export default function ContinueActions({ result, onOpenSession, onCopySessionId
       onSelect: () => onOpenSession(result.sessionUuid, result.messageId),
     },
     ...(onShare ? [{
-      label: 'Share session',
-      icon: <Share2 size={ICON_SIZE} strokeWidth={ICON_STROKE} aria-hidden />,
+      label: 'Open in share editor',
+      icon: <BookText size={ICON_SIZE} strokeWidth={ICON_STROKE} aria-hidden />,
       onSelect: onShare,
     }] : []),
     ...(resumeCommand ? [{

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -1,16 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { SquareTerminal, Share2, MoreHorizontal, Copy } from 'lucide-react'
+import { SquareTerminal, BookText, MoreHorizontal, Copy } from 'lucide-react'
 import type { Session, Message } from '@spool-lab/core'
 import { type FindRange } from './MessageBubble.js'
 import MessageList, { type MessageListHandle } from './MessageList.js'
 import SessionFindBar from './SessionFindBar.js'
 import PinButton from './PinButton.js'
 import Menu from './Menu.js'
+import { FEATURES } from '../featureFlags.js'
 import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
 import { getSessionSourceColor, getSessionSourceShortLabel } from '../../shared/sessionSources.js'
 import { formatRelativeDate } from '../../shared/formatDate.js'
 import { useIsDark } from '../hooks/useIsDark.js'
 import { useHotkeys } from '../hooks/useHotkeys.js'
+import { useDraftCountForSession } from '../hooks/useShareDrafts.js'
 import { extractRenderedText } from '../markdown/extractRenderedText.js'
 
 type Props = {
@@ -37,6 +39,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
   const listRef = useRef<MessageListHandle>(null)
   const activeFindMatchRef = useRef<HTMLElement | null>(null)
   const isDark = useIsDark()
+  const hasDraft = useDraftCountForSession(sessionUuid) > 0
 
   const normalizedFindQuery = findQuery.trim().toLocaleLowerCase()
 
@@ -277,11 +280,15 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
             <button
               data-testid="detail-share"
               onClick={() => onShare(session, messages)}
-              title="Create a share from this session"
-              aria-label="Create a share from this session"
-              className="inline-flex items-center justify-center w-5 h-5 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors"
+              title={hasDraft ? 'Open draft' : 'Open in share editor'}
+              aria-label={hasDraft ? 'Open share draft' : 'Open in share editor'}
+              className={`inline-flex items-center justify-center w-5 h-5 rounded transition-colors ${
+                hasDraft
+                  ? 'text-accent dark:text-accent-dark hover:bg-warm-surface2 dark:hover:bg-dark-surface2'
+                  : 'text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text'
+              }`}
             >
-              <Share2 size={13} strokeWidth={1.6} aria-hidden />
+              <BookText size={13} strokeWidth={1.6} aria-hidden />
             </button>
           )}
 
@@ -291,7 +298,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
             disabled={resuming}
             title={resuming ? 'Opening…' : 'Resume in Terminal'}
             aria-label={resuming ? 'Opening…' : 'Resume in Terminal'}
-            className="inline-flex items-center justify-center w-5 h-5 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+            className="inline-flex items-center justify-center w-5 h-5 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
           >
             <SquareTerminal size={13} strokeWidth={1.6} aria-hidden />
           </button>
@@ -304,7 +311,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
                 type="button"
                 onClick={toggle}
                 aria-label="More actions"
-                className="inline-flex items-center justify-center w-5 h-5 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors"
+                className="inline-flex items-center justify-center w-5 h-5 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
               >
                 <MoreHorizontal size={13} strokeWidth={1.6} aria-hidden />
               </button>

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { SquareTerminal, MoreHorizontal, Copy, Loader2, Share2 } from 'lucide-react'
+import { SquareTerminal, MoreHorizontal, Copy, Loader2, BookText } from 'lucide-react'
 import type { Session } from '@spool-lab/core'
 import { SourceBadge } from './Badges.js'
 import PinButton from './PinButton.js'
@@ -112,8 +112,8 @@ export default function SessionRow({ session, pinned = false, showProject = fals
             )}
             items={[
               ...(onShare ? [{
-                label: 'Share session',
-                icon: <Share2 size={14} strokeWidth={1.6} aria-hidden />,
+                label: 'Open in share editor',
+                icon: <BookText size={14} strokeWidth={1.6} aria-hidden />,
                 onSelect: () => onShare(session.sessionUuid),
               }] : []),
               {

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import type { ProjectGroup, Session, SessionSource, StatusInfo } from '@spool-lab/core'
-import { Library as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, SquareTerminal, MoreHorizontal, Copy, Loader2, Share2 } from 'lucide-react'
+import { Library as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, SquareTerminal, MoreHorizontal, Copy, Loader2, BookText } from 'lucide-react'
 import PinIcon from './PinIcon.js'
 import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
 import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
@@ -657,8 +657,8 @@ function PinnedRow({
           )}
           items={[
             ...(onShare ? [{
-              label: 'Share session',
-              icon: <Share2 size={14} strokeWidth={1.6} aria-hidden />,
+              label: 'Open in share editor',
+              icon: <BookText size={14} strokeWidth={1.6} aria-hidden />,
               onSelect: () => onShare(session.sessionUuid),
             }] : []),
             {

--- a/packages/app/src/renderer/hooks/useShareDrafts.ts
+++ b/packages/app/src/renderer/hooks/useShareDrafts.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import type { ShareDraftListItem, ShareDraftRow } from '@spool-lab/core'
+import { FEATURES } from '../featureFlags.js'
 
 interface UseShareDraftsResult {
   drafts: ShareDraftListItem[]
@@ -72,4 +73,31 @@ export function useShareDrafts(opts: { limit?: number } = {}): UseShareDraftsRes
   }, [refresh])
 
   return { drafts, loading, error, refresh, removeDraft, restoreDraft }
+}
+
+/**
+ * Cheap count of share drafts whose `source_kind = 'spool-session'` and
+ * origin matches the given session uuid. Used by the ShareSourceChip on
+ * SessionDetail to show that a session already has drafts at a glance.
+ *
+ * Fetches once per `sessionUuid` change; callers don't need to worry
+ * about render-loop refetches. Returns 0 when the share feature flag
+ * is off, and skips the IPC entirely in that case.
+ */
+export function useDraftCountForSession(sessionUuid: string): number {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    if (!FEATURES.share) {
+      setCount(0)
+      return
+    }
+    let cancelled = false
+    window.spool.shareDraft.countBySession(sessionUuid)
+      .then((n) => { if (!cancelled) setCount(n) })
+      .catch(() => { if (!cancelled) setCount(0) })
+    return () => { cancelled = true }
+  }, [sessionUuid])
+
+  return count
 }


### PR DESCRIPTION
## What

Replace the OS share-arrow (Lucide Share2) with a more accurate "open the editor" affordance across every share entry point: SessionDetail header, SessionRow ⋯ menu, sidebar PinnedRow ⋯ menu, and FragmentResults ⋯ menu in search results.

## Why

The previous Share2 icon read as a direct-send/broadcast action, but the actual flow is "open a composer to make an artifact." A BookText icon better fits that mental model (it pairs with the sidebar's Newspaper "Shares" nav), and adding state to the tooltip lets users tell at a glance whether a session already has draft work-in-progress.

## How it connects

- Icon: Lucide BookText, sized to the existing 13px ghost-icon topbar baseline. Resting `text-warm-faint`, `text-warm-text` on hover.
- Tooltip + aria-label are state-aware on SessionDetail via a new `useDraftCountForSession` hook (uses the existing `countDraftsBySession` IPC, no new channels):
  - **No draft:** muted icon, tooltip "Open in share editor".
  - **Has draft:** accent-colored icon, tooltip "Open draft".
- Menu copy ("Open in share editor") is shared across SessionRow, PinnedRow, and ContinueActions for one consistent verb across surfaces.
- SessionDetail's 4 top-bar icon buttons (Share / Pin / Resume / More) now share PinButton's hover treatment (`hover:bg-warm-surface2`, `text-warm-faint` rest), so the row reads as a single visual rhythm.

The chip-style "1 draft" / "N drafts" hint that earlier iterations explored is dropped — `sessionDraftId()` makes the count always 0 or 1, and a separate chip read louder than the action it surfaced. State information lives in the icon's color + tooltip instead.

## Test plan

- [x] `pnpm -C packages/app exec tsc --noEmit` clean
- [x] Open a session never shared → icon muted, tooltip "Open in share editor"
- [x] Use ⋯ menu's "Open in share editor" from SessionRow / Pinned / Search results → editor opens
- [x] Click Share2 icon on SessionDetail → composes a fresh draft → close editor → reopen session → icon accent-colored, tooltip "Open draft"
- [x] Hover all four SessionDetail top-bar icons → identical hover treatment (warm-surface2 bg, warm-text fg)