### PR TITLE
test(app): share feature e2e coverage

### DIFF
--- a/packages/app/e2e/helpers/launch.ts
+++ b/packages/app/e2e/helpers/launch.ts
@@ -12,6 +12,7 @@ export interface AppContext {
   app: ElectronApplication
   window: Page
   dbPath: string
+  env: Record<string, string>
   cleanup: () => Promise<void>
 }
 
@@ -59,9 +60,41 @@ export async function launchApp(opts: { mockAgent?: 'success' | 'error' } = {}):
     app,
     window,
     dbPath: join(tmpDir, 'data', 'spool.db'),
+    env,
     cleanup: async () => {
       await app.close()
       rmSync(tmpDir, { recursive: true, force: true })
+    },
+  }
+}
+
+/**
+ * Close the app and re-launch reusing the same env (SPOOL_HOME, data dir,
+ * etc), so any persisted state survives. Returns a fresh AppContext that
+ * shares the same tmpDir + cleanup target. The caller is responsible for
+ * calling cleanup() on the returned context.
+ */
+export async function restartApp(ctx: AppContext): Promise<AppContext> {
+  await ctx.app.close()
+  const args = [join(APP_DIR, 'out', 'main', 'index.js')]
+  if (process.platform === 'linux') args.unshift('--no-sandbox')
+  const app = await electron.launch({ args, cwd: APP_DIR, env: ctx.env })
+  const window = await app.firstWindow()
+  return {
+    app,
+    window,
+    dbPath: ctx.dbPath,
+    env: ctx.env,
+    cleanup: async () => {
+      await app.close()
+      // tmpDir cleanup uses the original env's SPOOL_DATA_DIR's grandparent,
+      // which is what ctx.cleanup also targets. Run the original cleanup
+      // path so the dir gets removed exactly once.
+      const dataDir = ctx.env['SPOOL_DATA_DIR']
+      if (dataDir) {
+        const tmpDir = dataDir.replace(/\/data$/, '')
+        rmSync(tmpDir, { recursive: true, force: true })
+      }
     },
   }
 }

