### PR TITLE
feat(videos): launch-video infra — capture helpers, template, skill

### DIFF
--- a/.claude/skills/launch-video/SKILL.md
+++ b/.claude/skills/launch-video/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: launch-video
+description: Use when creating a launch, release, or announcement video for the Spool desktop app from real screen recordings. Covers the capture pipeline (Electron + native macOS window recording), the HyperFrames composition layout, common trailer-vs-PPT pitfalls, and the first-frame poster trick for social media. Invoke when the user mentions release video, launch video, announcement video, trailer, demo video, or wants to ship a video for a Spool version bump.
+user-invocable: true
+argument-hint: "[version (e.g. v0.5.0)]"
+---
+
+Build a release video for a Spool version. The output is a 1080p MP4 plus a
+poster JPG, intended for X / Twitter. Total runtime ≈ 20s, four feature
+beats + brand outro.
+
+## Mental model
+
+A release video for Spool has two halves running in parallel on screen:
+
+1. **Left third** — a text panel that introduces the current scene
+   (kicker `01 / 04 — POLISH`, a 2-line headline, a 1–2 line sub).
+2. **Right two-thirds** — the real Spool app, recorded as a native macOS
+   window. The camera (CSS `transform-origin + scale` on the `.window`)
+   zooms into the specific UI region for each feature.
+
+Amber annotation rectangles, positioned inside `.window` so they track the
+camera, call out the new feature region (`PINNED · 2 sessions` strip,
+`Update available` banner, etc).
+
+This is **not** a PPT: text panel and demo coexist continuously, with hard
+match-cuts between feature clips. Don't reintroduce slide-style title cards.
+
+## Required preparation
+
+Read these references before you start composing. They are not optional —
+each captures hard-won decisions from prior releases.
+
+- `references/composition.md` — the proven layout, dimensions, drop-shadow
+  recipe, panel + annotation timing patterns, beat-sync approach
+- `references/capture.md` — how to record native macOS windows of the
+  Electron app, helper functions to use, per-release seed authoring
+- `references/pitfalls.md` — things we tried that look bad in motion
+  (faked cursor, decorative chrome, smooth camera drifts, etc.) and why
+- `references/poster.md` — the `tpad clone` trick so Twitter's auto-
+  thumbnail grabs the hero frame instead of a leading black frame
+
+## End-to-end checklist
+
+1. **Inventory the features to demo.** A release video shows 3–4 features
+   max. Pick the ones with the most visible UI change.
+2. **Author a per-release seed.** Write a `ProjectSeed[]` array (see
+   `packages/app/e2e/helpers/demo-fixtures.ts` for the type). Titles
+   should be English-only and **must not reference real user sessions**
+   — invent plausible session titles relevant to the release theme.
+3. **Write an ad-hoc capture spec.** A Playwright spec under
+   `packages/app/e2e/` (not committed) that:
+   - Calls `launchDemoApp(seed)` + `setDemoWindowBounds(ctx, 1080, 740)`
+   - Records one `.mov` per feature via `recordNativeWindow()` from
+     `helpers/native-window-capture.ts`
+   - Outputs to `videos/spool-vX.Y.Z/assets/live/` (gitignored)
+4. **Copy `videos/launch-template/` to `videos/spool-vX.Y.Z/`.**
+5. **Customise the composition** (`index.html`):
+   - Update `<video>` `data-start`, `data-duration`, `src` per clip
+   - Author one text panel per scene (kicker + headline + sub)
+   - **Measure annotation coords fresh** from your raw `.mov` frames —
+     last release's `top: 15%` is wrong for this release
+   - Update the brand-mark version + outro version strings
+6. **Drop in BGM** at `assets/bgm.mp3`. Identify strong beats with
+   `ffmpeg silencedetect`; align scene cuts or camera punches to them.
+7. **Iterate with drafts.**
+   ```
+   cd videos/spool-vX.Y.Z
+   npm run check     # lint + validate + inspect
+   npm run render -- --quality draft --output renders/draft.mp4
+   ```
+   Pull frames at scene boundaries to verify before re-rendering.
+8. **Render standard quality.**
+   ```
+   npm run render -- --quality standard --output renders/spool-vX.Y.Z-raw.mp4
+   ```
+9. **Patch the first frame** for social media (see `references/poster.md`).
+   The output of this step is the file you upload to X.
+10. **Extract a poster JPG** for tweet thumbnail fallback / preview imagery.
+
+## Hard rules
+
+- **No simulated cursor.** Real screen recordings show real interactions;
+  faked GSAP cursors look uncanny. If a click is invisible in the clip,
+  use an amber annotation to call out the *result*, not the action.
+- **First frame must be the full hero state.** Brand mark + panel 1 + UI
+  window all visible at `t=0`, not faded in. Twitter's auto-thumbnail
+  grabs this frame.
+- **Annotations live inside `.window`**, not on the outer canvas. They
+  must move with the camera transform.
+- **No decorative chrome.** No vignette, callsign, progress bar, or
+  trailer-style overlay flashes. The UI is the protagonist.
+- **No "pull back to neutral" before the outro.** End scene 4 on its
+  feature focus, then hard-cut/fade to the Spool lockup.
+
+## Files this skill touches
+
+- Reads: `packages/app/e2e/helpers/{demo-fixtures,demo-launch,demo-interactions,native-window-capture}.ts`
+- Reads: `videos/launch-template/`
+- Creates: `videos/spool-vX.Y.Z/` (new release directory)
+- Creates: a temporary Playwright spec under `packages/app/e2e/` (do not commit)
+- Outputs: `videos/spool-vX.Y.Z/renders/spool-vX.Y.Z-final.mp4` and `.jpg` poster (both gitignored)

--- a/.claude/skills/launch-video/SKILL.md
+++ b/.claude/skills/launch-video/SKILL.md
@@ -5,64 +5,43 @@ user-invocable: true
 argument-hint: "[version (e.g. v0.5.0)]"
 ---
 
-Build a release video for a Spool version. The output is a 1080p MP4 plus a
-poster JPG, intended for X / Twitter. Total runtime ≈ 20s, four feature
-beats + brand outro.
+Build a release video for a Spool version. The output is a 1080p MP4 plus a poster JPG, intended for X / Twitter. Total runtime ≈ 20s, four feature beats + brand outro.
 
 ## Mental model
 
 A release video for Spool has two halves running in parallel on screen:
 
-1. **Left third** — a text panel that introduces the current scene
-   (kicker `01 / 04 — POLISH`, a 2-line headline, a 1–2 line sub).
-2. **Right two-thirds** — the real Spool app, recorded as a native macOS
-   window. The camera (CSS `transform-origin + scale` on the `.window`)
-   zooms into the specific UI region for each feature.
+1. **Left third** — a text panel that introduces the current scene (kicker `01 / 04 — POLISH`, a 2-line headline, a 1–2 line sub).
+2. **Right two-thirds** — the real Spool app, recorded as a native macOS window. The camera (CSS `transform-origin + scale` on the `.window`) zooms into the specific UI region for each feature.
 
-Amber annotation rectangles, positioned inside `.window` so they track the
-camera, call out the new feature region (`PINNED · 2 sessions` strip,
-`Update available` banner, etc).
+Amber annotation rectangles, positioned inside `.window` so they track the camera, call out the new feature region (`PINNED · 2 sessions` strip, `Update available` banner, etc).
 
-This is **not** a PPT: text panel and demo coexist continuously, with hard
-match-cuts between feature clips. Don't reintroduce slide-style title cards.
+This is **not** a PPT: text panel and demo coexist continuously, with hard match-cuts between feature clips. Don't reintroduce slide-style title cards.
 
 ## Required preparation
 
-Read these references before you start composing. They are not optional —
-each captures hard-won decisions from prior releases.
+Read these references before you start composing. They are not optional — each captures hard-won decisions from prior releases.
 
-- `references/composition.md` — the proven layout, dimensions, drop-shadow
-  recipe, panel + annotation timing patterns, beat-sync approach
-- `references/capture.md` — how to record native macOS windows of the
-  Electron app, helper functions to use, per-release seed authoring
-- `references/pitfalls.md` — things we tried that look bad in motion
-  (faked cursor, decorative chrome, smooth camera drifts, etc.) and why
-- `references/poster.md` — the `tpad clone` trick so Twitter's auto-
-  thumbnail grabs the hero frame instead of a leading black frame
+- `references/composition.md` — the proven layout, dimensions, drop-shadow recipe, panel + annotation timing patterns, beat-sync approach
+- `references/capture.md` — how to record native macOS windows of the Electron app, helper functions to use, per-release seed authoring
+- `references/pitfalls.md` — things we tried that look bad in motion (faked cursor, decorative chrome, smooth camera drifts, etc.) and why
+- `references/poster.md` — the `tpad clone` trick so Twitter's auto-thumbnail grabs the hero frame instead of a leading black frame
 
 ## End-to-end checklist
 
-1. **Inventory the features to demo.** A release video shows 3–4 features
-   max. Pick the ones with the most visible UI change.
-2. **Author a per-release seed.** Write a `ProjectSeed[]` array (see
-   `packages/app/e2e/helpers/demo-fixtures.ts` for the type). Titles
-   should be English-only and **must not reference real user sessions**
-   — invent plausible session titles relevant to the release theme.
-3. **Write an ad-hoc capture spec.** A Playwright spec under
-   `packages/app/e2e/` (not committed) that:
+1. **Inventory the features to demo.** A release video shows 3–4 features max. Pick the ones with the most visible UI change.
+2. **Author a per-release seed.** Write a `ProjectSeed[]` array (see `packages/app/e2e/helpers/demo-fixtures.ts` for the type). Titles should be English-only and **must not reference real user sessions** — invent plausible session titles relevant to the release theme.
+3. **Write an ad-hoc capture spec.** A Playwright spec under `packages/app/e2e/` (not committed) that:
    - Calls `launchDemoApp(seed)` + `setDemoWindowBounds(ctx, 1080, 740)`
-   - Records one `.mov` per feature via `recordNativeWindow()` from
-     `helpers/native-window-capture.ts`
+   - Records one `.mov` per feature via `recordNativeWindow()` from `helpers/native-window-capture.ts`
    - Outputs to `videos/spool-vX.Y.Z/assets/live/` (gitignored)
 4. **Copy `videos/launch-template/` to `videos/spool-vX.Y.Z/`.**
 5. **Customise the composition** (`index.html`):
    - Update `<video>` `data-start`, `data-duration`, `src` per clip
    - Author one text panel per scene (kicker + headline + sub)
-   - **Measure annotation coords fresh** from your raw `.mov` frames —
-     last release's `top: 15%` is wrong for this release
+   - **Measure annotation coords fresh** from your raw `.mov` frames — last release's `top: 15%` is wrong for this release
    - Update the brand-mark version + outro version strings
-6. **Drop in BGM** at `assets/bgm.mp3`. Identify strong beats with
-   `ffmpeg silencedetect`; align scene cuts or camera punches to them.
+6. **Drop in BGM** at `assets/bgm.mp3`. Identify strong beats with `ffmpeg silencedetect`; align scene cuts or camera punches to them.
 7. **Iterate with drafts.**
    ```
    cd videos/spool-vX.Y.Z
@@ -74,24 +53,16 @@ each captures hard-won decisions from prior releases.
    ```
    npm run render -- --quality standard --output renders/spool-vX.Y.Z-raw.mp4
    ```
-9. **Patch the first frame** for social media (see `references/poster.md`).
-   The output of this step is the file you upload to X.
+9. **Patch the first frame** for social media (see `references/poster.md`). The output of this step is the file you upload to X.
 10. **Extract a poster JPG** for tweet thumbnail fallback / preview imagery.
 
 ## Hard rules
 
-- **No simulated cursor.** Real screen recordings show real interactions;
-  faked GSAP cursors look uncanny. If a click is invisible in the clip,
-  use an amber annotation to call out the *result*, not the action.
-- **First frame must be the full hero state.** Brand mark + panel 1 + UI
-  window all visible at `t=0`, not faded in. Twitter's auto-thumbnail
-  grabs this frame.
-- **Annotations live inside `.window`**, not on the outer canvas. They
-  must move with the camera transform.
-- **No decorative chrome.** No vignette, callsign, progress bar, or
-  trailer-style overlay flashes. The UI is the protagonist.
-- **No "pull back to neutral" before the outro.** End scene 4 on its
-  feature focus, then hard-cut/fade to the Spool lockup.
+- **No simulated cursor.** Real screen recordings show real interactions; faked GSAP cursors look uncanny. If a click is invisible in the clip, use an amber annotation to call out the *result*, not the action.
+- **First frame must be the full hero state.** Brand mark + panel 1 + UI window all visible at `t=0`, not faded in. Twitter's auto-thumbnail grabs this frame.
+- **Annotations live inside `.window`**, not on the outer canvas. They must move with the camera transform.
+- **No decorative chrome.** No vignette, callsign, progress bar, or trailer-style overlay flashes. The UI is the protagonist.
+- **No "pull back to neutral" before the outro.** End scene 4 on its feature focus, then hard-cut/fade to the Spool lockup.
 
 ## Files this skill touches
 

--- a/.claude/skills/launch-video/references/capture.md
+++ b/.claude/skills/launch-video/references/capture.md
@@ -1,27 +1,19 @@
 # Capture
 
-How to record the Spool Electron app as a native macOS window. Output is a
-`.mov` per feature, used as the source for each scene in the composition.
+How to record the Spool Electron app as a native macOS window. Output is a `.mov` per feature, used as the source for each scene in the composition.
 
 ## Why native window, not Playwright screenshots
 
-Playwright's `page.screenshot()` and `video` recording only capture the
-WebContents — no traffic lights, no rounded corners, no shadow. The
-composition shows the window-on-stage, so we need the real OS window.
+Playwright's `page.screenshot()` and `video` recording only capture the WebContents — no traffic lights, no rounded corners, no shadow. The composition shows the window-on-stage, so we need the real OS window.
 
-Solution: capture the rectangular region the macOS window occupies via
-`screencapture -R`. Use a Swift one-liner to find the Quartz window id
-matching the Electron process pid + bounds.
+Solution: capture the rectangular region the macOS window occupies via `screencapture -R`. Use a Swift one-liner to find the Quartz window id matching the Electron process pid + bounds.
 
 ## Helper functions (already in `packages/app/e2e/helpers/`)
 
-- `nativeWindowInfo(app)` — returns `{id, x, y, width, height}` for the
-  front-most Electron BrowserWindow.
+- `nativeWindowInfo(app)` — returns `{id, x, y, width, height}` for the front-most Electron BrowserWindow.
 - `captureNativeWindow(app, path)` — single PNG (uses `screencapture -l <id>`).
-- `recordNativeWindow(app, path, seconds, perform)` — runs `screencapture
-  -V <seconds> -R <rect>` while `perform()` drives the app concurrently.
-- `launchDemoApp(seed)` + `setDemoWindowBounds(ctx, 1080, 740)` — boot
-  Electron with programmatic fixtures, force dark, set canonical size.
+- `recordNativeWindow(app, path, seconds, perform)` — runs `screencapture -V <seconds> -R <rect>` while `perform()` drives the app concurrently.
+- `launchDemoApp(seed)` + `setDemoWindowBounds(ctx, 1080, 740)` — boot Electron with programmatic fixtures, force dark, set canonical size.
 - `emitUpdateStatus(app, payload)` — push updater banner state via IPC.
 - `pinFirstRowInProject(window, name)` — hover + pin first session row.
 
@@ -51,18 +43,14 @@ const PROJECTS: ProjectSeed[] = [
 **Rules for seed data:**
 
 - English-only titles
-- **Must not reference real user sessions** — invent plausible titles thematically
-  relevant to the release (e.g. for a share-feature release, titles about
-  "share flow review", "share rate limiting", etc).
+- **Must not reference real user sessions** — invent plausible titles thematically relevant to the release (e.g. for a share-feature release, titles about "share flow review", "share rate limiting", etc).
 - 10–15 projects total feels right in the sidebar.
 - One project's `total` should be high (≥ 70) to demo the count badge.
 - Mix `source` between `claude` and `codex` so the badges look varied.
 
 ## Writing the ad-hoc capture spec
 
-The capture spec is **per-release, not committed**. Put it at
-`packages/app/e2e/release-capture.spec.ts` and gitignore-add it (or just
-delete after the release ships).
+The capture spec is **per-release, not committed**. Put it at `packages/app/e2e/release-capture.spec.ts` and gitignore-add it (or just delete after the release ships).
 
 Structure:
 
@@ -95,6 +83,7 @@ test('record release clips', async () => {
 ```
 
 Run with:
