### PR TITLE
feat(share): unify share entry as Edit icon + 'Edit share draft' label

### DIFF
--- a/packages/app/e2e/helpers/share.ts
+++ b/packages/app/e2e/helpers/share.ts
@@ -34,7 +34,7 @@ export async function openSessionDetail(window: Page, sessionUuid: string): Prom
 }
 
 /**
- * Open a SessionRow ⋯ menu and pick "Open in share editor".
+ * Open a SessionRow ⋯ menu and pick "Edit share draft".
  */
 export async function shareFromSessionRowMenu(window: Page, sessionUuid: string): Promise<void> {
   await window.locator('[data-testid="sidebar-project-row"]').first().click()
@@ -42,7 +42,7 @@ export async function shareFromSessionRowMenu(window: Page, sessionUuid: string)
   await expect(row).toBeVisible({ timeout: 5000 })
   await row.hover()
   await row.getByLabel('More actions').click()
-  await window.getByRole('menuitem', { name: 'Open in share editor' }).click()
+  await window.getByRole('menuitem', { name: 'Edit share draft' }).click()
   await expect(window.locator('[data-testid="share-editor-page"]')).toBeVisible({ timeout: 5000 })
 }
 

--- a/packages/app/e2e/share-entry-points.spec.ts
+++ b/packages/app/e2e/share-entry-points.spec.ts
@@ -68,7 +68,7 @@ test('entry point: LibraryLanding ⋯ menu Share opens editor', async () => {
   await expect(row).toBeVisible({ timeout: 5000 })
   await row.hover()
   await row.getByLabel('More actions').click()
-  await ctx.window.getByRole('menuitem', { name: 'Open in share editor' }).click()
+  await ctx.window.getByRole('menuitem', { name: 'Edit share draft' }).click()
   await expect(ctx.window.locator('[data-testid="share-editor-page"]')).toBeVisible({ timeout: 5000 })
   await closeEditorIfOpen()
 })

--- a/packages/app/src/renderer/components/ContinueActions.tsx
+++ b/packages/app/src/renderer/components/ContinueActions.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { MoreHorizontal, Eye, SquareTerminal, BookText, Copy, Loader2 } from 'lucide-react'
+import { MoreHorizontal, Eye, SquareTerminal, SquarePen, Copy, Loader2 } from 'lucide-react'
 import type { FragmentResult } from '@spool-lab/core'
 import Menu from './Menu.js'
 import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
