### PR TITLE
fix(app): drop leading day-divider before the first message

### DIFF
--- a/packages/app/src/renderer/components/MessageList.tsx
+++ b/packages/app/src/renderer/components/MessageList.tsx
@@ -60,13 +60,18 @@ function makeDividerLabel(today: string, yesterday: string, locale: string | und
 }
 
 /** Build the virtualised row list. A divider is inserted whenever the
- *  message's local day differs from the previous row, including before the
- *  very first message. `showAvatar` is pre-computed here so itemContent
- *  stays cheap and so role-grouping resets across day boundaries (the
- *  first message after a divider always shows its avatar). */
+ *  message's local day differs from the previous row — except before the
+ *  very first message, since the session header already shows the start
+ *  date and a duplicate divider there just reads as chrome noise.
+ *  `showAvatar` is pre-computed here so itemContent stays cheap and so
+ *  role-grouping resets across day boundaries (the first message after
+ *  a divider always shows its avatar). */
 function buildRows(messages: Message[], label: DividerLabel): Row[] {
   const rows: Row[] = []
-  let prevDay: string | null = null
+  // Seed prevDay with the first message's day so the divider branch
+  // only fires on actual day transitions — the leading divider above
+  // the very first message is suppressed without a separate guard.
+  let prevDay: string | null = messages[0] ? localDayKey(messages[0].timestamp) : null
   let prevMsg: Message | null = null
   const now = new Date()
   for (const msg of messages) {


### PR DESCRIPTION
## What

In the session detail message list, suppress the day-divider that would otherwise render directly above the very first message. Subsequent day boundaries still get a divider — only the leading one is gone.

## Why

The session header already displays the session's start date in its meta row ("· May 11 · 5 messages"). The leading "MON, MAY 11" divider right under it duplicates that information and reads as visual noise. Removing it tightens the top of the conversation panel without losing the cross-day signal that matters mid-session.

## How it connects

- `buildRows` in `packages/app/src/renderer/components/MessageList.tsx` now skips the divider push when `prevDay === null` (i.e. before the first row). Day-change detection logic is otherwise unchanged.
- Header date row, day-divider styling, virtualisation, scroll-to-message, find-bar match indexing, and `data-testid="day-divider"` all remain intact.

## Test plan

- [ ] Open a single-day session — header shows the date, no divider above the first message.
- [ ] Open a multi-day session — no leading divider; each subsequent day transition still shows its divider.
- [ ] Find-bar navigation, scroll-to-message, and per-row avatar grouping all still behave correctly across day boundaries.