+
 ```bash
 pnpm --filter @spool/app exec playwright test e2e/release-capture.spec.ts --workers=1
 ```
@@ -110,16 +99,7 @@ pnpm --filter @spool/app exec playwright test e2e/release-capture.spec.ts --work
 
 ## Common capture issues
 
-- **Window not found.** `screencapture -R` failures usually mean the Electron
-  window hasn't focused. Call `app.focus({steal: true})` + `win.focus()` before
-  recording.
-- **Playwright `mouse.click()` does NOT move the OS cursor.** It dispatches
-  DOM events directly. If you need cursor-in-frame, drive the OS cursor
-  separately (e.g. `cliclick`) — but this is usually a sign you should drop
-  the cursor entirely and let the UI change carry the story.
-- **First-frame black pixels in the output `.mov`.** `screencapture -V` has
-  ~21ms latency before the first frame lands. Padded out at composition time
-  via `tpad` (see `poster.md`).
-- **Timing slips between perform() and screencapture.** `recordNativeWindow`
-  starts the recording, then runs `perform()`. There's a ~500ms lead-in
-  where you can `waitForTimeout` to settle before the first action.
+- **Window not found.** `screencapture -R` failures usually mean the Electron window hasn't focused. Call `app.focus({steal: true})` + `win.focus()` before recording.
+- **Playwright `mouse.click()` does NOT move the OS cursor.** It dispatches DOM events directly. If you need cursor-in-frame, drive the OS cursor separately (e.g. `cliclick`) — but this is usually a sign you should drop the cursor entirely and let the UI change carry the story.
+- **First-frame black pixels in the output `.mov`.** `screencapture -V` has ~21ms latency before the first frame lands. Padded out at composition time via `tpad` (see `poster.md`).
+- **Timing slips between perform() and screencapture.** `recordNativeWindow` starts the recording, then runs `perform()`. There's a ~500ms lead-in where you can `waitForTimeout` to settle before the first action.

--- a/.claude/skills/launch-video/references/capture.md
+++ b/.claude/skills/launch-video/references/capture.md
@@ -1,0 +1,125 @@
+# Capture
+
+How to record the Spool Electron app as a native macOS window. Output is a
+`.mov` per feature, used as the source for each scene in the composition.
+
+## Why native window, not Playwright screenshots
+
+Playwright's `page.screenshot()` and `video` recording only capture the
+WebContents — no traffic lights, no rounded corners, no shadow. The
+composition shows the window-on-stage, so we need the real OS window.
+
+Solution: capture the rectangular region the macOS window occupies via
+`screencapture -R`. Use a Swift one-liner to find the Quartz window id
+matching the Electron process pid + bounds.
+
+## Helper functions (already in `packages/app/e2e/helpers/`)
+
+- `nativeWindowInfo(app)` — returns `{id, x, y, width, height}` for the
+  front-most Electron BrowserWindow.
+- `captureNativeWindow(app, path)` — single PNG (uses `screencapture -l <id>`).
+- `recordNativeWindow(app, path, seconds, perform)` — runs `screencapture
+  -V <seconds> -R <rect>` while `perform()` drives the app concurrently.
+- `launchDemoApp(seed)` + `setDemoWindowBounds(ctx, 1080, 740)` — boot
+  Electron with programmatic fixtures, force dark, set canonical size.
+- `emitUpdateStatus(app, payload)` — push updater banner state via IPC.
+- `pinFirstRowInProject(window, name)` — hover + pin first session row.
+
+## Authoring the per-release seed
+
+Each release demos different features → different sidebar content.
+
+Build a `ProjectSeed[]` (type in `packages/app/e2e/helpers/demo-fixtures.ts`):
+
+```ts
+import type { ProjectSeed } from '../e2e/helpers/demo-fixtures'
+
+const PROJECTS: ProjectSeed[] = [
+  {
+    name: 'spool',
+    total: 79,
+    leadSessions: [
+      { title: 'Audit the share flow in a fresh worktree', source: 'claude', iso: '2026-05-13T15:12:00Z' },
+      // ... more titles per project
+    ],
+    fillerSources: ['claude', 'codex'],
+  },
+  // ... more projects
+]
+```
+
+**Rules for seed data:**
+
+- English-only titles
+- **Must not reference real user sessions** — invent plausible titles thematically
+  relevant to the release (e.g. for a share-feature release, titles about
+  "share flow review", "share rate limiting", etc).
+- 10–15 projects total feels right in the sidebar.
+- One project's `total` should be high (≥ 70) to demo the count badge.
+- Mix `source` between `claude` and `codex` so the badges look varied.
+
+## Writing the ad-hoc capture spec
+
+The capture spec is **per-release, not committed**. Put it at
+`packages/app/e2e/release-capture.spec.ts` and gitignore-add it (or just
+delete after the release ships).
+
+Structure:
+
+```ts
+import { test } from '@playwright/test'
+import { launchDemoApp, setDemoWindowBounds, waitForDemoSync } from './helpers/demo-launch'
+import { recordNativeWindow } from './helpers/native-window-capture'
+import { emitUpdateStatus, pinFirstRowInProject } from './helpers/demo-interactions'
+
+const PROJECTS = [/* per-release seed */]
+
+const OUT_DIR = path.join(__dirname, '../../../videos/spool-vX.Y.Z/assets/live')
+
+test('record release clips', async () => {
+  test.setTimeout(180_000)
+
+  const ctx = await launchDemoApp(PROJECTS)
+  await setDemoWindowBounds(ctx, 1080, 740)
+  await waitForDemoSync(ctx.window)
+
+  await recordNativeWindow(ctx.app, path.join(OUT_DIR, '01-home.mov'), 4.0, async () => {
+    // Drive the app for ~4s while screencapture records.
+    // e.g. ctx.window.mouse.wheel(0, 900)
+  })
+
+  // ... more clips per feature
+
+  await ctx.cleanup()
+})
+```
+
+Run with:
+```bash
+pnpm --filter @spool/app exec playwright test e2e/release-capture.spec.ts --workers=1
+```
+
+## Capture-time constants
+
+| | Value | Why |
+|---|---|---|
+| Window logical size | 1080×740 | Matches app default (`packages/app/src/main/index.ts`); the composition assumes this aspect |
+| Theme | dark forced | `nativeTheme.themeSource = 'dark'` in `setDemoWindowBounds()` |
+| GPU | disabled | `ELECTRON_DISABLE_GPU=1` for deterministic frames |
+| `screencapture` cursor | off | Default. Add `-C` to args if you want the system cursor in frame — usually you don't, the simulated cursors look unnatural |
+
+## Common capture issues
+
+- **Window not found.** `screencapture -R` failures usually mean the Electron
+  window hasn't focused. Call `app.focus({steal: true})` + `win.focus()` before
+  recording.
+- **Playwright `mouse.click()` does NOT move the OS cursor.** It dispatches
+  DOM events directly. If you need cursor-in-frame, drive the OS cursor
+  separately (e.g. `cliclick`) — but this is usually a sign you should drop
+  the cursor entirely and let the UI change carry the story.
+- **First-frame black pixels in the output `.mov`.** `screencapture -V` has
+  ~21ms latency before the first frame lands. Padded out at composition time
+  via `tpad` (see `poster.md`).
+- **Timing slips between perform() and screencapture.** `recordNativeWindow`
+  starts the recording, then runs `perform()`. There's a ~500ms lead-in
+  where you can `waitForTimeout` to settle before the first action.

--- a/.claude/skills/launch-video/references/composition.md
+++ b/.claude/skills/launch-video/references/composition.md
@@ -1,0 +1,106 @@
+# Composition
+
+The proven HyperFrames composition layout. Copy from
+`videos/launch-template/index.html` and customise per release; this doc
+explains *why* the template looks the way it does so you don't accidentally
+revert hard-won decisions.
+
+## Canvas + window dimensions
+
+| Element | Value | Notes |
+|---|---|---|
+| Canvas | 1920×1080 | 16:9, Twitter-friendly |
+| Window logical size | 1000×685 | Renders the captured 1080×740 .mov at 1.46:1 aspect |
+| Window position | left 700, top 197 | Right of canvas centre, vertical centre |
+| Window `border-radius` | 8px | Matches macOS native window curve in the captured `.mov`. Smaller → `screencapture -R` desktop background bleeds into corners. Larger → app chrome gets clipped. |
+| Drop shadow | three layers (60/120, 24/48, 6/12 px) | Gives a "floating" feel. Single-layer shadow looks flat. |
+
+## Text panel (left)
+
+- `x=132, top=410, width=540`
+- Three rows: `panel-kicker` (mono, 13px) → `panel-headline` (sans 70px, 2 lines, weight 600, letter-spacing -0.05em) → `panel-sub` (18px, 1.45 line-height)
+- Amber accent bar before the kicker (`width: 40px, height: 2px`)
+- Period in headline ends with `<span class="accent">.</span>` for the amber dot
+
+## Persistent brand mark (top-left)
+
+- `x=132, top=200`, always visible
+- `Spool. vX.Y.Z · Launch` in 26px wordmark + 11px mono version
+- Anchors the composition; without it the left-third can feel empty during scene 1
+
+## Camera moves
+
+Camera = `transform-origin + scale` on the `.window`. The annotation rectangles inherit the same transform because they live inside `.window`.
+
+| Scene | Pattern |
+|---|---|
+| First-screen / overview | No zoom (`scale: 1`) |
+| Sidebar collapse / expand | Light zoom (`scale: 1.12–1.18`) with origin near sidebar centre (`8%, 50%`) |
+| Pinned-section emergence | Tight zoom (`scale: 1.25–1.35`) with origin on top-left sidebar (`12%, 17%`) |
+| Updater banner | Tight zoom (`scale: 1.28–1.5`) with origin on bottom-left sidebar (`10%, 85–95%`) |
+
+Avoid:
+- Smooth slow drifts during a scene — they read as "PowerPoint pan" not "trailer move". Zoom into a region, hold, cut.
+- "Pull back to neutral" before the outro — end on the feature focus, cut to the lockup.
+
+## Annotation rectangles
+
+The amber outline that says "look here". Lives inside `.window`. Coords are in `%` of the un-transformed window.
+
+```html
+<div id="annot-feature-X" class="annot"></div>
+<div id="annot-feature-X-label" class="annot-label">Feature X</div>
+```
+
+```css
+#annot-feature-X { left: 1%; top: 15%; width: 21%; height: 16%; }
+#annot-feature-X-label { left: 1%; top: 10.5%; }
+```
+
+**Measuring annotation coords (do this fresh every release):**
+
+1. Pick a raw `.mov` frame where the feature is fully visible. Extract with
+   `ffmpeg -ss <t> -i <clip>.mov -frames:v 1 frame.png`.
+2. Crop the relevant region:
+   `ffmpeg -i frame.png -vf "crop=600:600:0:0" cropped.png` (adjust to where
+   the feature lives in the frame).
+3. Open the crop in any image viewer that shows pixel coords. Measure the
+   bounding box of the feature region in source pixels.
+4. Divide by the source frame dimensions (typically 2160×1480 for retina
+   recordings) to get `%`. Apply small internal padding (1% on left/right)
+   so the rectangle has breathing room.
+
+Symmetry matters — `left: 0.5%, width: 22%` will look unbalanced (touches
+sidebar left edge but stops short of right edge). Pick `left: 1%, width: 20%`
+for symmetric inset.
+
+## Annotation timing
+
+Fade the annotation in **after** the feature is fully visible in the clip,
+not when the clip starts. For example, if the `PINNED · N sessions` strip
+finishes populating at clip-time `2.5s`, the annotation should fade in at
+timeline `clip-start + 2.5s + 0.1s`. Earlier = empty rectangle on screen.
+
+Fade out **with the scene**, not after. When the panel exits and the camera
+transitions, the annotation goes with them.
+
+## Beat sync
+
+Run `ffmpeg -i bgm.mp3 -af "highpass=200,lowpass=4000,silencedetect=n=-30dB:d=0.05" -f null -` to find strong beats in the BGM (look at `silence_end` timestamps). Align:
+
+- Scene cuts (clip swap) — to a beat if possible
+- Camera punches — to a beat
+- Annotation fade-ins — slightly after a beat (so it lands as an answer to the beat, not on it)
+
+The video doesn't need to be tightly beat-locked — just lining up the major
+moments to phrase boundaries makes the whole thing feel intentional.
+
+## Panel + annotation animations
+
+Already encoded in the template as `panelIn()`, `panelOut()`, `zoomTo()`,
+`clipFade()` GSAP helpers. Don't rewrite them per release; just call them
+with new timing values.
+
+Word-by-word stagger on `panel-headline` is the one place where motion is
+*allowed* to be slightly playful — keeps the text from feeling like a static
+slide.

