### PR TITLE
ci(unit): run @spool-lab/redact and @spool/share-kit tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,9 @@ jobs:
       - run: pnpm --filter @spool-lab/core test
       - run: pnpm --filter @spool-lab/cli build
       - run: pnpm --filter @spool-lab/cli test
+      - run: pnpm --filter @spool-lab/redact build
+      - run: pnpm --filter @spool-lab/redact test
+      - run: pnpm --filter @spool/share-kit test
 
   e2e:
     strategy:


### PR DESCRIPTION
## Summary

The `unit` job in `e2e.yml` currently only builds and tests `@spool-lab/core` and `@spool-lab/cli`. Two workspace packages have their own vitest suites that CI never runs directly:

- `@spool-lab/redact` — 65 tests (detectors, masking, value-hash exclusion)
- `@spool/share-kit` — 38 tests (template rendering, redact integration, preview-document, paper/typeface/colorway registries + coercion)

They get exercised transitively when the Electron e2e job builds the app, but a logic regression inside either package can sit on a PR for the full ~10 minute e2e cycle without a clear signal — and a flaky e2e run can mask a real share-kit failure.

## What changed

Three extra steps in the `unit` job, after the existing core + cli builds and tests:

```yaml
- run: pnpm --filter @spool-lab/redact build
- run: pnpm --filter @spool-lab/redact test
- run: pnpm --filter @spool/share-kit test
```

`@spool-lab/redact` ships from `./dist` (its package.json `main` / `types` point there), so its build is required before sibling workspaces can resolve it at test-time. `@spool/share-kit`'s vitest run compiles TS on the fly — no build step needed for the test to run.

## Test plan

- [x] `pnpm --filter @spool-lab/redact test` — 65/65 pass locally.
- [x] `pnpm --filter @spool/share-kit test` — 38/38 pass locally.
- [ ] CI on this PR exercises the new steps end-to-end on both `ubuntu-latest` and `macos-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)