--- a/packages/app/e2e/helpers/share.ts
+++ b/packages/app/e2e/helpers/share.ts
@@ -1,0 +1,289 @@
+import { expect, type Page } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+const FIXTURES_DIR = join(__dirname, '..', 'fixtures')
+
+/**
+ * Click into a session by sessionUuid (drilling down through the first
+ * project row that contains it), then trigger Share from the SessionDetail
+ * header. Leaves the share editor open. Caller is responsible for
+ * `expectShareEditorVisible` if it wants to await readiness.
+ */
+export async function openShareEditorFromSessionDetail(window: Page, sessionUuid: string): Promise<void> {
+  await openSessionDetail(window, sessionUuid)
+  await window.locator('[data-testid="detail-share"]').click()
+  await expect(window.locator('[data-testid="share-editor-page"]')).toBeVisible({ timeout: 5000 })
+}
+
+/**
+ * Open a session by sessionUuid via the first project row containing it.
+ * Does not open the share editor — useful for entry-point tests that want
+ * to verify the ⋯ menu Share item.
+ */
+export async function openSessionDetail(window: Page, sessionUuid: string): Promise<void> {
+  // First make sure a project is selected and SessionRow is in the list.
+  // We don't know which project hosts the session ahead of time, so we
+  // click each project row and look. For fixtures all sessions are under
+  // the single test-project, so the first project row works.
+  await window.locator('[data-testid="sidebar-project-row"]').first().click()
+  const row = window.locator(`[data-testid="session-row"][data-session-uuid="${sessionUuid}"]`)
+  await expect(row).toBeVisible({ timeout: 5000 })
+  await row.click()
+  await expect(window.locator(`[data-testid="session-detail"]`)).toBeVisible({ timeout: 5000 })
+}
+
+/**
+ * Open a SessionRow ⋯ menu and pick "Open in share editor".
+ */
+export async function shareFromSessionRowMenu(window: Page, sessionUuid: string): Promise<void> {
+  await window.locator('[data-testid="sidebar-project-row"]').first().click()
+  const row = window.locator(`[data-testid="session-row"][data-session-uuid="${sessionUuid}"]`)
+  await expect(row).toBeVisible({ timeout: 5000 })
+  await row.hover()
+  await row.getByLabel('More actions').click()
+  await window.getByRole('menuitem', { name: 'Open in share editor' }).click()
+  await expect(window.locator('[data-testid="share-editor-page"]')).toBeVisible({ timeout: 5000 })
+}
+
+/** Navigate the sidebar to the Shares page. */
+export async function navigateToShares(window: Page): Promise<void> {
+  await window.locator('[data-testid="sidebar-shares"]').click()
+  // SharesPage is mounted in App when isSharesView is true; we wait for
+  // either the empty state CTA or the drafts grid to render.
+  await expect(
+    window.locator('[data-testid="shares-empty-start"], [data-testid="shares-draft-row"]').first(),
+  ).toBeVisible({ timeout: 5000 })
+}
+
+/**
+ * Replace `window.showSaveFilePicker` with a stub that captures the bytes
+ * written through createWritable().write() into a global array
+ * `__spoolE2EWrites`. Tests can then read that array after triggering an
+ * export to inspect the produced blob.
+ */
+export async function installSaveFilePickerMock(window: Page): Promise<void> {
+  await window.evaluate(() => {
+    interface CapturedWrite {
+      filename: string
+      bytes: number[]
+    }
+    const winAny = window as unknown as {
+      __spoolE2EWrites: CapturedWrite[]
+      showSaveFilePicker?: unknown
+    }
+    winAny.__spoolE2EWrites = []
+    const fakePicker = (opts: { suggestedName: string }) => {
+      const filename = opts.suggestedName
+      const chunks: Uint8Array[] = []
+      const writable = {
+        write: async (chunk: Blob | ArrayBuffer | Uint8Array | string) => {
+          let bytes: Uint8Array
+          if (chunk instanceof Blob) {
+            bytes = new Uint8Array(await chunk.arrayBuffer())
+          } else if (chunk instanceof Uint8Array) {
+            bytes = chunk
+          } else if (chunk instanceof ArrayBuffer) {
+            bytes = new Uint8Array(chunk)
+          } else {
+            bytes = new TextEncoder().encode(String(chunk))
+          }
+          chunks.push(bytes)
+        },
+        close: async () => {
+          const total = chunks.reduce((n, c) => n + c.length, 0)
+          const merged = new Uint8Array(total)
+          let off = 0
+          for (const c of chunks) {
+            merged.set(c, off)
+            off += c.length
+          }
+          winAny.__spoolE2EWrites.push({ filename, bytes: Array.from(merged) })
+        },
+      }
+      const handle = {
+        kind: 'file' as const,
+        name: filename,
+        createWritable: async () => writable,
+      }
+      return Promise.resolve(handle)
+    }
+    winAny.showSaveFilePicker = fakePicker
+  })
+}
+
+/** Pop the most recent write captured by `installSaveFilePickerMock`. */
+export async function readLastSavedFile(window: Page): Promise<{ filename: string; bytes: Uint8Array } | null> {
+  const result = await window.evaluate(() => {
+    const winAny = window as unknown as {
+      __spoolE2EWrites?: { filename: string; bytes: number[] }[]
+    }
+    const arr = winAny.__spoolE2EWrites ?? []
+    return arr[arr.length - 1] ?? null
+  })
+  if (!result) return null
+  return { filename: result.filename, bytes: new Uint8Array(result.bytes) }
+}
+
+/**
+ * Wait until a write with `expectedExt` extension has been captured.
+ * Polls because writeToSlot.close() is async after the click returns.
+ */
+export async function waitForSavedFile(
+  window: Page,
+  expectedExt: string,
+  timeoutMs = 5000,
+): Promise<{ filename: string; bytes: Uint8Array }> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    const last = await readLastSavedFile(window)
+    if (last && last.filename.endsWith(expectedExt)) return last
+    await new Promise((r) => setTimeout(r, 50))
+  }
+  throw new Error(`Timed out waiting for ${expectedExt} save`)
+}
+
+/**
+ * Seed a share_drafts row via the renderer's IPC bridge. Returns the
+ * generated draft_id so the test can reference it later. The conversation
+ * + opts fields default to a minimal Conversation + DEFAULT_OPTS-ish
+ * shape; tests can override either.
+ */
+export async function seedShareDraft(
+  window: Page,
+  overrides: {
+    title?: string
+    sourceKind?: 'spool-session' | 'pasted-url' | 'imported-file' | 'imported-jsonl'
+    sourceOrigin?: string | null
+    conversation?: Record<string, unknown>
+    opts?: Record<string, unknown>
+  } = {},
+): Promise<string> {
+  return window.evaluate(async (payload) => {
+    const draftId = `e2e-draft-${Math.random().toString(36).slice(2, 10)}`
+    const convo = payload.conversation ?? {
+      source: 'claude',
+      sourceLabel: 'Claude',
+      origin: { kind: 'pasted', platform: 'Claude' },
+      title: payload.title ?? 'Seeded draft',
+      shareUrl: null,
+      createdAt: new Date().toISOString(),
+      wordCount: 4,
+      readMin: 1,
+      turns: [
+        { role: 'user', body: 'hello' },
+        { role: 'assistant', body: 'hi there' },
+      ],
+    }
+    const opts = payload.opts ?? {
+      template: 'chat',
+      paper: 'snow',
+      typeface: 'inter',
+      colorway: 'amber',
+      accentHex: '#C85A00',
+      density: 'compact',
+      avatars: true,
+      redact: true,
+      showGaps: true,
+      showMasthead: true,
+      showColophon: true,
+      hideEmptyTurns: true,
+    }
+    const doc = { version: 1, conversation: convo, opts, exportedAt: new Date().toISOString() }
+    const preview = { ...doc, conversation: { ...convo, turns: (convo.turns as unknown[]).slice(0, 6) } }
+    await (window as unknown as {
+      spool: { shareDraft: { upsert: (input: unknown) => Promise<unknown> } }
+    }).spool.shareDraft.upsert({
+      draft_id: draftId,
+      source_kind: payload.sourceKind ?? 'spool-session',
+      source_origin: payload.sourceOrigin ?? null,
+      title: payload.title ?? (convo as { title: string }).title,
+      snapshot_json: JSON.stringify(doc),
+      preview_json: JSON.stringify(preview),
+    })
+    return draftId
+  }, overrides)
+}
+
+/** A minimal SpoolDocument suitable for drop-import tests. */
+export function buildSampleSpoolDocument(opts: { title?: string; bodySuffix?: string } = {}): string {
+  const conversation = {
+    source: 'claude',
+    sourceLabel: 'Claude',
+    origin: { kind: 'file', filename: 'fixture.spool' },
+    title: opts.title ?? 'Imported sample',
+    shareUrl: null,
+    createdAt: '2026-05-01T00:00:00.000Z',
+    wordCount: 12,
+    readMin: 1,
+    turns: [
+      { role: 'user', body: `Hello from the e2e fixture${opts.bodySuffix ?? ''}` },
+      { role: 'assistant', body: 'Imported reply — nice to meet you.' },
+      { role: 'user', body: 'Just checking the import works end-to-end.' },
+    ],
+  }
+  const editorOpts = {
+    template: 'letter',
+    paper: 'bone',
+    typeface: 'fraunces',
+    colorway: 'iris',
+    accentHex: '#7E6BB5',
+    density: 'relaxed',
+    avatars: true,
+    redact: true,
+    showGaps: true,
+    showMasthead: true,
+    showColophon: true,
+    hideEmptyTurns: true,
+  }
+  return JSON.stringify({
+    version: 1,
+    conversation,
+    opts: editorOpts,
+    exportedAt: '2026-05-01T00:00:00.000Z',
+  })
+}
+
+/**
+ * Write a .spool fixture under e2e/fixtures/share-drafts/ so a test can
+ * later read it from disk (e.g. to feed into a synthesized drop event).
+ * Returns the absolute path.
+ */
+export function writeSpoolFixture(name: string, content: string): string {
+  const path = join(FIXTURES_DIR, 'share-drafts', name)
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, content)
+  return path
+}
+
+/**
+ * Simulate dropping a File onto a target element. Playwright doesn't have
+ * a first-class drop event with File, so we synthesize the DataTransfer
+ * inside the page and dispatch dragenter / dragover / drop in sequence —
+ * which is what `useSpoolDrop` listens for.
+ */
+export async function dropFileOn(
+  window: Page,
+  selector: string,
+  filename: string,
+  content: string,
+  mime = 'application/spool+json',
+): Promise<void> {
+  await window.evaluate(
+    async (args) => {
+      const target = document.querySelector(args.selector)
+      if (!target) throw new Error(`drop target not found: ${args.selector}`)
+      const file = new File([args.content], args.filename, { type: args.mime })
+      const dt = new DataTransfer()
+      dt.items.add(file)
+      const fire = (type: string) => {
+        const ev = new DragEvent(type, { bubbles: true, cancelable: true, dataTransfer: dt })
+        target.dispatchEvent(ev)
+      }
+      fire('dragenter')
+      fire('dragover')
+      fire('drop')
+    },
+    { selector, filename, content, mime },
+  )
+}

