### PR TITLE
fix(share): right-panel polish — Messages sizing + Privacy header pin

### DIFF
--- a/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
+++ b/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
@@ -744,9 +744,12 @@ function PrivacyView({
   return (
     <div
       data-testid="share-editor-privacy-panel"
-      className="flex-1 min-h-0 overflow-y-auto scrollbar-none"
+      className="flex-1 min-h-0 flex flex-col"
     >
-      <div className="px-4 pt-3 pb-4">
+      {/* Fixed header — REDACTIONS / count / Reset + master toggle.
+       *  Stays put when the category list scrolls below so the user
+       *  always has the master control + leak-count in view. */}
+      <div className="flex-none px-4 pt-3">
         <div className="flex items-center justify-between mb-3 gap-2">
           <div className="text-[11px] font-medium tracking-[0.08em] uppercase text-warm-muted dark:text-dark-muted leading-none">
             Redactions
@@ -785,19 +788,10 @@ function PrivacyView({
           value={opts.redact}
           onChange={(v) => setOpts({ ...opts, redact: v })}
         />
-        {opts.redact && (
-          <RedactSummary
-            groups={pii.groups}
-            authorNames={pii.names}
-            manualValues={pii.manual}
-            opts={opts}
-            setOpts={setOpts}
-          />
-        )}
         {!opts.redact && totalRedactions > 0 && (
           <div
             data-testid="share-editor-privacy-warning"
-            className="mt-3 px-3 py-2.5 rounded-md border leading-snug"
+            className="mt-3 mb-4 px-3 py-2.5 rounded-md border leading-snug"
             style={{ borderColor: `${opts.accentHex}4D`, background: `${opts.accentHex}1A` }}
           >
             <div
@@ -812,6 +806,19 @@ function PrivacyView({
           </div>
         )}
       </div>
+      {/* Only the categorised list scrolls. Header + master toggle
+       *  stay pinned above. */}
+      {opts.redact && (
+        <div className="flex-1 min-h-0 overflow-y-auto scrollbar-none px-4 pb-4">
+          <RedactSummary
+            groups={pii.groups}
+            authorNames={pii.names}
+            manualValues={pii.manual}
+            opts={opts}
+            setOpts={setOpts}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/app/src/renderer/components/share-editor/TurnSelector.tsx
+++ b/packages/app/src/renderer/components/share-editor/TurnSelector.tsx
@@ -37,7 +37,14 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
     return rows.filter(({ turn }) => turn.body.trim() !== '')
   }, [convo.turns, opts.hideEmptyTurns])
 
-  const kept = selectedSet === null ? total : opts.selected!.length
+  // The displayed list filters out empty turns when `hideEmptyTurns`
+  // is on. The header counts must reflect what the user actually sees
+  // in the panel — otherwise "526 of 526" looks wrong next to a
+  // scrolled list of ~150 visible rows.
+  const visibleTotal = visibleTurns.length
+  const visibleKept = selectedSet === null
+    ? visibleTotal
+    : visibleTurns.filter(({ originalIndex }) => selectedSet.has(originalIndex)).length
 
   const writeSelection = useCallback(
     (next: number[]) => {
@@ -108,7 +115,7 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
     <div className="flex flex-col min-h-0 flex-1">
       <div className="flex items-center justify-between px-4 pt-3 pb-2">
         <span className="text-[10px] uppercase tracking-wider font-medium text-warm-faint dark:text-dark-faint">
-          Messages {kept} of {total}
+          Messages {visibleKept} of {visibleTotal}
         </span>
         <span className="flex items-center gap-0.5">
           <button
@@ -133,7 +140,7 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
           </button>
         </span>
       </div>
-      <ul className="flex-1 min-h-0 overflow-y-auto py-1">
+      <ul className="flex-1 min-h-0 overflow-y-auto scrollbar-none py-1">
         {visibleTurns.map(({ turn, originalIndex: i }) => {
           const included = selectedSet === null ? true : selectedSet.has(i)
           const preview = firstLinePreview(turn.body)
@@ -143,7 +150,7 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
               data-testid="share-editor-turn-row"
               data-row-turn-index={i}
               data-included={included ? '' : undefined}
-              className={`group flex items-center gap-3 pl-3 pr-4 py-1 transition-colors hover:bg-warm-surface dark:hover:bg-dark-surface ${
+              className={`group flex items-center gap-3 pl-4 pr-4 py-1 transition-colors hover:bg-warm-surface dark:hover:bg-dark-surface ${
                 included ? '' : 'opacity-60'
               }`}
             >
@@ -158,14 +165,14 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
                 className="shrink-0 p-1 -m-1 rounded"
               >
                 <span
-                  className={`block w-[18px] h-[18px] rounded-[4px] flex items-center justify-center transition-colors ${
+                  className={`block w-[14px] h-[14px] rounded-[3px] flex items-center justify-center transition-colors ${
                     included
                       ? 'bg-accent dark:bg-accent-dark'
                       : 'border border-warm-border2 dark:border-dark-border2'
                   }`}
                   aria-hidden="true"
                 >
-                  {included && <Check size={12} strokeWidth={2.5} className="text-white" />}
+                  {included && <Check size={10} strokeWidth={2.5} className="text-white" />}
                 </span>
               </button>
               <button
@@ -175,12 +182,12 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
                 onClick={() => jumpToTurn(i)}
                 title={previewTooltip(turn.body)}
                 aria-label={`Jump to message ${i + 1}`}
-                className="flex-1 min-w-0 flex items-center gap-3 text-left"
+                className="flex-1 min-w-0 flex items-center gap-2.5 text-left"
               >
-                <span className="font-mono text-[11px] tabular-nums text-warm-faint dark:text-dark-faint shrink-0">
+                <span className="font-mono text-[10.5px] tabular-nums text-warm-faint dark:text-dark-faint shrink-0">
                   {padIndex(i + 1, total)}
                 </span>
-                <span className="text-[13px] text-warm-text dark:text-dark-text truncate flex-1">
+                <span className="text-[12px] text-warm-text dark:text-dark-text truncate flex-1">
                   {preview || <span className="text-warm-faint dark:text-dark-faint italic">empty</span>}
                 </span>
               </button>


### PR DESCRIPTION
## Summary

Two small share-editor polish items in one diff — they touch the same right-hand panel surfaces (Messages tab + Privacy tab) and the Messages changes wouldn't be coherent without the Privacy structural change for visual consistency.

### Messages tab (TurnSelector)

- **Checkbox sizing** drops from 18×18 → 14×14 to match the Privacy panel's bulk checkbox. Body text 13→12px, mono index 11→10.5px. Inside the share editor the Messages list previously looked noticeably chunkier than every neighbouring control after the Privacy panel landed; now the two views feel like the same family.
- **Left alignment fix**: row padding `pl-3` → `pl-4` so the checkbox aligns with the \"MESSAGES …\" header's `px-4` baseline. The checkbox was sitting slightly left of the title before.
- **Header count tracks visible list**: previously read \"526 of 526\" even when `hideEmptyTurns` had filtered the rendered rows down to ~170. Now reports \"{visibleKept} of {visibleTotal}\" so the number matches what the user actually sees scrolling through.
- **Drop the always-on scrollbar** with `scrollbar-none`. Long sessions no longer paint a permanent grey rail on the right of the list.

### Privacy tab (PrivacyView)

- **Pin the header + master toggle**, scroll only the categorised list. Before, scrolling the long list of detected categories pushed the REDACTIONS title, count, Reset button, and master toggle off the top. The master control + leak count now stay in view at all times — the only meaningful surface to scroll is the per-category accordions.

## Why

Direct fallout from PR #211 (Privacy panel). The new Privacy tab introduced a tighter visual baseline (14px checkboxes, 12px label) and the existing Messages tab next to it now looked oversized by comparison. Plus the Privacy tab itself accumulated enough categories on real coding-agent sessions that the no-fixed-header pattern stopped working well — users scrolling through Cloud credentials / API key / Connection string / etc. lost track of the master toggle.

## Test plan

- [x] App typecheck clean
- [x] Existing TurnSelector e2e (`share-turn-selector.spec.ts`) — 3/3 still passing locally
- [x] Manual: Messages list checkbox aligns with header; no scrollbar; count matches visible row count when `hideEmptyTurns` is on
- [x] Manual: Privacy tab — header pinned, only category list scrolls
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)