### PR TITLE
feat(app): share editor — collapse zoom HUD; tuck rename+delete into ⋯ menu

### DIFF
--- a/packages/app/src/renderer/components/Menu.tsx
+++ b/packages/app/src/renderer/components/Menu.tsx
@@ -106,13 +106,23 @@ export default function Menu({ trigger, items, align = 'right', testId }: Props)
                 item.onSelect()
                 setOpen(false)
               }}
-              className={`w-full flex items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors ${
+              className={`group w-full flex items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors ${
                 item.active
                   ? 'text-accent dark:text-accent-dark bg-accent/10 dark:bg-accent-dark/10'
                   : 'text-warm-text dark:text-dark-text hover:bg-warm-surface2 dark:hover:bg-dark-surface2'
               } disabled:opacity-50 disabled:cursor-not-allowed`}
             >
-              {item.icon && <span className="flex-none w-3.5 h-3.5 flex items-center justify-center">{item.icon}</span>}
+              {item.icon && (
+                <span
+                  className={`flex-none w-3.5 h-3.5 flex items-center justify-center transition-colors ${
+                    item.active
+                      ? ''
+                      : 'text-warm-faint dark:text-dark-muted group-hover:text-warm-text dark:group-hover:text-dark-text'
+                  }`}
+                >
+                  {item.icon}
+                </span>
+              )}
               <span className="flex-1 truncate">{item.label}</span>
             </button>
           ))}

--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { flushSync } from 'react-dom'
-import { Download, PanelRight, Pencil, Trash2 } from 'lucide-react'
+import { Download, MoreHorizontal, PanelRight, Pencil, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import {
   TEMPLATE_RATIO,
@@ -18,6 +18,7 @@ import PageLayout from './PageLayout.js'
 import { PreviewPane, type Zoom } from './share-editor/PreviewPane.js'
 import { ControlPanel } from './share-editor/ControlPanel.js'
 import { DownloadButton } from './share-editor/DownloadButton.js'
+import Menu from './Menu.js'
 import { buildPreviewDocument } from '../lib/compose-from-session.js'
 
 type Props = {
@@ -113,11 +114,6 @@ export default function ShareEditorPage({
     if (!pdfPreview) return
     return () => URL.revokeObjectURL(pdfPreview.url)
   }, [pdfPreview])
-
-  const meta = useMemo(() => {
-    const wordLabel = `${conversation.wordCount.toLocaleString()} ${conversation.wordCount === 1 ? 'word' : 'words'}`
-    return `${conversation.createdAt} · ${wordLabel}`
-  }, [conversation])
 
   // Force React to commit the "Exporting…" state and let the browser
   // paint before kicking off rasterization. Without this, batched
@@ -249,13 +245,13 @@ export default function ShareEditorPage({
         onClick={onBack}
         aria-label="Back"
         title="Back"
-        className="flex-none flex items-center justify-center w-5 h-5 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
+        className="flex-none flex items-center justify-center w-5 h-5 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
       >
         <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
           <path d="M8 3L4 6.5L8 10" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
         </svg>
       </button>
-      <div className="min-w-0 flex-1 flex items-center gap-2">
+      <div className="min-w-0 flex items-center gap-1.5">
         <h1
           data-testid="share-editor-title"
           title={title.trim() || 'Untitled'}
@@ -263,37 +259,35 @@ export default function ShareEditorPage({
         >
           {title.trim() || 'Untitled'}
         </h1>
-        <button
-          type="button"
-          onClick={() => setRenaming(true)}
-          aria-label="Rename draft"
-          title="Rename draft"
-          data-testid="share-editor-rename"
-          className="flex-none flex items-center justify-center w-5 h-5 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
-        >
-          <Pencil size={13} strokeWidth={1.75} aria-hidden />
-        </button>
-        <span
-          className="min-w-0 text-[11px] text-warm-faint dark:text-dark-muted truncate whitespace-nowrap"
-          title={meta}
-        >
-          {meta}
-        </span>
+        <Menu
+          align="left"
+          testId="share-editor-more"
+          trigger={({ toggle }) => (
+            <button
+              type="button"
+              onClick={toggle}
+              aria-label="More options"
+              title="More options"
+              className="flex-none inline-flex items-center justify-center w-5 h-5 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
+            >
+              <MoreHorizontal size={13} strokeWidth={1.6} aria-hidden />
+            </button>
+          )}
+          items={[
+            {
+              label: 'Rename draft',
+              icon: <Pencil size={13} strokeWidth={1.6} aria-hidden />,
+              onSelect: () => setRenaming(true),
+            },
+            {
+              label: 'Delete draft',
+              icon: <Trash2 size={13} strokeWidth={1.6} aria-hidden />,
+              onSelect: () => setConfirmingDelete(true),
+            },
+          ]}
+        />
       </div>
-      {/* Reset-to-original slot — PR5 will render <ResetButton /> here. */}
-      <div data-testid="share-editor-reset-slot" className="flex-none" />
-      <EditorDeleteChip
-        confirming={confirmingDelete}
-        onClick={() => {
-          if (confirmingDelete) {
-            setConfirmingDelete(false)
-            void handleDelete()
-          } else {
-            setConfirmingDelete(true)
-          }
-        }}
-        onCancel={() => setConfirmingDelete(false)}
-      />
+      <div className="flex-1" />
       <DownloadButton
         saving={saveState === 'saving'}
         onPng={() => { void exportPng() }}
@@ -373,6 +367,16 @@ export default function ShareEditorPage({
           initialTitle={title}
           onSave={setTitle}
           onClose={() => setRenaming(false)}
+        />
+      )}
+      {confirmingDelete && (
+        <DeleteDraftModal
+          title={title.trim() || 'Untitled'}
+          onConfirm={async () => {
+            setConfirmingDelete(false)
+            await handleDelete()
+          }}
+          onClose={() => setConfirmingDelete(false)}
         />
       )}
     </PageLayout>
@@ -480,70 +484,87 @@ function RenameDraftModal({
 }
 
 /**
- * Click-twice delete affordance in the editor top bar. Resting: a small
- * trash button. First click expands it into a "Delete?" pill with
- * destructive color. Second click fires onClick. Escape, mouse-leave,
- * or clicking outside cancels the primed state.
+ * Confirm-delete modal for the editor. Replaces the older click-twice
+ * in-place delete chip — for editor surfaces the user is about to
+ * navigate away from the deleted thing, so an explicit modal with a
+ * destructive button reads more clearly than a primed-pill confirm.
+ * Chrome mirrors RenameDraftModal: warm-bg backdrop blur + warm-bg panel,
+ * 440px max width. Esc + click-outside + Cancel close without deleting;
+ * Enter (or clicking the focused Delete) confirms.
  */
-/**
- * Click-twice delete affordance in the editor top bar. The outer wrapper
- * reserves a fixed 24×24 slot so neighbouring elements never move. When
- * primed, the inner span absolutely-positions itself and grows
- * rightward into a "Delete?" pill that overlays whatever sits beside it
- * — temporary visual occlusion is acceptable here; layout reflow is not.
- */
-function EditorDeleteChip({
-  confirming,
-  onClick,
-  onCancel,
+function DeleteDraftModal({
+  title,
+  onConfirm,
+  onClose,
 }: {
-  confirming: boolean
-  onClick: () => void
-  onCancel: () => void
+  title: string
+  onConfirm: () => void | Promise<void>
+  onClose: () => void
 }) {
-  const wrapRef = useRef<HTMLButtonElement | null>(null)
+  const deleteRef = useRef<HTMLButtonElement | null>(null)
 
   useEffect(() => {
-    if (!confirming) return
-    function onDown(e: MouseEvent) {
-      if (!wrapRef.current?.contains(e.target as Node)) onCancel()
+    deleteRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
     }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') onCancel()
-    }
-    window.addEventListener('mousedown', onDown)
-    window.addEventListener('keydown', onKey)
-    return () => {
-      window.removeEventListener('mousedown', onDown)
-      window.removeEventListener('keydown', onKey)
-    }
-  }, [confirming, onCancel])
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
 
   return (
-    <button
-      ref={wrapRef}
-      type="button"
-      data-testid="share-editor-delete"
-      data-confirming={confirming ? '' : undefined}
-      onClick={onClick}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          onClick()
-        }
-      }}
-      onMouseLeave={() => {
-        if (confirming) onCancel()
-      }}
-      aria-label={confirming ? 'Click again to confirm delete' : 'Delete draft'}
-      title={confirming ? 'Click again to confirm' : 'Delete draft'}
-      className={`flex-none inline-flex items-center justify-center h-6 rounded cursor-pointer select-none transition-[width,padding,background-color,color] duration-150 text-[11.5px] font-medium tracking-[-0.005em] whitespace-nowrap overflow-hidden ${
-        confirming
-          ? 'w-[60px] px-2.5 bg-[color:var(--color-status-error)] dark:bg-[color:var(--color-status-error-dark)] text-white shadow-[0_1px_3px_rgba(0,0,0,0.18)]'
-          : 'w-6 text-warm-faint dark:text-dark-muted hover:text-[color:var(--color-status-error)] dark:hover:text-[color:var(--color-status-error-dark)] hover:bg-[color:var(--color-status-error)]/8 dark:hover:bg-[color:var(--color-status-error-dark)]/12'
-      }`}
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="delete-draft-title"
+      data-testid="delete-draft-modal"
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}
+      className="fixed inset-0 z-50 flex items-start justify-center bg-warm-bg/60 dark:bg-dark-bg/70 backdrop-blur-sm px-4 pt-[20vh] animate-in fade-in duration-150"
     >
-      {confirming ? 'Delete' : <Trash2 size={13} strokeWidth={1.75} />}
-    </button>
+      <div
+        onMouseDown={(e) => e.stopPropagation()}
+        className="w-full max-w-[440px] rounded-[10px] border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg shadow-xl flex flex-col overflow-hidden"
+      >
+        <div className="px-5 pt-5 pb-4">
+          <h2 id="delete-draft-title" className="text-base font-semibold text-warm-text dark:text-dark-text">
+            Delete draft?
+          </h2>
+          <p className="mt-2 text-[13px] leading-relaxed text-warm-muted dark:text-dark-muted">
+            This will permanently remove “{title}” from your Shares. This cannot be undone —
+            autosave is already off for this draft once you confirm.
+          </p>
+        </div>
+        <div className="flex items-center justify-end gap-2 px-5 pb-5">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3.5 h-8 rounded-[6px] text-[12px] font-medium text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+          >
+            Cancel
+          </button>
+          <button
+            ref={deleteRef}
+            type="button"
+            data-testid="delete-draft-confirm"
+            onClick={() => { void onConfirm() }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                void onConfirm()
+              }
+            }}
+            className="px-3.5 h-8 rounded-[6px] text-[12px] font-medium text-white bg-[color:var(--color-status-error)] dark:bg-[color:var(--color-status-error-dark)] hover:opacity-90 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-status-error)]/40"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
+++ b/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, useCallback, useEffect, useLayoutEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
+import { MoreHorizontal } from 'lucide-react'
 import {
   TemplateRender,
   TEMPLATE_RATIO,
@@ -288,28 +289,71 @@ type ZoomControlProps = {
 function ZoomControl({ percent, isFit, onIn, onOut, onFit }: ZoomControlProps) {
   const minPercent = ZOOM_STEPS[0]! * 100
   const maxPercent = ZOOM_STEPS[ZOOM_STEPS.length - 1]! * 100
+  const [expanded, setExpanded] = useState(false)
+  const rootRef = useRef<HTMLDivElement | null>(null)
+
+  // Collapse on outside click + Escape. Don't trap focus — the user
+  // should be free to click anywhere else on the canvas and the
+  // controls just tuck away.
+  useEffect(() => {
+    if (!expanded) return
+    function onDown(e: MouseEvent) {
+      if (!rootRef.current?.contains(e.target as Node)) setExpanded(false)
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setExpanded(false)
+    }
+    window.addEventListener('mousedown', onDown)
+    window.addEventListener('keydown', onKey)
+    return () => {
+      window.removeEventListener('mousedown', onDown)
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [expanded])
+
+  // One container, always there. Collapsed state shows just the ⋯
+  // trigger. Expanded state grows leftward (since the bar is right-
+  // anchored), keeping the ⋯ at the same pixel position — no jitter
+  // at the user's click point. Bg stays so the trigger is visible
+  // against the dark backdrop, but it's a quiet warm-surface tint
+  // rather than a high-contrast pill.
   return (
     <div
+      ref={rootRef}
       data-pan-ignore
-      className="absolute right-4 bottom-4 z-20 flex items-center gap-0.5 px-1 h-7 rounded-md bg-warm-surface dark:bg-dark-surface shadow-sm text-[11px] text-warm-text dark:text-dark-text"
+      className="absolute right-4 bottom-4 z-20 flex items-center gap-0 h-5 rounded bg-warm-surface dark:bg-dark-surface text-[10.5px] text-warm-text dark:text-dark-text"
     >
-      <ZoomBtn label="−" onClick={onOut} ariaLabel="Zoom out" disabled={percent <= minPercent} />
-      <span className="min-w-[34px] text-center select-none text-warm-text dark:text-dark-text tabular-nums">
-        {percent}%
-      </span>
-      <ZoomBtn label="+" onClick={onIn} ariaLabel="Zoom in" disabled={percent >= maxPercent} />
+      {expanded && (
+        <>
+          <ZoomBtn label="−" onClick={onOut} ariaLabel="Zoom out" disabled={percent <= minPercent} />
+          <span className="min-w-[26px] text-center select-none text-warm-text dark:text-dark-text tabular-nums">
+            {percent}%
+          </span>
+          <ZoomBtn label="+" onClick={onIn} ariaLabel="Zoom in" disabled={percent >= maxPercent} />
+          <button
+            type="button"
+            onClick={onFit}
+            aria-label="Zoom to fit"
+            aria-pressed={isFit}
+            className={`px-1.5 h-5 rounded transition-colors ${
+              isFit
+                ? 'text-accent dark:text-accent-dark bg-accent-bg dark:bg-accent-bg-dark'
+                : 'text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text hover:bg-warm-surface2 dark:hover:bg-dark-surface2'
+            }`}
+          >
+            Fit
+          </button>
+        </>
+      )}
       <button
         type="button"
-        onClick={onFit}
-        aria-label="Zoom to fit"
-        aria-pressed={isFit}
-        className={`px-2 h-5 rounded transition-colors ${
-          isFit
-            ? 'text-accent dark:text-accent-dark bg-accent-bg dark:bg-accent-bg-dark'
-            : 'text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text hover:bg-warm-surface2 dark:hover:bg-dark-surface2'
-        }`}
+        onClick={() => setExpanded((v) => !v)}
+        aria-label={expanded ? 'Hide zoom controls' : 'Zoom controls'}
+        aria-expanded={expanded}
+        title="Zoom controls"
+        className="w-5 h-5 grid place-items-center rounded text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition-colors"
       >
-        Fit
+        <MoreHorizontal size={11} strokeWidth={1.75} aria-hidden />
       </button>
     </div>
   )
@@ -332,7 +376,7 @@ function ZoomBtn({
       onClick={onClick}
       aria-label={ariaLabel}
       disabled={disabled}
-      className={`w-5 h-5 grid place-items-center rounded text-[13px] leading-none ${
+      className={`w-5 h-5 grid place-items-center rounded text-[12px] leading-none ${
         disabled
           ? 'text-warm-faint dark:text-dark-muted cursor-default'
           : 'text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text hover:bg-warm-surface2 dark:hover:bg-dark-surface2 cursor-pointer'


### PR DESCRIPTION
## What

Two related polish passes on the share editor:
- Top bar: drop the meta line, drop the standalone Pencil and EditorDeleteChip, fold both actions into a single `⋯ More` menu next to the title. New `DeleteDraftModal` replaces the click-twice in-place delete.
- Preview pane bottom-right: collapse the always-on zoom bar into a tiny square ⋯ trigger that expands leftward on click.

Plus a small global tweak to `Menu` so item icons dim at rest and brighten on hover (a subtle "row comes alive on hover" cue across every menu in the app).

## Why

Both control clusters were reading busy against the canvas. The topbar had 3 buttons + a meta line competing for attention with the title; the zoom HUD permanently occupied a 4-control row in the corner. With these changes the editor's resting state is significantly quieter — title + a single trigger up top, and a 20×20 square in the corner — while every action stays one click away.

The click-twice in-place delete also gets replaced by an explicit confirmation modal, which reads more clearly for a destructive action and matches the rest of Spool's modal language.

## How it connects

**Topbar (ShareEditorPage)**
- `Menu` (the same shared component SessionRow / PinnedRow / FragmentResults already use) gets `align: 'left'` so the popover anchors under the title. Items: `Rename draft` → existing `RenameDraftModal`; `Delete draft` → new `DeleteDraftModal`.
- The Pencil button next to the title and the entire `EditorDeleteChip` rendering are gone. The chip's component definition stays out of the file too — nothing else imports it.
- Date · word-count meta is dropped. The title alone is the draft's identity in the top strip.
- All ghost-icon buttons (back arrow / ⋯ trigger / menu icons) unified to 13px stroke 1.6, resting `text-warm-faint dark:text-dark-muted`, `hover:text-warm-text`. Back-arrow SVG canvas bumped to 13×13 to match.

**DeleteDraftModal**
- File-local in `ShareEditorPage.tsx`, mirrors `RenameDraftModal`'s chrome: 440px max width, `bg-warm-bg/60 backdrop-blur-sm` overlay, `bg-warm-bg rounded-[10px] border + shadow-xl` panel. Header "Delete draft?", body has the title interpolated. Footer: Cancel (ghost) + Delete (destructive `--color-status-error` fill, text-only — the color carries the signal). Enter confirms (Delete autofocused); Esc / click-outside / Cancel dismiss without deleting.

**ZoomControl (PreviewPane)**
- One always-on pill anchored at `right-4 bottom-4`, `h-5 rounded bg-warm-surface`. Collapsed = the pill is just a `w-5 h-5` ⋯ trigger (a perfect 20×20 square). Expanded = the same pill grows leftward with `[−] [percent] [+] [Fit] [⋯]`. The ⋯ stays at the same pixel position throughout, so the user's click target doesn't jitter mid-toggle.
- Outside-click and Esc close the expanded state.
- All inner buttons are `w-5 h-5` squares; Fit is a small text pill at the same height.

**Menu component**
- Item icons get their own `text-warm-faint group-hover:text-warm-text` treatment instead of inheriting the label color. Active items unchanged (accent). Touches every consumer in the app; visually a subtle increase in hover contrast.

## Test plan

- [x] `pnpm -C packages/app exec tsc --noEmit` clean
- [x] Open share editor: title shows alone in the top strip with a ⋯ More trigger immediately to its right; no Pencil, no delete chip, no meta line
- [x] ⋯ → Rename draft → existing rename modal
- [x] ⋯ → Delete draft → new delete modal; Esc / click-outside / Cancel all dismiss; Enter or Delete commits + closes
- [x] Preview canvas corner: 20×20 ⋯ button at rest; click → full zoom bar appears with ⋯ staying anchored at the right; click ⋯ / Esc / click outside → collapses; ⌘= / ⌘- / ⌘0 still drive zoom
- [x] All menus across the app (SessionRow, sidebar PinnedRow, search results ⋯): item icons dim at rest, brighten on row hover