### PR TITLE
feat(share-kit): split Conversation.origin.kind 'pasted' into web-share + agent-session

### DIFF
--- a/packages/app/e2e/helpers/share.ts
+++ b/packages/app/e2e/helpers/share.ts
@@ -164,7 +164,7 @@ export async function seedShareDraft(
     const convo = payload.conversation ?? {
       source: 'claude',
       sourceLabel: 'Claude',
-      origin: { kind: 'pasted', platform: 'Claude' },
+      origin: { kind: 'web-share', platform: 'Claude' },
       title: payload.title ?? 'Seeded draft',
       shareUrl: null,
       createdAt: new Date().toISOString(),

--- a/packages/app/e2e/share-privacy.spec.ts
+++ b/packages/app/e2e/share-privacy.spec.ts
@@ -59,7 +59,7 @@ async function seedSensitiveDraft(window: Page, title: string): Promise<string> 
     conversation: {
       source: 'claude',
       sourceLabel: 'Claude',
-      origin: { kind: 'pasted', platform: 'Claude' },
+      origin: { kind: 'web-share', platform: 'Claude' },
       title,
       shareUrl: null,
       createdAt: new Date().toISOString(),
@@ -352,7 +352,7 @@ test('No sensitive data → empty state', async () => {
     conversation: {
       source: 'claude',
       sourceLabel: 'Claude',
-      origin: { kind: 'pasted', platform: 'Claude' },
+      origin: { kind: 'web-share', platform: 'Claude' },
       title: draftTitle,
       shareUrl: null,
       createdAt: new Date().toISOString(),

--- a/packages/app/src/renderer/lib/compose-from-session.ts
+++ b/packages/app/src/renderer/lib/compose-from-session.ts
@@ -1,5 +1,5 @@
 import type { Session, Message, SessionSource } from '@spool-lab/core'
-import type { Conversation, Platform, Turn } from '@spool/share-kit'
+import type { Conversation, Turn } from '@spool/share-kit'
 
 /**
  * Stable per-session draft id. Re-opening the same Spool session always
@@ -10,19 +10,6 @@ import type { Conversation, Platform, Turn } from '@spool/share-kit'
  */
 export function sessionDraftId(sessionUuid: string): string {
   return `session:${sessionUuid}`
-}
-
-/**
- * share-kit's Platform union currently covers ChatGPT / Claude / Gemini —
- * Codex doesn't exist there yet. We map it onto 'ChatGPT' since the two
- * share OpenAI tooling lineage; the field only drives the source chip's
- * label tinting, not behavior. TODO: extend share-kit's Platform with
- * 'Codex' when the kit's parsers grow Codex support.
- */
-const PLATFORM_BY_SOURCE: Record<SessionSource, Platform> = {
-  claude: 'Claude',
-  codex: 'ChatGPT',
-  gemini: 'Gemini',
 }
 
 const SOURCE_LABEL: Record<SessionSource, string> = {
@@ -54,7 +41,6 @@ export function composeFromSession(
   messages: Message[],
   opts: ComposeOpts = {},
 ): Conversation {
-  const platform = PLATFORM_BY_SOURCE[session.source]
   const sourceLabel = SOURCE_LABEL[session.source]
 
   const turns: Turn[] = messages
@@ -73,7 +59,11 @@ export function composeFromSession(
   return {
     source: session.source,
     sourceLabel,
-    origin: { kind: 'pasted', platform },
+    origin: {
+      kind: 'agent-session',
+      agent: session.source,
+      sessionUuid: session.sessionUuid,
+    },
     title,
     shareUrl: null,
     createdAt: formatCreatedAt(session.startedAt),

--- a/packages/share-kit/src/lib/fixtures.ts
+++ b/packages/share-kit/src/lib/fixtures.ts
@@ -6,7 +6,11 @@ import type { Conversation } from './types'
 export const FIXTURE_PASTED: Conversation = {
   source: 'claude',
   sourceLabel: 'Claude',
-  origin: { kind: 'pasted', platform: 'Claude' },
+  origin: {
+    kind: 'web-share',
+    platform: 'Claude',
+    url: 'https://claude.ai/share/8f3a2e1b-d4c7-4a90-b3f2-1e9c7a0d5f8b',
+  },
   title: 'Debugging a race condition in the cache layer',
   shareUrl: 'https://claude.ai/share/8f3a2e1b-d4c7-4a90-b3f2-1e9c7a0d5f8b',
   shortUrl: 'spool.share/s/3fm2',

--- a/packages/share-kit/src/lib/parsers/sources/chatgpt.ts
+++ b/packages/share-kit/src/lib/parsers/sources/chatgpt.ts
@@ -62,7 +62,7 @@ export const chatgptSource: ParserSource = {
     return {
       source: 'chatgpt',
       sourceLabel: 'ChatGPT',
-      origin: { kind: 'pasted', platform: 'ChatGPT' },
+      origin: { kind: 'web-share', platform: 'ChatGPT', url },
       title: cleanedTitle,
       shareUrl: url,
       createdAt: humanDate(),

--- a/packages/share-kit/src/lib/parsers/sources/claude.ts
+++ b/packages/share-kit/src/lib/parsers/sources/claude.ts
@@ -56,7 +56,7 @@ export const claudeSource: ParserSource = {
     return {
       source: 'claude',
       sourceLabel: 'Claude',
-      origin: { kind: 'pasted', platform: 'Claude' },
+      origin: { kind: 'web-share', platform: 'Claude', url },
       title,
       shareUrl: url,
       createdAt,

--- a/packages/share-kit/src/lib/parsers/sources/gemini.ts
+++ b/packages/share-kit/src/lib/parsers/sources/gemini.ts
@@ -69,7 +69,7 @@ export const geminiSource: ParserSource = {
     return {
       source: 'gemini',
       sourceLabel: 'Gemini',
-      origin: { kind: 'pasted', platform: 'Gemini' },
+      origin: { kind: 'web-share', platform: 'Gemini', url },
       title,
       shareUrl: url,
       createdAt: humanDate(),

--- a/packages/share-kit/src/lib/storage/preview-document.test.ts
+++ b/packages/share-kit/src/lib/storage/preview-document.test.ts
@@ -16,7 +16,7 @@ function makeDoc(turns: Turn[], optsOverrides: Partial<typeof DEFAULT_OPTS> = {}
     conversation: {
       source: 'claude',
       sourceLabel: 'Claude',
-      origin: { kind: 'pasted', platform: 'Claude' },
+      origin: { kind: 'web-share', platform: 'Claude' },
       title: 'Test',
       shareUrl: null,
       createdAt: '2026-05-14T00:00:00.000Z',

--- a/packages/share-kit/src/lib/types.ts
+++ b/packages/share-kit/src/lib/types.ts
@@ -8,8 +8,24 @@
 
 export type Platform = 'ChatGPT' | 'Claude' | 'Gemini'
 
+/** Where a `Conversation` came from. Drives the source chip in the
+ *  editor topbar and lets future security/cleanup features
+ *  distinguish web pastes from local agent recordings.
+ *
+ *  - `web-share`: user pasted a public share URL (chatgpt.com /
+ *    claude.ai / gemini.google.com). The shared URL is the user's
+ *    own published artifact — public-by-design.
+ *  - `agent-session`: user opened a local `.spool` session captured
+ *    from a coding agent (Claude Code, codex, gemini-cli). The
+ *    transcript was never public — agent transcripts can contain
+ *    secrets the agent read off disk and that the user never
+ *    intended to publish, which is why the Privacy panel exists.
+ *    The planned Security Scan feature only sweeps `agent-session`
+ *    conversations.
+ *  - `file`: user dropped a `.spool` file (Spool's portable format). */
 export type Origin =
-  | { kind: 'pasted'; platform: Platform }
+  | { kind: 'web-share'; platform: Platform; url?: string }
+  | { kind: 'agent-session'; agent: string; sessionUuid?: string }
   | { kind: 'file'; filename: string }
 
 export type TurnRole = 'user' | 'assistant'


### PR DESCRIPTION
## Summary

Splits the overloaded `'pasted'` origin kind into two semantically distinct kinds.

### Before

```ts
type Origin =
  | { kind: 'pasted'; platform: Platform }
  | { kind: 'file'; filename: string }
```

`'pasted'` tagged BOTH:
- User-pasted public share URL (chatgpt.com / claude.ai / gemini.google.com) — `shareUrl` non-null
- Local `.spool` session opened from SessionDetail \"Open in share editor\" — `shareUrl` null

### After

```ts
type Origin =
  | { kind: 'web-share'; platform: Platform; url?: string }
  | { kind: 'agent-session'; agent: string; sessionUuid?: string }
  | { kind: 'file'; filename: string }
```

## Why

The two were different sources but tagged identically:

- **`web-share`** is the user's public artifact — already published, already scoped by them. Low novelty leak surface.
- **`agent-session`** is a local recording that may contain whatever the agent read off disk during its run — credentials, absolute paths, internal hostnames. The Privacy panel exists because of this surface; the planned Security Scan feature only sweeps `agent-session` conversations.

The collapsed encoding made it impossible to (a) distinguish them in the editor topbar's source chip, (b) filter them in the upcoming Security Scan, (c) build features like \"open the original session\" (where we'd want the `sessionUuid`) or \"open the original share URL\" (where we'd want the `url`). The new union carries the contextual identifiers directly.

Followups built on this split (separate PRs):
- Source chip in the editor topbar gets distinct treatment per kind (\"From Claude\" vs \"From Claude Code · local\").
- Security Scan filters its sweep to `kind === 'agent-session'`.

## Migration

**None.** Share editor isn't in a published version yet, so any persisted drafts on developer machines are disposable. No legacy coercion in the codepath; if a stale draft with `kind: 'pasted'` ever loads, TypeScript narrowing will exhaustively miss it and the editor will fail loud at the type boundary — exactly what we want for a clean split.

## Call sites updated

- 3 web parsers (`chatgpt.ts` / `claude.ts` / `gemini.ts`) — emit `{ kind: 'web-share', platform, url }`; carries the original URL for future \"open original\" affordances.
- `compose-from-session.ts` — emits `{ kind: 'agent-session', agent: session.source, sessionUuid: session.sessionUuid }`. Removed the no-longer-needed `PLATFORM_BY_SOURCE` map (agent kind doesn't go through web Platform).
- `fixtures.ts` (FIXTURE_PASTED) + `preview-document.test.ts` — updated to new shape.
- `e2e/helpers/share.ts` (`seedShareDraft` default convo) + `e2e/share-privacy.spec.ts` — updated.

No consumer in app code reads anything other than `kind === 'file'` today (`drafts.ts:58`), so the rest of the rename is internal.

## Test plan

- [x] `@spool/share-kit` unit — 38/38 still pass
- [x] App typecheck clean
- [x] Manual: open a local Claude Code session → share editor mounts, preview renders, draft autosaves correctly
- [x] Manual: paste a Claude share URL → editor mounts the same way
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)