### PR TITLE
polish settings panel and theme editor

### DIFF
--- a/packages/app/src/renderer/components/SettingsPanel.tsx
+++ b/packages/app/src/renderer/components/SettingsPanel.tsx
@@ -6,6 +6,7 @@ import type { ThemeEditorStateV1 } from '../theme/editorTypes.js'
 import ThemeEditorSection from './ThemeEditorSection.js'
 import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
 import { useHotkeys } from '../hooks/useHotkeys.js'
+import Menu from './Menu.js'
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -101,7 +102,11 @@ export default function SettingsPanel({
   useHotkeys({ Escape: onClose }, { modal: true })
 
   return (
-    <div data-testid="settings-panel" className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+    <div
+      data-testid="settings-panel"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
       <div className="w-[720px] h-[560px] max-w-[calc(100vw-32px)] max-h-[calc(100vh-32px)] bg-warm-bg dark:bg-dark-bg border border-warm-border dark:border-dark-border rounded-[10px] shadow-xl overflow-hidden flex">
         {/* Sidebar */}
         <div className="w-[176px] flex-none bg-warm-surface dark:bg-dark-surface border-r border-warm-border dark:border-dark-border flex flex-col py-3">
@@ -115,7 +120,7 @@ export default function SettingsPanel({
                 type="button"
                 aria-pressed={tab === def.id}
                 onClick={() => setTab(def.id)}
-                className={`flex w-full items-center gap-2 rounded-[8px] px-3 py-2 text-[12px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent focus-visible:ring-offset-0 ${
+                className={`flex w-full items-center gap-2 rounded-[6px] px-3 py-2 text-[12px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent focus-visible:ring-offset-0 ${
                   tab === def.id
                     ? 'text-accent dark:text-accent-dark bg-accent-bg dark:bg-[#2A1800] font-medium'
                     : 'text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text hover:bg-warm-bg/70 dark:hover:bg-dark-bg/60'
@@ -127,9 +132,7 @@ export default function SettingsPanel({
             ))}
           </div>
           <div className="flex-1" />
-          <div className="px-4 py-2 text-[10px] text-warm-faint dark:text-dark-muted">
-            {t('settings.localData_footer')}
-          </div>
+          <FooterPath text={t('settings.localData_footer')} />
         </div>
 
         {/* Content */}
@@ -406,7 +409,7 @@ function AgentTab() {
                 key={agent.id}
                 onClick={() => isReady && updateConfig({ defaultAgent: agent.id })}
                 disabled={!isReady}
-                className={`w-full flex items-center gap-3 px-3 py-2.5 border rounded-[8px] text-left transition-colors ${
+                className={`w-full flex items-center gap-3 px-3 py-3 border rounded-[6px] text-left transition-colors ${
                   isSelected
                     ? 'bg-accent-bg dark:bg-[#2A1800] border-accent/30 dark:border-accent-dark/30'
                     : isReady
@@ -420,7 +423,7 @@ function AgentTab() {
                     <span className={`text-xs font-medium ${isReady ? 'text-warm-text dark:text-dark-text' : 'text-warm-faint dark:text-dark-muted'}`}>
                       {agent.name}
                     </span>
-                    <span className="text-[9px] font-mono text-warm-faint dark:text-dark-muted px-1.5 py-0.5 bg-warm-surface2 dark:bg-dark-surface2 rounded">
+                    <span className="text-[10px] font-mono text-warm-faint dark:text-dark-muted px-1.5 py-0.5 bg-warm-surface2 dark:bg-dark-surface2 rounded-[4px]">
                       {modeLabel(agent.acpMode)}
                     </span>
                   </div>
@@ -428,7 +431,7 @@ function AgentTab() {
                     {isReady ? agent.path : `${agent.id} — ${t('settings.agentStatus_not_found')}`}
                   </span>
                 </div>
-                <span className={`text-[10px] font-medium flex-none ${isReady ? 'text-green-500' : 'text-warm-faint dark:text-dark-muted'}`}>
+                <span className={`text-[10px] font-medium flex-none ${isReady ? 'text-status-success dark:text-status-success-dark' : 'text-warm-faint dark:text-dark-muted'}`}>
                   {isReady ? t('settings.agentStatus_ready') : t('settings.agentStatus_not_found')}
                 </span>
               </button>
@@ -448,7 +451,7 @@ function AgentTab() {
 function Section({ title, children }: { title: string; children: ReactNode }) {
   return (
     <div>
-      <h4 className="text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.04em] uppercase mb-2">
+      <h4 className="text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.08em] uppercase mb-2">
         {title}
       </h4>
       {children}
@@ -466,7 +469,7 @@ function BuiltInSource({ name, color, count }: { name: string; color: string; co
         {count === null ? '…' : t('sidebar.sessionCount_other', { count })}
       </span>
       <span className="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.06em] text-warm-faint dark:text-dark-muted">
-        <span className="w-1.5 h-1.5 rounded-full bg-green-500 flex-none" />
+        <span className="w-1.5 h-1.5 rounded-full bg-status-success dark:bg-status-success-dark flex-none" />
         auto
       </span>
     </div>
@@ -484,16 +487,51 @@ function RadioDot({ selected }: { selected: boolean }) {
 }
 
 function SmallSelect({ value, onChange, options }: { value: string; onChange: (v: string) => void; options: { value: string; label: string }[] }) {
+  const current = options.find(o => o.value === value) ?? options[0]
   return (
-    <div className="relative flex-none">
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="appearance-none h-7 rounded-[6px] border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface pl-2.5 pr-7 text-xs text-warm-text dark:text-dark-text outline-none transition-colors hover:border-warm-border2 dark:hover:border-dark-border2 focus:border-accent"
-      >
-        {options.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-      </select>
-      <ChevronDown />
+    <Menu
+      align="right"
+      items={options.map(o => ({
+        label: o.label,
+        active: o.value === value,
+        onSelect: () => onChange(o.value),
+      }))}
+      trigger={({ open, toggle }) => (
+        <button
+          type="button"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          onClick={toggle}
+          className={`inline-flex items-center gap-2 h-7 min-w-[140px] rounded-[6px] border bg-warm-surface dark:bg-dark-surface pl-3 pr-2 text-[12px] text-warm-text dark:text-dark-text outline-none transition-colors focus-visible:ring-1 focus-visible:ring-accent focus-visible:ring-offset-0 ${
+            open
+              ? 'border-accent dark:border-accent-dark'
+              : 'border-warm-border dark:border-dark-border hover:border-warm-border2 dark:hover:border-dark-border2'
+          }`}
+        >
+          <span className="flex-1 text-left truncate">{current?.label ?? value}</span>
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 12 12"
+            className={`h-3 w-3 flex-none text-warm-muted dark:text-dark-muted transition-transform ${open ? 'rotate-180' : ''}`}
+            fill="none"
+          >
+            <path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      )}
+    />
+  )
+}
+
+function FooterPath({ text }: { text: string }) {
+  const path = '~/.spool/'
+  const idx = text.indexOf(path)
+  const lead = idx >= 0 ? text.slice(0, idx).replace(/[\s,，:：]+$/, '').trim() : text
+  const trail = idx >= 0 ? text.slice(idx + path.length).trim() : ''
+  return (
+    <div className="px-4 py-2 text-[11px] leading-snug text-warm-faint dark:text-dark-muted">
+      <span className="block">{lead}{trail ? ` ${trail}` : ''}</span>
+      {idx >= 0 && <span className="block mt-0.5 font-mono">{path}</span>}
     </div>
   )
 }
@@ -540,10 +578,3 @@ function ToggleRow({
   )
 }
 
-function ChevronDown() {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 12 12" className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-warm-muted dark:text-dark-muted" fill="none">
-      <path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  )
-}

--- a/packages/app/src/renderer/components/ThemeEditorSection.tsx
+++ b/packages/app/src/renderer/components/ThemeEditorSection.tsx
@@ -5,6 +5,7 @@ import { THEME_PRESETS } from '../theme/editorTypes.js'
 import { lightPresetSeed, darkPresetSeed } from '../theme/presetSeeds.js'
 import { parseHex, toHex, adaptiveCardTone, hexToRgba, mixHex } from '../theme/colorUtils.js'
 import SegmentedPill from './SegmentedPill.js'
+import Menu from './Menu.js'
 
 function colorInputValue(hex: string): string {
   const parsed = parseHex(hex)
@@ -12,7 +13,7 @@ function colorInputValue(hex: string): string {
 }
 
 const sideInputBase =
-  'rounded-full border outline-none transition-colors focus-visible:ring-1 focus-visible:ring-offset-0 focus-visible:ring-[var(--side-accent)]'
+  'rounded-[6px] border outline-none transition-colors focus-visible:ring-1 focus-visible:ring-offset-0 focus-visible:ring-[var(--side-accent)]'
 
 function tintForValue(hex: string) {
   const tone = adaptiveCardTone(hex)
@@ -28,55 +29,55 @@ function ColorRow(props: {
   label: string
   value: string
   tone: ReturnType<typeof adaptiveCardTone>
+  fieldBg: string
+  divider: string
   onChange: (next: string) => void
   /** Match outer card border — divide-y ignores parent borderColor (not inherited). */
   showTopRule?: boolean
   ruleColor: string
 }) {
   const { t } = useTranslation()
-  const { id, label, value, tone, onChange, showTopRule, ruleColor } = props
+  const { id, label, value, tone, fieldBg, divider, onChange, showTopRule, ruleColor } = props
   const swatch = tintForValue(colorInputValue(value))
 
   return (
     <div
-      className={`grid grid-cols-[112px_minmax(0,1fr)] items-center gap-3 px-4 py-3 ${showTopRule ? 'border-t border-solid' : ''}`}
+      className={`flex items-center gap-3 px-4 py-3 ${showTopRule ? 'border-t border-solid' : ''}`}
       style={showTopRule ? { borderTopColor: ruleColor } : undefined}
     >
+      <div className="relative h-7 w-7 flex-none">
+        <input
+          id={`${id}-picker`}
+          name={`${id}-picker`}
+          type="color"
+          value={colorInputValue(value)}
+          onChange={(e) => onChange(e.target.value.toUpperCase())}
+          className="absolute inset-0 cursor-pointer opacity-0"
+          aria-label={t('themeEditor.accent_color_aria', { label })}
+        />
+        <div className="h-full w-full rounded-full border shadow-sm" style={swatch} />
+      </div>
       <label
         htmlFor={`${id}-hex`}
-        className="text-[11px] font-medium"
+        className="flex-1 min-w-0 text-[12px] font-medium"
         style={{ color: tone.primary }}
       >
         {label}
       </label>
-      <div className="flex min-w-0 items-center gap-2">
-        <div className="relative h-9 w-9 flex-none">
-          <input
-            id={`${id}-picker`}
-            name={`${id}-picker`}
-            type="color"
-            value={colorInputValue(value)}
-            onChange={(e) => onChange(e.target.value.toUpperCase())}
-            className="absolute inset-0 cursor-pointer opacity-0"
-            aria-label={t('themeEditor.accent_color_aria', { label })}
-          />
-          <div className="h-full w-full rounded-full border shadow-sm" style={swatch} />
-        </div>
-        <input
-          id={`${id}-hex`}
-          name={`${id}-hex`}
-          type="text"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          spellCheck={false}
-          autoCapitalize="off"
-          autoCorrect="off"
-          autoComplete="off"
-          className={`h-9 min-w-0 flex-1 px-3 font-mono text-[11px] ${sideInputBase}`}
-          style={swatch}
-          aria-label={t('themeEditor.accent_hex_aria', { label })}
-        />
-      </div>
+      <input
+        id={`${id}-hex`}
+        name={`${id}-hex`}
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        autoComplete="off"
+        className={`h-7 w-[112px] text-right px-2 font-mono text-[11px] tabular-nums ${sideInputBase}`}
+        style={{ backgroundColor: fieldBg, borderColor: divider, color: tone.primary }}
+        aria-label={t('themeEditor.accent_hex_aria', { label })}
+      />
     </div>
   )
 }
@@ -149,36 +150,57 @@ function SideBlock(props: {
         <div className="min-w-0">
           <h4 className="text-xs font-semibold" style={{ color: tone.primary }}>{title}</h4>
         </div>
-        <div className="relative min-w-[168px]">
-          <select
-            id={`${prefix}-preset`}
-            name={`${prefix}-preset`}
-            value={presetValue}
-            onChange={(e) => onPreset(e.target.value)}
-            className={`h-9 w-full appearance-none pl-3 pr-9 text-[11px] font-medium ${sideInputBase}`}
-            style={{
-              backgroundColor: fieldBg,
-              borderColor: divider,
-              color: tone.primary,
+        <div className="flex justify-end min-w-[168px]">
+          <Menu
+            align="right"
+            items={[
+              { value: 'spool', label: t('themeEditor.preset_spool') },
+              { value: 'solarized', label: t('themeEditor.preset_solarized') },
+              { value: 'everforest', label: t('themeEditor.preset_everforest') },
+              { value: 'custom', label: t('themeEditor.preset_custom') },
+            ].map(o => ({
+              label: o.label,
+              active: o.value === presetValue,
+              onSelect: () => onPreset(o.value),
+            }))}
+            trigger={({ open, toggle }) => {
+              const currentLabel = (() => {
+                switch (presetValue) {
+                  case 'spool': return t('themeEditor.preset_spool')
+                  case 'solarized': return t('themeEditor.preset_solarized')
+                  case 'everforest': return t('themeEditor.preset_everforest')
+                  default: return t('themeEditor.preset_custom')
+                }
+              })()
+              return (
+                <button
+                  type="button"
+                  id={`${prefix}-preset`}
+                  aria-haspopup="listbox"
+                  aria-expanded={open}
+                  aria-label={t('themeEditor.presetAria', { title })}
+                  onClick={toggle}
+                  className={`inline-flex min-w-[120px] items-center gap-2 h-8 rounded-[6px] border pl-3 pr-2 text-[11px] font-medium outline-none transition-colors focus-visible:ring-1 focus-visible:ring-offset-0 focus-visible:ring-[var(--side-accent)]`}
+                  style={{
+                    backgroundColor: fieldBg,
+                    borderColor: open ? slot.accent : divider,
+                    color: tone.primary,
+                  }}
+                >
+                  <span className="flex-1 text-left truncate">{currentLabel}</span>
+                  <svg
+                    aria-hidden="true"
+                    viewBox="0 0 12 12"
+                    className={`h-3 w-3 flex-none transition-transform ${open ? 'rotate-180' : ''}`}
+                    fill="none"
+                    style={{ color: tone.muted }}
+                  >
+                    <path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </button>
+              )
             }}
-            aria-label={t('themeEditor.presetAria', { title })}
-          >
-            <>
-              <option value="spool">{t('themeEditor.preset_spool')}</option>
-              <option value="solarized">{t('themeEditor.preset_solarized')}</option>
-              <option value="everforest">{t('themeEditor.preset_everforest')}</option>
-              <option value="custom">{t('themeEditor.preset_custom')}</option>
-            </>
-          </select>
-          <svg
-            aria-hidden="true"
-            viewBox="0 0 12 12"
-            className="pointer-events-none absolute right-3 top-1/2 h-3 w-3 -translate-y-1/2"
-            fill="none"
-            style={{ color: tone.muted }}
-          >
-            <path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
+          />
         </div>
       </div>
 
@@ -188,6 +210,8 @@ function SideBlock(props: {
           label={t('themeEditor.accent')}
           value={slot.accent}
           tone={tone}
+          fieldBg={fieldBg}
+          divider={divider}
           ruleColor={divider}
           onChange={(next) => patch({ accent: next })}
         />
@@ -196,6 +220,8 @@ function SideBlock(props: {
           label={t('themeEditor.background')}
           value={slot.background}
           tone={tone}
+          fieldBg={fieldBg}
+          divider={divider}
           showTopRule
           ruleColor={divider}
           onChange={(next) => patch({ background: next })}
@@ -205,38 +231,38 @@ function SideBlock(props: {
           label={t('themeEditor.foreground')}
           value={slot.foreground}
           tone={tone}
+          fieldBg={fieldBg}
+          divider={divider}
           showTopRule
           ruleColor={divider}
           onChange={(next) => patch({ foreground: next })}
         />
 
         <div
-          className="grid grid-cols-[112px_minmax(0,1fr)] items-center gap-3 border-t border-solid px-4 py-3"
+          className="flex items-center gap-3 border-t border-solid px-4 py-3"
           style={{ borderTopColor: divider }}
         >
           <label
             htmlFor={`${prefix}-contrast`}
-            className="text-[11px] font-medium"
+            className="flex-1 text-[12px] font-medium"
             style={{ color: tone.primary }}
           >
             {t('themeEditor.contrast')}
           </label>
-          <div className="flex items-center gap-3">
-            <input
-              id={`${prefix}-contrast`}
-              name={`${prefix}-contrast`}
-              type="range"
-              min={0}
-              max={100}
-              value={slot.contrast}
-              onChange={(e) => onSlotChange({ ...slot, contrast: Number(e.target.value) })}
-              className="w-full"
-              style={{ accentColor: slot.accent }}
-            />
-            <span className="w-8 text-right font-mono text-[11px] tabular-nums" style={{ color: tone.faint }}>
-              {slot.contrast}
-            </span>
-          </div>
+          <input
+            id={`${prefix}-contrast`}
+            name={`${prefix}-contrast`}
+            type="range"
+            min={0}
+            max={100}
+            value={slot.contrast}
+            onChange={(e) => onSlotChange({ ...slot, contrast: Number(e.target.value) })}
+            className="w-[180px] h-1.5"
+            style={{ accentColor: slot.accent }}
+          />
+          <span className="w-7 text-right font-mono text-[11px] tabular-nums" style={{ color: tone.muted }}>
+            {slot.contrast}
+          </span>
         </div>
       </div>
     </section>
@@ -300,7 +326,7 @@ export default function ThemeEditorSection(props: {
   return (
     <div className="mb-6">
       <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
-        <h4 className="text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.04em] uppercase">
+        <h4 className="text-[11px] font-medium text-warm-faint dark:text-dark-muted tracking-[0.08em] uppercase">
           {t('themeEditor.title')}
         </h4>
         <SegmentedPill


### PR DESCRIPTION
## Summary

Polish the Settings modal and the Appearance tab so they read as part of the same library-warm system the rest of the app uses, instead of feeling like a separately-built micro-app on top of macOS-native primitives.

## What changed

### Settings modal
- Dismiss on backdrop click (in addition to the existing close button and Escape).
- Replace native `<select>`s for language / search-sort / terminal with a Menu-based dropdown — same component the sidebar sort menu already uses. Native macOS pickers were the most visible source of theme drift on this surface.
- Warm-tuned status tokens (`status-success` light/dark) replace `green-500` on the agent "ready" label and the watcher dot; this was the last cold-status leak per DESIGN.md.
- Footer "All data stays local in `~/.spool/`" renders the path on its own monospace line so the 11px body sentence stops wrapping mid-string inside the 176px sidebar column.
- Spec drift swept up in the same pass:
  - Tab nav buttons + agent rows: 8px → 6px radius (sidebar-row scale).
  - Agent rows: off-scale `py-2.5` → `py-3`.
  - Agent mode badge lifted from 9px to the 10px labels-and-caps floor.
  - Settings footer body lifted from 10px to the 11px body floor.
  - Section labels track `0.08em` to match the DESIGN type scale.

### Theme editor (Appearance tab)
- Hex inputs no longer rendered as full-width theme-colored pills. Per DESIGN.md, pill radius is reserved for the ⌘K overlay input + mode toggle.
- Each color row now reads left-to-right as **swatch → label → narrow right-aligned hex**:
  - 28px round swatch on the left, which is itself the picker trigger.
  - 12px label in the card's adaptive tone.
  - Right-aligned 6px hex input (`w-[112px]`, mono, tabular-nums) so the row stops feeling left-heavy / right-stretched.
- Contrast slider constrained to 180px and right-aligned so it sits in the same column as the hex inputs.
- Preset selector also replaced with the Menu dropdown; right-aligned inside the card header with a `min-w-[120px]` so light and dark cards stay visually balanced regardless of preset label length.

Everything is behavior-preserving (color values and config keys unchanged) — purely a visual + interaction pass.

## Test plan

- [ ] Open Settings (gear in status bar). Verify each tab renders correctly in both light and dark mode.
- [ ] Click the dimmed backdrop → modal closes. Click inside content → stays open.
- [ ] Language / Default search sort / Terminal: open dropdown, navigate with mouse and Esc; selection persists.
- [ ] Appearance tab: confirm hex inputs are no longer pill-shaped color bars; swatches still open native color picker; hex values remain editable.
- [ ] Appearance tab: change preset on either side — fields update; light/dark cards stay aligned.
- [ ] Drag the contrast slider; value updates live; range is now constrained right-side.
- [ ] Data sources tab: AUTO status dot is warm green, not Tailwind green.
- [ ] Agent tab: "ready" label is warm green; cards have 6px radius and consistent vertical padding.