### PR TITLE
fix(app): shorten update-banner copy so it stops truncating

### DIFF
--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -290,9 +290,9 @@
     "noResults_body": "Probieren Sie andere Stichwörter oder erweitern Sie den Suchbereich."
   },
   "update": {
-    "available": "Eine neue Version von Spool ist verfügbar",
+    "available": "Update verfügbar",
     "downloading": "Update wird heruntergeladen… {{percent}}%",
-    "ready": "Update bereit – Neustart zum Installieren",
+    "ready": "Zum Installieren neu starten",
     "restart": "Neu starten"
   },
   "status": {

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -290,9 +290,9 @@
     "noResults_body": "Try a different query, or widen the scope."
   },
   "update": {
-    "available": "A new version of Spool is available",
+    "available": "Update available",
     "downloading": "Downloading update… {{percent}}%",
-    "ready": "Update ready — restart to install",
+    "ready": "Restart to install",
     "restart": "Restart"
   },
   "status": {

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -290,9 +290,9 @@
     "noResults_body": "Essayez une autre requête, ou élargissez la portée."
   },
   "update": {
-    "available": "Une nouvelle version de Spool est disponible",
+    "available": "Nouvelle version",
     "downloading": "Téléchargement de la mise à jour… {{percent}}%",
-    "ready": "Mise à jour prête — redémarrer pour installer",
+    "ready": "Redémarrer pour installer",
     "restart": "Redémarrer"
   },
   "status": {

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -283,9 +283,9 @@
     "noResults_body": "キーワードを変えるか、検索範囲を広げてみてください。"
   },
   "update": {
-    "available": "Spool の新しいバージョンが利用可能です",
+    "available": "アップデート利用可能",
     "downloading": "更新をダウンロード中… {{percent}}%",
-    "ready": "更新の準備が完了 — 再起動でインストール",
+    "ready": "再起動して適用",
     "restart": "再起動"
   },
   "status": {

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -283,9 +283,9 @@
     "noResults_body": "다른 키워드를 시도하거나 범위를 넓혀 보세요."
   },
   "update": {
-    "available": "Spool의 새 버전이 사용 가능합니다",
+    "available": "업데이트 사용 가능",
     "downloading": "업데이트 다운로드 중… {{percent}}%",
-    "ready": "업데이트 준비 완료 — 재시작하여 설치",
+    "ready": "재시작하여 설치",
     "restart": "재시작"
   },
   "status": {

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -283,9 +283,9 @@
     "noResults_body": "换个关键词，或扩大搜索范围。"
   },
   "update": {
-    "available": "Spool 有新版本可用",
+    "available": "有可用更新",
     "downloading": "下载更新中… {{percent}}%",
-    "ready": "更新已就绪 — 重启完成安装",
+    "ready": "重启以安装",
     "restart": "重启"
   },
   "status": {

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -283,9 +283,9 @@
     "noResults_body": "換個關鍵字，或擴大搜尋範圍。"
   },
   "update": {
-    "available": "Spool 有新版本可用",
+    "available": "有可用更新",
     "downloading": "下載更新中… {{percent}}%",
-    "ready": "更新已就緒 — 重新啟動以安裝",
+    "ready": "重新啟動以安裝",
     "restart": "重新啟動"
   },
   "status": {


### PR DESCRIPTION
## What

Tighter copy for the sidebar update banner across all 7 supported locales (en, de, fr, ja, ko, zh-CN, zh-TW). Affects two of the four \`update.*\` strings: \`available\` and \`ready\`. \`downloading\` and \`restart\` are unchanged.

## Why

The sidebar banner row has ~180px of body-text width once icon, padding and outer margin are subtracted. The original strings — "A new version of Spool is available", "Update ready — restart to install", and their localised equivalents — overran that and clipped to "…" in every locale, **especially** once the \` · v{version}\` suffix was concatenated onto the \`available\` label. The truncated banner couldn't even convey which state the app was in, defeating its purpose.

## How it connects

- Each locale's \`update.available\` and \`update.ready\` strings are now short, action-oriented phrasings that fit the row body with the version suffix still appended (e.g. "Update available · v0.4.14" → fits at 26 chars).
- \`Sidebar.tsx\` itself is unchanged — the version suffix concat, banner layout, and percent interpolation still work exactly as before; only the source strings shrank.
- French was tightened further to "Nouvelle version" because "Mise à jour disponible · v0.4.14" was the worst offender (32 chars) and still truncated.

| locale | \`available\` (was → now) | \`ready\` (was → now) |
| --- | --- | --- |
| en | A new version of Spool is available → Update available | Update ready — restart to install → Restart to install |
| de | Eine neue Version von Spool ist verfügbar → Update verfügbar | Update bereit – Neustart zum Installieren → Zum Installieren neu starten |
| fr | Une nouvelle version de Spool est disponible → Nouvelle version | Mise à jour prête — redémarrer pour installer → Redémarrer pour installer |
| ja | Spool の新しいバージョンが利用可能です → アップデート利用可能 | 更新の準備が完了 — 再起動でインストール → 再起動して適用 |
| ko | Spool의 새 버전이 사용 가능합니다 → 업데이트 사용 가능 | 업데이트 준비 완료 — 재시작하여 설치 → 재시작하여 설치 |
| zh-CN | Spool 有新版本可用 → 有可用更新 | 更新已就绪 — 重启完成安装 → 重启以安装 |
| zh-TW | Spool 有新版本可用 → 有可用更新 | 更新已就緒 — 重新啟動以安裝 → 重新啟動以安裝 |

## Test plan

- [ ] Eyeball banner in each locale across \`available · v0.4.14\` / \`downloading\` / \`ready\` / \`error\` states — no truncation.
- [ ] \`update.downloading\` percent interpolation still renders correctly.
- [ ] No other place in the renderer references these strings (grepped \`update.available\` / \`update.ready\`).