### PR TITLE
polish(app): drop role dot from TurnSelector rows

### DIFF
--- a/packages/app/src/renderer/components/share-editor/TurnSelector.tsx
+++ b/packages/app/src/renderer/components/share-editor/TurnSelector.tsx
@@ -168,19 +168,6 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
                 aria-label={`Jump to message ${i + 1}`}
                 className="flex-1 min-w-0 flex items-center gap-3 text-left"
               >
-                <span
-                  className={`w-1.5 h-1.5 rounded-full shrink-0 ${
-                    turn.role === 'assistant'
-                      ? ''
-                      : 'bg-warm-text dark:bg-dark-text'
-                  }`}
-                  style={
-                    turn.role === 'assistant'
-                      ? { backgroundColor: opts.accentHex }
-                      : undefined
-                  }
-                  aria-hidden="true"
-                />
                 <span className="font-mono text-[11px] tabular-nums text-warm-faint dark:text-dark-faint shrink-0">
                   {padIndex(i + 1, total)}
                 </span>


### PR DESCRIPTION
## What

Remove the 6×6 colored dot that sat between the checkbox and the index in each TurnSelector row. Rows now read: `[checkbox] [index] [preview]`.

## Why

The dot was meant to encode role (user vs assistant) by tracking the active colorway's accent — assistant dot used `opts.accentHex`. Worked fine for amber / iris / moss / bone, but the Ink colorway has a near-black accent (`#1C1C18`) that dissolves into the dark UI panel bg (`#141410`) and renders the assistant dot invisible.

Two patch routes were explored before giving up on the dot entirely:
- 1px ring perimeter — visually noisy on a 6px decoration.
- WCAG luminance threshold + fallback color — works but adds a 15-line `relativeLuminance` helper to a file that otherwise just lays out a list.

For a tiny decoration carrying secondary information, the principled fix didn't earn its complexity. The role is implicit from the preview text in each row (which the user reads anyway), so dropping the dot is the cleanest answer.

## How it connects

- One element removed from `TurnSelector.tsx`. Row gap stays the same; the index + preview just slide left to fill the space.
- No share-kit, no Menu, no preview-side changes.

## Test plan

- [x] `pnpm -C packages/app exec tsc --noEmit` clean
- [ ] Open share editor → Messages tab → rows show `[checkbox] [01] [first-line preview]` with no role dot
- [ ] Switch colorway to Ink → no missing-dot artifact