--- a/.claude/skills/launch-video/references/composition.md
+++ b/.claude/skills/launch-video/references/composition.md
@@ -1,9 +1,6 @@
 # Composition
 
-The proven HyperFrames composition layout. Copy from
-`videos/launch-template/index.html` and customise per release; this doc
-explains *why* the template looks the way it does so you don't accidentally
-revert hard-won decisions.
+The proven HyperFrames composition layout. Copy from `videos/launch-template/index.html` and customise per release; this doc explains *why* the template looks the way it does so you don't accidentally revert hard-won decisions.
 
 ## Canvas + window dimensions
 
@@ -40,6 +37,7 @@ Camera = `transform-origin + scale` on the `.window`. The annotation rectangles 
 | Updater banner | Tight zoom (`scale: 1.28–1.5`) with origin on bottom-left sidebar (`10%, 85–95%`) |
 
 Avoid:
+
 - Smooth slow drifts during a scene — they read as "PowerPoint pan" not "trailer move". Zoom into a region, hold, cut.
 - "Pull back to neutral" before the outro — end on the feature focus, cut to the lockup.
 
@@ -59,30 +57,18 @@ The amber outline that says "look here". Lives inside `.window`. Coords are in `
 
 **Measuring annotation coords (do this fresh every release):**
 
-1. Pick a raw `.mov` frame where the feature is fully visible. Extract with
-   `ffmpeg -ss <t> -i <clip>.mov -frames:v 1 frame.png`.
-2. Crop the relevant region:
-   `ffmpeg -i frame.png -vf "crop=600:600:0:0" cropped.png` (adjust to where
-   the feature lives in the frame).
-3. Open the crop in any image viewer that shows pixel coords. Measure the
-   bounding box of the feature region in source pixels.
-4. Divide by the source frame dimensions (typically 2160×1480 for retina
-   recordings) to get `%`. Apply small internal padding (1% on left/right)
-   so the rectangle has breathing room.
+1. Pick a raw `.mov` frame where the feature is fully visible. Extract with `ffmpeg -ss <t> -i <clip>.mov -frames:v 1 frame.png`.
+2. Crop the relevant region: `ffmpeg -i frame.png -vf "crop=600:600:0:0" cropped.png` (adjust to where the feature lives in the frame).
+3. Open the crop in any image viewer that shows pixel coords. Measure the bounding box of the feature region in source pixels.
+4. Divide by the source frame dimensions (typically 2160×1480 for retina recordings) to get `%`. Apply small internal padding (1% on left/right) so the rectangle has breathing room.
 
-Symmetry matters — `left: 0.5%, width: 22%` will look unbalanced (touches
-sidebar left edge but stops short of right edge). Pick `left: 1%, width: 20%`
-for symmetric inset.
+Symmetry matters — `left: 0.5%, width: 22%` will look unbalanced (touches sidebar left edge but stops short of right edge). Pick `left: 1%, width: 20%` for symmetric inset.
 
 ## Annotation timing
 
-Fade the annotation in **after** the feature is fully visible in the clip,
-not when the clip starts. For example, if the `PINNED · N sessions` strip
-finishes populating at clip-time `2.5s`, the annotation should fade in at
-timeline `clip-start + 2.5s + 0.1s`. Earlier = empty rectangle on screen.
+Fade the annotation in **after** the feature is fully visible in the clip, not when the clip starts. For example, if the `PINNED · N sessions` strip finishes populating at clip-time `2.5s`, the annotation should fade in at timeline `clip-start + 2.5s + 0.1s`. Earlier = empty rectangle on screen.
 
-Fade out **with the scene**, not after. When the panel exits and the camera
-transitions, the annotation goes with them.
+Fade out **with the scene**, not after. When the panel exits and the camera transitions, the annotation goes with them.
 
 ## Beat sync
 
@@ -92,15 +78,10 @@ Run `ffmpeg -i bgm.mp3 -af "highpass=200,lowpass=4000,silencedetect=n=-30dB:d=0.
 - Camera punches — to a beat
 - Annotation fade-ins — slightly after a beat (so it lands as an answer to the beat, not on it)
 
-The video doesn't need to be tightly beat-locked — just lining up the major
-moments to phrase boundaries makes the whole thing feel intentional.
+The video doesn't need to be tightly beat-locked — just lining up the major moments to phrase boundaries makes the whole thing feel intentional.
 
 ## Panel + annotation animations
 
-Already encoded in the template as `panelIn()`, `panelOut()`, `zoomTo()`,
-`clipFade()` GSAP helpers. Don't rewrite them per release; just call them
-with new timing values.
+Already encoded in the template as `panelIn()`, `panelOut()`, `zoomTo()`, `clipFade()` GSAP helpers. Don't rewrite them per release; just call them with new timing values.
 
-Word-by-word stagger on `panel-headline` is the one place where motion is
-*allowed* to be slightly playful — keeps the text from feeling like a static
-slide.
+Word-by-word stagger on `panel-headline` is the one place where motion is *allowed* to be slightly playful — keeps the text from feeling like a static slide.

--- a/.claude/skills/launch-video/references/pitfalls.md
+++ b/.claude/skills/launch-video/references/pitfalls.md
@@ -1,0 +1,121 @@
+# Pitfalls
+
+What we tried during v0.4.11 that looked bad in motion, and what to do
+instead. Read this **before** improvising on the proven layout.
+
+## 1. Faked cursors look uncanny
+
+We built three iterations of an overlaid SVG cursor that flew across the
+screen to "click" buttons. Every version felt wrong:
+
+- Linear motion → robotic
+- Bezier + overshoot → bouncy in a video-game way
+- Designed amber dot with click pulse → still felt artificial because it
+  wasn't synced to anything physical in the clip
+
+**Why:** the real clip has no cursor. Adding one creates a disconnect
+between the cursor's "intent" and the UI's actual response timing.
+
+**Do instead:** drop the cursor entirely. Use amber annotation rectangles
+to call out the *result* of an interaction (the new pinned section, the
+status banner change). The viewer doesn't need to see the click — they
+see the effect.
+
+If you absolutely need to show a click for clarity, a single amber pulse
+ring at the click point (no cursor) is the most you should add.
+
+## 2. Decorative chrome adds nothing
+
+We tried, in turn: a vignette over the canvas, a top-right "callsign"
+(`SPOOL · v0.4.11 · LAUNCH`), a bottom 1px amber progress strip, a film
+grain overlay. Each one made the video feel more "designed" and *less*
+intentional — like a YouTuber's title sequence rather than a product
+announcement.
+
+**Do instead:** trust the brand mark in the top-left and the text panel
+on the left to anchor the composition. The amber annotations on the
+demo window are the only accent layer that earns its place.
+
+## 3. PPT-style title cards kill momentum
+
+First attempt: each scene started with a centered title card (kicker +
+big headline), held for ~1s, then cut to the demo. Watching back it
+felt like a slide deck.
+
+**Why:** the pause between "title" and "demo" makes the viewer's brain
+treat them as separate beats — interrupting the flow.
+
+**Do instead:** text panel + demo coexist continuously. The panel
+contents change per scene, the demo plays in parallel. Hard-cuts
+between feature clips, no card pauses.
+
+## 4. Smooth multi-second camera drifts feel like PowerPoint pans
+
+We tried slow zooms (~3s) over a scene to "show" the feature area.
+Reads as a Ken Burns slideshow effect, not a trailer move.
+
+**Do instead:** zoom into the focal region within ~0.6s (`power2.inOut`),
+hold there for the scene, then hard-cut to the next. Camera moves are
+short and motivated, not ambient.
+
+## 5. "Pull back to neutral" before the outro feels deflating
+
+We had the camera zoom back out to `scale: 1` before fading to the
+Spool lockup. It made the ending feel like the show was retreating
+instead of resolving.
+
+**Do instead:** end scene 4 on its feature focus. Fade window + brand +
+annotation directly to the outro card from that zoomed state. The cut
+is sharper.
+
+## 6. First frame must be content, not animation prelude
+
+When window/panel/brand mark all fade in from `opacity: 0` over the
+first 0.5s, the encoded MP4's first frame is mostly black. Twitter
+auto-thumbnails grab that black frame as the preview.
+
+**Do instead:** scene 1's elements (`#panel1`, `#window`, `#brand-mark`)
+must be `opacity: 1` at `t=0` in the CSS. No entrance animation for
+scene 1. Then `tpad clone` the first 0.5s during post-processing for
+extra insurance (see `poster.md`).
+
+## 7. The annotation rectangle position is per-release
+
+`pinned-section: top 15%, height 13%` was right for v0.4.11. For
+v0.5.0 the UI WILL be different — different feature regions, possibly
+different sidebar density, etc.
+
+**Don't:** copy old coords forward.
+**Do:** measure fresh from your captured `.mov` frames every release.
+The `composition.md` reference explains how.
+
+## 8. Avoid background-bleed at window corners
+
+`screencapture -R` records a rectangle. Outside the macOS window's
+rounded corners, you see the desktop background — sometimes white,
+sometimes light depending on the user's wallpaper.
+
+**Solution:** the `.window` element in the composition has
+`border-radius: 8px; overflow: hidden`. This clips the corners to a
+radius close enough to macOS's native that no background pixels show.
+
+`8px` is empirically right. Smaller → background bleeds through.
+Larger → app chrome (traffic lights) gets clipped.
+
+## 9. Don't beat-lock everything
+
+The video has ~6–8 strong beats from the BGM. Don't try to land every
+scene cut + annotation reveal + camera move on a beat — over-syncing
+reads as desperate.
+
+**Do:** anchor the major scene transitions to phrase boundaries
+(every ~7s in our BGM). Let everything else float naturally.
+
+## 10. Real screen recordings, not mock UIs
+
+Early v0.4.11 attempts (livecut v1–v6) used a hand-built HTML mockup
+of the Spool UI inside the composition. It iterated for hours and
+still looked uncanny — wrong row heights, wrong icons, wrong rhythm.
+
+**Lesson:** always record the real Electron app. The capture pipeline
+exists for a reason. Don't try to recreate the UI in HTML, ever.

--- a/.claude/skills/launch-video/references/pitfalls.md
+++ b/.claude/skills/launch-video/references/pitfalls.md
@@ -1,121 +1,76 @@
 # Pitfalls
 
-What we tried during v0.4.11 that looked bad in motion, and what to do
-instead. Read this **before** improvising on the proven layout.
+What we tried during v0.4.11 that looked bad in motion, and what to do instead. Read this **before** improvising on the proven layout.
 
 ## 1. Faked cursors look uncanny
 
-We built three iterations of an overlaid SVG cursor that flew across the
-screen to "click" buttons. Every version felt wrong:
+We built three iterations of an overlaid SVG cursor that flew across the screen to "click" buttons. Every version felt wrong:
 
 - Linear motion → robotic
 - Bezier + overshoot → bouncy in a video-game way
-- Designed amber dot with click pulse → still felt artificial because it
-  wasn't synced to anything physical in the clip
+- Designed amber dot with click pulse → still felt artificial because it wasn't synced to anything physical in the clip
 
-**Why:** the real clip has no cursor. Adding one creates a disconnect
-between the cursor's "intent" and the UI's actual response timing.
+**Why:** the real clip has no cursor. Adding one creates a disconnect between the cursor's "intent" and the UI's actual response timing.
 
-**Do instead:** drop the cursor entirely. Use amber annotation rectangles
-to call out the *result* of an interaction (the new pinned section, the
-status banner change). The viewer doesn't need to see the click — they
-see the effect.
+**Do instead:** drop the cursor entirely. Use amber annotation rectangles to call out the *result* of an interaction (the new pinned section, the status banner change). The viewer doesn't need to see the click — they see the effect.
 
-If you absolutely need to show a click for clarity, a single amber pulse
-ring at the click point (no cursor) is the most you should add.
+If you absolutely need to show a click for clarity, a single amber pulse ring at the click point (no cursor) is the most you should add.
 
 ## 2. Decorative chrome adds nothing
 
-We tried, in turn: a vignette over the canvas, a top-right "callsign"
-(`SPOOL · v0.4.11 · LAUNCH`), a bottom 1px amber progress strip, a film
-grain overlay. Each one made the video feel more "designed" and *less*
-intentional — like a YouTuber's title sequence rather than a product
-announcement.
+We tried, in turn: a vignette over the canvas, a top-right "callsign" (`SPOOL · v0.4.11 · LAUNCH`), a bottom 1px amber progress strip, a film grain overlay. Each one made the video feel more "designed" and *less* intentional — like a YouTuber's title sequence rather than a product announcement.
 