--- a/packages/app/e2e/share-autosave.spec.ts
+++ b/packages/app/e2e/share-autosave.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, restartApp, waitForSync, type AppContext } from './helpers/launch'
+import { openShareEditorFromSessionDetail, navigateToShares } from './helpers/share'
+
+let ctx: AppContext
+
+const SESSION_UUID = 'test-session-uuid-001'
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+test('opts mutations + title rename survive a full app restart', async () => {
+  await waitForSync(ctx.window)
+  await openShareEditorFromSessionDetail(ctx.window, SESSION_UUID)
+
+  // Change a few opts.
+  await ctx.window.locator('[data-testid="share-editor-template-atelier"]').click()
+  await ctx.window.locator('[data-testid="share-editor-paper-ink"]').click()
+  await ctx.window.locator('[data-testid="share-editor-colorway-moss"]').click()
+
+  // Rename via the modal.
+  await ctx.window.locator('[data-testid="share-editor-more"]').click()
+  await ctx.window.getByRole('menuitem', { name: 'Rename draft' }).click()
+  const input = ctx.window.locator('[data-testid="rename-draft-input"]')
+  await expect(input).toBeVisible()
+  await input.fill('Autosave checkpoint')
+  await ctx.window.locator('[data-testid="rename-draft-save"]').click()
+  await expect(ctx.window.locator('[data-testid="share-editor-title"]')).toHaveText('Autosave checkpoint')
+
+  // Autosave is debounced at 400ms — give it a safe margin before
+  // tearing down the renderer.
+  await ctx.window.waitForTimeout(800)
+
+  ctx = await restartApp(ctx)
+  await waitForSync(ctx.window)
+
+  await navigateToShares(ctx.window)
+  // Open the persisted draft from the grid.
+  const draftCard = ctx.window
+    .locator('[data-testid="shares-draft-row"][aria-label="Open Autosave checkpoint"]')
+    .first()
+  await expect(draftCard).toBeVisible({ timeout: 5000 })
+  await draftCard.click()
+
+  await expect(ctx.window.locator('[data-testid="share-editor-title"]')).toHaveText('Autosave checkpoint')
+  const preview = ctx.window.locator('[data-testid="share-preview-render"]')
+  await expect(preview).toHaveAttribute('data-template', 'atelier')
+  await expect(preview).toHaveAttribute('data-paper', 'ink')
+  await expect(preview).toHaveAttribute('data-colorway', 'moss')
+})

--- a/packages/app/e2e/share-delete.spec.ts
+++ b/packages/app/e2e/share-delete.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, waitForSync, type AppContext } from './helpers/launch'
+import { navigateToShares, openShareEditorFromSessionDetail, seedShareDraft } from './helpers/share'
+
+let ctx: AppContext
+
+const SESSION_UUID = 'test-session-uuid-001'
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+test('Shares card click-twice deletes; Undo toast restores', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+  await seedShareDraft(window, { title: 'Delete-and-undo draft' })
+  await navigateToShares(window)
+
+  const card = window
+    .locator('[data-testid="shares-draft-row"][aria-label="Open Delete-and-undo draft"]')
+    .first()
+  await expect(card).toBeVisible({ timeout: 5000 })
+  // Hover the wrapping <div>, not the inner <button>, so React's
+  // onMouseEnter on the wrapper fires and the DeleteChip mounts.
+  const wrapper = card.locator('xpath=..')
+  await wrapper.hover()
+  const deleteChip = wrapper.locator('[data-testid="shares-draft-delete"]')
+  await expect(deleteChip).toBeVisible({ timeout: 5000 })
+  // First click — primes the confirm pill.
+  await deleteChip.click()
+  await expect(deleteChip).toHaveAttribute('data-confirming', '')
+  // Second click — actually deletes.
+  await deleteChip.click()
+  await expect(card).toBeHidden({ timeout: 5000 })
+
+  // Undo from the sonner toast.
+  await window.getByRole('button', { name: 'Undo' }).click()
+  await expect(
+    window.locator('[data-testid="shares-draft-row"][aria-label="Open Delete-and-undo draft"]'),
+  ).toBeVisible({ timeout: 5000 })
+})
+
+test('editor topbar delete modal closes the editor and removes the draft', async () => {
+  const { window } = ctx
+  await openShareEditorFromSessionDetail(window, SESSION_UUID)
+
+  await window.locator('[data-testid="share-editor-more"]').click()
+  await window.getByRole('menuitem', { name: 'Delete draft' }).click()
+  await expect(window.locator('[data-testid="delete-draft-modal"]')).toBeVisible({ timeout: 5000 })
+  await window.locator('[data-testid="delete-draft-confirm"]').click()
+
+  // Editor should close; navigation lands back on the session detail.
+  await expect(window.locator('[data-testid="share-editor-page"]')).toBeHidden({ timeout: 5000 })
+
+  // The session-derived draft should not appear on Shares.
+  await navigateToShares(window)
+  await expect(
+    window.locator(`[data-testid="shares-draft-row"]`).filter({ hasText: /XYLOPHONE|test-session-001/ }),
+  ).toHaveCount(0)
+})

