### PR TITLE
feat(app): new-draft picker on Shares — FTS search + cmdk-style nav

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -863,6 +863,7 @@ export default function App() {
           <SharesPage
             onOpenDraft={handleOpenDraft}
             {...(FEATURES.share ? { onImportSpool: handleImportSpoolFile } : {})}
+            {...(FEATURES.share ? { onStartNewDraft: handleStartShareFromUuid } : {})}
           />
         ) : isHomeMode ? (
           <LibraryLanding

--- a/packages/app/src/renderer/components/EmptyState.tsx
+++ b/packages/app/src/renderer/components/EmptyState.tsx
@@ -4,10 +4,12 @@ export function FeaturedEmptyState({
   icon,
   title,
   hint,
+  action,
 }: {
   icon: ReactNode
   title: string
   hint: ReactNode
+  action?: ReactNode
 }) {
   return (
     <div className="h-full flex flex-col items-center justify-center text-center px-6">
@@ -23,6 +25,7 @@ export function FeaturedEmptyState({
       <p className="text-sm leading-relaxed text-warm-muted dark:text-dark-muted max-w-[360px]">
         {hint}
       </p>
+      {action && <div className="mt-6">{action}</div>}
     </div>
   )
 }

--- a/packages/app/src/renderer/components/FragmentResults.tsx
+++ b/packages/app/src/renderer/components/FragmentResults.tsx
@@ -6,6 +6,7 @@ import Menu from './Menu.js'
 import { SEARCH_SORT_OPTIONS, type SearchSortOrder } from '../../shared/searchSort.js'
 import { getSessionSourceLabel } from '../../shared/sessionSources.js'
 import { formatRelativeDate } from '../../shared/formatDate.js'
+import { snippetToStrongHtml } from '../lib/snippet.js'
 
 type FragmentRowResult = FragmentResult & { kind: 'fragment' }
 
@@ -137,7 +138,7 @@ function FragmentRow({
   onCopySessionId: (source: FragmentResult['source']) => void
   onShareSession?: (uuid: string) => void
 }) {
-  const snippet = result.snippet.replace(/<mark>/g, '<strong>').replace(/<\/mark>/g, '</strong>')
+  const snippet = snippetToStrongHtml(result.snippet)
   const date = formatRelativeDate(result.startedAt)
   const project = result.project.split('/').pop() ?? result.project
   const title = result.sessionTitle?.trim() || '(untitled session)'

--- a/packages/app/src/renderer/components/Hint.tsx
+++ b/packages/app/src/renderer/components/Hint.tsx
@@ -1,0 +1,21 @@
+type Props = {
+  keys: string[]
+  label: string
+}
+
+/** Single keyboard-hint chip used in the footer of command-palette-style surfaces. */
+export default function Hint({ keys, label }: Props) {
+  return (
+    <span className="flex items-center gap-1">
+      {keys.map((k, i) => (
+        <kbd
+          key={i}
+          className="font-mono text-[9.5px] px-1 py-px rounded border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg text-warm-muted dark:text-dark-muted"
+        >
+          {k}
+        </kbd>
+      ))}
+      <span>{label}</span>
+    </span>
+  )
+}

--- a/packages/app/src/renderer/components/NewDraftPicker.tsx
+++ b/packages/app/src/renderer/components/NewDraftPicker.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from 'react'
+import type { Session } from '@spool-lab/core'
+import { SourceBadge } from './Badges.js'
+import { formatRelativeDate } from '../../shared/formatDate.js'
+
+type Props = {
+  onSelect: (sessionUuid: string) => void
+  onClose: () => void
+}
+
+const PICKER_LIMIT = 50
+
+export default function NewDraftPicker({ onSelect, onClose }: Props) {
+  const [sessions, setSessions] = useState<Session[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    window.spool.listSessions(PICKER_LIMIT)
+      .then((rows) => {
+        if (cancelled) return
+        setSessions(rows)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : 'Could not load sessions')
+        setSessions([])
+      })
+    return () => { cancelled = true }
+  }, [])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="new-draft-picker-title"
+      data-testid="new-draft-picker"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 px-4 pt-[12vh] animate-in fade-in duration-150"
+    >
+      <div
+        className="w-full max-w-[520px] max-h-[70vh] rounded-[10px] border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg shadow-xl flex flex-col overflow-hidden"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-5 pt-4 pb-3 border-b border-warm-border dark:border-dark-border">
+          <h2
+            id="new-draft-picker-title"
+            className="text-[13px] font-semibold text-warm-text dark:text-dark-text"
+          >
+            Start a draft from a session
+          </h2>
+          <span className="font-mono text-[11px] text-warm-faint dark:text-dark-muted tabular-nums">
+            Esc to close
+          </span>
+        </div>
+
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          {sessions === null ? (
+            <PickerSkeleton count={6} />
+          ) : error ? (
+            <p className="px-5 py-8 text-center text-sm text-warm-muted dark:text-dark-muted">
+              Couldn't load sessions: {error}
+            </p>
+          ) : sessions.length === 0 ? (
+            <p className="px-5 py-8 text-center text-sm text-warm-muted dark:text-dark-muted">
+              No sessions yet — index some first and they'll show up here.
+            </p>
+          ) : (
+            <ul>
+              {sessions.map((session) => (
+                <li key={session.sessionUuid}>
+                  <PickerRow
+                    session={session}
+                    onSelect={() => onSelect(session.sessionUuid)}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function PickerRow({ session, onSelect }: { session: Session; onSelect: () => void }) {
+  const title = session.title?.trim() || '(no title)'
+  const date = formatRelativeDate(session.startedAt)
+  return (
+    <button
+      type="button"
+      data-testid="new-draft-picker-row"
+      data-session-uuid={session.sessionUuid}
+      onClick={onSelect}
+      className="group w-full flex items-start gap-3 px-5 py-3 text-left hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors duration-75 focus:outline-none focus:bg-warm-surface dark:focus:bg-dark-surface"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 mb-0.5">
+          <SourceBadge source={session.source} />
+          <span className="text-sm font-medium text-warm-text dark:text-dark-text truncate">
+            {title}
+          </span>
+        </div>
+        <p className="pl-1.5 text-xs text-warm-faint dark:text-dark-muted truncate">
+          <span className="text-warm-muted dark:text-dark-muted">{session.projectDisplayName}</span>
+          {' · '}
+          {date} · {session.messageCount} {session.messageCount === 1 ? 'msg' : 'msgs'}
+        </p>
+      </div>
+    </button>
+  )
+}
+
+function PickerSkeleton({ count }: { count: number }) {
+  return (
+    <div aria-hidden>
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="flex items-start gap-3 px-5 py-3">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1.5">
+              <div className="h-4 w-12 rounded bg-warm-surface2 dark:bg-dark-surface2 opacity-60 animate-pulse" />
+              <div className="h-4 w-1/2 rounded bg-warm-surface2 dark:bg-dark-surface2 opacity-60 animate-pulse" />
+            </div>
+            <div className="h-3 w-1/3 rounded bg-warm-surface2 dark:bg-dark-surface2 opacity-60 animate-pulse" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/app/src/renderer/components/NewDraftPicker.tsx
+++ b/packages/app/src/renderer/components/NewDraftPicker.tsx
@@ -1,33 +1,113 @@
-import { useEffect, useState } from 'react'
-import type { Session } from '@spool-lab/core'
+import { useEffect, useRef, useState } from 'react'
+import { Search as SearchIcon } from 'lucide-react'
+import type { Session, SearchResult, SessionSource } from '@spool-lab/core'
 import { SourceBadge } from './Badges.js'
+import Hint from './Hint.js'
 import { formatRelativeDate } from '../../shared/formatDate.js'
+import { snippetToStrongHtml } from '../lib/snippet.js'
 
 type Props = {
   onSelect: (sessionUuid: string) => void
   onClose: () => void
 }
 
-const PICKER_LIMIT = 50
+// Match SearchOverlay's 30 for consistent footer counts across both
+// command-palette surfaces.
+const RECENT_LIMIT = 30
+const SEARCH_LIMIT = 30
+const DEBOUNCE_MS = 150
+
+/**
+ * Picker row shape — a thin union of the two backends. Recent mode
+ * gives us Session objects (with messageCount + projectDisplayName);
+ * search mode gives SearchResult (FragmentResult with a snippet but
+ * a raw project path). We render the same row component for both.
+ */
+type Row = {
+  sessionUuid: string
+  title: string
+  source: SessionSource
+  projectLabel: string
+  startedAt: string
+  msgCount?: number | undefined
+  /** HTML-with-<mark> from FTS; undefined in recent mode. */
+  snippet?: string | undefined
+}
+
+function sessionToRow(s: Session): Row {
+  return {
+    sessionUuid: s.sessionUuid,
+    title: s.title?.trim() || '(no title)',
+    source: s.source,
+    projectLabel: s.projectDisplayName ?? '',
+    startedAt: s.startedAt,
+    msgCount: s.messageCount,
+  }
+}
+
+function searchResultToRow(r: SearchResult): Row {
+  // FragmentResult.project is a raw path; show its basename for parity
+  // with SessionRow's display style on this list.
+  const basename = r.project.split('/').filter(Boolean).pop() ?? r.project
+  return {
+    sessionUuid: r.sessionUuid,
+    title: r.sessionTitle?.trim() || '(no title)',
+    source: r.source,
+    projectLabel: basename,
+    startedAt: r.startedAt,
+    snippet: r.snippet,
+  }
+}
 
 export default function NewDraftPicker({ onSelect, onClose }: Props) {
-  const [sessions, setSessions] = useState<Session[] | null>(null)
+  const [recent, setRecent] = useState<Session[] | null>(null)
+  const [results, setResults] = useState<Row[] | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [query, setQuery] = useState('')
+  const [isSearching, setIsSearching] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const searchRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLUListElement>(null)
 
+  // Fetch recent on mount.
   useEffect(() => {
     let cancelled = false
-    window.spool.listSessions(PICKER_LIMIT)
-      .then((rows) => {
-        if (cancelled) return
-        setSessions(rows)
-      })
+    window.spool.listSessions(RECENT_LIMIT)
+      .then((rows) => { if (!cancelled) setRecent(rows) })
       .catch((err) => {
         if (cancelled) return
         setError(err instanceof Error ? err.message : 'Could not load sessions')
-        setSessions([])
+        setRecent([])
       })
     return () => { cancelled = true }
   }, [])
+
+  // Debounced FTS search; falls back to "no results" until backend
+  // responds. Empty query clears results and re-shows recent.
+  useEffect(() => {
+    const q = query.trim()
+    if (!q) {
+      setResults(null)
+      setIsSearching(false)
+      return
+    }
+    setIsSearching(true)
+    let cancelled = false
+    const handle = setTimeout(() => {
+      window.spool.searchPreview(q, SEARCH_LIMIT)
+        .then((rows) => {
+          if (cancelled) return
+          setResults(rows.map(searchResultToRow))
+          setIsSearching(false)
+        })
+        .catch(() => {
+          if (cancelled) return
+          setResults([])
+          setIsSearching(false)
+        })
+    }, DEBOUNCE_MS)
+    return () => { cancelled = true; clearTimeout(handle) }
+  }, [query])
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -40,6 +120,50 @@ export default function NewDraftPicker({ onSelect, onClose }: Props) {
     return () => document.removeEventListener('keydown', onKey)
   }, [onClose])
 
+  useEffect(() => {
+    searchRef.current?.focus()
+  }, [])
+
+  const inSearchMode = query.trim().length > 0
+  const rows: Row[] | null = inSearchMode
+    ? results
+    : recent?.map(sessionToRow) ?? null
+
+  const queryTokens = inSearchMode
+    ? query.trim().toLowerCase().split(/\s+/).filter(Boolean)
+    : []
+
+  // Reset active index whenever the result set changes shape.
+  useEffect(() => { setActiveIndex(0) }, [rows?.length, inSearchMode])
+
+  // Keep the active row visible as the user navigates.
+  useEffect(() => {
+    if (!listRef.current) return
+    const el = listRef.current.querySelector<HTMLElement>(`[data-row-index="${activeIndex}"]`)
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex])
+
+  const onSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!rows || rows.length === 0) return
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActiveIndex((i) => Math.min(rows.length - 1, i + 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActiveIndex((i) => Math.max(0, i - 1))
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      setActiveIndex(0)
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      setActiveIndex(rows.length - 1)
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      const row = rows[activeIndex]
+      if (row) onSelect(row.sessionUuid)
+    }
+  }
+
   return (
     <div
       role="dialog"
@@ -49,77 +173,140 @@ export default function NewDraftPicker({ onSelect, onClose }: Props) {
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onClose()
       }}
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 px-4 pt-[12vh] animate-in fade-in duration-150"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-warm-bg/60 dark:bg-dark-bg/70 backdrop-blur-sm px-4 pt-[12vh] animate-in fade-in duration-150"
     >
       <div
-        className="w-full max-w-[520px] max-h-[70vh] rounded-[10px] border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg shadow-xl flex flex-col overflow-hidden"
+        className="w-full max-w-[560px] max-h-[70vh] rounded-[10px] border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg shadow-xl flex flex-col overflow-hidden"
         onMouseDown={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between px-5 pt-4 pb-3 border-b border-warm-border dark:border-dark-border">
-          <h2
-            id="new-draft-picker-title"
-            className="text-[13px] font-semibold text-warm-text dark:text-dark-text"
-          >
-            Start a draft from a session
-          </h2>
-          <span className="font-mono text-[11px] text-warm-faint dark:text-dark-muted tabular-nums">
-            Esc to close
-          </span>
+        <h2 id="new-draft-picker-title" className="sr-only">
+          Start a draft from a session
+        </h2>
+
+        <div className="flex-none flex items-center gap-2.5 px-5 py-3">
+          <SearchIcon
+            size={15}
+            strokeWidth={1.6}
+            aria-hidden
+            className="flex-none text-warm-faint dark:text-dark-muted"
+          />
+          <input
+            ref={searchRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onSearchKeyDown}
+            placeholder="Start a draft from a session"
+            className="flex-1 bg-transparent outline-none text-sm text-warm-text dark:text-dark-text placeholder:text-warm-faint dark:placeholder:text-dark-muted"
+          />
+          {isSearching && (
+            <span className="flex-none text-[10px] text-warm-faint dark:text-dark-muted">searching…</span>
+          )}
         </div>
 
         <div className="flex-1 min-h-0 overflow-y-auto">
-          {sessions === null ? (
+          {rows === null ? (
             <PickerSkeleton count={6} />
-          ) : error ? (
+          ) : error && !inSearchMode ? (
             <p className="px-5 py-8 text-center text-sm text-warm-muted dark:text-dark-muted">
               Couldn't load sessions: {error}
             </p>
-          ) : sessions.length === 0 ? (
+          ) : rows.length === 0 ? (
             <p className="px-5 py-8 text-center text-sm text-warm-muted dark:text-dark-muted">
-              No sessions yet — index some first and they'll show up here.
+              {inSearchMode
+                ? isSearching ? 'Searching…' : `No sessions match "${query.trim()}".`
+                : 'No sessions yet — index some first and they\'ll show up here.'}
             </p>
           ) : (
-            <ul>
-              {sessions.map((session) => (
-                <li key={session.sessionUuid}>
+            <ul ref={listRef} role="listbox">
+              {rows.map((row, index) => (
+                <li
+                  key={row.sessionUuid}
+                  role="option"
+                  aria-selected={index === activeIndex}
+                  data-row-index={index}
+                  onMouseEnter={() => setActiveIndex(index)}
+                >
                   <PickerRow
-                    session={session}
-                    onSelect={() => onSelect(session.sessionUuid)}
+                    row={row}
+                    queryTokens={queryTokens}
+                    active={index === activeIndex}
+                    onSelect={() => onSelect(row.sessionUuid)}
                   />
                 </li>
               ))}
             </ul>
           )}
         </div>
+
+        <div className="flex-none w-full px-4 py-2 text-[11px] flex items-center justify-between text-warm-faint dark:text-dark-muted gap-3">
+          <div className="flex items-center gap-3 flex-wrap">
+            {rows && rows.length > 0 && (
+              <>
+                <Hint keys={['↑', '↓']} label="navigate" />
+                <Hint keys={['↵']} label="open" />
+              </>
+            )}
+            <Hint keys={['esc']} label="close" />
+          </div>
+          <div className="flex-none">
+            {rows && rows.length > 0 && (
+              <span>
+                {inSearchMode
+                  ? `${rows.length} ${rows.length === 1 ? 'result' : 'results'}`
+                  : `${rows.length} recent ${rows.length === 1 ? 'session' : 'sessions'}`}
+              </span>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   )
 }
 
-function PickerRow({ session, onSelect }: { session: Session; onSelect: () => void }) {
-  const title = session.title?.trim() || '(no title)'
-  const date = formatRelativeDate(session.startedAt)
+function PickerRow({
+  row,
+  queryTokens,
+  active,
+  onSelect,
+}: {
+  row: Row
+  queryTokens: string[]
+  active: boolean
+  onSelect: () => void
+}) {
+  const date = formatRelativeDate(row.startedAt)
+  const inSearchMode = queryTokens.length > 0
+  const snippetHtml = inSearchMode && row.snippet
+    ? snippetToStrongHtml(row.snippet)
+    : null
+  const activeBg = active ? 'bg-warm-surface2 dark:bg-dark-surface2' : ''
+
   return (
     <button
       type="button"
       data-testid="new-draft-picker-row"
-      data-session-uuid={session.sessionUuid}
+      data-session-uuid={row.sessionUuid}
       onClick={onSelect}
-      className="group w-full flex items-start gap-3 px-5 py-3 text-left hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors duration-75 focus:outline-none focus:bg-warm-surface dark:focus:bg-dark-surface"
+      className={`w-full flex items-start gap-3 px-5 py-2 text-left transition-colors duration-75 ${activeBg}`}
     >
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2 mb-0.5">
-          <SourceBadge source={session.source} />
-          <span className="text-sm font-medium text-warm-text dark:text-dark-text truncate">
-            {title}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <SourceBadge source={row.source} />
+          <span className="flex-1 min-w-0 text-sm text-warm-text dark:text-dark-text truncate">
+            {row.title}
           </span>
         </div>
-        <p className="pl-1.5 text-xs text-warm-faint dark:text-dark-muted truncate">
-          <span className="text-warm-muted dark:text-dark-muted">{session.projectDisplayName}</span>
-          {' · '}
-          {date} · {session.messageCount} {session.messageCount === 1 ? 'msg' : 'msgs'}
-        </p>
+        {snippetHtml && (
+          <div
+            className="mt-0.5 pl-1.5 text-[11px] text-warm-faint dark:text-dark-muted truncate [&_strong]:font-medium [&_strong]:text-accent dark:[&_strong]:text-accent-dark"
+            dangerouslySetInnerHTML={{ __html: snippetHtml }}
+          />
+        )}
       </div>
+      <span className="flex-none font-mono text-[11px] leading-[20px] text-warm-faint dark:text-dark-muted tabular-nums">
+        {date}
+      </span>
     </button>
   )
 }
@@ -128,14 +315,10 @@ function PickerSkeleton({ count }: { count: number }) {
   return (
     <div aria-hidden>
       {Array.from({ length: count }).map((_, i) => (
-        <div key={i} className="flex items-start gap-3 px-5 py-3">
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1.5">
-              <div className="h-4 w-12 rounded bg-warm-surface2 dark:bg-dark-surface2 opacity-60 animate-pulse" />
-              <div className="h-4 w-1/2 rounded bg-warm-surface2 dark:bg-dark-surface2 opacity-60 animate-pulse" />
-            </div>
-            <div className="h-3 w-1/3 rounded bg-warm-surface2 dark:bg-dark-surface2 opacity-60 animate-pulse" />
-          </div>
+        <div key={i} className="flex items-center gap-3 px-5 py-2">
+          <div className="h-4 w-12 rounded bg-warm-surface2 dark:bg-dark-surface2 opacity-60 animate-pulse" />
+          <div className="flex-1 h-4 rounded bg-warm-surface2 dark:bg-dark-surface2 opacity-60 animate-pulse" />
+          <div className="h-3 w-16 rounded bg-warm-surface2 dark:bg-dark-surface2 opacity-40 animate-pulse" />
         </div>
       ))}
     </div>

--- a/packages/app/src/renderer/components/SearchOverlay.tsx
+++ b/packages/app/src/renderer/components/SearchOverlay.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import type { FragmentResult, Session } from '@spool-lab/core'
 import { SourceBadge } from './Badges.js'
+import Hint from './Hint.js'
 import { formatRelativeDate } from '../../shared/formatDate.js'
 import SegmentedPill from './SegmentedPill.js'
 import { bucketSessionsByDate } from './LibraryLanding.js'
 import type { SearchMode } from './SearchBar.js'
+import { snippetToStrongHtml } from '../lib/snippet.js'
 
 type FragmentSearchResult = FragmentResult & { kind: 'fragment' }
 
@@ -162,7 +164,7 @@ export default function SearchOverlay({
       className="fixed inset-0 z-50 flex items-start justify-center pt-[12vh] bg-warm-bg/60 dark:bg-dark-bg/70 backdrop-blur-sm"
       onClick={(event) => { if (event.target === event.currentTarget) onClose() }}
     >
-      <div className="w-full max-w-xl rounded-xl border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface shadow-xl overflow-hidden">
+      <div className="w-full max-w-xl rounded-[10px] border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg shadow-xl overflow-hidden">
         <div className="flex items-center gap-2 px-4 py-3">
           <SearchIcon />
           <input
@@ -245,15 +247,19 @@ export default function SearchOverlay({
                                 aria-selected={active}
                                 onMouseEnter={() => setActiveIndex(idx)}
                                 onClick={() => onOpenResult(session.sessionUuid, undefined, '')}
-                                className={`px-4 py-2 cursor-pointer flex items-center gap-2 ${
+                                className={`flex items-start gap-3 px-4 py-2 cursor-pointer transition-colors duration-75 ${
                                   active ? 'bg-warm-surface2 dark:bg-dark-surface2' : ''
                                 }`}
                               >
-                                <SourceBadge source={session.source} />
-                                <span className="flex-1 truncate text-sm text-warm-text dark:text-dark-text">
-                                  {session.title?.trim() || '(no title)'}
-                                </span>
-                                <span className="flex-none text-[11px] text-warm-faint dark:text-dark-muted">
+                                <div className="flex-1 min-w-0">
+                                  <div className="flex items-center gap-2 min-w-0">
+                                    <SourceBadge source={session.source} />
+                                    <span className="flex-1 min-w-0 text-sm text-warm-text dark:text-dark-text truncate">
+                                      {session.title?.trim() || '(no title)'}
+                                    </span>
+                                  </div>
+                                </div>
+                                <span className="flex-none font-mono text-[11px] leading-[20px] text-warm-faint dark:text-dark-muted tabular-nums">
                                   {formatRelativeDate(session.startedAt)}
                                 </span>
                               </li>
@@ -283,21 +289,25 @@ export default function SearchOverlay({
                   aria-selected={index === activeIndex}
                   onMouseEnter={() => setActiveIndex(index)}
                   onClick={() => onOpenResult(result.sessionUuid, result.messageId, query)}
-                  className={`px-4 py-2.5 cursor-pointer ${
+                  className={`flex items-start gap-3 px-4 py-2 cursor-pointer transition-colors duration-75 ${
                     index === activeIndex ? 'bg-warm-surface2 dark:bg-dark-surface2' : ''
                   }`}
                 >
-                  <div className="flex items-center gap-2 mb-0.5">
-                    <SourceBadge source={result.source} />
-                    <span className="text-xs text-warm-muted dark:text-dark-muted truncate flex-1">
-                      {result.project.split('/').pop() ?? result.project}
-                    </span>
-                    <span className="text-[11px] text-warm-faint flex-none">{formatRelativeDate(result.startedAt)}</span>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <SourceBadge source={result.source} />
+                      <span className="flex-1 min-w-0 text-sm text-warm-text dark:text-dark-text truncate">
+                        {result.sessionTitle?.trim() || '(no title)'}
+                      </span>
+                    </div>
+                    <div
+                      className="mt-0.5 pl-1.5 text-[11px] text-warm-faint dark:text-dark-muted truncate [&_strong]:font-medium [&_strong]:text-accent dark:[&_strong]:text-accent-dark"
+                      dangerouslySetInnerHTML={{ __html: snippetToStrongHtml(result.snippet) }}
+                    />
                   </div>
-                  <p
-                    className="font-mono text-xs text-warm-text dark:text-dark-text leading-relaxed [&>strong]:font-semibold [&>strong]:text-accent dark:[&>strong]:text-accent-dark line-clamp-2"
-                    dangerouslySetInnerHTML={{ __html: snippetWithStrong(result.snippet) }}
-                  />
+                  <span className="flex-none font-mono text-[11px] leading-[20px] text-warm-faint dark:text-dark-muted tabular-nums">
+                    {formatRelativeDate(result.startedAt)}
+                  </span>
                 </li>
               ))}
             </ul>
@@ -334,22 +344,6 @@ export default function SearchOverlay({
         </div>
       </div>
     </div>
-  )
-}
-
-function Hint({ keys, label }: { keys: string[]; label: string }) {
-  return (
-    <span className="flex items-center gap-1">
-      {keys.map((k, i) => (
-        <kbd
-          key={i}
-          className="font-mono text-[9.5px] px-1 py-px rounded border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg text-warm-muted dark:text-dark-muted"
-        >
-          {k}
-        </kbd>
-      ))}
-      <span>{label}</span>
-    </span>
   )
 }
 
@@ -412,6 +406,3 @@ function SparklesIcon() {
   )
 }
 
-function snippetWithStrong(snippet: string): string {
-  return snippet.replace(/<mark>/g, '<strong>').replace(/<\/mark>/g, '</strong>')
-}

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
-import { Newspaper, Trash2 } from 'lucide-react'
+import { Newspaper, Plus, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useShareDrafts } from '../hooks/useShareDrafts'
 import { useSpoolDrop } from '../hooks/useSpoolDrop.js'
 import { FeaturedEmptyState, SmallEmptyState } from './EmptyState.js'
+import NewDraftPicker from './NewDraftPicker.js'
 import type { ShareDraftListItem } from '@spool-lab/core'
 import {
   TemplateRender,
@@ -17,6 +18,7 @@ import { getSessionSourceColor } from '../../shared/sessionSources.js'
 type Props = {
   onOpenDraft?: ((draft: ShareDraftListItem) => void) | undefined
   onImportSpool?: ((file: File) => void | Promise<void>) | undefined
+  onStartNewDraft?: ((sessionUuid: string) => void | Promise<void>) | undefined
 }
 
 /**
@@ -25,9 +27,17 @@ type Props = {
  * "Coming in a future update" placeholder reads as a broken promise.
  * The tab strip lands in Phase 2 alongside the actual publish flow.
  */
-export default function SharesPage({ onOpenDraft, onImportSpool }: Props) {
+export default function SharesPage({ onOpenDraft, onImportSpool, onStartNewDraft }: Props) {
   const { drafts, loading, error, removeDraft, restoreDraft } = useShareDrafts()
   const hasDrafts = drafts.length > 0
+  const [pickerOpen, setPickerOpen] = useState(false)
+
+  const handleOpenPicker = useCallback(() => setPickerOpen(true), [])
+  const handleClosePicker = useCallback(() => setPickerOpen(false), [])
+  const handlePickSession = useCallback((uuid: string) => {
+    setPickerOpen(false)
+    void onStartNewDraft?.(uuid)
+  }, [onStartNewDraft])
 
   const onImport = useCallback(
     (file: File) => onImportSpool?.(file),
@@ -70,9 +80,22 @@ export default function SharesPage({ onOpenDraft, onImportSpool }: Props) {
   return (
     <div className="relative flex flex-col flex-1 min-h-0" {...dragHandlers}>
       {isDragActive && <SpoolDropOverlay />}
-      {hasDrafts && (
-        <div className="flex-none px-6 pt-1.5 pb-3 font-mono text-[11px] text-warm-faint dark:text-dark-muted tabular-nums">
-          Drafts · {drafts.length}
+      {(hasDrafts || onStartNewDraft) && (
+        <div className="flex-none flex items-center justify-between gap-3 px-6 pt-1.5 pb-3">
+          <span className="font-mono text-[11px] text-warm-faint dark:text-dark-muted tabular-nums">
+            {hasDrafts ? <>Drafts · {drafts.length}</> : null}
+          </span>
+          {onStartNewDraft && (
+            <button
+              type="button"
+              data-testid="shares-new-draft"
+              onClick={handleOpenPicker}
+              className="inline-flex items-center gap-1.5 h-6 px-2 rounded text-xs font-medium text-white bg-accent dark:bg-accent-dark hover:opacity-90 transition-opacity"
+            >
+              <Plus size={12} strokeWidth={2} aria-hidden />
+              <span>New draft</span>
+            </button>
+          )}
         </div>
       )}
       <div className="flex-1 min-h-0 overflow-y-auto">
@@ -84,6 +107,9 @@ export default function SharesPage({ onOpenDraft, onImportSpool }: Props) {
           onDeleteDraft={handleDelete}
         />
       </div>
+      {pickerOpen && onStartNewDraft && (
+        <NewDraftPicker onSelect={handlePickSession} onClose={handleClosePicker} />
+      )}
     </div>
   )
 }

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -80,8 +80,8 @@ export default function SharesPage({ onOpenDraft, onImportSpool, onStartNewDraft
   return (
     <div className="relative flex flex-col flex-1 min-h-0" {...dragHandlers}>
       {isDragActive && <SpoolDropOverlay />}
-      {(hasDrafts || onStartNewDraft) && (
-        <div className="flex-none flex items-center justify-between gap-3 px-6 pt-1.5 pb-3">
+      {hasDrafts && (
+        <div className="flex-none flex items-center gap-3 px-6 pt-1.5 pb-3">
           <span className="font-mono text-[11px] text-warm-faint dark:text-dark-muted tabular-nums">
             {hasDrafts ? <>Drafts · {drafts.length}</> : null}
           </span>
@@ -90,10 +90,11 @@ export default function SharesPage({ onOpenDraft, onImportSpool, onStartNewDraft
               type="button"
               data-testid="shares-new-draft"
               onClick={handleOpenPicker}
-              className="inline-flex items-center gap-1.5 h-6 px-2 rounded text-xs font-medium text-white bg-accent dark:bg-accent-dark hover:opacity-90 transition-opacity"
+              title="Start a draft from a session"
+              aria-label="Start a draft from a session"
+              className="inline-flex items-center justify-center w-5 h-5 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
             >
-              <Plus size={12} strokeWidth={2} aria-hidden />
-              <span>New draft</span>
+              <Plus size={13} strokeWidth={1.6} aria-hidden />
             </button>
           )}
         </div>
@@ -105,6 +106,7 @@ export default function SharesPage({ onOpenDraft, onImportSpool, onStartNewDraft
           error={error}
           onOpenDraft={onOpenDraft}
           onDeleteDraft={handleDelete}
+          {...(onStartNewDraft ? { onStartNewDraft: handleOpenPicker } : {})}
         />
       </div>
       {pickerOpen && onStartNewDraft && (
@@ -134,12 +136,14 @@ function DraftsList({
   error,
   onOpenDraft,
   onDeleteDraft,
+  onStartNewDraft,
 }: {
   drafts: ShareDraftListItem[]
   loading: boolean
   error: string | null
   onOpenDraft?: ((draft: ShareDraftListItem) => void) | undefined
   onDeleteDraft: (draft: ShareDraftListItem) => void
+  onStartNewDraft?: (() => void) | undefined
 }) {
   const [skeletonCount] = useState(readSkeletonCount)
   // Defer skeleton render by 150ms so sub-threshold loads (local sqlite is
@@ -176,7 +180,20 @@ function DraftsList({
       <FeaturedEmptyState
         icon={<Newspaper size={22} strokeWidth={1.5} />}
         title="No shares yet"
-        hint="Start a share from a session, a search result, or an AI answer — drafts you create land here, ready to keep editing."
+        hint="Start a share from any session or search result — drafts you create land here, ready to keep editing."
+        {...(onStartNewDraft ? {
+          action: (
+            <button
+              type="button"
+              data-testid="shares-empty-start"
+              onClick={onStartNewDraft}
+              className="inline-flex items-center gap-1.5 h-8 px-3 rounded text-sm font-medium text-white bg-accent dark:bg-accent-dark hover:opacity-90 transition-opacity"
+            >
+              <Plus size={14} strokeWidth={2} aria-hidden />
+              <span>Start a draft</span>
+            </button>
+          ),
+        } : {})}
       />
     )
   }

--- a/packages/app/src/renderer/lib/snippet.ts
+++ b/packages/app/src/renderer/lib/snippet.ts
@@ -1,0 +1,7 @@
+/** Rewrites `<mark>` tags from core's buildLikeSnippet to `<strong>`
+ *  so renderer surfaces can style highlights via their own `<strong>`
+ *  rules (accent color, font weight, etc.) without each surface
+ *  carrying the same regex. */
+export function snippetToStrongHtml(snippet: string): string {
+  return snippet.replace(/<mark>/g, '<strong>').replace(/<\/mark>/g, '</strong>')
+}


### PR DESCRIPTION
## What

Adds a "Start a draft" entry point to the Shares page so a user doesn't have to first navigate to a session before composing a share. Empty surface picks up a centered CTA; once drafts exist, a quiet `+` icon next to "Drafts · N" opens a command-palette-style picker. Picker rows + helpers are shared with the existing sidebar Search overlay so the two cmdk surfaces stay visually paired.

## Why

The only Phase-0 entry point lived on SessionDetail's BookText icon, so users with a session in mind had to drill into it to start. For a quick "let me find any conversation about typefaces and make a share" flow, a top-level picker on Shares is the natural shortcut. Aligning the row layout + Hint chips with SearchOverlay means muscle memory transfers.

## How it connects

**Shares page**
- `FeaturedEmptyState` picks up an optional `action` slot.
- Empty surface renders a centered accent-fill "Start a draft" CTA in place of the corner '+', so the only entry point becomes the obvious one. Copy says "any session or search result".
- When drafts exist, a 20×20 ghost `+` icon button sits next to "Drafts · N" — quiet, doesn't compete with the grid.

**NewDraftPicker**
- Overlay (`bg-warm-bg/60 dark:bg-dark-bg/70 backdrop-blur-sm`) and panel (`bg-warm-bg` + `rounded-[10px]`) match SearchOverlay's modal styling.
- Search row reads as a command bar: borderless transparent input, inline 15px Lucide search icon, no surface fill. Placeholder doubles as the title (heading moves to sr-only). Inline 'searching…' chip while an FTS request is in flight.
- Search switches to FTS via `window.spool.searchPreview` — the same backend the sidebar Search uses — so message-body matches surface in the picker, not just title hits. Recent mode lists the top 30 by startedAt; search mode shows up to 30 ranked results.
- Keyboard nav: Arrow / Home / End / Enter on the input drive `activeIndex`; mouseenter→activeIndex so mouse and keyboard cooperate; activeIndex scrolls into view; `bg-warm-surface2` marks the active row.
- Footer matches SearchOverlay's: `↑↓ navigate · ↵ open · esc close` on the left, "N results" / "N recent sessions" on the right.
- Row layout: badge inline with title (text-sm), mono date right-aligned; search-mode rows add a second line with a highlighted snippet (line-clamp-1, accent `<strong>`, `pl-1.5` so the snippet's left aligns with the badge's text — same trick SessionRow uses).

**SearchOverlay**
- Recent bucket rows + search-result rows restyle to the same shape as NewDraftPicker rows: nested content column, title (sessionTitle) on the first line, snippet uses the compact 11px faint line + accent `<strong>`, mono date right-aligned.

**Dedup**
- New `Hint` component (verbatim from SearchOverlay's prior inline copy) and `snippetToStrongHtml` util (replaces three identical regex chains in SearchOverlay, FragmentResults, NewDraftPicker).

## Test plan

- [x] `pnpm -C packages/app exec tsc --noEmit` clean
- [x] Empty Shares surface → centered "Start a draft" CTA visible; click → picker opens
- [x] Non-empty Shares → corner `+` next to "Drafts · N"; click → picker opens
- [x] Picker: type a query → FTS results with snippet preview + accent-highlighted match
- [x] Picker: ↑↓ navigate, ↵ open, Esc close, click outside closes
- [x] Sidebar Search (⌘K) recent + search rows render with the same row layout as Picker