-**Do instead:** trust the brand mark in the top-left and the text panel
-on the left to anchor the composition. The amber annotations on the
-demo window are the only accent layer that earns its place.
+**Do instead:** trust the brand mark in the top-left and the text panel on the left to anchor the composition. The amber annotations on the demo window are the only accent layer that earns its place.
 
 ## 3. PPT-style title cards kill momentum
 
-First attempt: each scene started with a centered title card (kicker +
-big headline), held for ~1s, then cut to the demo. Watching back it
-felt like a slide deck.
+First attempt: each scene started with a centered title card (kicker + big headline), held for ~1s, then cut to the demo. Watching back it felt like a slide deck.
 
-**Why:** the pause between "title" and "demo" makes the viewer's brain
-treat them as separate beats — interrupting the flow.
+**Why:** the pause between "title" and "demo" makes the viewer's brain treat them as separate beats — interrupting the flow.
 
-**Do instead:** text panel + demo coexist continuously. The panel
-contents change per scene, the demo plays in parallel. Hard-cuts
-between feature clips, no card pauses.
+**Do instead:** text panel + demo coexist continuously. The panel contents change per scene, the demo plays in parallel. Hard-cuts between feature clips, no card pauses.
 
 ## 4. Smooth multi-second camera drifts feel like PowerPoint pans
 
-We tried slow zooms (~3s) over a scene to "show" the feature area.
-Reads as a Ken Burns slideshow effect, not a trailer move.
+We tried slow zooms (~3s) over a scene to "show" the feature area. Reads as a Ken Burns slideshow effect, not a trailer move.
 
-**Do instead:** zoom into the focal region within ~0.6s (`power2.inOut`),
-hold there for the scene, then hard-cut to the next. Camera moves are
-short and motivated, not ambient.
+**Do instead:** zoom into the focal region within ~0.6s (`power2.inOut`), hold there for the scene, then hard-cut to the next. Camera moves are short and motivated, not ambient.
 
 ## 5. "Pull back to neutral" before the outro feels deflating
 
-We had the camera zoom back out to `scale: 1` before fading to the
-Spool lockup. It made the ending feel like the show was retreating
-instead of resolving.
+We had the camera zoom back out to `scale: 1` before fading to the Spool lockup. It made the ending feel like the show was retreating instead of resolving.
 
-**Do instead:** end scene 4 on its feature focus. Fade window + brand +
-annotation directly to the outro card from that zoomed state. The cut
-is sharper.
+**Do instead:** end scene 4 on its feature focus. Fade window + brand + annotation directly to the outro card from that zoomed state. The cut is sharper.
 
 ## 6. First frame must be content, not animation prelude
 
-When window/panel/brand mark all fade in from `opacity: 0` over the
-first 0.5s, the encoded MP4's first frame is mostly black. Twitter
-auto-thumbnails grab that black frame as the preview.
+When window/panel/brand mark all fade in from `opacity: 0` over the first 0.5s, the encoded MP4's first frame is mostly black. Twitter auto-thumbnails grab that black frame as the preview.
 
-**Do instead:** scene 1's elements (`#panel1`, `#window`, `#brand-mark`)
-must be `opacity: 1` at `t=0` in the CSS. No entrance animation for
-scene 1. Then `tpad clone` the first 0.5s during post-processing for
-extra insurance (see `poster.md`).
+**Do instead:** scene 1's elements (`#panel1`, `#window`, `#brand-mark`) must be `opacity: 1` at `t=0` in the CSS. No entrance animation for scene 1. Then `tpad clone` the first 0.5s during post-processing for extra insurance (see `poster.md`).
 
 ## 7. The annotation rectangle position is per-release
 
-`pinned-section: top 15%, height 13%` was right for v0.4.11. For
-v0.5.0 the UI WILL be different — different feature regions, possibly
-different sidebar density, etc.
+`pinned-section: top 15%, height 13%` was right for v0.4.11. For v0.5.0 the UI WILL be different — different feature regions, possibly different sidebar density, etc.
 
 **Don't:** copy old coords forward.
-**Do:** measure fresh from your captured `.mov` frames every release.
-The `composition.md` reference explains how.
+**Do:** measure fresh from your captured `.mov` frames every release. The `composition.md` reference explains how.
 
 ## 8. Avoid background-bleed at window corners
 
-`screencapture -R` records a rectangle. Outside the macOS window's
-rounded corners, you see the desktop background — sometimes white,
-sometimes light depending on the user's wallpaper.
+`screencapture -R` records a rectangle. Outside the macOS window's rounded corners, you see the desktop background — sometimes white, sometimes light depending on the user's wallpaper.
 
-**Solution:** the `.window` element in the composition has
-`border-radius: 8px; overflow: hidden`. This clips the corners to a
-radius close enough to macOS's native that no background pixels show.
+**Solution:** the `.window` element in the composition has `border-radius: 8px; overflow: hidden`. This clips the corners to a radius close enough to macOS's native that no background pixels show.
 
-`8px` is empirically right. Smaller → background bleeds through.
-Larger → app chrome (traffic lights) gets clipped.
+`8px` is empirically right. Smaller → background bleeds through. Larger → app chrome (traffic lights) gets clipped.
 
 ## 9. Don't beat-lock everything
 
-The video has ~6–8 strong beats from the BGM. Don't try to land every
-scene cut + annotation reveal + camera move on a beat — over-syncing
-reads as desperate.
+The video has ~6–8 strong beats from the BGM. Don't try to land every scene cut + annotation reveal + camera move on a beat — over-syncing reads as desperate.
 
-**Do:** anchor the major scene transitions to phrase boundaries
-(every ~7s in our BGM). Let everything else float naturally.
+**Do:** anchor the major scene transitions to phrase boundaries (every ~7s in our BGM). Let everything else float naturally.
 
 ## 10. Real screen recordings, not mock UIs
 
-Early v0.4.11 attempts (livecut v1–v6) used a hand-built HTML mockup
-of the Spool UI inside the composition. It iterated for hours and
-still looked uncanny — wrong row heights, wrong icons, wrong rhythm.
+Early v0.4.11 attempts (livecut v1–v6) used a hand-built HTML mockup of the Spool UI inside the composition. It iterated for hours and still looked uncanny — wrong row heights, wrong icons, wrong rhythm.
 
-**Lesson:** always record the real Electron app. The capture pipeline
-exists for a reason. Don't try to recreate the UI in HTML, ever.
+**Lesson:** always record the real Electron app. The capture pipeline exists for a reason. Don't try to recreate the UI in HTML, ever.

--- a/.claude/skills/launch-video/references/poster.md
+++ b/.claude/skills/launch-video/references/poster.md
@@ -1,26 +1,20 @@
 # Poster
 
-How to make the rendered MP4's first frame social-media-friendly so X /
-Twitter auto-thumbnails grab the full hero, not a black frame.
+How to make the rendered MP4's first frame social-media-friendly so X / Twitter auto-thumbnails grab the full hero, not a black frame.
 
 ## The problem
 
-After `hyperframes render`, the MP4 looks correct in any player, but its
-**first encoded frame** can be:
+After `hyperframes render`, the MP4 looks correct in any player, but its **first encoded frame** can be:
 
-1. Black or partially loaded (Chrome's video element hasn't decoded its
-   first frame at composition time `t=0`)
+1. Black or partially loaded (Chrome's video element hasn't decoded its first frame at composition time `t=0`)
 2. Slightly offset (`screencapture -V` introduces a ~21ms lead-in)
-3. Missing one of the composition layers (panel + window + brand mark
-   not all fully composited at the exact `t=0` snapshot)
+3. Missing one of the composition layers (panel + window + brand mark not all fully composited at the exact `t=0` snapshot)
 
-X / Twitter, Finder, Quicklook, and most embedded video players sample
-the first frame as the preview thumbnail. Black preview = nobody clicks.
+X / Twitter, Finder, Quicklook, and most embedded video players sample the first frame as the preview thumbnail. Black preview = nobody clicks.
 
 ## Solution: `tpad clone` the first 0.5s
 
-Use FFmpeg's `tpad` filter to clone the first decoded frame for an
-extra 0.5s at the start. Combined with `adelay` to keep audio in sync.
+Use FFmpeg's `tpad` filter to clone the first decoded frame for an extra 0.5s at the start. Combined with `adelay` to keep audio in sync.
 
 ```bash
 ffmpeg -i renders/spool-vX.Y.Z-raw.mp4 \
@@ -31,27 +25,20 @@ ffmpeg -i renders/spool-vX.Y.Z-raw.mp4 \
   renders/spool-vX.Y.Z-final.mp4
 ```
 
-Output: total duration is `original + 0.5s`. The added 0.5s shows the
-first decoded frame frozen. Players paused at the start now show the
-hero state.
+Output: total duration is `original + 0.5s`. The added 0.5s shows the first decoded frame frozen. Players paused at the start now show the hero state.
 
 ## Belt + braces: also keep scene 1 elements visible at `t=0`
 
-The `tpad` trick handles encoder-level leading frames, but the
-composition itself should also have scene 1 visible at `t=0`:
+The `tpad` trick handles encoder-level leading frames, but the composition itself should also have scene 1 visible at `t=0`:
 
-- `#panel1`, `#window`, `#brand-mark` all `opacity: 1` from CSS (no
-  entrance `fromTo`)
-- `clip-home` (or whatever clip plays first) has `data-start="0.00"`
-  so HyperFrames doesn't hide it before its play window starts
+- `#panel1`, `#window`, `#brand-mark` all `opacity: 1` from CSS (no entrance `fromTo`)
+- `clip-home` (or whatever clip plays first) has `data-start="0.00"` so HyperFrames doesn't hide it before its play window starts
 
-Both layers (composition CSS + post-process `tpad`) protect against
-different failure modes. Use both.
+Both layers (composition CSS + post-process `tpad`) protect against different failure modes. Use both.
 
 ## Extracting a poster JPG
 
-Some tweet workflows want a separate poster image to attach as the
-preview (e.g. Premium accounts that can set custom thumbnails):
+Some tweet workflows want a separate poster image to attach as the preview (e.g. Premium accounts that can set custom thumbnails):
 
 ```bash
 ffmpeg -i renders/spool-vX.Y.Z-final.mp4 \
@@ -60,8 +47,7 @@ ffmpeg -i renders/spool-vX.Y.Z-final.mp4 \
   renders/spool-vX.Y.Z-poster.jpg
 ```
 
-The first frame of the final MP4 (after `tpad`) is the hero state, so
-this grabs the right thumbnail.
+The first frame of the final MP4 (after `tpad`) is the hero state, so this grabs the right thumbnail.
 
 ## Verifying
 
@@ -79,15 +65,10 @@ ffprobe -v error -select_streams v:0 -show_entries packet=pts_time -of csv \
 ffmpeg -i renders/final.mp4 -vframes 1 /tmp/check-t0.png
 ```
 
-The first packet `pts_time` should be `0.000000` (or very close).
-`/tmp/check-t0.png` should show the full Scene 1 hero state.
+The first packet `pts_time` should be `0.000000` (or very close). `/tmp/check-t0.png` should show the full Scene 1 hero state.
 
 ## Sanity check by opening in QuickTime
 
-Open the final `.mp4` in QuickTime Player without pressing play. The
-paused frame should be the hero state. If it's black, the `tpad` step
-didn't take — re-run with verbose ffmpeg output to debug.
+Open the final `.mp4` in QuickTime Player without pressing play. The paused frame should be the hero state. If it's black, the `tpad` step didn't take — re-run with verbose ffmpeg output to debug.
 
-This is the closest local proxy to "what Twitter will show as the
-preview thumbnail before someone clicks play". If QuickTime shows
-hero, Twitter will too.
+This is the closest local proxy to "what Twitter will show as the preview thumbnail before someone clicks play". If QuickTime shows hero, Twitter will too.

--- a/.claude/skills/launch-video/references/poster.md
+++ b/.claude/skills/launch-video/references/poster.md
@@ -1,0 +1,93 @@
+# Poster
+
+How to make the rendered MP4's first frame social-media-friendly so X /
+Twitter auto-thumbnails grab the full hero, not a black frame.
+
+## The problem
+
+After `hyperframes render`, the MP4 looks correct in any player, but its
+**first encoded frame** can be:
+
+1. Black or partially loaded (Chrome's video element hasn't decoded its
+   first frame at composition time `t=0`)
+2. Slightly offset (`screencapture -V` introduces a ~21ms lead-in)
+3. Missing one of the composition layers (panel + window + brand mark
+   not all fully composited at the exact `t=0` snapshot)
+
+X / Twitter, Finder, Quicklook, and most embedded video players sample
+the first frame as the preview thumbnail. Black preview = nobody clicks.
+
+## Solution: `tpad clone` the first 0.5s
+
+Use FFmpeg's `tpad` filter to clone the first decoded frame for an
+extra 0.5s at the start. Combined with `adelay` to keep audio in sync.
+
+```bash
+ffmpeg -i renders/spool-vX.Y.Z-raw.mp4 \
+  -vf "tpad=start_mode=clone:start_duration=0.5" \
+  -af "adelay=500|500" \
+  -c:v libx264 -preset slow -crf 18 \
+  -c:a aac -b:a 192k -pix_fmt yuv420p -movflags +faststart \
+  renders/spool-vX.Y.Z-final.mp4
+```
+
+Output: total duration is `original + 0.5s`. The added 0.5s shows the
+first decoded frame frozen. Players paused at the start now show the
+hero state.
+
+## Belt + braces: also keep scene 1 elements visible at `t=0`
+
+The `tpad` trick handles encoder-level leading frames, but the
+composition itself should also have scene 1 visible at `t=0`:
+
+- `#panel1`, `#window`, `#brand-mark` all `opacity: 1` from CSS (no
+  entrance `fromTo`)
+- `clip-home` (or whatever clip plays first) has `data-start="0.00"`
+  so HyperFrames doesn't hide it before its play window starts
+
+Both layers (composition CSS + post-process `tpad`) protect against
+different failure modes. Use both.
+
+## Extracting a poster JPG
+
+Some tweet workflows want a separate poster image to attach as the
+preview (e.g. Premium accounts that can set custom thumbnails):
+
+```bash
+ffmpeg -i renders/spool-vX.Y.Z-final.mp4 \
+  -vframes 1 \
+  -q:v 1 \
+  renders/spool-vX.Y.Z-poster.jpg
+```
+
+The first frame of the final MP4 (after `tpad`) is the hero state, so
+this grabs the right thumbnail.
+
+## Verifying
+
+Quick checks after post-processing:
+
+```bash
+# duration
+ffprobe -v error -show_entries format=duration -of csv=p=0 renders/final.mp4
+
+# first packet timestamp (should be 0.000)
+ffprobe -v error -select_streams v:0 -show_entries packet=pts_time -of csv \
+  renders/final.mp4 | head -2
+
+# extract t=0 frame to look at
+ffmpeg -i renders/final.mp4 -vframes 1 /tmp/check-t0.png
+```
+
+The first packet `pts_time` should be `0.000000` (or very close).
+`/tmp/check-t0.png` should show the full Scene 1 hero state.
+
+## Sanity check by opening in QuickTime
+
+Open the final `.mp4` in QuickTime Player without pressing play. The
+paused frame should be the hero state. If it's black, the `tpad` step
+didn't take — re-run with verbose ffmpeg output to debug.
+
+This is the closest local proxy to "what Twitter will show as the
+preview thumbnail before someone clicks play". If QuickTime shows
+hero, Twitter will too.

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ dist-electron/
 
 # Git worktrees
 .worktrees/