--- a/packages/app/e2e/share-editor.spec.ts
+++ b/packages/app/e2e/share-editor.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, waitForSync, type AppContext } from './helpers/launch'
+import { openShareEditorFromSessionDetail } from './helpers/share'
+
+let ctx: AppContext
+
+const SESSION_UUID = 'test-session-uuid-001'
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+test('share editor opens from SessionDetail with default opts', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+  await openShareEditorFromSessionDetail(window, SESSION_UUID)
+  const preview = window.locator('[data-testid="share-preview-render"]')
+  await expect(preview).toBeVisible()
+  await expect(preview).toHaveAttribute('data-template', 'chat')
+  await expect(preview).toHaveAttribute('data-paper', 'snow')
+  await expect(preview).toHaveAttribute('data-typeface', 'inter')
+  await expect(preview).toHaveAttribute('data-colorway', 'amber')
+})
+
+test('template / typeface / paper / colorway switches reflect in preview', async () => {
+  const { window } = ctx
+  const preview = window.locator('[data-testid="share-preview-render"]')
+
+  await window.locator('[data-testid="share-editor-template-letter"]').click()
+  await expect(preview).toHaveAttribute('data-template', 'letter')
+
+  await window.locator('[data-testid="share-editor-typeface-fraunces"]').click()
+  await expect(preview).toHaveAttribute('data-typeface', 'fraunces')
+
+  await window.locator('[data-testid="share-editor-paper-bone"]').click()
+  await expect(preview).toHaveAttribute('data-paper', 'bone')
+
+  await window.locator('[data-testid="share-editor-colorway-iris"]').click()
+  await expect(preview).toHaveAttribute('data-colorway', 'iris')
+
+  await window.locator('[data-testid="share-editor-density-relaxed"]').click()
+  await expect(preview).toHaveAttribute('data-density', 'relaxed')
+})
+
+test('chrome toggles (masthead, colophon, avatars, hideEmptyTurns, showGaps) flip aria-checked', async () => {
+  const { window } = ctx
+  // Each toggle is a role="switch" with aria-checked reflecting state.
+  const ids = ['hideEmptyTurns', 'showGaps', 'avatars', 'showMasthead', 'showColophon']
+  for (const key of ids) {
+    const sel = `[data-testid="share-editor-toggle-${key}"]`
+    const before = await window.locator(sel).getAttribute('aria-checked')
+    await window.locator(sel).click()
+    const after = await window.locator(sel).getAttribute('aria-checked')
+    expect(after).not.toBe(before)
+    // Flip back so subsequent tests start from defaults-on.
+    await window.locator(sel).click()
+    const final = await window.locator(sel).getAttribute('aria-checked')
+    expect(final).toBe(before)
+  }
+})
+
+test('Back returns to SessionDetail', async () => {
+  const { window } = ctx
+  await window.getByRole('button', { name: 'Back' }).first().click()
+  await expect(window.locator('[data-testid="session-detail"]')).toBeVisible({ timeout: 5000 })
+})

--- a/packages/app/e2e/share-entry-points.spec.ts
+++ b/packages/app/e2e/share-entry-points.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, waitForSync, type AppContext } from './helpers/launch'
+import {
+  navigateToShares,
+  openShareEditorFromSessionDetail,
+  shareFromSessionRowMenu,
+} from './helpers/share'
+
+let ctx: AppContext
+
+const SESSION_UUID = 'test-session-uuid-001'
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+async function closeEditorIfOpen() {
+  const editor = ctx.window.locator('[data-testid="share-editor-page"]')
+  if (await editor.isVisible().catch(() => false)) {
+    await ctx.window.getByRole('button', { name: 'Back' }).first().click()
+    await expect(editor).toBeHidden({ timeout: 5000 })
+  }
+}
+
+test('entry point: SessionDetail header BookText button opens editor', async () => {
+  await waitForSync(ctx.window)
+  await openShareEditorFromSessionDetail(ctx.window, SESSION_UUID)
+  await closeEditorIfOpen()
+})
+
+test('entry point: SessionRow ⋯ menu in project view opens editor', async () => {
+  await shareFromSessionRowMenu(ctx.window, SESSION_UUID)
+  await closeEditorIfOpen()
+})
+
+test('entry point: Sidebar Shares row navigates to Shares', async () => {
+  await navigateToShares(ctx.window)
+  await expect(ctx.window.locator('[data-testid="shares-page"]')).toBeVisible({ timeout: 5000 })
+})
+
+test('entry point: NewDraftPicker opens (via empty-state CTA or + button)', async () => {
+  // After the previous header / menu tests we now have at least one
+  // persisted draft, so the empty state is hidden and the `+` button is
+  // the live entry point. Tolerate either surface.
+  const empty = ctx.window.locator('[data-testid="shares-empty-start"]')
+  const plus = ctx.window.locator('[data-testid="shares-new-draft"]')
+  if (await empty.isVisible().catch(() => false)) {
+    await empty.click()
+  } else {
+    await expect(plus).toBeVisible({ timeout: 5000 })
+    await plus.click()
+  }
+  await expect(ctx.window.locator('[data-testid="new-draft-picker"]')).toBeVisible({ timeout: 5000 })
+  await ctx.window.keyboard.press('Escape')
+  await expect(ctx.window.locator('[data-testid="new-draft-picker"]')).toBeHidden({ timeout: 5000 })
+})
+
+test('entry point: LibraryLanding ⋯ menu Share opens editor', async () => {
+  await ctx.window.locator('[data-testid="sidebar-library"]').click()
+  await expect(ctx.window.locator('[data-testid="library-landing"]')).toBeVisible({ timeout: 5000 })
+  const row = ctx.window
+    .locator(`[data-testid="session-row"][data-session-uuid="${SESSION_UUID}"]`)
+    .first()
+  await expect(row).toBeVisible({ timeout: 5000 })
+  await row.hover()
+  await row.getByLabel('More actions').click()
+  await ctx.window.getByRole('menuitem', { name: 'Open in share editor' }).click()
+  await expect(ctx.window.locator('[data-testid="share-editor-page"]')).toBeVisible({ timeout: 5000 })
+  await closeEditorIfOpen()
+})