@@ -50,7 +50,7 @@ export default function ContinueActions({ result, onOpenSession, onCopySessionId
     },
     ...(onShare ? [{
       label: t('shareEditor.openNew'),
-      icon: <BookText size={ICON_SIZE} strokeWidth={ICON_STROKE} aria-hidden />,
+      icon: <SquarePen size={ICON_SIZE} strokeWidth={ICON_STROKE} aria-hidden />,
       onSelect: onShare,
     }] : []),
     ...(resumeCommand ? [{

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { SquareTerminal, BookText, MoreHorizontal, Copy } from 'lucide-react'
+import { SquareTerminal, SquarePen, MoreHorizontal, Copy } from 'lucide-react'
 import type { Session, Message } from '@spool-lab/core'
 import { type FindRange } from './MessageBubble.js'
 import MessageList, { type MessageListHandle } from './MessageList.js'
@@ -290,7 +290,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
                   : 'text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text'
               }`}
             >
-              <BookText size={13} strokeWidth={1.6} aria-hidden />
+              <SquarePen size={13} strokeWidth={1.6} aria-hidden />
             </button>
           )}
 

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { SquareTerminal, MoreHorizontal, Copy, Loader2, BookText } from 'lucide-react'
+import { SquareTerminal, MoreHorizontal, Copy, Loader2, SquarePen } from 'lucide-react'
 import type { Session } from '@spool-lab/core'
 import { SourceBadge } from './Badges.js'
 import PinButton from './PinButton.js'
@@ -119,7 +119,7 @@ export default function SessionRow({ session, pinned = false, showProject = fals
             items={[
               ...(onShare ? [{
                 label: t('shareEditor.openNew'),
-                icon: <BookText size={14} strokeWidth={1.6} aria-hidden />,
+                icon: <SquarePen size={14} strokeWidth={1.6} aria-hidden />,
                 onSelect: () => onShare(session.sessionUuid),
               }] : []),
               {

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import type { ProjectGroup, Session, SessionSource, StatusInfo } from '@spool-lab/core'
-import { MessagesSquare as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, SquareTerminal, MoreHorizontal, Copy, Loader2, BookText } from 'lucide-react'
+import { MessagesSquare as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, SquareTerminal, MoreHorizontal, Copy, Loader2, SquarePen } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import PinIcon from './PinIcon.js'
 import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
@@ -680,7 +680,7 @@ function PinnedRow({
           items={[
             ...(onShare ? [{
               label: t('shareEditor.openNew'),
-              icon: <BookText size={14} strokeWidth={1.6} aria-hidden />,
+              icon: <SquarePen size={14} strokeWidth={1.6} aria-hidden />,
               onSelect: () => onShare(session.sessionUuid),
             }] : []),
             {

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -216,8 +216,8 @@
     "sourceKind_imported": "Importiert"
   },
   "shareEditor": {
-    "openExisting": "Freigabe-Entwurf öffnen",
-    "openNew": "Im Freigabe-Editor öffnen",
+    "openExisting": "Freigabe-Entwurf bearbeiten",
+    "openNew": "Freigabe-Entwurf bearbeiten",
     "back": "Zurück",
     "panel_privacy": "Datenschutz",
     "panel_timeline": "Verlauf",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -216,8 +216,8 @@
     "sourceKind_imported": "Imported"
   },
   "shareEditor": {
-    "openExisting": "Open share draft",
-    "openNew": "Open in share editor",
+    "openExisting": "Edit share draft",
+    "openNew": "Edit share draft",
     "back": "Back",
     "panel_privacy": "Privacy",
     "panel_timeline": "Timeline",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -216,8 +216,8 @@
     "sourceKind_imported": "Importé"
   },
   "shareEditor": {
-    "openExisting": "Ouvrir le brouillon de partage",
-    "openNew": "Ouvrir dans l'éditeur de partage",
+    "openExisting": "Modifier le brouillon de partage",
+    "openNew": "Modifier le brouillon de partage",
     "back": "Retour",
     "panel_privacy": "Confidentialité",
     "panel_timeline": "Chronologie",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -209,8 +209,8 @@
     "sourceKind_imported": "インポート済み"
   },
   "shareEditor": {
-    "openExisting": "共有下書きを開く",
-    "openNew": "共有エディタで開く",
+    "openExisting": "共有下書きを編集",
+    "openNew": "共有下書きを編集",
     "back": "戻る",
     "panel_privacy": "プライバシー",
     "panel_timeline": "タイムライン",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -209,8 +209,8 @@
     "sourceKind_imported": "가져옴"
   },
   "shareEditor": {
-    "openExisting": "공유 초안 열기",
-    "openNew": "공유 편집기에서 열기",
+    "openExisting": "공유 초안 편집",
+    "openNew": "공유 초안 편집",
     "back": "뒤로",
     "panel_privacy": "개인정보",
     "panel_timeline": "타임라인",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -209,8 +209,8 @@
     "sourceKind_imported": "已导入"
   },
   "shareEditor": {
-    "openExisting": "打开分享草稿",
-    "openNew": "在分享编辑器中打开",
+    "openExisting": "编辑分享草稿",
+    "openNew": "编辑分享草稿",
     "back": "返回",
     "panel_privacy": "隐私",
     "panel_timeline": "时间线",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -209,8 +209,8 @@
     "sourceKind_imported": "已匯入"
   },
   "shareEditor": {
-    "openExisting": "開啟分享草稿",
-    "openNew": "在分享編輯器中開啟",
+    "openExisting": "編輯分享草稿",
+    "openNew": "編輯分享草稿",
     "back": "返回",
     "panel_privacy": "隱私",
     "panel_timeline": "時間軸",


### PR DESCRIPTION
Replaces the BookText icon with SquarePen and renames the action to **Edit share draft** across Sidebar, SessionDetail, SessionRow, and ContinueActions.

The split between `Open share draft` (existing) and `Open in share editor` (new) was confusing — both actions land in the same editor regardless of draft state. A single "Edit share draft" label and pencil-in-frame icon better convey intent. `SquarePen` matches the visual weight of the neighbouring `SquareTerminal`/`MoreHorizontal` icons (square framed, same stroke).

Translations updated for all seven locales: en, zh-CN, zh-TW, ja, ko, de, fr.