+.claude/worktrees/
 
 # Native binaries (rebuilt per-platform via electron-rebuild)
 build/
@@ -59,3 +60,14 @@ playwright-report/
 # Superpowers (agent-generated plans/specs)
 .superpowers/
 docs/superpowers/
+
+# Demo capture artifacts (rebuilt per release video; not source)
+packages/app/artifacts/
+
+# Release video build outputs (per-release; never committed)
+# Source of truth is index.html + scripts. Assets (clips, audio, logos) are
+# regenerated/sourced per release, not stored in git.
+videos/*/assets/
+videos/*/renders/
+videos/*/.hyperframes/
+videos/*/node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,17 @@ Key rules at a glance:
 
 In QA mode, flag any code that doesn't match DESIGN.md.
 
+## Release videos
+
+When asked to make a launch / release / announcement video for Spool,
+invoke the `launch-video` skill. It covers the capture pipeline, the
+HyperFrames composition layout, common pitfalls, and the social-media
+poster trick.
+
+- Capture primitives live in `packages/app/e2e/helpers/`
+  (`native-window-capture.ts`, `demo-fixtures.ts`, `demo-launch.ts`,
+  `demo-interactions.ts`).
+- The composition skeleton lives at `videos/launch-template/`.
+- Per-release assets (raw `.mov`, audio, renders) are gitignored —
+  source of truth is the composition `index.html` plus the helpers.
+

--- a/packages/app/e2e/helpers/demo-fixtures.ts
+++ b/packages/app/e2e/helpers/demo-fixtures.ts
@@ -1,0 +1,209 @@
+/**
+ * Build programmatic Claude / Codex / Gemini fixture files for a release demo.
+ *
+ * Different from the static fixtures in `e2e/fixtures/` — those are for the
+ * regular test suite. This builder is for release video captures where you
+ * want to shape exactly which projects, session titles, and counts the
+ * Library view shows.
+ *
+ * Pass in a `ProjectSeed[]` describing the projects you want to demo, plus
+ * filler topics for padding. Each release writes its own seed.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+export type SessionSource = 'claude' | 'codex'
+
+export interface LeadSession {
+  title: string
+  source: SessionSource
+  /** ISO 8601 timestamp. Determines sort order in Recent. */
+  iso: string
+}
+
+export interface ProjectSeed {
+  /** Project name as shown in sidebar. */
+  name: string
+  /** Total sessions to show in the count badge. Includes fillers. */
+  total: number
+  /** Real session titles that appear at the top of the project + in Recent. */
+  leadSessions: LeadSession[]
+  /** Round-robin sources used to pad up to `total`. */
+  fillerSources: SessionSource[]
+}
+
+export interface BuildDemoFixturesOptions {
+  /** Filler session titles cycled to pad up to each project's `total`. */
+  fillerTopics?: string[]
+  /** Counter start for synthetic UUIDs. Defaults to 1. */
+  sessionCounterStart?: number
+}
+
+const DEFAULT_FILLER_TOPICS = [
+  'Polish sidebar density',
+  'Tighten the library row hit-area',
+  'Review folder icon balance in the nav',
+  'Confirm title truncation stays graceful',
+  'Stress-test recent buckets after sync',
+  'Compare pinned ordering with production data',
+  'Tune footer status alignment',
+  'Refine session meta rhythm in dark mode',
+  'Check contrast of muted metadata labels',
+  'Prepare a clean first-run screenshot set',
+]
+
+/** Build a deterministic synthetic UUID for fixture session IDs. */
+function toUuid(counter: number): string {
+  return `00000000-0000-4000-8000-${counter.toString(16).padStart(12, '0')}`
+}
+
+function workspacePath(tmpDir: string, name: string): string {
+  return join(tmpDir, 'workspaces', name)
+}
+
+function writeJson(path: string, value: unknown) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, JSON.stringify(value, null, 2), 'utf8')
+}
+
+function writeText(path: string, value: string) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, value, 'utf8')
+}
+
+function makeClaudeSession(sessionId: string, cwd: string, title: string, iso: string): string {
+  const followupIso = new Date(Date.parse(iso) + 45_000).toISOString()
+  return [
+    JSON.stringify({
+      type: 'custom-title',
+      sessionId,
+      cwd,
+      customTitle: title,
+    }),
+    JSON.stringify({
+      type: 'user',
+      sessionId,
+      cwd,
+      uuid: `${sessionId}-u1`,
+      timestamp: iso,
+      message: {
+        role: 'user',
+        content: `Help me with: ${title}`,
+      },
+    }),
+    JSON.stringify({
+      type: 'assistant',
+      uuid: `${sessionId}-a1`,
+      parentUuid: `${sessionId}-u1`,
+      timestamp: followupIso,
+      message: {
+        role: 'assistant',
+        model: 'claude-sonnet-4.20250514',
+        content: [
+          {
+            type: 'text',
+            text: `Working through ${title} with the latest shell and sidebar assumptions.`,
+          },
+        ],
+      },
+    }),
+  ].join('\n') + '\n'
+}
+
+function makeCodexSession(sessionId: string, cwd: string, title: string, iso: string): string {
+  const t0 = new Date(Date.parse(iso) + 2_000).toISOString()
+  const t1 = new Date(Date.parse(iso) + 10_000).toISOString()
+  return [
+    JSON.stringify({
+      timestamp: iso,
+      type: 'session_meta',
+      payload: { id: sessionId, cwd },
+    }),
+    JSON.stringify({
+      timestamp: t0,
+      type: 'turn_context',
+      payload: { model: 'gpt-5.4', cwd },
+    }),
+    JSON.stringify({
+      timestamp: t0,
+      type: 'event_msg',
+      payload: { type: 'user_message', message: title },
+    }),
+    JSON.stringify({
+      timestamp: t1,
+      type: 'event_msg',
+      payload: { type: 'agent_message', message: `Shaping a rollout plan for ${title}.` },
+    }),
+  ].join('\n') + '\n'
+}
+
+/**
+ * Materialize Claude/Codex/Gemini fixture files under `tmpDir` shaped by the
+ * given project seed. The caller is responsible for setting the matching
+ * SPOOL_*_DIR env vars when launching Electron.
+ */
+export function buildDemoFixtures(
+  tmpDir: string,
+  projects: ProjectSeed[],
+  options: BuildDemoFixturesOptions = {},
+): void {
+  const claudeDir = join(tmpDir, 'claude', 'projects')
+  const codexDir = join(tmpDir, 'codex', 'sessions')
+  const geminiHome = join(tmpDir, 'gemini-cli-home')
+  const dataDir = join(tmpDir, 'data')
+
+  const fillerTopics = options.fillerTopics ?? DEFAULT_FILLER_TOPICS
+  let sessionCounter = options.sessionCounterStart ?? 1
+
+  mkdirSync(claudeDir, { recursive: true })
+  mkdirSync(codexDir, { recursive: true })
+  mkdirSync(join(geminiHome, '.gemini'), { recursive: true })
+  mkdirSync(dataDir, { recursive: true })
+
+  writeJson(join(dataDir, 'ui.json'), {
+    themeSource: 'dark',
+    sidebarCollapsed: false,
+    spoolDaemonNoticeShown: true,
+  })
+  writeJson(join(geminiHome, '.gemini', 'projects.json'), { projects: {} })
+
+  for (const project of projects) {
+    const cwd = workspacePath(tmpDir, project.name)
+    mkdirSync(cwd, { recursive: true })
+
+    const sessions: LeadSession[] = [...project.leadSessions]
+    const fillerCount = Math.max(0, project.total - project.leadSessions.length)
+    for (let i = 0; i < fillerCount; i += 1) {
+      const source = project.fillerSources[i % project.fillerSources.length]
+      const dayOffset = 3 + Math.floor(i / 4)
+      const hour = 17 - (i % 6)
+      const minute = (i * 7) % 60
+      sessions.push({
+        title: `${fillerTopics[i % fillerTopics.length]} ${i + 1}`,
+        source,
+        iso: new Date(Date.UTC(2026, 4, Math.max(1, 10 - dayOffset), hour, minute, 0)).toISOString(),
+      })
+    }
+
+    sessions.forEach((session, index) => {
+      const sessionId = toUuid(sessionCounter++)
+      if (session.source === 'claude') {
+        const relDir = join(claudeDir, project.name.toLowerCase())
+        const filePath = join(relDir, `${project.name.toLowerCase()}-${String(index + 1).padStart(3, '0')}.jsonl`)
+        writeText(filePath, makeClaudeSession(sessionId, cwd, session.title, session.iso))
+        return
+      }
+
+      const date = new Date(session.iso)
+      const relDir = join(
+        codexDir,
+        String(date.getUTCFullYear()),
+        String(date.getUTCMonth() + 1).padStart(2, '0'),
+        String(date.getUTCDate()).padStart(2, '0'),
+      )
+      const slug = `rollout-${session.iso.replace(/:/g, '-').replace('.000Z', 'Z').replace('T', 'T')}-${sessionId}.jsonl`
+      const filePath = join(relDir, slug)
+      writeText(filePath, makeCodexSession(sessionId, cwd, session.title, session.iso))
+    })
+  }
+}