--- a/packages/app/e2e/share-exports.spec.ts
+++ b/packages/app/e2e/share-exports.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, waitForSync, type AppContext } from './helpers/launch'
+import {
+  installSaveFilePickerMock,
+  openShareEditorFromSessionDetail,
+  waitForSavedFile,
+} from './helpers/share'
+
+let ctx: AppContext
+
+const SESSION_UUID = 'test-session-uuid-001'
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+async function pickFormat(window: Awaited<ReturnType<typeof launchApp>>['window'], k: 'png' | 'pdf' | 'md' | 'spool') {
+  await window.locator('[data-testid="share-editor-download-caret"]').click()
+  await window.locator(`[data-testid="share-editor-download-option-${k}"]`).click()
+}
+
+test('.spool export captures a valid SpoolDocument', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+  await openShareEditorFromSessionDetail(window, SESSION_UUID)
+  await installSaveFilePickerMock(window)
+
+  await pickFormat(window, 'spool')
+  await window.locator('[data-testid="share-editor-download-trigger"]').click()
+
+  const saved = await waitForSavedFile(window, '.spool')
+  expect(saved.filename).toMatch(/\.spool$/)
+  expect(saved.bytes.byteLength).toBeGreaterThan(0)
+  const text = new TextDecoder().decode(saved.bytes)
+  const doc = JSON.parse(text) as {
+    version: number
+    conversation: { turns: unknown[]; title: string }
+    opts: { template: string }
+  }
+  expect(doc.version).toBe(1)
+  expect(doc.opts.template).toBe('chat')
+  expect(Array.isArray(doc.conversation.turns)).toBe(true)
+  expect(doc.conversation.turns.length).toBeGreaterThan(0)
+})
+
+test('Markdown export captures frontmatter + body', async () => {
+  const { window } = ctx
+  // Editor still open from the previous test in the same browser context.
+  await installSaveFilePickerMock(window)
+
+  await pickFormat(window, 'md')
+  await window.locator('[data-testid="share-editor-download-trigger"]').click()
+
+  const saved = await waitForSavedFile(window, '.md')
+  expect(saved.filename).toMatch(/\.md$/)
+  const text = new TextDecoder().decode(saved.bytes)
+  // Frontmatter delimiters at top.
+  expect(text.startsWith('---\n')).toBe(true)
+  expect(text).toMatch(/\n---\n/)
+  // At least one of the conversation roles renders as a heading-like marker.
+  expect(text.toLowerCase()).toMatch(/user|assistant|claude/i)
+  // And some recognisable fixture content from test-session-001.
+  expect(text).toContain('XYLOPHONE_CANARY_42')
+})

--- a/packages/app/e2e/share-import.spec.ts
+++ b/packages/app/e2e/share-import.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, waitForSync, type AppContext } from './helpers/launch'
+import {
+  buildSampleSpoolDocument,
+  dropFileOn,
+  navigateToShares,
+} from './helpers/share'
+
+let ctx: AppContext
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+test('drop .spool on Shares opens editor with imported content', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+  await navigateToShares(window)
+
+  const spool = buildSampleSpoolDocument({ title: 'Imported sample one' })
+  await dropFileOn(window, '[data-testid="shares-page"]', 'sample-one.spool', spool)
+  // The drop hook is wired on the SharesPage root; dropping on the empty
+  // state's button bubbles up to the same handler.
+  await expect(window.locator('[data-testid="share-editor-page"]')).toBeVisible({ timeout: 5000 })
+  await expect(window.locator('[data-testid="share-editor-title"]')).toHaveText('Imported sample one')
+})
+
+test('dropping the same content again opens the same draft (content-hash dedup)', async () => {
+  const { window } = ctx
+  // Capture the current draft id from the persisted snapshot by inspecting
+  // a stable signal: the draft title round-trips through the editor.
+  // Back out, then re-drop the identical bytes — there should still be
+  // exactly one row in the Shares grid.
+  await window.getByRole('button', { name: 'Back' }).first().click()
+  await navigateToShares(window)
+
+  await expect(window.locator('[data-testid="shares-draft-row"]')).toHaveCount(1)
+
+  const same = buildSampleSpoolDocument({ title: 'Imported sample one' })
+  await dropFileOn(window, '[data-testid="shares-page"]', 'sample-one.spool', same)
+  await expect(window.locator('[data-testid="share-editor-page"]')).toBeVisible({ timeout: 5000 })
+  await window.getByRole('button', { name: 'Back' }).first().click()
+  await expect(window.locator('[data-testid="shares-draft-row"]')).toHaveCount(1)
+})
+
+test('dropping a non-.spool file surfaces a reject toast', async () => {
+  const { window } = ctx
+  await dropFileOn(
+    window,
+    '[data-testid="shares-page"]',
+    'not-a-spool.txt',
+    'plain text body',
+    'text/plain',
+  )
+  await expect(window.getByText(/Couldn't import not-a-spool\.txt/)).toBeVisible({ timeout: 5000 })
+})

--- a/packages/app/e2e/share-new-draft-picker.spec.ts
+++ b/packages/app/e2e/share-new-draft-picker.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, waitForSync, type AppContext } from './helpers/launch'
+import { navigateToShares } from './helpers/share'
+
+let ctx: AppContext
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+test('Recent mode lists sessions; Esc closes', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+  await navigateToShares(window)
+
+  await window.locator('[data-testid="shares-empty-start"]').click()
+  const picker = window.locator('[data-testid="new-draft-picker"]')
+  await expect(picker).toBeVisible({ timeout: 5000 })
+
+  // Recent: at least one row (we have 6 fixtures including the large one).
+  await expect(picker.locator('[data-testid="new-draft-picker-row"]').first()).toBeVisible({ timeout: 5000 })
+
+  await window.keyboard.press('Escape')
+  await expect(picker).toBeHidden({ timeout: 5000 })
+})
+
+test('FTS search narrows results; keyboard nav + Enter opens editor', async () => {
+  const { window } = ctx
+  await window.locator('[data-testid="shares-empty-start"]').click()
+  const picker = window.locator('[data-testid="new-draft-picker"]')
+  await expect(picker).toBeVisible({ timeout: 5000 })
+
+  // Type a unique fragment-only token from fixtures.
+  await picker.locator('input').fill('XYLOPHONE_CANARY_42')
+  // Allow debounce + FTS roundtrip. Two fixtures mention this token, so
+  // we just require *some* match rather than an exact count.
+  await expect(picker.locator('[data-testid="new-draft-picker-row"]').first()).toBeVisible({ timeout: 5000 })
+
+  // Active row is row 0 after a result set lands.
+  await window.keyboard.press('ArrowDown')
+  await window.keyboard.press('ArrowUp')
+  await window.keyboard.press('Enter')
+
+  await expect(window.locator('[data-testid="share-editor-page"]')).toBeVisible({ timeout: 5000 })
+})

