### PR TITLE
feat(app): TurnSelector — Messages view in ControlPanel + jump-to-message

### DIFF
--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -319,7 +319,7 @@ export default function ShareEditorPage({
       sidebarCollapsed={sidebarCollapsed}
       onToggleSidebar={onToggleSidebar}
       topBar={topBarContent}
-      rightPanel={<ControlPanel opts={opts} setOpts={setOpts} />}
+      rightPanel={<ControlPanel convo={conversation} opts={opts} setOpts={setOpts} />}
       rightPanelOpen={panelOpen}
     >
       <div className="flex flex-col h-full" data-testid="share-editor-page">

--- a/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
+++ b/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
@@ -4,11 +4,15 @@ import {
   PAPERS,
   TEMPLATES,
   TYPEFACES,
+  type Conversation,
   type EditorOpts,
   type Paper,
   type Typeface,
 } from '@spool/share-kit'
 import { TemplateThumb } from './TemplateThumb.js'
+import { TurnSelector } from './TurnSelector.js'
+
+type View = 'style' | 'messages'
 
 // Curated subset of share-kit's option sets so the panel feels
 // editorial-curated rather than "every variation we've ever shipped".
@@ -24,12 +28,14 @@ const TYPEFACE_CHOICES = TYPEFACES.filter((t) => (TYPEFACE_IDS as Set<string>).h
 const COLORWAY_CHOICES = COLORWAYS.filter((c) => (COLORWAY_IDS as Set<string>).has(c.id))
 
 type Props = {
+  convo: Conversation
   opts: EditorOpts
   setOpts: (next: EditorOpts) => void
 }
 
-export function ControlPanel({ opts, setOpts }: Props) {
+export function ControlPanel({ convo, opts, setOpts }: Props) {
   const [advancedOpen, setAdvancedOpen] = useState(true)
+  const [view, setView] = useState<View>('style')
   const currentColor = COLORWAY_CHOICES.find((c) => c.id === opts.colorway) ?? COLORWAY_CHOICES[0]!
   const currentPaper = PAPER_CHOICES.find((p) => p.id === opts.paper) ?? PAPER_CHOICES[0]!
   const currentTypeface = TYPEFACE_CHOICES.find((t) => t.id === opts.typeface) ?? TYPEFACE_CHOICES[0]!
@@ -38,8 +44,22 @@ export function ControlPanel({ opts, setOpts }: Props) {
     <div className="w-full h-full p-2 pt-0">
     <aside
       data-testid="share-editor-style-panel"
-      className="w-full h-full bg-warm-bg dark:bg-dark-bg overflow-y-auto scrollbar-none flex flex-col rounded-[10px] border border-warm-border dark:border-dark-border"
+      className="w-full h-full bg-warm-bg dark:bg-dark-bg flex flex-col rounded-[10px] border border-warm-border dark:border-dark-border overflow-hidden"
     >
+      <div className="flex-none px-3 pt-3 pb-2">
+        <div
+          role="tablist"
+          aria-label="Panel view"
+          className="inline-flex items-center gap-0.5 p-0.5 rounded-md bg-warm-surface dark:bg-dark-surface"
+        >
+          <ViewTab active={view === 'style'} onClick={() => setView('style')}>Style</ViewTab>
+          <ViewTab active={view === 'messages'} onClick={() => setView('messages')}>Messages</ViewTab>
+        </div>
+      </div>
+      {view === 'messages' ? (
+        <TurnSelector convo={convo} opts={opts} setOpts={setOpts} />
+      ) : (
+      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-none">
       <div className="px-4 pt-3 pb-4">
         <div className="flex items-baseline justify-between mb-3">
           <div className="text-[11px] font-medium tracking-[0.08em] uppercase text-warm-muted dark:text-dark-muted leading-none">
@@ -170,8 +190,36 @@ export function ControlPanel({ opts, setOpts }: Props) {
           onChange={(v) => setOpts({ ...opts, showColophon: v })}
         />
       </Collapsible>
+      </div>
+      )}
     </aside>
     </div>
+  )
+}
+
+function ViewTab({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      onClick={onClick}
+      aria-selected={active}
+      className={`h-6 px-2.5 rounded text-[11.5px] font-medium transition-colors ${
+        active
+          ? 'bg-warm-bg dark:bg-dark-bg text-warm-text dark:text-dark-text shadow-[0_1px_1px_rgba(0,0,0,0.2)]'
+          : 'bg-transparent text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text'
+      }`}
+    >
+      {children}
+    </button>
   )
 }
 

--- a/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
+++ b/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
@@ -210,6 +210,7 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
     <div className="relative flex-1 min-w-0 flex">
       <div
         ref={scrollRef}
+        data-share-preview-scroll
         onMouseDown={beginPan}
         style={scrollCursor ? { cursor: scrollCursor } : undefined}
         className="flex-1 overflow-auto scrollbar-none relative bg-warm-bg dark:bg-dark-bg cursor-grab"

--- a/packages/app/src/renderer/components/share-editor/TurnSelector.tsx
+++ b/packages/app/src/renderer/components/share-editor/TurnSelector.tsx
@@ -1,0 +1,229 @@
+import { useCallback, useMemo } from 'react'
+import { Check, CheckCheck, Eraser } from 'lucide-react'
+import type { Conversation, EditorOpts } from '@spool/share-kit'
+
+type Props = {
+  convo: Conversation
+  opts: EditorOpts
+  setOpts: (opts: EditorOpts) => void
+}
+
+/**
+ * Embedded messages view for the right ControlPanel — header + scrolling
+ * list of turns + Select all / Clear footer. The chrome (chip, popover,
+ * dismissal) lives in the panel's view switcher; this component just
+ * draws the picker itself.
+ *
+ * Canonical write rule: when every turn is included, write
+ * `selected: undefined` (not a fully-populated array) so the downstream
+ * `isExcerpt` flag flips back to false.
+ */
+export function TurnSelector({ convo, opts, setOpts }: Props) {
+  const total = convo.turns.length
+
+  const selectedSet = useMemo(() => {
+    if (opts.selected === undefined) return null
+    return new Set(opts.selected)
+  }, [opts.selected])
+
+  // Mirror what the preview renders. When `hideEmptyTurns` is on, empty
+  // turns are skipped here too — indices stay as the original turn
+  // positions in `convo.turns`, so the displayed list may show 01 / 03 /
+  // 07 with gaps. The selected[] we write back still references the
+  // original array.
+  const visibleTurns = useMemo(() => {
+    const rows = convo.turns.map((turn, i) => ({ turn, originalIndex: i }))
+    if (!opts.hideEmptyTurns) return rows
+    return rows.filter(({ turn }) => turn.body.trim() !== '')
+  }, [convo.turns, opts.hideEmptyTurns])
+
+  const kept = selectedSet === null ? total : opts.selected!.length
+
+  const writeSelection = useCallback(
+    (next: number[]) => {
+      const fullyIncluded = next.length === total
+      setOpts({ ...opts, selected: fullyIncluded ? undefined : next })
+    },
+    [opts, setOpts, total],
+  )
+
+  const toggleTurn = useCallback(
+    (index: number) => {
+      const current =
+        opts.selected === undefined
+          ? Array.from({ length: total }, (_, i) => i)
+          : [...opts.selected]
+      const at = current.indexOf(index)
+      if (at >= 0) current.splice(at, 1)
+      else current.push(index)
+      current.sort((a, b) => a - b)
+      writeSelection(current)
+    },
+    [opts.selected, total, writeSelection],
+  )
+
+  const selectAll = useCallback(() => {
+    setOpts({ ...opts, selected: undefined })
+  }, [opts, setOpts])
+
+  const clearAll = useCallback(() => {
+    setOpts({ ...opts, selected: [] })
+  }, [opts, setOpts])
+
+  const jumpToTurn = useCallback((index: number) => {
+    const el = document.querySelector<HTMLElement>(`[data-turn-index="${index}"]`)
+    if (!el) return
+    // Compute scrollTop manually instead of `scrollIntoView` so we
+    // only touch the vertical axis. scrollIntoView walks up the DOM
+    // and (under zoom transform) ends up shifting the artifact card
+    // horizontally off-center too.
+    const sc = el.closest<HTMLElement>('[data-share-preview-scroll]')
+    if (sc) {
+      const turnRect = el.getBoundingClientRect()
+      const scRect = sc.getBoundingClientRect()
+      const offsetFromContainerTop = (turnRect.top - scRect.top) + sc.scrollTop
+      const centered = offsetFromContainerTop - (scRect.height - turnRect.height) / 2
+      sc.scrollTop = Math.max(0, centered)
+    } else {
+      // Fallback for anything not inside our preview pane.
+      el.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'nearest' })
+    }
+    // Brief flash so the user sees where they landed. Remove + force
+    // reflow + re-add so the animation restarts on repeated clicks.
+    el.removeAttribute('data-spool-share-flash')
+    void el.offsetWidth
+    el.setAttribute('data-spool-share-flash', '')
+    window.setTimeout(() => el.removeAttribute('data-spool-share-flash'), 1700)
+  }, [])
+
+  if (total === 0) {
+    return (
+      <div className="px-4 py-6 text-center text-[11px] text-warm-faint dark:text-dark-muted">
+        No messages in this conversation.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col min-h-0 flex-1">
+      <div className="flex items-center justify-between px-4 pt-3 pb-2">
+        <span className="text-[10px] uppercase tracking-wider font-medium text-warm-faint dark:text-dark-faint">
+          Messages {kept} of {total}
+        </span>
+        <span className="flex items-center gap-0.5">
+          <button
+            type="button"
+            onClick={selectAll}
+            title="Include all messages"
+            aria-label="Include all messages"
+            className="w-5 h-5 inline-flex items-center justify-center rounded text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors"
+          >
+            <CheckCheck size={13} strokeWidth={1.75} />
+          </button>
+          <button
+            type="button"
+            onClick={clearAll}
+            title="Exclude all messages"
+            aria-label="Exclude all messages"
+            className="w-5 h-5 inline-flex items-center justify-center rounded text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors"
+          >
+            <Eraser size={12} strokeWidth={1.75} />
+          </button>
+        </span>
+      </div>
+      <ul className="flex-1 min-h-0 overflow-y-auto py-1">
+        {visibleTurns.map(({ turn, originalIndex: i }) => {
+          const included = selectedSet === null ? true : selectedSet.has(i)
+          const preview = firstLinePreview(turn.body)
+          return (
+            <li
+              key={i}
+              className={`group flex items-center gap-3 pl-3 pr-4 py-1 transition-colors hover:bg-warm-surface dark:hover:bg-dark-surface ${
+                included ? '' : 'opacity-60'
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => toggleTurn(i)}
+                title={included ? 'Click to exclude' : 'Click to include'}
+                aria-pressed={included}
+                aria-label={`${included ? 'Exclude' : 'Include'} message ${i + 1}`}
+                className="shrink-0 p-1 -m-1 rounded"
+              >
+                <span
+                  className={`block w-[18px] h-[18px] rounded-[4px] flex items-center justify-center transition-colors ${
+                    included
+                      ? 'bg-accent dark:bg-accent-dark'
+                      : 'border border-warm-border2 dark:border-dark-border2'
+                  }`}
+                  aria-hidden="true"
+                >
+                  {included && <Check size={12} strokeWidth={2.5} className="text-white" />}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => jumpToTurn(i)}
+                title={previewTooltip(turn.body)}
+                aria-label={`Jump to message ${i + 1}`}
+                className="flex-1 min-w-0 flex items-center gap-3 text-left"
+              >
+                <span
+                  className={`w-1.5 h-1.5 rounded-full shrink-0 ${
+                    turn.role === 'assistant'
+                      ? ''
+                      : 'bg-warm-text dark:bg-dark-text'
+                  }`}
+                  style={
+                    turn.role === 'assistant'
+                      ? { backgroundColor: opts.accentHex }
+                      : undefined
+                  }
+                  aria-hidden="true"
+                />
+                <span className="font-mono text-[11px] tabular-nums text-warm-faint dark:text-dark-faint shrink-0">
+                  {padIndex(i + 1, total)}
+                </span>
+                <span className="text-[13px] text-warm-text dark:text-dark-text truncate flex-1">
+                  {preview || <span className="text-warm-faint dark:text-dark-faint italic">empty</span>}
+                </span>
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+/** Longer body excerpt used as the native tooltip on row hover.
+ *  Collapses internal whitespace and truncates at ~240 chars so the
+ *  OS tooltip doesn't run off the screen. */
+function previewTooltip(body: string): string {
+  const collapsed = body.replace(/\s+/g, ' ').trim()
+  if (collapsed.length <= 240) return collapsed
+  return collapsed.slice(0, 240).trimEnd() + '…'
+}
+
+/** Strip a few obvious markdown markers from the first non-empty line. */
+function firstLinePreview(body: string): string {
+  const lines = body.split('\n')
+  for (const raw of lines) {
+    const trimmed = raw.trim()
+    if (!trimmed) continue
+    return trimmed
+      .replace(/^`{3,}.*$/, '')
+      .replace(/^#{1,6}\s+/, '')
+      .replace(/^>\s?/, '')
+      .replace(/^[-*+]\s+/, '')
+      .replace(/`/g, '')
+      .trim()
+  }
+  return ''
+}
+
+/** Zero-pad to the digit width of `total` so columns align. */
+function padIndex(n: number, total: number): string {
+  const width = Math.max(2, String(total).length)
+  return String(n).padStart(width, '0')
+}

--- a/packages/app/src/renderer/styles.css
+++ b/packages/app/src/renderer/styles.css
@@ -160,3 +160,29 @@ body {
 .scrollbar-none::-webkit-scrollbar {
   display: none;
 }
+
+/* Brief highlight applied to a share-editor turn after the user clicks
+ * jump-to-message in the TurnSelector. Replaces a smooth-scroll
+ * animation (which over long distances felt sluggish) with an instant
+ * snap + an overlay flash so the user gets a confirmation that they
+ * arrived. Implemented as a `::after` overlay so the bubble's own
+ * background / border / shadow are left untouched (animating
+ * background-color directly was clobbering the user bubble's surface
+ * fill at the end of the keyframe). */
+@keyframes spool-share-jump-flash {
+  0%   { opacity: 0.22; }
+  60%  { opacity: 0.16; }
+  100% { opacity: 0; }
+}
+[data-spool-share-flash] [data-turn-body] {
+  position: relative;
+}
+[data-spool-share-flash] [data-turn-body]::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-color: #F07020;
+  pointer-events: none;
+  border-radius: inherit;
+  animation: spool-share-jump-flash 1600ms ease-out forwards;
+}

--- a/packages/share-kit/src/templates/atelier.tsx
+++ b/packages/share-kit/src/templates/atelier.tsx
@@ -95,7 +95,7 @@ export function Atelier({ convo, opts }: Props) {
             {opts.showGaps && segments.gapBefore[i]! > 0 && (
               <GapMarker count={segments.gapBefore[i]!} tokens={t} accent={accent} />
             )}
-            <div style={{ marginBottom: gap }}>
+            <div data-turn-body style={{ marginBottom: gap }}>
               <div
                 style={{
                   fontFamily: tf,

--- a/packages/share-kit/src/templates/chat.tsx
+++ b/packages/share-kit/src/templates/chat.tsx
@@ -96,6 +96,7 @@ export function Chat({ convo, opts }: Props) {
               {isUser ? (
                 <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
                   <div
+                    data-turn-body
                     style={{
                       maxWidth: '74%',
                       background: t.surface,
@@ -119,7 +120,7 @@ export function Chat({ convo, opts }: Props) {
                   </div>
                 </div>
               ) : (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                <div data-turn-body style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
                   <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                     <span
                       aria-hidden

--- a/packages/share-kit/src/templates/interview.tsx
+++ b/packages/share-kit/src/templates/interview.tsx
@@ -99,7 +99,7 @@ export function Interview({ convo, opts }: Props) {
             <div key={turn.origIndex} data-turn-index={turn.origIndex} style={{ scrollMarginTop: 40 }}>
               {showGap && <GapMarker count={segments.gapBefore[i]!} tokens={t} accent={accent} />}
               {isUser ? (
-                <div style={{ display: 'flex', gap: 16, alignItems: 'baseline' }}>
+                <div data-turn-body style={{ display: 'flex', gap: 16, alignItems: 'baseline' }}>
                   <div
                     style={{
                       flexShrink: 0,
@@ -135,7 +135,7 @@ export function Interview({ convo, opts }: Props) {
                   </div>
                 </div>
               ) : (
-                <div style={{ display: 'flex', gap: 16, alignItems: 'baseline' }}>
+                <div data-turn-body style={{ display: 'flex', gap: 16, alignItems: 'baseline' }}>
                   <div
                     style={{
                       flexShrink: 0,

--- a/packages/share-kit/src/templates/letter.tsx
+++ b/packages/share-kit/src/templates/letter.tsx
@@ -123,38 +123,40 @@ export function Letter({ convo, opts }: Props) {
                 <GapMarker count={segments.gapBefore[i]!} tokens={t} accent={accent} />
               </div>
             )}
-            <div
-              style={{
-                fontFamily: tf,
-                fontSize: 11,
-                fontWeight: 600,
-                letterSpacing: '0.14em',
-                textTransform: 'uppercase',
-                color: turn.role === 'user' ? accent : t.muted,
-                marginBottom: 8,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
-              }}
-            >
-              <span
+            <div data-turn-body>
+              <div
                 style={{
-                  width: turn.role === 'user' ? 10 : 4,
-                  height: 2,
-                  background: turn.role === 'user' ? accent : t.muted,
-                  opacity: turn.role === 'user' ? 1 : 0.5,
-                  flexShrink: 0,
+                  fontFamily: tf,
+                  fontSize: 11,
+                  fontWeight: 600,
+                  letterSpacing: '0.14em',
+                  textTransform: 'uppercase',
+                  color: turn.role === 'user' ? accent : t.muted,
+                  marginBottom: 8,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
                 }}
+              >
+                <span
+                  style={{
+                    width: turn.role === 'user' ? 10 : 4,
+                    height: 2,
+                    background: turn.role === 'user' ? accent : t.muted,
+                    opacity: turn.role === 'user' ? 1 : 0.5,
+                    flexShrink: 0,
+                  }}
+                />
+                {turn.role === 'user' ? (turn.author ?? 'User').replace(/[\[\]]/g, '') : convo.sourceLabel}
+              </div>
+              <Body
+                text={turn.body}
+                redact={opts.redact ? redactList : undefined}
+                sansFont={tf}
+                accent={accent}
+                accentBg={t.accentBg}
               />
-              {turn.role === 'user' ? (turn.author ?? 'User').replace(/[\[\]]/g, '') : convo.sourceLabel}
             </div>
-            <Body
-              text={turn.body}
-              redact={opts.redact ? redactList : undefined}
-              sansFont={tf}
-              accent={accent}
-              accentBg={t.accentBg}
-            />
           </div>
         ))}
       </div>

--- a/packages/share-kit/src/templates/transcript.tsx
+++ b/packages/share-kit/src/templates/transcript.tsx
@@ -87,7 +87,7 @@ export function Transcript({ convo, opts }: Props) {
             {opts.showGaps && segments.gapBefore[i]! > 0 && (
               <GapMarker count={segments.gapBefore[i]!} tokens={t} accent={accent} variant="block" />
             )}
-            <div style={{ display: 'flex', gap: 14 }}>
+            <div data-turn-body style={{ display: 'flex', gap: 14 }}>
               <div style={{ width: 68, flexShrink: 0, paddingTop: 2 }}>
                 <div
                   style={{


### PR DESCRIPTION
## What

Adds the missing UI for `EditorOpts.selected` so users can pick which turns to include in a rendered share artifact. The data model + template plumbing have been in share-kit since #162; this PR is the view that drives them, plus a small set of share-kit and preview-pane tweaks that make jump-to-message work cleanly.

## Why

Until now, a draft always included every turn in the source session. For drafts with 100+ turns (many of them tool-only / "empty" assistant calls), users had no way to cut the artifact down to the conversation they actually wanted to share. The data model has always supported it — the missing piece was just the picker.

## How it connects

**Right ControlPanel grows a view switcher** — Style / Messages tabs at the top of the panel (segmented pill, raised-tile active state matching the DaemonNoticeModal chrome language). Style stays as the existing template/paper/typeface/colorway surface; Messages is the new picker. Living in the panel column means the picker never overlaps the preview — a prior prototype used a floating chip + popover anchored to the preview's bottom, but the popover blocked the content the user was about to edit. Single locus of control instead of dual entry points.

**TurnSelector list**
- Header reads `Messages N of total` with two icon buttons on the right: `CheckCheck` (Include all) + `Eraser` (Exclude all). Tooltip-only chrome — no permanent footer.
- Rows: `[checkbox] [role dot] [zero-padded index] [first-line preview]`. Checkbox is its own click target (toggle include/exclude). The rest of the row is a separate button — click to jump to the turn in the preview canvas. Hovering shows a 240-char `title` excerpt of the body so users can read context before jumping. Excluded rows: 60% opacity on the entire row.
- Role dot tracks `opts.accentHex` for assistant turns (so it follows the active colorway live — Iris / Moss / Ink / Bone all update in place).
- Respects `opts.hideEmptyTurns` (the default): empty-body turns hide from the list too, so the selector mirrors what the preview shows. Indices stay original-position, so the displayed list may go 01 / 03 / 07 with gaps — clicking 03 still writes index 3 into `selected[]`.

**Jump-to-message**
- Every template already exposes `data-turn-index={origIndex}` on its turn wrapper (shipped in #162). We use that as the scroll anchor.
- Manually computes scrollTop on the preview's scroll container (now marked `data-share-preview-scroll`) so only the vertical axis moves. `scrollIntoView` walks up the DOM and, under zoom transform, tried to also shift horizontal scroll — which shoved the artifact card off-center.
- Instant snap, not smooth — long drafts produce scroll distances of thousands of pixels, where smooth animation feels sluggish. Matches the Google Docs / Notion / Linear pattern: jump fast, confirm visually.
- Visual confirmation: brief overlay flash on the target turn. Each template gains a `[data-turn-body]` attribute on its inner content block (chat bubble for chat-user, content column for chat-assistant, the inner `<div>` for atelier, the flex row for interview/transcript, the new wrapping div for letter). The flash is a `::after` pseudo-element animating opacity from ~22% to 0 over 1.6s — overlay, not background-color, so the bubble's own surface fill is preserved through and after the animation. Re-applying the attribute triggers a reflow so repeated clicks re-trigger the animation.

## Test plan

- [x] `pnpm -C packages/app exec tsc --noEmit` clean
- [x] `pnpm -C packages/share-kit build` clean
- [x] Open share editor on a session → right panel shows Style / Messages tabs at top
- [x] Switch to Messages → list of turns appears with checkbox / role dot / index / preview
- [x] Toggle a few checkboxes — preview updates with `⋯ N turns skipped` gap markers
- [x] CheckCheck (header icon) → all messages included; Eraser → all excluded
- [x] Click the text area of a row → preview scrolls vertically to center that turn; brief accent flash overlay confirms arrival
- [x] `hideEmptyTurns` default behavior: only non-empty turns appear in the list
- [x] Switch colorway (Style tab) → role dot color follows opts.accentHex live
- [x] Hover a row's text area → tooltip shows ~240-char excerpt of the body