### PR TITLE
feat(app): day-divider headers in MessageList for cross-day sessions

### DIFF
--- a/packages/app/src/renderer/components/MessageList.tsx
+++ b/packages/app/src/renderer/components/MessageList.tsx
@@ -1,7 +1,10 @@
 import { forwardRef, useImperativeHandle, useMemo, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
 import type { Message } from '@spool-lab/core'
 import MessageBubble, { type FindRange } from './MessageBubble.js'
+
+type DividerLabel = (iso: string, now: Date) => string
 
 export interface MessageListHandle {
   scrollToMessageId: (id: number) => void
@@ -23,17 +26,92 @@ interface Props {
   showTargetHighlight: boolean
 }
 
+/** A virtualised row is either an actual message or a day-divider header. */
+type Row =
+  | { kind: 'msg'; msg: Message; showAvatar: boolean }
+  | { kind: 'divider'; key: string; isoDay: string; label: string }
+
+/** Stable per-local-day key used for divider grouping + dedup. */
+function localDayKey(iso: string): string {
+  const d = new Date(iso)
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`
+}
+
+function sameLocalDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  )
+}
+
+function makeDividerLabel(today: string, yesterday: string, locale: string | undefined): DividerLabel {
+  return (iso, now) => {
+    const d = new Date(iso)
+    if (sameLocalDay(d, now)) return today
+    const y = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1)
+    if (sameLocalDay(d, y)) return yesterday
+    const opts: Intl.DateTimeFormatOptions =
+      d.getFullYear() === now.getFullYear()
+        ? { weekday: 'short', month: 'short', day: 'numeric' }
+        : { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' }
+    return new Intl.DateTimeFormat(locale, opts).format(d)
+  }
+}
+
+/** Build the virtualised row list. A divider is inserted whenever the
+ *  message's local day differs from the previous row, including before the
+ *  very first message. `showAvatar` is pre-computed here so itemContent
+ *  stays cheap and so role-grouping resets across day boundaries (the
+ *  first message after a divider always shows its avatar). */
+function buildRows(messages: Message[], label: DividerLabel): Row[] {
+  const rows: Row[] = []
+  let prevDay: string | null = null
+  let prevMsg: Message | null = null
+  const now = new Date()
+  for (const msg of messages) {
+    const day = localDayKey(msg.timestamp)
+    if (day !== prevDay) {
+      rows.push({
+        kind: 'divider',
+        key: `div-${day}`,
+        isoDay: day,
+        label: label(msg.timestamp, now),
+      })
+      prevDay = day
+      prevMsg = null
+    }
+    const showAvatar =
+      !prevMsg || prevMsg.role !== msg.role || prevMsg.role === 'system'
+    rows.push({ kind: 'msg', msg, showAvatar })
+    prevMsg = msg
+  }
+  return rows
+}
+
 const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
   { messages, isDark, showFindBar, messageFindRanges, activeMatchIndex, onActiveMatchRef, targetMessageId, showTargetHighlight },
   ref,
 ) {
+  const { t, i18n } = useTranslation()
   const virtuosoRef = useRef<VirtuosoHandle | null>(null)
 
-  const idToIndex = useMemo(() => {
+  const dividerLabel = useMemo(
+    () => makeDividerLabel(t('session.divider_today'), t('session.divider_yesterday'), i18n.language),
+    [t, i18n.language],
+  )
+  const rows = useMemo(() => buildRows(messages, dividerLabel), [messages, dividerLabel])
+
+  // Maps a message id to its row index. Row indices include day dividers,
+  // so this is the only correct way to translate "scroll to message X" into
+  // a Virtuoso index after dividers are inserted.
+  const idToRowIndex = useMemo(() => {
     const map = new Map<number, number>()
-    messages.forEach((m, i) => map.set(m.id, i))
+    rows.forEach((row, i) => {
+      if (row.kind === 'msg') map.set(row.msg.id, i)
+    })
     return map
-  }, [messages])
+  }, [rows])
 
   // Captured once at mount: Virtuoso reads this before its first paint, so the
   // target row is already centered when the user sees the list. Subsequent
@@ -43,18 +121,18 @@ const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
   // initialTopMostItemIndex with the fresh target.
   const initialIndex = useMemo(() => {
     if (targetMessageId == null) return undefined
-    const idx = idToIndex.get(targetMessageId)
+    const idx = idToRowIndex.get(targetMessageId)
     return idx == null ? undefined : { index: idx, align: 'center' as const }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useImperativeHandle(ref, () => ({
     scrollToMessageId(id) {
-      const idx = idToIndex.get(id)
+      const idx = idToRowIndex.get(id)
       if (idx == null) return
       virtuosoRef.current?.scrollIntoView({ index: idx, align: 'center', behavior: 'auto' })
     },
-  }), [idToIndex])
+  }), [idToRowIndex])
 
   if (messages.length === 0) {
     return (
@@ -67,21 +145,36 @@ const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
   return (
     <Virtuoso
       ref={virtuosoRef}
-      data={messages}
-      computeItemKey={(_index, msg) => msg.id}
+      data={rows}
+      computeItemKey={(_index, row) => row.kind === 'msg' ? `m-${row.msg.id}` : row.key}
       defaultItemHeight={64}
       {...(initialIndex ? { initialTopMostItemIndex: initialIndex } : {})}
       increaseViewportBy={400}
       data-testid="message-list-scroll"
       className="flex-1 [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]"
-      itemContent={(index, msg) => {
+      itemContent={(index, row) => {
+        if (row.kind === 'divider') {
+          return (
+            <div
+              data-index={index}
+              data-testid="day-divider"
+              data-day={row.isoDay}
+              className="px-6 pt-5 pb-2 flex items-center gap-3 select-none"
+            >
+              <span className="flex-1 h-px bg-warm-border dark:bg-dark-border" />
+              <span className="text-[10px] font-semibold tracking-[0.08em] uppercase text-warm-faint dark:text-dark-muted">
+                {row.label}
+              </span>
+              <span className="flex-1 h-px bg-warm-border dark:bg-dark-border" />
+            </div>
+          )
+        }
+        const msg = row.msg
         const matchState = showFindBar ? messageFindRanges.get(msg.id) : undefined
         const containsActive = matchState != null
           && activeMatchIndex >= matchState.offset
           && activeMatchIndex < matchState.offset + matchState.ranges.length
         const isTarget = msg.id === targetMessageId
-        const prev = index > 0 ? messages[index - 1] : undefined
-        const showAvatar = !prev || prev.role !== msg.role || prev.role === 'system'
 
         return (
           <div
@@ -95,7 +188,7 @@ const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
             <MessageBubble
               message={msg}
               isDark={isDark}
-              showAvatar={showAvatar}
+              showAvatar={row.showAvatar}
               {...(matchState ? { findRanges: matchState.ranges, matchIndexOffset: matchState.offset } : {})}
               activeMatchIndex={containsActive ? activeMatchIndex : -1}
               {...(containsActive ? { onActiveMatchRef } : {})}

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -118,7 +118,9 @@
     "copySessionId_short": "ID kopieren",
     "scrollToBottom": "Nach unten scrollen",
     "msgs_one": "{{count}} Nachr.",
-    "msgs_other": "{{count}} Nachr."
+    "msgs_other": "{{count}} Nachr.",
+    "divider_today": "Heute",
+    "divider_yesterday": "Gestern"
   },
   "library": {
     "greeting": "Willkommen zurück",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -118,7 +118,9 @@
     "copySessionId_short": "Copy ID",
     "scrollToBottom": "Scroll to bottom",
     "msgs_one": "{{count}} msg",
-    "msgs_other": "{{count}} msgs"
+    "msgs_other": "{{count}} msgs",
+    "divider_today": "Today",
+    "divider_yesterday": "Yesterday"
   },
   "library": {
     "greeting": "Welcome back",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -118,7 +118,9 @@
     "copySessionId_short": "Copier l'ID",
     "scrollToBottom": "Aller en bas",
     "msgs_one": "{{count}} msg",
-    "msgs_other": "{{count}} msgs"
+    "msgs_other": "{{count}} msgs",
+    "divider_today": "Aujourd'hui",
+    "divider_yesterday": "Hier"
   },
   "library": {
     "greeting": "Bon retour",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -112,7 +112,9 @@
     "resume_inTerminal": "ターミナルで再開",
     "copySessionId_short": "ID をコピー",
     "scrollToBottom": "末尾までスクロール",
-    "msgs_other": "{{count}} 件"
+    "msgs_other": "{{count}} 件",
+    "divider_today": "今日",
+    "divider_yesterday": "昨日"
   },
   "library": {
     "greeting": "おかえりなさい",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -112,7 +112,9 @@
     "resume_inTerminal": "터미널에서 재개",
     "copySessionId_short": "ID 복사",
     "scrollToBottom": "맨 아래로 스크롤",
-    "msgs_other": "{{count}}개"
+    "msgs_other": "{{count}}개",
+    "divider_today": "오늘",
+    "divider_yesterday": "어제"
   },
   "library": {
     "greeting": "환영합니다",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -112,7 +112,9 @@
     "resume_inTerminal": "在终端继续",
     "copySessionId_short": "复制 ID",
     "scrollToBottom": "滚到底部",
-    "msgs_other": "{{count}} 条"
+    "msgs_other": "{{count}} 条",
+    "divider_today": "今天",
+    "divider_yesterday": "昨天"
   },
   "library": {
     "greeting": "欢迎回来",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -112,7 +112,9 @@
     "resume_inTerminal": "在終端機繼續",
     "copySessionId_short": "複製 ID",
     "scrollToBottom": "捲到底部",
-    "msgs_other": "{{count}} 則"
+    "msgs_other": "{{count}} 則",
+    "divider_today": "今天",
+    "divider_yesterday": "昨天"
   },
   "library": {
     "greeting": "歡迎回來",


### PR DESCRIPTION
Inserts a sticky divider row before each new local day in SessionDetail's virtualised message list. Reads **Today** / **Yesterday** from i18n and falls back to a locale-aware short date (`Wed, May 13` / `周三 5月13日`) for older days.

## Why

A 1200-message session that spans multiple days currently gives no visual anchor for "when did this conversation actually happen." Matching what iMessage / Telegram / WhatsApp / Slack do — a small day header before the first message of each new day — restores that anchor without taking real estate from messages.

## How it connects

- `MessageList.tsx` builds a `Row[]` union (`'msg' | 'divider'`) ahead of the Virtuoso `data` prop. Day boundaries are detected by stable local-day keys; the divider's label is computed once per language change via `useMemo` over `t()` + `i18n.language`.
- Row-index → message-id mapping accounts for divider rows so `scrollToMessageId` still lands on the right message; `initialTopMostItemIndex` is captured at mount.
- `session.divider_today` / `session.divider_yesterday` added to all seven locales (en/zh-CN/zh-TW/ja/ko/de/fr).
- The first message of each day always shows its avatar (role grouping resets across day boundaries).

## Test plan

- [x] `tsc --noEmit`: 0 errors
- [x] Manual: cross-day session shows `今天 / 昨天 / 周三 5月13日` dividers; UI language switch updates labels and the date format
- [x] 1500-message virtualisation still passes (<35 rendered rows at steady state) — verified by existing e2e