### PR TITLE
feat(share): markdown download — frontmatter + clean turns

### DIFF
--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -5,6 +5,8 @@ import { toast } from 'sonner'
 import {
   TEMPLATE_RATIO,
   buildSpoolDocument,
+  buildMarkdownDocument,
+  markdownFilenameFor,
   openSaveSlot,
   writeToSlot,
   rasterizeToPngBlob,
@@ -213,6 +215,29 @@ export default function ShareEditorPage({
     onBack()
   }, [draftId, onBack])
 
+  const exportMarkdown = useCallback(async () => {
+    const filename = markdownFilenameFor(conversation)
+    const slot = await openSaveSlot(filename, {
+      description: 'Markdown document',
+      mime: 'text/markdown',
+      ext: '.md',
+    })
+    if (slot.kind === 'cancelled') return
+
+    await beginSaving()
+    try {
+      const md = buildMarkdownDocument(conversation, opts)
+      const blob = new Blob([md], { type: 'text/markdown' })
+      await writeToSlot(slot, blob, filename)
+      setSaveState('idle')
+      toast.success(`Saved ${filename}`)
+    } catch (err) {
+      console.error('Export to Markdown failed:', err)
+      setSaveState('error')
+      toast.error("Couldn't export Markdown", { description: 'See console for details.' })
+    }
+  }, [beginSaving, conversation, opts])
+
   const exportSpoolFile = useCallback(async () => {
     // Same pre-pick discipline as PNG; JSON.stringify is fast but
     // saveBlob's picker call still needs the user gesture.
@@ -290,9 +315,12 @@ export default function ShareEditorPage({
       <div className="flex-1" />
       <DownloadButton
         saving={saveState === 'saving'}
-        onPng={() => { void exportPng() }}
-        onPdf={() => { void exportPdf() }}
-        onSpool={() => { void exportSpoolFile() }}
+        onExport={(fmt) => {
+          if (fmt === 'png') void exportPng()
+          else if (fmt === 'pdf') void exportPdf()
+          else if (fmt === 'md') void exportMarkdown()
+          else void exportSpoolFile()
+        }}
       />
       <button
         type="button"

--- a/packages/app/src/renderer/components/share-editor/DownloadButton.tsx
+++ b/packages/app/src/renderer/components/share-editor/DownloadButton.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Download } from 'lucide-react'
 
-export type ExportFormat = 'png' | 'pdf' | 'spool'
+export type ExportFormat = 'png' | 'pdf' | 'md' | 'spool'
 
 type FormatDef = {
   k: ExportFormat
@@ -16,6 +16,7 @@ type FormatDef = {
 const FORMATS: FormatDef[] = [
   { k: 'png', l: 'PNG image', b: 'Download PNG', s: '3× pixel ratio · social-feed friendly' },
   { k: 'pdf', l: 'PDF', b: 'Download PDF', s: 'A4 paginated · print-ready' },
+  { k: 'md', l: 'Markdown', b: 'Download .md', s: 'Plain text · Obsidian / GitHub friendly' },
   { k: 'spool', l: 'Spool file', b: 'Download .spool', s: 'Editable in Spool · keeps your styling' },
 ]
 
@@ -24,18 +25,16 @@ const STORAGE_KEY = 'spool:share:lastFormat'
 function loadInitial(): ExportFormat {
   if (typeof window === 'undefined') return 'pdf'
   const raw = window.localStorage.getItem(STORAGE_KEY)
-  if (raw === 'png' || raw === 'pdf' || raw === 'spool') return raw
+  if (FORMATS.some(f => f.k === raw)) return raw as ExportFormat
   return 'pdf'
 }
 
 type Props = {
   saving: boolean
-  onPng: () => void
-  onPdf: () => void
-  onSpool: () => void
+  onExport: (fmt: ExportFormat) => void
 }
 
-export function DownloadButton({ saving, onPng, onPdf, onSpool }: Props) {
+export function DownloadButton({ saving, onExport }: Props) {
   const [format, setFormat] = useState<ExportFormat>(loadInitial)
   const [open, setOpen] = useState(false)
   const rootRef = useRef<HTMLDivElement | null>(null)
@@ -64,9 +63,7 @@ export function DownloadButton({ saving, onPng, onPdf, onSpool }: Props) {
 
   const trigger = () => {
     if (saving) return
-    if (format === 'png') onPng()
-    else if (format === 'pdf') onPdf()
-    else onSpool()
+    onExport(format)
   }
 
   return (

--- a/packages/share-kit/src/index.ts
+++ b/packages/share-kit/src/index.ts
@@ -75,6 +75,13 @@ export {
   readSpoolFile,
 } from './lib/storage/spool-file'
 
+// Markdown export ─────────────────────────────────────────────────
+export {
+  buildMarkdownDocument,
+  downloadMarkdownFile,
+  markdownFilenameFor,
+} from './lib/storage/markdown-file'
+
 // ─── Parsers (Phase 1 — accepts public ChatGPT/Claude/Gemini share URLs) ──
 export { parseShareUrl, detectPlatform, ParseError } from './lib/parsers'
 export type { ParseErrorReason } from './lib/parsers'

--- a/packages/share-kit/src/lib/export/index.ts
+++ b/packages/share-kit/src/lib/export/index.ts
@@ -4,10 +4,8 @@
 // PDF: clone the artifact into a print-only host and call window.print().
 //      The browser's Save-as-PDF path keeps text as real text (selectable,
 //      searchable, copyable), which embedding a PNG into pdf-lib cannot.
-//
-// (Markdown export was intentionally dropped from this port; MD cannot
-//  faithfully carry tool calls, redaction overlays, or audit chips.
-//  Revisit in a later phase if real demand surfaces.)
+// Markdown lives in ../storage/markdown-file.ts — text-only, honors
+// the editor's content opts (selection, redact, gaps).
 //
 // Save UX: when the browser supports File System Access API
 // (`showSaveFilePicker`), we surface a native save dialog so the user

--- a/packages/share-kit/src/lib/storage/markdown-file.ts
+++ b/packages/share-kit/src/lib/storage/markdown-file.ts
@@ -1,0 +1,107 @@
+// Markdown export — plain text, template-agnostic.
+//
+// Honors the editor's content-affecting opts (selected, redact,
+// hideEmptyTurns, showGaps, showMasthead, showColophon). Visual opts
+// (template, paper, typeface, colorway, density, avatars) don't
+// translate to markdown and are ignored.
+//
+// Body redactions reuse the same auto-detection used by the templates
+// (emails + bracketed author names + manual turn.redact entries), with
+// each match swapped for a backticked `[redacted]` so it reads as a
+// chip in any markdown renderer.
+
+import type { Conversation, EditorOpts } from '../types'
+import { selectSegments } from '@/templates/selection'
+import { collectRedactList } from '@/templates/redact'
+import { saveBlob } from '../export'
+import { sanitizeFilename } from '../filename'
+
+const MIME = 'text/markdown'
+
+export function buildMarkdownDocument(conversation: Conversation, opts: EditorOpts): string {
+  const { turns, gapBefore } = selectSegments(conversation, opts)
+  const redactList = opts.redact ? collectRedactList(turns) : []
+  const redactRx = redactList.length
+    ? new RegExp(redactList.map(escapeRx).join('|'), 'g')
+    : null
+
+  const lines: string[] = []
+
+  lines.push('---')
+  lines.push(`title: ${yamlStr(conversation.title)}`)
+  lines.push(`source: ${yamlStr(conversation.sourceLabel)}`)
+  if (conversation.shareUrl) lines.push(`source_url: ${yamlStr(conversation.shareUrl)}`)
+  lines.push(`captured_at: ${yamlStr(conversation.createdAt)}`)
+  lines.push(`exported_at: ${yamlStr(new Date().toISOString())}`)
+  lines.push('---')
+  lines.push('')
+
+  lines.push(`# ${conversation.title}`)
+  lines.push('')
+
+  if (opts.showMasthead) {
+    const bits: string[] = [`From ${conversation.sourceLabel}`]
+    if (conversation.shareUrl) bits.push(`[original](${conversation.shareUrl})`)
+    bits.push(conversation.createdAt)
+    lines.push(`*${bits.join(' · ')}*`)
+    lines.push('')
+  }
+
+  turns.forEach((turn, i) => {
+    const gap = gapBefore[i] ?? 0
+    if (opts.showGaps && gap > 0) {
+      lines.push(`*⋯ ${gap} turn${gap === 1 ? '' : 's'} skipped*`)
+      lines.push('')
+      lines.push('---')
+      lines.push('')
+    } else if (i > 0) {
+      lines.push('---')
+      lines.push('')
+    }
+    const name = turn.role === 'user'
+      ? (turn.author?.replace(/^\[|\]$/g, '').trim() || 'User')
+      : conversation.sourceLabel
+    lines.push(`**${name}:**`)
+    lines.push('')
+    lines.push(redactRx ? turn.body.replace(redactRx, '`[redacted]`') : turn.body)
+    lines.push('')
+  })
+
+  return lines.join('\n')
+}
+
+export async function downloadMarkdownFile(
+  conversation: Conversation,
+  opts: EditorOpts,
+): Promise<void> {
+  const md = buildMarkdownDocument(conversation, opts)
+  const blob = new Blob([md], { type: MIME })
+  await saveBlob(blob, filenameFor(conversation), {
+    description: 'Markdown document',
+    mime: MIME,
+    ext: '.md',
+  })
+}
+
+export function markdownFilenameFor(c: Conversation): string {
+  return filenameFor(c)
+}
+
+/** Keep in sync with `templates/body.tsx#preprocess` — both must
+ *  substitute the same literal so the on-screen chip and the exported
+ *  markdown carry the same redaction marker. */
+function escapeRx(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/** YAML 1.2 is a JSON superset for quoted scalars, so JSON.stringify
+ *  produces a valid double-quoted YAML string with correct escaping. */
+function yamlStr(s: string): string {
+  return JSON.stringify(s)
+}
+
+function filenameFor(c: Conversation): string {
+  const safe = sanitizeFilename(c.title)
+  const date = new Date().toISOString().slice(0, 10)
+  return `${safe || 'spool'} · ${date}.md`
+}


### PR DESCRIPTION
## What

Fourth export format in the share editor — Markdown — sitting alongside PNG, PDF, and `.spool`.

## Why

Users have been asking for a plain-text export they can paste into Obsidian / Notion / a GitHub gist / a personal log. PNG and PDF are good for sharing screenshots; `.spool` keeps the editor's styling for later round-tripping; but neither is ergonomic when the destination is text-first. The original share-kit port intentionally dropped MD because the team worried about tool-call fidelity, but turn bodies are now Jina-normalized markdown strings — so the conversion is a direct pass-through, not a lossy translation.

## How it connects

- `packages/share-kit/src/lib/storage/markdown-file.ts` (new) — `buildMarkdownDocument` / `downloadMarkdownFile` / `markdownFilenameFor`. Honors content-affecting `EditorOpts` (`selected`, `redact`, `hideEmptyTurns`, `showGaps`, `showMasthead`) and ignores visual-only opts.
- Output shape: YAML frontmatter (title, source, source_url when present, captured_at, exported_at) → visible `# title` → optional `*From {source} · [original](…) · date*` subtitle → turns with `**Name:**` bold prefix, `---` rule between turns, `*⋯ N turns skipped*` markers between non-adjacent kept turns. No Spool branding in the file body.
- Redactions reuse the same `collectRedactList` helper the templates use; the substitution literal is kept in sync with `templates/body.tsx#preprocess` so the on-screen chip and the exported file always agree on what counts as "redacted".
- `DownloadButton` now takes a single `onExport(fmt)` instead of four per-format callbacks; `loadInitial` validates against `FORMATS` so adding a future format won't drift.
- `ShareEditorPage` follows the existing pre-pick discipline (`openSaveSlot` on the live user gesture before any async work) so the native save dialog doesn't reject with SecurityError on slow machines.

## Test plan

- [x] Open a share draft; pick "Markdown" from the download dropdown — file lands with `.md` extension and reads cleanly in a markdown previewer
- [x] Trim turns via TurnSelector → exported MD only contains kept turns with gap markers between non-adjacent ones
- [x] Toggle `showMasthead` off → subtitle line disappears, title remains
- [x] Title with special chars (quotes, colons) survives YAML frontmatter intact
- [x] File picker cancellation is a clean no-op (no toast, no error)