--- a/packages/app/e2e/helpers/demo-interactions.ts
+++ b/packages/app/e2e/helpers/demo-interactions.ts
@@ -1,0 +1,58 @@
+/**
+ * Spool-specific UI interactions that release-video capture scripts reach for.
+ * Kept thin and orthogonal — combine them in per-release recording flows.
+ */
+import { expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+
+import type { AppContext } from './demo-launch'
+
+export type UpdateStatusPayload =
+  | { status: 'available'; version: string }
+  | { status: 'downloading'; percent: number }
+  | { status: 'ready'; version: string }
+  | { status: 'error'; message?: string }
+
+/**
+ * Push an updater-state IPC event into the renderer so the Auto-update banner
+ * paints the requested state without needing a real download cycle.
+ */
+export async function emitUpdateStatus(app: ElectronApplication, payload: UpdateStatusPayload): Promise<void> {
+  await app.evaluate(async ({ BrowserWindow }, data) => {
+    const win = BrowserWindow.getAllWindows()[0]
+    if (!win) throw new Error('No Electron window found')
+    win.webContents.send('spool:update-status', data)
+  }, payload)
+  await new Promise(resolve => setTimeout(resolve, 200))
+}
+
+/**
+ * Click the first session row inside the given project and press its pin
+ * button (revealed on hover). Returns the pinned session's UUID for follow-up
+ * assertions.
+ */
+export async function pinFirstRowInProject(window: Page, projectName: string): Promise<string> {
+  const projectRow = window.locator('[data-testid="sidebar-project-row"]').filter({ hasText: projectName }).first()
+  await expect(projectRow).toBeVisible({ timeout: 5000 })
+  await projectRow.click()
+  const sessionRow = window.locator('[data-testid="session-row"]').first()
+  await expect(sessionRow).toBeVisible({ timeout: 5000 })
+  const uuid = await sessionRow.getAttribute('data-session-uuid')
+  if (!uuid) throw new Error('First session row has no data-session-uuid')
+  await sessionRow.hover()
+  await sessionRow.locator('[data-testid="pin-button"]').click()
+  return uuid
+}
+
+/**
+ * Reset a demo context by closing the existing app and relaunching with the
+ * same seed. Useful between recording passes that mutate state (pinning,
+ * collapsing sidebar, etc).
+ */
+export async function resetDemoContext(
+  ctx: AppContext,
+  relaunch: () => Promise<AppContext>,
+): Promise<AppContext> {
+  await ctx.cleanup()
+  return relaunch()
+}

--- a/packages/app/e2e/helpers/demo-launch.ts
+++ b/packages/app/e2e/helpers/demo-launch.ts
@@ -1,0 +1,88 @@
+/**
+ * Launch the Spool Electron app pre-seeded with a programmatic project list
+ * for release-video captures. Separate from `launchApp()` in `launch.ts`,
+ * which uses the static test fixtures.
+ */
+import { _electron as electron, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { buildDemoFixtures, type ProjectSeed, type BuildDemoFixturesOptions } from './demo-fixtures'
+
+const APP_DIR = join(__dirname, '..', '..')
+
+export interface AppContext {
+  app: ElectronApplication
+  window: Page
+  tmpDir: string
+  cleanup: () => Promise<void>
+}
+
+/**
+ * Build demo fixtures under a fresh tmpdir and launch Electron pointing at
+ * them. Forces dark mode and disables GPU for deterministic frames.
+ */
+export async function launchDemoApp(
+  projects: ProjectSeed[],
+  fixtureOptions: BuildDemoFixturesOptions = {},
+): Promise<AppContext> {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'spool-demo-capture-'))
+  buildDemoFixtures(tmpDir, projects, fixtureOptions)
+
+  const env: Record<string, string> = {
+    ...process.env as Record<string, string>,
+    SPOOL_DATA_DIR: join(tmpDir, 'data'),
+    SPOOL_ELECTRON_USER_DATA_DIR: join(tmpDir, 'electron-user-data'),
+    SPOOL_HOME: join(tmpDir, 'spool-home'),
+    SPOOL_CLAUDE_DIR: join(tmpDir, 'claude', 'projects'),
+    SPOOL_CODEX_DIR: join(tmpDir, 'codex', 'sessions'),
+    SPOOL_GEMINI_DIR: join(tmpDir, 'gemini-cli-home'),
+    GEMINI_CLI_HOME: join(tmpDir, 'gemini-cli-home'),
+    ELECTRON_DISABLE_GPU: '1',
+    SPOOL_E2E_TEST: '1',
+  }
+
+  const args = [join(APP_DIR, 'out', 'main', 'index.js')]
+  if (process.platform === 'linux') args.unshift('--no-sandbox')
+
+  const app = await electron.launch({ args, cwd: APP_DIR, env })
+  const window = await app.firstWindow()
+
+  return {
+    app,
+    window,
+    tmpDir,
+    cleanup: async () => {
+      await app.close()
+      rmSync(tmpDir, { recursive: true, force: true })
+    },
+  }
+}
+
+/**
+ * Force the Electron window into the given logical size + dark theme.
+ * Use `1080×740` to match the app's documented default for release videos.
+ */
+export async function setDemoWindowBounds(ctx: AppContext, width: number, height: number): Promise<void> {
+  await ctx.app.evaluate(async ({ app, BrowserWindow, nativeTheme }, bounds) => {
+    nativeTheme.themeSource = 'dark'
+    const win = BrowserWindow.getAllWindows()[0]
+    if (!win) throw new Error('No Electron window found')
+    win.setBounds(bounds)
+    win.center()
+    win.show()
+    app.focus({ steal: true })
+  }, { width, height })
+  await ctx.window.emulateMedia({ colorScheme: 'dark' })
+  await ctx.window.waitForTimeout(300)
+}
+
+/**
+ * Block until the library finishes its initial sync — status footer reports
+ * a non-zero session count.
+ */
+export async function waitForDemoSync(window: Page): Promise<void> {
+  await expect(window.locator('[data-testid="status-text"]')).toContainText(/[1-9]\d*\s+session/, { timeout: 15000 })
+}