--- a/packages/app/e2e/share-turn-selector.spec.ts
+++ b/packages/app/e2e/share-turn-selector.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, waitForSync, type AppContext } from './helpers/launch'
+import { openShareEditorFromSessionDetail } from './helpers/share'
+
+let ctx: AppContext
+
+// Use the large fixture so we have plenty of turns to select / skip.
+const SESSION_UUID = 'large-session-uuid-001'
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+test('switch to Messages view, exclude turns, see preview reflect change', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+  await openShareEditorFromSessionDetail(window, SESSION_UUID)
+
+  // Switch to Messages view on the right ControlPanel.
+  await window.locator('[data-testid="share-editor-view-messages"]').click()
+  const firstRow = window.locator('[data-testid="share-editor-turn-row"]').first()
+  await expect(firstRow).toBeVisible({ timeout: 5000 })
+
+  // The preview renders the full conversation at first. We count its
+  // turn anchors as a baseline.
+  const previewTurns = window.locator('[data-share-preview-scroll] [data-turn-index]')
+  const startCount = await previewTurns.count()
+  expect(startCount).toBeGreaterThan(0)
+
+  // Exclude the first turn (toggle from included → excluded).
+  await window.locator('[data-testid="share-editor-turn-toggle"]').first().click()
+  await expect(firstRow).not.toHaveAttribute('data-included', '')
+
+  // The preview now has one fewer rendered turn (or, with showGaps on,
+  // the same number but with a "skipped" marker — share-kit renders a
+  // gap row between non-adjacent kept turns). Either way the original
+  // 0-index anchor should disappear, since the excluded turn doesn't
+  // render its body.
+  await expect(window.locator('[data-share-preview-scroll] [data-turn-index="0"]')).toHaveCount(0)
+})
+
+test('Select all restores the full set; Clear excludes everything', async () => {
+  const { window } = ctx
+  await window.locator('[data-testid="share-editor-turns-select-all"]').click()
+  await expect(
+    window.locator('[data-testid="share-editor-turn-row"][data-included=""]').first(),
+  ).toBeVisible()
+  // Every row should now report included.
+  const rows = window.locator('[data-testid="share-editor-turn-row"]')
+  const total = await rows.count()
+  expect(total).toBeGreaterThan(0)
+  for (let i = 0; i < Math.min(total, 5); i += 1) {
+    await expect(rows.nth(i)).toHaveAttribute('data-included', '')
+  }
+
+  await window.locator('[data-testid="share-editor-turns-clear"]').click()
+  // After clear, no row is included.
+  for (let i = 0; i < Math.min(total, 5); i += 1) {
+    await expect(rows.nth(i)).not.toHaveAttribute('data-included', '')
+  }
+})
+
+test('Jump scrolls the preview to the selected turn', async () => {
+  const { window } = ctx
+  await window.locator('[data-testid="share-editor-turns-select-all"]').click()
+
+  // Pick a turn well past the initial viewport.
+  const target = window.locator('[data-testid="share-editor-turn-jump"][data-row-turn-index="20"]')
+  await expect(target).toBeVisible({ timeout: 5000 })
+  await target.click()
+  // After jump the preview's data-turn-index="20" should have scrolled
+  // into view.
+  const anchor = window.locator('[data-share-preview-scroll] [data-turn-index="20"]')
+  await expect(anchor).toBeVisible({ timeout: 5000 })
+})

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -17,7 +17,7 @@
     "build:electron": "pnpm run build:deps && electron-vite build",
     "preview": "electron-vite preview",
     "clean": "rm -rf out dist-electron",