--- a/packages/app/e2e/helpers/native-window-capture.ts
+++ b/packages/app/e2e/helpers/native-window-capture.ts
@@ -1,0 +1,173 @@
+/**
+ * macOS-only helpers for capturing the Spool Electron window as a real OS window
+ * (with traffic lights, rounded corners, shadow — not the WebContents-only
+ * renderer screenshot Playwright produces by default).
+ *
+ * Used by ad-hoc release-video recording scripts. Not part of the regular
+ * e2e suite. Requires `swift` and `screencapture` on PATH (Xcode CLT).
+ */
+import type { ElectronApplication } from '@playwright/test'
+import { execFileSync, spawn } from 'node:child_process'
+import { mkdirSync, rmSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+export interface NativeWindowInfo {
+  id: string
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/**
+ * Find the Quartz window-id that corresponds to the Electron app's
+ * front-most BrowserWindow. We use the Electron pid + bounds reported by
+ * `BrowserWindow.getBounds()` to disambiguate when multiple windows exist.
+ */
+export async function nativeWindowInfo(app: ElectronApplication): Promise<NativeWindowInfo> {
+  const meta = await app.evaluate(async ({ BrowserWindow }) => {
+    const win = BrowserWindow.getAllWindows()[0]
+    if (!win) throw new Error('No Electron window found')
+    const bounds = win.getBounds()
+    return {
+      pid: process.pid,
+      width: bounds.width,
+      height: bounds.height,
+      x: bounds.x,
+      y: bounds.y,
+    }
+  })
+
+  const swiftScript = `
+import CoreGraphics
+import Foundation
+
+let targetPid = Int(CommandLine.arguments[1])!
+let targetWidth = Int(CommandLine.arguments[2])!
+let targetHeight = Int(CommandLine.arguments[3])!
+let targetX = Int(CommandLine.arguments[4])!
+let targetY = Int(CommandLine.arguments[5])!
+
+let list = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] ?? []
+
+struct Candidate {
+  let id: Int
+  let score: Int
+  let x: Int
+  let y: Int
+  let width: Int
+  let height: Int
+}
+
+func number(_ any: Any?) -> Int? {
+  if let n = any as? NSNumber { return n.intValue }
+  if let n = any as? Int { return n }
+  return nil
+}
+
+var best: Candidate?
+
+for item in list {
+  guard number(item["kCGWindowOwnerPID"]) == targetPid else { continue }
+  guard number(item["kCGWindowLayer"]) == 0 else { continue }
+  guard let bounds = item["kCGWindowBounds"] as? [String: Any] else { continue }
+  guard let width = number(bounds["Width"]),
+        let height = number(bounds["Height"]),
+        let x = number(bounds["X"]),
+        let y = number(bounds["Y"]),
+        let windowId = number(item["kCGWindowNumber"]) else { continue }
+
+  let score = abs(width - targetWidth) + abs(height - targetHeight) + abs(x - targetX) + abs(y - targetY)
+  if best == nil || score < best!.score {
+    best = Candidate(id: windowId, score: score, x: x, y: y, width: width, height: height)
+  }
+}
+
+if let best {
+  print("{\\"id\\":\\"\\(best.id)\\",\\"x\\":\\(best.x),\\"y\\":\\(best.y),\\"width\\":\\(best.width),\\"height\\":\\(best.height)}")
+} else {
+  fputs("No matching Quartz window found\\n", stderr)
+  Foundation.exit(1)
+}
+`
+
+  const raw = execFileSync('swift', [
+    '-e',
+    swiftScript,
+    String(meta.pid),
+    String(meta.width),
+    String(meta.height),
+    String(meta.x),
+    String(meta.y),
+  ], { encoding: 'utf8' }).trim()
+
+  return JSON.parse(raw) as NativeWindowInfo
+}
+
+/**
+ * Capture a single PNG of the native window (includes traffic lights + rounded
+ * corners + shadow). Output path is created if missing.
+ */
+export async function captureNativeWindow(app: ElectronApplication, outputPath: string): Promise<void> {
+  await app.evaluate(async ({ app: electronApp, BrowserWindow }) => {
+    const win = BrowserWindow.getAllWindows()[0]
+    if (!win) throw new Error('No Electron window found')
+    win.show()
+    win.focus()
+    electronApp.focus({ steal: true })
+  })
+
+  const info = await nativeWindowInfo(app)
+  mkdirSync(dirname(outputPath), { recursive: true })
+  execFileSync('screencapture', ['-x', '-l', info.id, outputPath])
+}
+
+/**
+ * Record the native window to .mov for the given duration. The `perform`
+ * callback runs concurrently with the recording — use it to drive the app
+ * through the interactions you want filmed. Returns when screencapture exits.
+ *
+ * Note: macOS `screencapture -V` records the rectangle area (which we set to
+ * the exact native window bounds). The system cursor is NOT included; if you
+ * want a cursor in frame, add `-C` to the args.
+ */
+export async function recordNativeWindow(
+  app: ElectronApplication,
+  outputPath: string,
+  seconds: number,
+  perform: () => Promise<void>,
+): Promise<void> {
+  await app.evaluate(async ({ app: electronApp, BrowserWindow }) => {
+    const win = BrowserWindow.getAllWindows()[0]
+    if (!win) throw new Error('No Electron window found')
+    win.show()
+    win.focus()
+    electronApp.focus({ steal: true })
+  })
+
+  const info = await nativeWindowInfo(app)
+  mkdirSync(dirname(outputPath), { recursive: true })
+  rmSync(outputPath, { force: true })
+
+  const rect = `${info.x},${info.y},${info.width},${info.height}`
+  const proc = spawn('screencapture', ['-x', '-V', String(seconds), '-R', rect, outputPath], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  await perform()
+
+  await new Promise<void>((resolve, reject) => {
+    let stderr = ''
+    proc.stderr?.on('data', chunk => {
+      stderr += String(chunk)
+    })
+    proc.on('close', code => {
+      if (code === 0) {
+        resolve()
+        return
+      }
+      reject(new Error(`screencapture failed (${code}): ${stderr.trim()}`))
+    })
+    proc.on('error', reject)
+  })
+}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -59,6 +59,13 @@
         "repo": "spool"
       }
     ],
+    "files": [
+      "**/*",
+      "!e2e/**/*",
+      "!artifacts/**/*",
+      "!src/**/*",
+      "!**/*.map"
+    ],
     "asarUnpack": [
       "node_modules/better-sqlite3/**",
       "node_modules/bindings/**",

--- a/videos/README.md
+++ b/videos/README.md
@@ -1,0 +1,96 @@
+# Release videos
+
+Production pipeline for Spool's release announcement videos (Twitter / X clips).
+
+Each release gets a directory: `videos/spool-vX.Y.Z/`. The flow is:
+
+1. **Capture** raw `.mov` clips from a real Electron build via the e2e helpers
+2. **Compose** the clips into a HyperFrames timeline based on the template
+3. **Render** to MP4
+4. **Post-process** the first frame so social-media auto-thumbnails grab something
+   informative
+
+For the underlying methodology (text-panel + window layout, annotation tracking,
+common pitfalls, beat sync), invoke the `launch-video` skill — it walks Claude
+Code through the workflow with current best practices. This README is the
+human-facing entry point.
+
+## Capture (macOS only)
+
+The helpers under `packages/app/e2e/helpers/` are the building blocks:
+
+- `demo-fixtures.ts` — `buildDemoFixtures(tmpDir, projects)` writes Claude /
+  Codex / Gemini fixture files for a programmatic project list. Per release,
+  you author a fresh `ProjectSeed[]` that reflects what the demo should show.
+- `demo-launch.ts` — `launchDemoApp(seed)` + `setDemoWindowBounds(ctx, w, h)`
+  launch the Electron app pointing at those fixtures, force dark mode, and set
+  the canonical `1080×740` window size.
+- `demo-interactions.ts` — Spool-specific UI helpers: `emitUpdateStatus()` (push
+  updater banner state via IPC without a real download), `pinFirstRowInProject()`
+  (hover + click the pin button on the first row).
+- `native-window-capture.ts` — macOS-native screen capture: `recordNativeWindow()`
+  uses `screencapture -V -R` against the Quartz window id (resolved via a tiny
+  Swift one-liner so we get the right window when multiple are open).
+
+For each release you write a small ad-hoc Playwright spec that imports these
+helpers and choreographs the clips you want — typically one `.mov` per feature.
+Output goes to `videos/<release>/assets/live/`.
+
+The spec is **per-release and not committed**. After the release ships you can
+delete it; the helpers stay.
+
+## Compose
+
+`videos/launch-template/` is the starting point — a HyperFrames composition
+skeleton with the proven layout (left text panel + right UI window + amber
+feature annotations + Spool brand mark). Copy it to `videos/spool-vX.Y.Z/`,
+swap in your clips, update panel copy and annotation coords per feature.
+
+```bash
+cp -r videos/launch-template videos/spool-vX.Y.Z
+cd videos/spool-vX.Y.Z
+# drop your .mov clips into assets/live/
+# edit index.html — panel copy, scene order, annotation %s
+npm run check       # lint + validate + inspect
+npm run dev         # live preview
+```
+
+Coordinates for annotations (the amber outline + label that highlights a
+feature region) need to be measured fresh from your captured clips — the
+positions change every release. The skill explains how.
+
+## Render
+
+```bash
+npm run render -- --quality standard --output renders/spool-vX.Y.Z-final.mp4
+```
+
+Then patch the first frame so social-media auto-thumbnails grab the hero
+state instead of the leading black frame `screencapture` sometimes emits:
+
+```bash
+ffmpeg -i renders/spool-vX.Y.Z-final.mp4 \
+  -vf "tpad=start_mode=clone:start_duration=0.5" \
+  -af "adelay=500|500" \
+  -c:v libx264 -preset slow -crf 18 \
+  -c:a aac -b:a 192k -pix_fmt yuv420p -movflags +faststart \
+  renders/spool-vX.Y.Z-poster.mp4
+```
+
+## What lives where
+
+| | Where |
+|---|---|
+| Capture primitives | `packages/app/e2e/helpers/` (committed) |
+| Per-release seed + recording spec | ad-hoc, not committed |
+| Composition skeleton | `videos/launch-template/` (committed) |
+| Per-release composition source | `videos/spool-vX.Y.Z/index.html` etc. (committed) |
+| Per-release `assets/` (clips, audio, logos) | gitignored — regenerated per release |
+| Rendered `.mp4` / poster `.jpg` | `videos/*/renders/` (gitignored — ship to social, not git) |
+| Methodology + checklists | the `launch-video` skill |
+
+The `assets/` directory under each release is **entirely gitignored**. Raw
+`.mov` captures come from the e2e helpers; audio tracks are sourced per
+release (licensing varies); Spool brand assets (logo SVGs) should be
+referenced from the main repo or inlined into `index.html`, not duplicated
+into each video project.

--- a/videos/README.md
+++ b/videos/README.md
@@ -7,44 +7,26 @@ Each release gets a directory: `videos/spool-vX.Y.Z/`. The flow is:
 1. **Capture** raw `.mov` clips from a real Electron build via the e2e helpers
 2. **Compose** the clips into a HyperFrames timeline based on the template
 3. **Render** to MP4
-4. **Post-process** the first frame so social-media auto-thumbnails grab something
-   informative
+4. **Post-process** the first frame so social-media auto-thumbnails grab something informative
 
-For the underlying methodology (text-panel + window layout, annotation tracking,
-common pitfalls, beat sync), invoke the `launch-video` skill — it walks Claude
-Code through the workflow with current best practices. This README is the
-human-facing entry point.
+For the underlying methodology (text-panel + window layout, annotation tracking, common pitfalls, beat sync), invoke the `launch-video` skill — it walks Claude Code through the workflow with current best practices. This README is the human-facing entry point.
 
 ## Capture (macOS only)
 
 The helpers under `packages/app/e2e/helpers/` are the building blocks:
 
-- `demo-fixtures.ts` — `buildDemoFixtures(tmpDir, projects)` writes Claude /
-  Codex / Gemini fixture files for a programmatic project list. Per release,
-  you author a fresh `ProjectSeed[]` that reflects what the demo should show.
-- `demo-launch.ts` — `launchDemoApp(seed)` + `setDemoWindowBounds(ctx, w, h)`
-  launch the Electron app pointing at those fixtures, force dark mode, and set
-  the canonical `1080×740` window size.
-- `demo-interactions.ts` — Spool-specific UI helpers: `emitUpdateStatus()` (push
-  updater banner state via IPC without a real download), `pinFirstRowInProject()`
-  (hover + click the pin button on the first row).
-- `native-window-capture.ts` — macOS-native screen capture: `recordNativeWindow()`
-  uses `screencapture -V -R` against the Quartz window id (resolved via a tiny
-  Swift one-liner so we get the right window when multiple are open).
+- `demo-fixtures.ts` — `buildDemoFixtures(tmpDir, projects)` writes Claude / Codex / Gemini fixture files for a programmatic project list. Per release, you author a fresh `ProjectSeed[]` that reflects what the demo should show.
+- `demo-launch.ts` — `launchDemoApp(seed)` + `setDemoWindowBounds(ctx, w, h)` launch the Electron app pointing at those fixtures, force dark mode, and set the canonical `1080×740` window size.
+- `demo-interactions.ts` — Spool-specific UI helpers: `emitUpdateStatus()` (push updater banner state via IPC without a real download), `pinFirstRowInProject()` (hover + click the pin button on the first row).
+- `native-window-capture.ts` — macOS-native screen capture: `recordNativeWindow()` uses `screencapture -V -R` against the Quartz window id (resolved via a tiny Swift one-liner so we get the right window when multiple are open).
 
-For each release you write a small ad-hoc Playwright spec that imports these
-helpers and choreographs the clips you want — typically one `.mov` per feature.
-Output goes to `videos/<release>/assets/live/`.
+For each release you write a small ad-hoc Playwright spec that imports these helpers and choreographs the clips you want — typically one `.mov` per feature. Output goes to `videos/<release>/assets/live/`.
 
-The spec is **per-release and not committed**. After the release ships you can
-delete it; the helpers stay.
+The spec is **per-release and not committed**. After the release ships you can delete it; the helpers stay.
 
 ## Compose
 
-`videos/launch-template/` is the starting point — a HyperFrames composition
-skeleton with the proven layout (left text panel + right UI window + amber
-feature annotations + Spool brand mark). Copy it to `videos/spool-vX.Y.Z/`,
-swap in your clips, update panel copy and annotation coords per feature.
+`videos/launch-template/` is the starting point — a HyperFrames composition skeleton with the proven layout (left text panel + right UI window + amber feature annotations + Spool brand mark). Copy it to `videos/spool-vX.Y.Z/`, swap in your clips, update panel copy and annotation coords per feature.
 
 ```bash
 cp -r videos/launch-template videos/spool-vX.Y.Z
@@ -55,9 +37,7 @@ npm run check       # lint + validate + inspect
 npm run dev         # live preview
 ```
 
-Coordinates for annotations (the amber outline + label that highlights a
-feature region) need to be measured fresh from your captured clips — the
-positions change every release. The skill explains how.
+Coordinates for annotations (the amber outline + label that highlights a feature region) need to be measured fresh from your captured clips — the positions change every release. The skill explains how.
 
 ## Render
 
@@ -65,8 +45,7 @@ positions change every release. The skill explains how.
 npm run render -- --quality standard --output renders/spool-vX.Y.Z-final.mp4
 ```
 
-Then patch the first frame so social-media auto-thumbnails grab the hero
-state instead of the leading black frame `screencapture` sometimes emits:
+Then patch the first frame so social-media auto-thumbnails grab the hero state instead of the leading black frame `screencapture` sometimes emits:
 
 ```bash
 ffmpeg -i renders/spool-vX.Y.Z-final.mp4 \
@@ -89,8 +68,4 @@ ffmpeg -i renders/spool-vX.Y.Z-final.mp4 \
 | Rendered `.mp4` / poster `.jpg` | `videos/*/renders/` (gitignored — ship to social, not git) |
 | Methodology + checklists | the `launch-video` skill |
 
-The `assets/` directory under each release is **entirely gitignored**. Raw
-`.mov` captures come from the e2e helpers; audio tracks are sourced per
-release (licensing varies); Spool brand assets (logo SVGs) should be
-referenced from the main repo or inlined into `index.html`, not duplicated
-into each video project.
+The `assets/` directory under each release is **entirely gitignored**. Raw `.mov` captures come from the e2e helpers; audio tracks are sourced per release (licensing varies); Spool brand assets (logo SVGs) should be referenced from the main repo or inlined into `index.html`, not duplicated into each video project.

--- a/videos/launch-template/README.md
+++ b/videos/launch-template/README.md
@@ -1,7 +1,6 @@
 # Launch video template
 
-Starting point for a Spool release video. Copy this directory to
-`videos/spool-vX.Y.Z/`, fill in the placeholders, render.
+Starting point for a Spool release video. Copy this directory to `videos/spool-vX.Y.Z/`, fill in the placeholders, render.
 
 ## Layout (do not change without reason)
 
@@ -15,29 +14,17 @@ Starting point for a Spool release video. Copy this directory to
 - Per-feature amber annotation rectangles (inside `.window`, so they track the camera)
 - Outro fades to a `Spool.` lockup + version
 
-The proven aesthetic decisions live in the `launch-video` skill — read its
-`references/composition.md` and `references/pitfalls.md` before deviating.
+The proven aesthetic decisions live in the `launch-video` skill — read its `references/composition.md` and `references/pitfalls.md` before deviating.
 
 ## Per-release customisation
 
-The whole `assets/` directory under each release is **gitignored** — drop
-clips, audio, and logos in there, but never commit them. They're regenerated
-or re-sourced per release.
+The whole `assets/` directory under each release is **gitignored** — drop clips, audio, and logos in there, but never commit them. They're regenerated or re-sourced per release.
 
-1. Drop clips into `assets/live/` (one `.mov` per feature). Name them
-   `01-<feature>.mov`, `02-<feature>.mov`, etc.
-2. Update each `<video>` element in `index.html`:
-   - `id`, `src`, `data-start`, `data-duration`
-3. Update the text panels in `index.html`:
-   - kicker number + feature name
-   - headline (2 lines)
-   - sub copy
-4. Re-measure annotation coords for each feature region. The UI changes between
-   releases — last release's `top: 15%` will be wrong for this release. The
-   skill's `references/composition.md` explains how to measure.
-5. Pick a BGM track and drop it as `assets/bgm.mp3`. Licensing varies, source
-   per release. Beat-sync key camera moves to the strong beats
-   (`ffmpeg silencedetect` to find them).
+1. Drop clips into `assets/live/` (one `.mov` per feature). Name them `01-<feature>.mov`, `02-<feature>.mov`, etc.
+2. Update each `<video>` element in `index.html`: `id`, `src`, `data-start`, `data-duration`.
+3. Update the text panels in `index.html`: kicker number + feature name, headline (2 lines), sub copy.
+4. Re-measure annotation coords for each feature region. The UI changes between releases — last release's `top: 15%` will be wrong for this release. The skill's `references/composition.md` explains how to measure.
+5. Pick a BGM track and drop it as `assets/bgm.mp3`. Licensing varies, source per release. Beat-sync key camera moves to the strong beats (`ffmpeg silencedetect` to find them).
 
 ## Run
 

--- a/videos/launch-template/README.md
+++ b/videos/launch-template/README.md
@@ -1,0 +1,49 @@
+# Launch video template
+
+Starting point for a Spool release video. Copy this directory to
+`videos/spool-vX.Y.Z/`, fill in the placeholders, render.
+
+## Layout (do not change without reason)
+
+- Canvas 1920×1080
+- Left text panel at `x=132`, vertically centered around `y=540`
+  - Persistent `Spool. vX.Y.Z · LAUNCH` brand mark in upper-left
+  - Per-scene `panel-kicker` (mono) + `panel-headline` (sans, 2 lines) + `panel-sub`
+- Right window at `x=700, top=197, 1000×685, border-radius: 8px`
+  - Layered drop-shadow for "floating" feel
+  - Per-scene clip swap via opacity (instant), camera focus via `transform-origin + scale`
+- Per-feature amber annotation rectangles (inside `.window`, so they track the camera)
+- Outro fades to a `Spool.` lockup + version
+
+The proven aesthetic decisions live in the `launch-video` skill — read its
+`references/composition.md` and `references/pitfalls.md` before deviating.
+
+## Per-release customisation
+
+The whole `assets/` directory under each release is **gitignored** — drop
+clips, audio, and logos in there, but never commit them. They're regenerated
+or re-sourced per release.
+
+1. Drop clips into `assets/live/` (one `.mov` per feature). Name them
+   `01-<feature>.mov`, `02-<feature>.mov`, etc.
+2. Update each `<video>` element in `index.html`:
+   - `id`, `src`, `data-start`, `data-duration`
+3. Update the text panels in `index.html`:
+   - kicker number + feature name
+   - headline (2 lines)
+   - sub copy
+4. Re-measure annotation coords for each feature region. The UI changes between
+   releases — last release's `top: 15%` will be wrong for this release. The
+   skill's `references/composition.md` explains how to measure.
+5. Pick a BGM track and drop it as `assets/bgm.mp3`. Licensing varies, source
+   per release. Beat-sync key camera moves to the strong beats
+   (`ffmpeg silencedetect` to find them).
+
+## Run
+
+```bash
+npm install
+npm run check       # hyperframes lint + validate + inspect
+npm run dev         # preview in browser
+npm run render -- --quality standard --output renders/final.mp4
+```

--- a/videos/launch-template/index.html
+++ b/videos/launch-template/index.html
@@ -1,0 +1,406 @@
+<!doctype html>
+<!--
+  Spool launch video template.
+  Copy this directory to videos/spool-vX.Y.Z/, then:
+    1. Drop clips into assets/live/ (.gitignored)
+    2. Drop bgm.mp3 into assets/ (.gitignored)
+    3. Edit panels + clip data-start/data-duration + annotation coords
+    4. npm run check && npm run render
+
+  Layout (do not change without reason — see references/composition.md in the
+  launch-video skill):
+    - 1920×1080 canvas
+    - Left text panel at x=132, vertically centered (~y=540)
+    - Persistent Spool. brand mark top-left
+    - Right window at left=700, top=197, 1000×685, border-radius: 8px
+    - Per-feature amber annotation rectangles INSIDE .window so they track
+      the camera (transform-origin + scale)
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      @import url("https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700;800&family=Geist+Mono:wght@400;500;700&display=swap");
+
+      :root {
+        --bg: #141410;
+        --text: #f2f2ec;
+        --muted: rgba(242, 242, 236, 0.46);
+        --soft: rgba(242, 242, 236, 0.78);
+        --accent: #f07020;
+      }
+
+      * { box-sizing: border-box; }
+
+      html, body {
+        margin: 0;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: var(--bg);
+        color: var(--text);
+        font-family: "Geist", sans-serif;
+        -webkit-font-smoothing: antialiased;
+      }
+      body { position: relative; }
+
+      #root {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: var(--bg);
+      }
+
+      /* ---- Text panel (left) ---- */
+      .panel {
+        position: absolute;
+        left: 132px;
+        top: 410px;
+        width: 540px;
+        z-index: 10;
+        opacity: 0;
+      }
+      .panel-kicker {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        font-family: "Geist Mono", monospace;
+        font-size: 13px;
+        letter-spacing: 0.30em;
+        text-transform: uppercase;
+        color: var(--soft);
+        margin-bottom: 28px;
+      }
+      .panel-kicker .bar {
+        display: inline-block;
+        width: 40px;
+        height: 2px;
+        background: var(--accent);
+      }
+      .panel-kicker .index { color: var(--text); }
+      .panel-headline {
+        font-size: 70px;
+        line-height: 0.97;
+        font-weight: 600;
+        letter-spacing: -0.05em;
+        color: var(--text);
+      }
+      .panel-headline .word {
+        display: inline-block;
+        opacity: 0;
+        will-change: transform, opacity, filter;
+      }
+      .panel-headline .accent { color: var(--accent); }
+      .panel-sub {
+        margin-top: 32px;
+        font-size: 18px;
+        line-height: 1.45;
+        font-weight: 400;
+        color: var(--soft);
+        opacity: 0;
+      }
+
+      /* First-frame friendly: scene 1 visible at t=0 so social-media auto-thumbnails
+         grab a complete hero state. */
+      #panel1 { opacity: 1; }
+      #panel1 .panel-headline .word { opacity: 1; }
+      #panel1 .panel-sub { opacity: 1; }
+
+      /* ---- Persistent brand mark (top-left, visible from t=0) ---- */
+      .brand-mark {
+        position: absolute;
+        left: 132px;
+        top: 200px;
+        z-index: 9;
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        opacity: 1;
+      }
+      .brand-mark .wordmark {
+        font-size: 26px;
+        font-weight: 700;
+        letter-spacing: -0.045em;
+        color: var(--text);
+      }
+      .brand-mark .wordmark .accent { color: var(--accent); }
+      .brand-mark .version {
+        font-family: "Geist Mono", monospace;
+        font-size: 11px;
+        letter-spacing: 0.30em;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+
+      /* ---- Demo window (right) ---- */
+      .window {
+        position: absolute;
+        top: 197px;
+        left: 700px;
+        width: 1000px;
+        height: 685px;
+        z-index: 5;
+        transform-origin: 50% 50%;
+        border-radius: 8px;
+        overflow: hidden;
+        filter:
+          drop-shadow(0 60px 120px rgba(0, 0, 0, 0.75))
+          drop-shadow(0 24px 48px rgba(0, 0, 0, 0.55))
+          drop-shadow(0 6px 12px rgba(0, 0, 0, 0.35));
+        opacity: 1;
+      }
+      .window-media {
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        position: absolute;
+        top: 0;
+        left: 0;
+        opacity: 0;
+      }
+      .window-media.lead { opacity: 1; }
+
+      /* ---- Feature annotations (inside .window so they track the camera) ---- */
+      .annot {
+        position: absolute;
+        z-index: 20;
+        pointer-events: none;
+        border-radius: 8px;
+        border: 1.8px solid var(--accent);
+        box-shadow:
+          0 0 0 1px rgba(20, 20, 16, 0.5),
+          0 0 26px rgba(240, 112, 32, 0.42);
+        opacity: 0;
+      }
+      .annot-label {
+        position: absolute;
+        font-family: "Geist Mono", monospace;
+        font-size: 9px;
+        letter-spacing: 0.26em;
+        font-weight: 600;
+        text-transform: uppercase;
+        color: var(--accent);
+        background: rgba(20, 20, 16, 0.94);
+        padding: 4px 9px;
+        border-radius: 3px;
+        white-space: nowrap;
+        z-index: 21;
+        opacity: 0;
+        pointer-events: none;
+      }
+      /*
+        ANNOTATION COORDS — measure fresh per release (UI changes between
+        versions). Crop the relevant region out of a raw .mov frame, measure
+        the feature box in pixels, divide by frame size for %.
+        Example values shown are from v0.4.11; replace per release.
+      */
+      #annot-feature-a {
+        left: 1%;
+        top: 15%;
+        width: 21%;
+        height: 16%;
+      }
+      #annot-feature-a-label { left: 1%; top: 10.5%; }
+
+      /* ---- Outro lockup ---- */
+      .outro-scene {
+        position: absolute;
+        inset: 0;
+        z-index: 40;
+        display: none;
+        opacity: 0;
+      }
+      .outro-wrap {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .outro-lockup {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 24px;
+        opacity: 0;
+      }
+      .outro-logo { width: 92px; height: 92px; color: var(--text); }
+      .outro-logo svg { display: block; width: 100%; height: 100%; stroke: currentColor; }
+      .outro-wordmark {
+        font-size: 68px;
+        line-height: 1;
+        font-weight: 700;
+        letter-spacing: -0.05em;
+      }
+      .outro-wordmark .period { color: var(--accent); }
+      .outro-version {
+        font-family: "Geist Mono", monospace;
+        font-size: 13px;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        color: rgba(242, 242, 236, 0.6);
+      }
+      #outro-fade {
+        position: absolute;
+        inset: 0;
+        background: rgba(20, 20, 16, 0.97);
+        opacity: 0;
+        pointer-events: none;
+        z-index: 35;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="main"
+      data-start="0"
+      data-duration="20.00"
+      data-width="1920"
+      data-height="1080"
+    >
+      <audio
+        id="bgm"
+        data-start="0"
+        data-duration="20.00"
+        data-track-index="10"
+        src="assets/bgm.mp3"
+        data-volume="0.92"
+      ></audio>
+
+      <!-- Demo window — drop one <video> per feature -->
+      <div id="window" class="window">
+        <video
+          id="clip-feature-a"
+          class="window-media lead"
+          data-start="0.00"
+          data-duration="2.50"
+          data-track-index="1"
+          src="assets/live/01-feature-a.mov"
+          data-volume="0"
+          muted
+          playsinline
+        ></video>
+        <!-- Add more <video> elements per feature.
+             Example:
+             <video id="clip-feature-b" data-start="3.50" data-duration="3.20"
+                    data-track-index="2" src="assets/live/02-feature-b.mov" ... />
+        -->
+
+        <!-- Feature annotations — repeat per feature with measured coords -->
+        <div id="annot-feature-a" class="annot" aria-hidden="true"></div>
+        <div id="annot-feature-a-label" class="annot-label">Feature A</div>
+      </div>
+
+      <!-- Persistent brand mark -->
+      <div id="brand-mark" class="brand-mark">
+        <div class="wordmark">Spool<span class="accent">.</span></div>
+        <div class="version">vX.Y.Z · Launch</div>
+      </div>
+
+      <!-- Text panels — one per feature scene -->
+      <div id="panel1" class="panel">
+        <div class="panel-kicker">
+          <span class="bar"></span>
+          <span><span class="index">01</span> — Feature A</span>
+        </div>
+        <div class="panel-headline">
+          <span class="word">Headline</span>&nbsp;<span class="word">line</span><br>
+          <span class="word">one,</span>&nbsp;<span class="word">two<span class="accent">.</span></span>
+        </div>
+        <div class="panel-sub">Short supporting copy.<br>One or two lines max.</div>
+      </div>
+      <!-- Add #panel2, #panel3, ... per feature. -->
+
+      <!-- Outro -->
+      <div id="outro-fade" data-layout-ignore></div>
+      <section id="outro" class="outro-scene">
+        <div class="outro-wrap">
+          <div id="outro-lockup" class="outro-lockup">
+            <div class="outro-logo" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+                <ellipse cx="16" cy="9" rx="12" ry="4.5" stroke-width="1.8"></ellipse>
+                <line x1="4" y1="9" x2="4" y2="22" stroke-width="1.8"></line>
+                <line x1="28" y1="9" x2="28" y2="22" stroke-width="1.8"></line>
+                <path d="M4 22 C4 24.5 9 27 16 27 C23 27 28 24.5 28 22" stroke-width="1.8"></path>
+                <ellipse cx="16" cy="11" rx="7" ry="2.5" stroke-width="1.2"></ellipse>
+                <line x1="9" y1="11" x2="9" y2="20" stroke-width="1.2"></line>
+                <line x1="23" y1="11" x2="23" y2="20" stroke-width="1.2"></line>
+                <path d="M9 20 C9 21.5 12 23 16 23 C20 23 23 21.5 23 20" stroke-width="1.2"></path>
+                <ellipse cx="16" cy="11" rx="3" ry="1.2" fill="currentColor" stroke="none"></ellipse>
+              </svg>
+            </div>
+            <div class="outro-wordmark">Spool<span class="period">.</span></div>
+            <div class="outro-version">vX.Y.Z</div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <script>
+      // Minimal timeline skeleton. Add panel-in/out, camera zooms, clip-swaps,
+      // and annotation reveals per release. See references/composition.md in
+      // the launch-video skill for the patterns used in v0.4.11.
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+
+      // Panel helpers
+      function panelIn(sel, at) {
+        tl.set(sel, { opacity: 1 }, at - 0.001);
+        tl.fromTo(`${sel} .panel-kicker`,
+          { x: -10, opacity: 0 },
+          { x: 0, opacity: 1, duration: 0.30, ease: "power3.out" }, at);
+        tl.fromTo(`${sel} .word`,
+          { y: 18, opacity: 0, filter: "blur(6px)" },
+          { y: 0, opacity: 1, filter: "blur(0px)", duration: 0.38, ease: "power3.out", stagger: 0.055 }, at + 0.04);
+        tl.fromTo(`${sel} .panel-sub`,
+          { y: 10, opacity: 0 },
+          { y: 0, opacity: 1, duration: 0.36, ease: "power2.out" }, at + 0.28);
+      }
+      function panelOut(sel, at) {
+        tl.to(`${sel} .panel-kicker`, { x: -8, opacity: 0, duration: 0.26, ease: "power2.in" }, at);
+        tl.to(`${sel} .word`, { y: -12, opacity: 0, filter: "blur(4px)", duration: 0.30, ease: "power2.in" }, at + 0.02);
+        tl.to(`${sel} .panel-sub`, { opacity: 0, duration: 0.24, ease: "power2.in" }, at);
+        tl.set(sel, { opacity: 0 }, at + 0.36);
+      }
+
+      // Camera zoom (transform-origin + scale on .window)
+      function zoomTo(originX, originY, scale, at, duration = 0.60) {
+        tl.to("#window", {
+          transformOrigin: `${originX}% ${originY}%`,
+          scale,
+          duration,
+          ease: "power2.inOut",
+        }, at);
+      }
+
+      // Clip cross-fade (use during camera motion so the swap is hidden)
+      function clipFade(outSel, inSel, at, duration = 0.18) {
+        tl.to(outSel, { opacity: 0, duration, ease: "power2.in" }, at);
+        tl.to(inSel, { opacity: 1, duration, ease: "power2.out" }, at);
+      }
+
+      // Scene 1 — panel 1 is statically visible from t=0 (no panelIn).
+      panelOut("#panel1", 2.95);
+      // zoomTo(8, 50, 1.18, 3.10, 0.55);
+      // clipFade("#clip-feature-a", "#clip-feature-b", 3.50);
+      // ... add per-scene logic.
+
+      // Outro
+      // tl.to("#window", { opacity: 0, duration: 0.50, ease: "power2.in" }, 17.80);
+      // tl.to("#brand-mark", { opacity: 0, duration: 0.45, ease: "power2.in" }, 17.80);
+      // tl.to("#outro-fade", { opacity: 1, duration: 0.45, ease: "power2.inOut" }, 17.95);
+      // tl.set("#outro", { display: "block", opacity: 1 }, 18.30);
+      // tl.fromTo("#outro-lockup",
+      //   { y: 14, opacity: 0, scale: 0.97 },
+      //   { y: 0, opacity: 1, scale: 1, duration: 0.66, ease: "power3.out" }, 18.40);
+      // tl.set("#outro-lockup", { opacity: 1, y: 0, scale: 1 }, 19.30);
+
+      window.__timelines["main"] = tl;
+    </script>
+  </body>
+</html>

--- a/videos/launch-template/package.json
+++ b/videos/launch-template/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "spool-launch-template",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "npx --yes hyperframes@0.6.4 preview",
+    "check": "npx --yes hyperframes@0.6.4 lint && npx --yes hyperframes@0.6.4 validate && npx --yes hyperframes@0.6.4 inspect",
+    "render": "npx --yes hyperframes@0.6.4 render"
+  }
+}