-    "test:e2e": "pnpm run build:deps && pnpm run rebuild:native:electron && electron-vite build && npx playwright test --config e2e/playwright.config.ts"
+    "test:e2e": "pnpm run build:deps && pnpm run rebuild:native:electron && VITE_FEATURE_SHARE=1 electron-vite build && npx playwright test --config e2e/playwright.config.ts"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.17.1",

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -78,7 +78,7 @@ export default function SharesPage({ onOpenDraft, onImportSpool, onStartNewDraft
   }, [removeDraft, restoreDraft])
 
   return (
-    <div className="relative flex flex-col flex-1 min-h-0" {...dragHandlers}>
+    <div data-testid="shares-page" className="relative flex flex-col flex-1 min-h-0" {...dragHandlers}>
       {isDragActive && <SpoolDropOverlay />}
       {hasDrafts && (
         <div className="flex-none flex items-center gap-3 px-6 pt-1.5 pb-3">

--- a/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
+++ b/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
@@ -52,8 +52,8 @@ export function ControlPanel({ convo, opts, setOpts }: Props) {
           aria-label="Panel view"
           className="inline-flex items-center gap-0.5 p-0.5 rounded-md bg-warm-surface dark:bg-dark-surface"
         >
-          <ViewTab active={view === 'style'} onClick={() => setView('style')}>Style</ViewTab>
-          <ViewTab active={view === 'messages'} onClick={() => setView('messages')}>Messages</ViewTab>
+          <ViewTab testId="share-editor-view-style" active={view === 'style'} onClick={() => setView('style')}>Style</ViewTab>
+          <ViewTab testId="share-editor-view-messages" active={view === 'messages'} onClick={() => setView('messages')}>Messages</ViewTab>
         </div>
       </div>
       {view === 'messages' ? (
@@ -76,6 +76,7 @@ export function ControlPanel({ convo, opts, setOpts }: Props) {
               <button
                 key={tpl.id}
                 type="button"
+                data-testid={`share-editor-template-${tpl.id}`}
                 onClick={() => setOpts({ ...opts, template: tpl.id })}
                 className={`flex items-center gap-2.5 text-left px-2.5 py-2 rounded-md border transition-colors focus:outline-none ${
                   active
@@ -126,6 +127,7 @@ export function ControlPanel({ convo, opts, setOpts }: Props) {
               <button
                 key={c.id}
                 type="button"
+                data-testid={`share-editor-colorway-${c.id}`}
                 onClick={() => setOpts({ ...opts, colorway: c.id, accentHex: c.swatch })}
                 title={c.name}
                 aria-label={c.name}
@@ -151,39 +153,44 @@ export function ControlPanel({ convo, opts, setOpts }: Props) {
         <div className="flex items-center justify-between py-2">
           <span className="text-[12px] text-warm-text/85 dark:text-dark-text/85">Density</span>
           <div className="flex gap-1">
-            <Chip active={opts.density === 'compact'} onClick={() => setOpts({ ...opts, density: 'compact' })}>
+            <Chip testId="share-editor-density-compact" active={opts.density === 'compact'} onClick={() => setOpts({ ...opts, density: 'compact' })}>
               Compact
             </Chip>
-            <Chip active={opts.density === 'relaxed'} onClick={() => setOpts({ ...opts, density: 'relaxed' })}>
+            <Chip testId="share-editor-density-relaxed" active={opts.density === 'relaxed'} onClick={() => setOpts({ ...opts, density: 'relaxed' })}>
               Relaxed
             </Chip>
           </div>
         </div>
         <Toggle
+          testId="share-editor-toggle-hideEmptyTurns"
           label="Hide empty turns"
           sub="Skip role headers with no content (tool-only assistant turns)"
           value={opts.hideEmptyTurns}
           onChange={(v) => setOpts({ ...opts, hideEmptyTurns: v })}
         />
         <Toggle
+          testId="share-editor-toggle-showGaps"
           label="Gap markers"
           sub="Show ⋯ where turns are skipped"
           value={opts.showGaps}
           onChange={(v) => setOpts({ ...opts, showGaps: v })}
         />
         <Toggle
+          testId="share-editor-toggle-avatars"
           label="Show source mark"
           sub="Small glyph next to assistant turns"
           value={opts.avatars}
           onChange={(v) => setOpts({ ...opts, avatars: v })}
         />
         <Toggle
+          testId="share-editor-toggle-showMasthead"
           label="Masthead"
           sub="Spool wordmark and template label on top"
           value={opts.showMasthead}
           onChange={(v) => setOpts({ ...opts, showMasthead: v })}
         />
         <Toggle
+          testId="share-editor-toggle-showColophon"
           label="Colophon"
           sub='"Stitched on Spool" footer'
           value={opts.showColophon}
@@ -201,10 +208,12 @@ function ViewTab({
   active,
   onClick,
   children,
+  testId,
 }: {
   active: boolean
   onClick: () => void
   children: React.ReactNode
+  testId?: string
 }) {
   return (
     <button
@@ -212,6 +221,7 @@ function ViewTab({
       role="tab"
       onClick={onClick}
       aria-selected={active}
+      {...(testId ? { 'data-testid': testId } : {})}
       className={`h-6 px-2.5 rounded text-[11.5px] font-medium transition-colors ${
         active
           ? 'bg-warm-bg dark:bg-dark-bg text-warm-text dark:text-dark-text shadow-[0_1px_1px_rgba(0,0,0,0.2)]'
@@ -288,11 +298,13 @@ function Toggle({
   sub,
   value,
   onChange,
+  testId,
 }: {
   label: string
   sub?: string
   value: boolean
   onChange: (next: boolean) => void
+  testId?: string
 }) {
   return (
     <div className="flex items-center justify-between py-2 gap-3">
@@ -305,6 +317,7 @@ function Toggle({
         role="switch"
         aria-checked={value}
         onClick={() => onChange(!value)}
+        {...(testId ? { 'data-testid': testId } : {})}
         className={`relative flex-none w-8 h-[18px] rounded-full transition-colors focus:outline-none ${
           value ? 'bg-accent dark:bg-accent-dark' : 'bg-warm-border dark:bg-dark-border'
         }`}
@@ -320,11 +333,12 @@ function Toggle({
   )
 }
 
-function Chip({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+function Chip({ active, onClick, children, testId }: { active: boolean; onClick: () => void; children: React.ReactNode; testId?: string }) {
   return (
     <button
       type="button"
       onClick={onClick}
+      {...(testId ? { 'data-testid': testId } : {})}
       className={`px-2 py-0.5 rounded text-[11.5px] border transition-colors focus:outline-none ${
         active
           ? 'bg-accent-bg dark:bg-accent-bg-dark border-accent dark:border-accent-dark text-accent dark:text-accent-dark font-medium'
@@ -346,6 +360,7 @@ function TypefacePicker({ value, onChange }: { value: Typeface; onChange: (next:
           <button
             key={tf.id}
             type="button"
+            data-testid={`share-editor-typeface-${tf.id}`}
             onClick={() => onChange(tf.id)}
             title={tf.name}
             aria-label={tf.name}
@@ -379,6 +394,7 @@ function PaperPicker({ value, onChange }: { value: Paper; onChange: (next: Paper
           <button
             key={p.id}
             type="button"
+            data-testid={`share-editor-paper-${p.id}`}
             onClick={() => onChange(p.id)}
             title={p.name}
             aria-label={p.name}

--- a/packages/app/src/renderer/components/share-editor/DownloadButton.tsx
+++ b/packages/app/src/renderer/components/share-editor/DownloadButton.tsx
@@ -70,6 +70,8 @@ export function DownloadButton({ saving, onExport }: Props) {
     <div ref={rootRef} className="relative flex flex-none" data-testid="share-editor-download">
       <button
         type="button"
+        data-testid="share-editor-download-trigger"
+        data-format={format}
         onClick={trigger}
         disabled={saving}
         title={`${current.b}  ⌘S`}
@@ -80,6 +82,7 @@ export function DownloadButton({ saving, onExport }: Props) {
       </button>
       <button
         type="button"
+        data-testid="share-editor-download-caret"
         onClick={() => setOpen(o => !o)}
         aria-label="Choose format"
         aria-haspopup="menu"
@@ -102,6 +105,7 @@ export function DownloadButton({ saving, onExport }: Props) {
               <button
                 key={f.k}
                 type="button"
+                data-testid={`share-editor-download-option-${f.k}`}
                 role="menuitemradio"
                 aria-checked={active}
                 onClick={() => { setFormat(f.k); setOpen(false) }}

--- a/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
+++ b/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
@@ -256,7 +256,16 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
                 willChange: 'transform',
               }}
             >
-              <div ref={setRefs} style={{ width: ratio.w, userSelect: 'text' }}>
+              <div
+                ref={setRefs}
+                data-testid="share-preview-render"
+                data-template={opts.template}
+                data-paper={opts.paper}
+                data-typeface={opts.typeface}
+                data-colorway={opts.colorway}
+                data-density={opts.density}
+                style={{ width: ratio.w, userSelect: 'text' }}
+              >
                 <TemplateRender template={opts.template} convo={convo} opts={opts} />
               </div>
             </div>

--- a/packages/app/src/renderer/components/share-editor/TurnSelector.tsx
+++ b/packages/app/src/renderer/components/share-editor/TurnSelector.tsx
@@ -113,6 +113,7 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
         <span className="flex items-center gap-0.5">
           <button
             type="button"
+            data-testid="share-editor-turns-select-all"
             onClick={selectAll}
             title="Include all messages"
             aria-label="Include all messages"
@@ -122,6 +123,7 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
           </button>
           <button
             type="button"
+            data-testid="share-editor-turns-clear"
             onClick={clearAll}
             title="Exclude all messages"
             aria-label="Exclude all messages"
@@ -138,12 +140,17 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
           return (
             <li
               key={i}
+              data-testid="share-editor-turn-row"
+              data-row-turn-index={i}
+              data-included={included ? '' : undefined}
               className={`group flex items-center gap-3 pl-3 pr-4 py-1 transition-colors hover:bg-warm-surface dark:hover:bg-dark-surface ${
                 included ? '' : 'opacity-60'
               }`}
             >
               <button
                 type="button"
+                data-testid="share-editor-turn-toggle"
+                data-row-turn-index={i}
                 onClick={() => toggleTurn(i)}
                 title={included ? 'Click to exclude' : 'Click to include'}
                 aria-pressed={included}
@@ -163,6 +170,8 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
               </button>
               <button
                 type="button"
+                data-testid="share-editor-turn-jump"
+                data-row-turn-index={i}
                 onClick={() => jumpToTurn(i)}
                 title={previewTooltip(turn.body)}
                 aria-label={`Jump to message ${i + 1}`}


### PR DESCRIPTION
## Summary

Adds 22 Playwright tests across 8 specs covering the share feature surface, so a regression is caught before we flip the production gate for v0.5.0.

`VITE_FEATURE_SHARE` stays build-time and only the `test:e2e` script exports it. `pnpm build` / `build:mac` / `build:linux` / `build:electron` are untouched — production releases still ship with share OFF. The flip itself is a separate PR.

## What

| Spec | What it locks in |
|---|---|
| `share-editor.spec.ts` | Editor opens with default opts; template / typeface / paper / colorway / density switches reflect in preview; chrome toggles flip aria-checked; Back returns to SessionDetail. |
| `share-autosave.spec.ts` | Opts mutations + title rename survive `restartApp()` — DB persistence + rename modal round-trip. |
| `share-entry-points.spec.ts` | Share reachable from SessionDetail header, SessionRow ⋯ menu, Sidebar Shares row, NewDraftPicker (empty CTA or + button), LibraryLanding ⋯ menu. |
| `share-exports.spec.ts` | `.spool` export → captured Blob parses as a valid SpoolDocument v1; Markdown export → frontmatter + body + fixture content. PNG/PDF intentionally skipped (rasterization is flaky in headless CI). |
| `share-import.spec.ts` | Drop `.spool` opens editor with imported content; same content → same draft (content-hash dedup); non-`.spool` → reject toast. |
| `share-delete.spec.ts` | Shares card click-twice delete + sonner Undo restore; editor topbar ⋯ menu Delete modal closes editor and removes draft. |
| `share-new-draft-picker.spec.ts` | Recent mode + Esc; FTS search narrows + ↑↓/Enter opens editor. |
| `share-turn-selector.spec.ts` | Toggle turn excludes from preview; Select all / Clear all; Jump scrolls preview to selected turn anchor. |

## Why

Pre-launch we had zero e2e coverage on share. The data layer had unit tests, `share-kit` had a redaction unit test, but the renderer flow (autosave + IPC + templates + exports + drop import) was uncovered. A single careless refactor would silently break the user flow and we wouldn't see it until the next manual smoke. Locking it down now lets us flip the prod flag for v0.5.0 with confidence and keeps future polish PRs honest.

## How it connects

`launch.ts` grows a `restartApp(ctx)` helper that closes the app and re-launches with the same env, so persistence specs can verify state survives a renderer teardown. A new `helpers/share.ts` collects the share-flavored interactions (`openShareEditorFromSessionDetail`, `installSaveFilePickerMock`, `seedShareDraft`, `dropFileOn`, …) so each spec stays declarative.

Renderer-side: small testid additions on `ControlPanel` / `TurnSelector` / `DownloadButton` / `PreviewPane` / `SharesPage`. No behavior changes, with one minor naming fix: TurnSelector rows use `data-row-turn-index` so they don't collide with the template's `data-turn-index` anchors that drive jump-to-message.

## Test plan

- [x] `pnpm test:e2e` — 67/67 pass locally (22 new share specs + 45 existing). 46s total on M1.
- [x] `npx tsc --noEmit` clean across the app package.
- [x] `pnpm --filter @spool/share-kit test` — 11/11 pass.
- [x] Verified `pnpm build` does NOT set VITE_FEATURE_SHARE — release artifacts continue to ship with share gated off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)