### PR DESCRIPTION
## Summary

Splits the v0.4.11 launch-video work into durable pieces other developers can reuse for future releases.

- **`packages/app/e2e/helpers/`** — four reusable capture primitives:
  - `native-window-capture.ts`: macOS Quartz + `screencapture` for real OS window recordings (traffic lights, rounded corners, shadow)
  - `demo-fixtures.ts`: `ProjectSeed` type + `buildDemoFixtures()` to materialise Claude/Codex/Gemini fixture files programmatically
  - `demo-launch.ts`: `launchDemoApp()` + `setDemoWindowBounds()` boot Electron pointing at seeded fixtures, force dark mode
  - `demo-interactions.ts`: `emitUpdateStatus()` + `pinFirstRowInProject()` UI helpers
- **`videos/launch-template/`** — HyperFrames composition skeleton with the proven layout (left text panel + right window + amber annotations, brand mark, outro). Copy + customise per release.
- **`videos/README.md`** — process entry point.
- **`.claude/skills/launch-video/`** — portable skill walking Claude Code through the workflow. `SKILL.md` + 4 references (composition, capture, pitfalls, poster).
- **`packages/app/package.json`** — `electron-builder` `files[]` excludes `e2e/`, `artifacts/`, `src/`, and `*.map` from shipped builds (avoiding shipping test code + demo capture outputs in the `.dmg`).
- **`.gitignore`** — per-release video `assets/`, `renders/`, `.hyperframes/` and demo-capture artifacts.
- **`CLAUDE.md`** — pointer to the skill from project intro.

Per-release scripts (recording orchestration + composition customisations) are not committed — they're written fresh each release using the helpers + skill. v0.4.11 wasn't included as a worked example because the orchestration and seed data are version-specific.

## Why

- Other contributors making future release videos shouldn't have to redo the discovery work (which window radius matches macOS, what annotation positioning works, why faked cursors look uncanny, how to keep social-media thumbnails from being black, etc.).
- Keeping the helpers in the e2e dir lets future capture specs reuse the existing test-harness app launch + IPC injection patterns.
- Keeping the skill portable (no hardcoded paths into per-release video projects) means it survives multiple releases without rewriting.

## Test plan

- [x] `pnpm --filter @spool/app exec playwright test` — existing e2e suite unaffected (only new helpers added, no existing files modified)
- [x] `npm run check` inside `videos/launch-template/` — HyperFrames lint + validate + inspect pass
- [x] Build smoke: `electron-builder` `files[]` excludes don't break `pnpm --filter @spool/app build:mac` (haven't run locally — adding excludes-only should be safe but worth verifying in CI)
- [x] Invoke the `launch-video` skill from Claude Code — confirm trigger phrases match and references load

🤖 Generated with [Claude Code](https://claude.com/claude-code)