### PR TITLE
feat(app): virtualize session lists with cursor pagination

### DIFF
--- a/packages/app/e2e/pin.spec.ts
+++ b/packages/app/e2e/pin.spec.ts
@@ -27,9 +27,11 @@ test('pinning a session moves it into the Pinned segment', async () => {
   const pinButton = firstRow.locator('[data-testid="pin-button"]')
   await pinButton.click()
 
-  const pinnedSegment = window.locator('[data-testid="project-view-pinned"]')
-  await expect(pinnedSegment).toBeVisible({ timeout: 5000 })
-  await expect(pinnedSegment.locator(`[data-session-uuid="${targetUuid}"]`)).toBeVisible()
+  const pinnedHeader = window.locator('[data-testid="project-view-pinned-header"]')
+  await expect(pinnedHeader).toBeVisible({ timeout: 5000 })
+  await expect(
+    window.locator(`[data-testid="session-row"][data-pinned][data-session-uuid="${targetUuid}"]`),
+  ).toBeVisible()
 })
 
 test('unpinning removes session from Pinned segment', async () => {
@@ -37,15 +39,95 @@ test('unpinning removes session from Pinned segment', async () => {
   await waitForSync(window)
 
   await window.locator('[data-testid="sidebar-project-row"]').first().click()
-  const pinnedSegment = window.locator('[data-testid="project-view-pinned"]')
-  await expect(pinnedSegment).toBeVisible({ timeout: 5000 })
+  const pinnedHeader = window.locator('[data-testid="project-view-pinned-header"]')
+  await expect(pinnedHeader).toBeVisible({ timeout: 5000 })
 
-  const pinnedRow = pinnedSegment.locator('[data-testid="session-row"]').first()
+  const pinnedRow = window.locator('[data-testid="session-row"][data-pinned]').first()
   const targetUuid = await pinnedRow.getAttribute('data-session-uuid')
 
   const pinButton = pinnedRow.locator('[data-testid="pin-button"]')
   await pinButton.click()
 
-  // The pinned row should disappear
-  await expect(pinnedSegment.locator(`[data-session-uuid="${targetUuid}"]`)).toBeHidden({ timeout: 5000 })
+  // The pinned row should disappear from the pinned section.
+  await expect(
+    window.locator(`[data-testid="session-row"][data-pinned][data-session-uuid="${targetUuid}"]`),
+  ).toBeHidden({ timeout: 5000 })
+})
+
+test('session list renders the end-of-list footer once paginated', async () => {
+  // String content per locale is covered by the parity test under
+  // src/renderer/i18n/locales.test.ts; this just asserts the footer
+  // DOM is reachable after the list exhausts its cursor.
+  const { window } = ctx
+  await waitForSync(window)
+
+  await window.locator('[data-testid="sidebar-library"]').click()
+  await expect(
+    window.locator('[data-testid="library-landing"] [data-testid="session-list-done"]'),
+  ).toBeVisible({ timeout: 5000 })
+
+  await window.locator('[data-testid="sidebar-project-row"]').first().click()
+  await expect(
+    window.locator('[data-testid="project-view"] [data-testid="session-list-done"]'),
+  ).toBeVisible({ timeout: 5000 })
+})
+
+test('directory chip count matches the actual number of rows for that cwd', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  await window.locator('[data-testid="sidebar-project-row"]').first().click()
+  await expect(window.locator('[data-testid="project-view"]')).toBeVisible({ timeout: 5000 })
+
+  const chips = window.locator('[data-testid="project-directory-chip"]')
+  const chipCount = await chips.count()
+  if (chipCount < 2) test.skip(true, 'project has no sub-directories in fixtures — chip strip absent')
+
+  // Pick the first non-"All" chip; its badge value must equal the number of
+  // session-row entries that follow when isolated to that cwd.
+  const targetChip = chips.nth(1)
+  const badgeText = await targetChip.locator('span.font-mono').innerText()
+  const expected = parseInt(badgeText.trim(), 10)
+  await targetChip.click()
+
+  const visibleRows = window.locator('[data-testid="project-view"] [data-testid="session-row"]')
+  await expect(visibleRows).toHaveCount(expected, { timeout: 5000 })
+})
+
+test('pin then unpin keeps the session visible in recent (no vanishing)', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  await window.locator('[data-testid="sidebar-project-row"]').first().click()
+  // Make sure we start from a clean state: clear any pre-existing pins.
+  let stalePinned = window.locator('[data-testid="session-row"][data-pinned]').first()
+  while (await stalePinned.count() > 0) {
+    await stalePinned.locator('[data-testid="pin-button"]').click()
+    await expect(stalePinned).toBeHidden({ timeout: 2000 })
+    stalePinned = window.locator('[data-testid="session-row"][data-pinned]').first()
+  }
+
+  const firstRow = window.locator('[data-testid="session-row"]').first()
+  await expect(firstRow).toBeVisible({ timeout: 5000 })
+  const targetUuid = await firstRow.getAttribute('data-session-uuid')
+  expect(targetUuid).toBeTruthy()
+
+  await firstRow.hover()
+  await firstRow.locator('[data-testid="pin-button"]').click()
+
+  // After pin: session lives in the pinned section.
+  const pinnedRowSel = `[data-testid="session-row"][data-pinned][data-session-uuid="${targetUuid}"]`
+  await expect(window.locator(pinnedRowSel)).toBeVisible({ timeout: 5000 })
+
+  // Unpin from the pinned row.
+  await window.locator(pinnedRowSel).hover()
+  await window.locator(pinnedRowSel).locator('[data-testid="pin-button"]').click()
+
+  // After unpin: session must still exist somewhere in the list,
+  // just no longer marked pinned. Regression test for handlePinChange
+  // forgetting to reinsert into the recent list.
+  await expect(window.locator(pinnedRowSel)).toBeHidden({ timeout: 5000 })
+  await expect(
+    window.locator(`[data-testid="session-row"][data-session-uuid="${targetUuid}"]:not([data-pinned])`),
+  ).toBeVisible({ timeout: 5000 })
 })

--- a/packages/app/e2e/sidebar-pinned.spec.ts
+++ b/packages/app/e2e/sidebar-pinned.spec.ts
@@ -72,17 +72,28 @@ test('unpinning from sidebar also clears the Library pinned segment', async () =
 
   await window.locator('[data-testid="sidebar-library"]').click()
 
-  const libraryPinned = window.locator('[data-testid="library-pinned"]')
-  await expect(libraryPinned).toBeVisible({ timeout: 5000 })
-  await expect(libraryPinned.locator(`[data-session-uuid="${uuid}"]`)).toBeVisible()
+  const libraryPinnedHeader = window.locator('[data-testid="library-pinned-header"]')
+  await expect(libraryPinnedHeader).toBeVisible({ timeout: 5000 })
+  await expect(
+    window.locator(`[data-testid="session-row"][data-pinned][data-session-uuid="${uuid}"]`),
+  ).toBeVisible()
 
   // Unpin from sidebar
   const pinnedRow = window.locator(`[data-testid="sidebar-pinned-row"][data-session-uuid="${uuid}"]`)
   await pinnedRow.hover()
   await pinnedRow.locator('[data-testid="sidebar-pinned-unpin"]').click()
 
-  // Library's pinned segment should react immediately
-  await expect(libraryPinned.locator(`[data-session-uuid="${uuid}"]`)).toBeHidden({ timeout: 5000 })
+  // Library's pinned row should react immediately…
+  await expect(
+    window.locator(`[data-testid="session-row"][data-pinned][data-session-uuid="${uuid}"]`),
+  ).toBeHidden({ timeout: 5000 })
+
+  // …but the session itself must reappear in the recent list. Regression
+  // test for the cross-component pin-event listener forgetting to
+  // reinsert externally-unpinned sessions back into recent.
+  await expect(
+    window.locator(`[data-testid="session-row"][data-session-uuid="${uuid}"]:not([data-pinned])`),
+  ).toBeVisible({ timeout: 5000 })
 })
 
 test('sidebar pinned kebab menu exposes Resume and Copy actions', async () => {

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -29,13 +29,13 @@ process.on('uncaughtException', (err) => {
 
 import {
   getDB, wasNewDb, getInitialUserVersion, Syncer, SpoolWatcher,
-  searchFragments, searchSessionPreview, listRecentSessions, getSessionWithMessages, getStatus,
+  searchFragments, searchSessionPreview, listRecentSessionsPage, getSessionWithMessages, getStatus,
   pinSession, unpinSession, getPinnedUuids, listPinnedSessions,
-  listProjectGroups, listSessionsByIdentity, listPinnedSessionsByIdentity,
+  listProjectGroups, listSessionsByIdentity, listPinnedSessionsByIdentity, listProjectDirectoryCounts,
   listShareDrafts, getShareDraft, upsertShareDraft, deleteShareDraft, countDraftsBySession,
 } from '@spool-lab/core'
 import type {
-  FragmentResult, SessionSource, ListSessionsByIdentityOptions,
+  FragmentResult, SessionSource, ListSessionsByIdentityOptions, SessionsCursor,
   ShareDraftRow, UpsertShareDraftInput,
 } from '@spool-lab/core'
 import { setupTray } from './tray.js'
@@ -329,8 +329,8 @@ ipcMain.handle('spool:search-preview', (_e, { query, limit = 5, source }: { quer
   return fragments
 })
 
-ipcMain.handle('spool:list-sessions', (_e, { limit = 50 }: { limit?: number } = {}) => {
-  return listRecentSessions(db, limit)
+ipcMain.handle('spool:list-sessions', (_e, args: { limit?: number; cursor?: SessionsCursor } = {}) => {
+  return listRecentSessionsPage(db, args)
 })
 
 ipcMain.handle('spool:list-project-groups', () => {
@@ -339,6 +339,10 @@ ipcMain.handle('spool:list-project-groups', () => {
 
 ipcMain.handle('spool:list-sessions-by-identity', (_e, { identityKey, options }: { identityKey: string; options?: ListSessionsByIdentityOptions }) => {
   return listSessionsByIdentity(db, identityKey, options)
+})
+
+ipcMain.handle('spool:list-project-directory-counts', (_e, { identityKey, sources }: { identityKey: string; sources?: SessionSource[] }) => {
+  return listProjectDirectoryCounts(db, identityKey, sources ? { sources } : {})
 })
 
 ipcMain.handle('spool:get-session', (_e, { sessionUuid }: { sessionUuid: string }) => {

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -1,8 +1,9 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import type {
   FragmentResult, Session, Message, StatusInfo, SyncResult, SearchResult, ProjectGroup,
-  ListSessionsByIdentityOptions, ProjectSessionSortOrder,
+  ListSessionsByIdentityOptions, ProjectSessionSortOrder, SessionsCursor, SessionsPage, DirectoryCount,
   ShareDraftRow, ShareDraftListItem, UpsertShareDraftInput,
+  SessionSource,
 } from '@spool-lab/core'
 import type { SearchSortOrder } from '../shared/searchSort.js'
 import type { SidebarSortOrder } from '../shared/sidebarSort.js'
@@ -55,14 +56,17 @@ const api = {
   searchPreview: (query: string, limit?: number, source?: string): Promise<SearchResult[]> =>
     ipcRenderer.invoke('spool:search-preview', { query, limit, source }),
 
-  listSessions: (limit?: number): Promise<Session[]> =>
-    ipcRenderer.invoke('spool:list-sessions', { limit }),
+  listSessions: (options?: { limit?: number; cursor?: SessionsCursor }): Promise<SessionsPage> =>
+    ipcRenderer.invoke('spool:list-sessions', options ?? {}),
 
   listProjectGroups: (): Promise<ProjectGroup[]> =>
     ipcRenderer.invoke('spool:list-project-groups'),
 
-  listSessionsByIdentity: (identityKey: string, options?: ListSessionsByIdentityOptions): Promise<Session[]> =>
+  listSessionsByIdentity: (identityKey: string, options?: ListSessionsByIdentityOptions): Promise<SessionsPage> =>
     ipcRenderer.invoke('spool:list-sessions-by-identity', { identityKey, options }),
+
+  listProjectDirectoryCounts: (identityKey: string, sources?: SessionSource[]): Promise<DirectoryCount[]> =>
+    ipcRenderer.invoke('spool:list-project-directory-counts', { identityKey, sources }),
 
   getSession: (sessionUuid: string): Promise<{ session: Session; messages: Message[] } | null> =>
     ipcRenderer.invoke('spool:get-session', { sessionUuid }),

--- a/packages/app/src/renderer/components/LibraryLanding.tsx
+++ b/packages/app/src/renderer/components/LibraryLanding.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { MessagesSquare as LibraryIcon } from 'lucide-react'
-import type { Session } from '@spool-lab/core'
-import SessionRow from './SessionRow.js'
+import type { Session, SessionsCursor } from '@spool-lab/core'
+import VirtualSessionList, { type SessionListRow } from './VirtualSessionList.js'
 import { FeaturedEmptyState } from './EmptyState.js'
+import { insertSessionSorted } from '../../shared/sessionSort.js'
 
 type BucketKey = 'today' | 'yesterday' | 'earlierWeek' | 'earlierMonth' | 'older'
 
@@ -15,44 +16,144 @@ type Props = {
 }
 
 type DateBucket = {
-  /** Stable identity for keys, data attrs, and bucket prop drilling. */
   key: BucketKey
-  /** Already-localized display label for headers/aria. */
   label: string
   sessions: Session[]
 }
 
+const PAGE_SIZE = 50
+
 export default function LibraryLanding({ onOpenSession, onCopySessionId, onShare }: Props) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const [pinnedSessions, setPinnedSessions] = useState<Session[]>([])
   const [recentSessions, setRecentSessions] = useState<Session[] | null>(null)
-  const [reloadKey, setReloadKey] = useState(0)
+  const [cursor, setCursor] = useState<SessionsCursor | null>(null)
+  const [loadingMore, setLoadingMore] = useState(false)
+  // Per fetch we capture a token; only the freshest fetch is allowed to
+  // mutate state. Replaces the per-effect `cancelled` flag so the initial
+  // load and subsequent endReached pages share one rule.
+  const fetchTokenRef = useRef(0)
+
+  // Refs keep endReached's closure stable across renders.
+  const cursorRef = useRef(cursor)
+  cursorRef.current = cursor
+  const loadingRef = useRef(loadingMore)
+  loadingRef.current = loadingMore
+  const pinnedSessionsRef = useRef<Session[]>([])
+  pinnedSessionsRef.current = pinnedSessions
+  const pinnedUuidsRef = useRef(new Set<string>())
+  pinnedUuidsRef.current = new Set(pinnedSessions.map(s => s.sessionUuid))
 
   useEffect(() => {
-    let cancelled = false
+    const token = ++fetchTokenRef.current
+    setRecentSessions(null)
+    setCursor(null)
+    setLoadingMore(false)
     Promise.all([
       window.spool.listPinnedSessions(),
-      window.spool.listSessions(200),
+      window.spool.listSessions({ limit: PAGE_SIZE }),
     ])
-      .then(([pinned, recent]) => {
-        if (cancelled) return
+      .then(([pinned, page]) => {
+        if (fetchTokenRef.current !== token) return
         const pinnedUuids = new Set(pinned.map(s => s.sessionUuid))
         setPinnedSessions(pinned)
-        setRecentSessions(recent.filter(s => !pinnedUuids.has(s.sessionUuid)))
+        setRecentSessions(page.sessions.filter(s => !pinnedUuids.has(s.sessionUuid)))
+        setCursor(page.nextCursor)
       })
       .catch(() => {
-        if (!cancelled) {
-          setPinnedSessions([])
-          setRecentSessions([])
-        }
+        if (fetchTokenRef.current !== token) return
+        setPinnedSessions([])
+        setRecentSessions([])
       })
-    return () => { cancelled = true }
-  }, [reloadKey])
+  }, [])
 
   useEffect(() => {
-    function bump() { setReloadKey(k => k + 1) }
-    window.addEventListener('spool:pin-change', bump)
-    return () => window.removeEventListener('spool:pin-change', bump)
+    // Pin events from sibling components (sidebar, session detail).
+    // Diff the fresh pinned list against the current one: anything that
+    // disappeared was unpinned externally and must be reinserted into
+    // recent — otherwise the session vanishes from this view entirely.
+    //
+    // We force `exhausted=true` for the reinsertion. Without it,
+    // insertSessionSorted would drop candidates older than the last
+    // loaded row (they'd "live in a future page"), which is exactly
+    // the situation we're trying to avoid here — the user just had the
+    // session in their pinned section and expects it to stay visible.
+    // loadMore filters dedupe against already-loaded UUIDs so the
+    // keyset query won't surface this session a second time.
+    function handlePinEvent() {
+      window.spool.listPinnedSessions()
+        .then(freshPinned => {
+          const freshUuids = new Set(freshPinned.map(s => s.sessionUuid))
+          const newlyUnpinned = pinnedSessionsRef.current.filter(
+            s => !freshUuids.has(s.sessionUuid),
+          )
+          setPinnedSessions(freshPinned)
+          setRecentSessions(prev => {
+            if (!prev) return prev
+            let acc = prev.filter(s => !freshUuids.has(s.sessionUuid))
+            for (const candidate of newlyUnpinned) {
+              acc = insertSessionSorted(acc, candidate, 'recent', true)
+            }
+            return acc
+          })
+        })
+        .catch(() => {})
+    }
+    window.addEventListener('spool:pin-change', handlePinEvent)
+    return () => window.removeEventListener('spool:pin-change', handlePinEvent)
+  }, [])
+
+  useEffect(() => {
+    // New sessions arrived via sync: soft-merge them into the first page
+    // without unmounting the list. Skipped while we're between pages
+    // (`loadingMore`) because the merge would race with that fetch.
+    const off = window.spool.onNewSessions(() => {
+      if (loadingRef.current) return
+      window.spool.listSessions({ limit: PAGE_SIZE })
+        .then(page => {
+          setRecentSessions(prev => {
+            if (prev === null) return page.sessions
+            const known = new Set(prev.map(s => s.sessionUuid))
+            const pinnedUuids = pinnedUuidsRef.current
+            const additions = page.sessions.filter(s =>
+              !known.has(s.sessionUuid) && !pinnedUuids.has(s.sessionUuid),
+            )
+            return additions.length === 0 ? prev : [...additions, ...prev]
+          })
+        })
+        .catch(() => {})
+    })
+    return () => { off() }
+  }, [])
+
+  const loadMore = useCallback(() => {
+    if (loadingRef.current || !cursorRef.current) return
+    const token = ++fetchTokenRef.current
+    setLoadingMore(true)
+    window.spool.listSessions({ limit: PAGE_SIZE, cursor: cursorRef.current })
+      .then(page => {
+        if (fetchTokenRef.current !== token) return
+        setRecentSessions(prev => {
+          const base = prev ?? []
+          // Dedupe against pinned + already-loaded. The keyset cursor
+          // alone would suffice if nothing else mutated the list, but
+          // handlePinEvent reinserts unpinned candidates regardless of
+          // whether they sit beyond the loaded range, so they can
+          // re-appear here when the page is fetched.
+          const seen = new Set(base.map(s => s.sessionUuid))
+          const additions = page.sessions.filter(s =>
+            !pinnedUuidsRef.current.has(s.sessionUuid) && !seen.has(s.sessionUuid),
+          )
+          return [...base, ...additions]
+        })
+        setCursor(page.nextCursor)
+        setLoadingMore(false)
+      })
+      .catch(() => {
+        if (fetchTokenRef.current !== token) return
+        setLoadingMore(false)
+        setCursor(null)
+      })
   }, [])
 
   function handlePinChange(sessionUuid: string, pinned: boolean) {
@@ -63,83 +164,95 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId, onShare
         setPinnedSessions(prev => [candidate, ...prev])
       }
     } else {
+      const candidate = pinnedSessions.find(s => s.sessionUuid === sessionUuid)
       setPinnedSessions(prev => prev.filter(s => s.sessionUuid !== sessionUuid))
+      if (candidate) {
+        // exhausted=true so an unpinned session deeper than the loaded
+        // range still appears — see handlePinEvent for the rationale.
+        setRecentSessions(prev =>
+          prev ? insertSessionSorted(prev, candidate, 'recent', true) : prev,
+        )
+      }
     }
-    setReloadKey(k => k + 1)
   }
 
-  // Cast the typed t() down to a loose `(string) => string` so it can be
-  // passed to `bucketByDate`, which is called from contexts (tests,
-  // SearchOverlay) that don't share the resource literal-union type.
-  const tLoose: TranslateFn = (key) => (t as unknown as (k: string) => string)(key)
+  // i18n.language is a stable per-locale key; depending on `t` (which
+  // changes identity on most renders) would rebuild rows constantly.
   const buckets = useMemo(
-    () => (recentSessions ? bucketByDate(recentSessions, tLoose) : []),
+    () => (recentSessions ? bucketByDate(recentSessions, looseTranslator(t)) : []),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [recentSessions, t],
+    [recentSessions, i18n.language],
   )
-  const totalSessions = (pinnedSessions.length) + (recentSessions?.length ?? 0)
+  const totalSessions = pinnedSessions.length + (recentSessions?.length ?? 0)
+  const pinnedLabel = useMemo(
+    () => t('library.section_pinned', { count: pinnedSessions.length }),
+    [t, pinnedSessions.length],
+  )
+  const exhausted = recentSessions !== null && cursor === null
+
+  const rows = useMemo<SessionListRow[]>(() => {
+    const out: SessionListRow[] = []
+    if (pinnedSessions.length > 0) {
+      out.push({
+        kind: 'header',
+        id: 'pinned',
+        label: pinnedLabel,
+        testId: 'library-pinned-header',
+      })
+      for (const s of pinnedSessions) {
+        out.push({ kind: 'session', id: `p-${s.sessionUuid}`, session: s, pinned: true, showProject: true, headerId: 'pinned' })
+      }
+    }
+    for (const bucket of buckets) {
+      out.push({
+        kind: 'header',
+        id: `bucket-${bucket.key}`,
+        label: bucket.label,
+        testId: 'library-bucket-header',
+        dataAttr: { 'data-bucket': bucket.key },
+      })
+      for (const s of bucket.sessions) {
+        out.push({
+          kind: 'session',
+          id: s.sessionUuid,
+          session: s,
+          showProject: true,
+          bucket: bucket.key,
+          headerId: `bucket-${bucket.key}`,
+        })
+      }
+    }
+    out.push({ kind: 'footer', id: 'footer', loading: loadingMore, exhausted, total: totalSessions })
+    return out
+  }, [pinnedSessions, pinnedLabel, buckets, loadingMore, exhausted, totalSessions])
 
   return (
     <div data-testid="library-landing" className="flex flex-col h-full overflow-hidden">
-      <div className="flex-1 overflow-y-auto pb-12 [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]">
-        {recentSessions === null ? (
-          <SessionRowsSkeleton count={6} />
-        ) : totalSessions === 0 ? (
-          <FeaturedEmptyState
-            icon={<LibraryIcon size={22} strokeWidth={1.5} />}
-            title={t('library.empty_title')}
-            hint={t('library.empty_body')}
-          />
-        ) : (
-          <>
-            {pinnedSessions.length > 0 && (
-              <CollapsibleSection
-                label={t('library.section_pinned', { count: pinnedSessions.length })}
-                testId="library-pinned"
-              >
-                <div>
-                  {pinnedSessions.map(session => (
-                    <SessionRow
-                      key={session.sessionUuid}
-                      session={session}
-                      pinned
-                      showProject
-                      onPinChange={handlePinChange}
-                      onOpenSession={onOpenSession}
-                      onCopySessionId={onCopySessionId}
-                      {...(onShare ? { onShare } : {})}
-                    />
-                  ))}
-                </div>
-              </CollapsibleSection>
-            )}
-
-            {buckets.map(bucket => (
-              <CollapsibleSection
-                key={bucket.key}
-                label={bucket.label}
-                testId="library-bucket"
-                dataAttr={{ 'data-bucket': bucket.key }}
-              >
-                {bucket.sessions.map(session => (
-                  <SessionRow
-                    key={session.sessionUuid}
-                    session={session}
-                    showProject
-                    bucket={bucket.key}
-                    onPinChange={handlePinChange}
-                    onOpenSession={onOpenSession}
-                    onCopySessionId={onCopySessionId}
-                    {...(onShare ? { onShare } : {})}
-                  />
-                ))}
-              </CollapsibleSection>
-            ))}
-          </>
-        )}
-      </div>
+      {recentSessions === null ? (
+        <SessionRowsSkeleton count={6} />
+      ) : totalSessions === 0 ? (
+        <FeaturedEmptyState
+          icon={<LibraryIcon size={22} strokeWidth={1.5} />}
+          title={t('library.empty_title')}
+          hint={t('library.empty_body')}
+        />
+      ) : (
+        <VirtualSessionList
+          rows={rows}
+          onEndReached={loadMore}
+          onPinChange={handlePinChange}
+          onOpenSession={onOpenSession}
+          onCopySessionId={onCopySessionId}
+          {...(onShare ? { onShare } : {})}
+          testId="library-landing-scroll"
+        />
+      )}
     </div>
   )
+}
+
+function looseTranslator(t: ReturnType<typeof useTranslation>['t']): TranslateFn {
+  return (key) => (t as unknown as (k: string) => string)(key)
 }
 
 export function CollapsibleSection({
@@ -202,8 +315,6 @@ function SessionRowsSkeleton({ count }: { count: number }) {
 type TranslateFn = (key: string) => string
 
 export function bucketSessionsByDate(sessions: Session[], t?: TranslateFn): DateBucket[] {
-  // Default labels — callers that don't have a translator (e.g. tests) get
-  // the English bucket names so existing assertions keep matching.
   const fallback: TranslateFn = (key: string) => {
     switch (key) {
       case 'library.bucket_today': return 'TODAY'
@@ -231,15 +342,15 @@ function bucketByDate(sessions: Session[], t: TranslateFn): DateBucket[] {
   const older: Session[] = []
 
   for (const session of sessions) {
-    const t = Date.parse(session.startedAt)
-    if (Number.isNaN(t)) {
+    const ts = Date.parse(session.startedAt)
+    if (Number.isNaN(ts)) {
       older.push(session)
       continue
     }
-    if (t >= startOfToday) today.push(session)
-    else if (t >= startOfYesterday) yesterday.push(session)
-    else if (t >= startOfWeek) earlierWeek.push(session)
-    else if (t >= startOfMonth) earlierMonth.push(session)
+    if (ts >= startOfToday) today.push(session)
+    else if (ts >= startOfYesterday) yesterday.push(session)
+    else if (ts >= startOfWeek) earlierWeek.push(session)
+    else if (ts >= startOfMonth) earlierMonth.push(session)
     else older.push(session)
   }
 

--- a/packages/app/src/renderer/components/NewDraftPicker.tsx
+++ b/packages/app/src/renderer/components/NewDraftPicker.tsx
@@ -75,8 +75,8 @@ export default function NewDraftPicker({ onSelect, onClose }: Props) {
   // Fetch recent on mount.
   useEffect(() => {
     let cancelled = false
-    window.spool.listSessions(RECENT_LIMIT)
-      .then((rows) => { if (!cancelled) setRecent(rows) })
+    window.spool.listSessions({ limit: RECENT_LIMIT })
+      .then((page) => { if (!cancelled) setRecent(page.sessions) })
       .catch((err) => {
         if (cancelled) return
         setError(err instanceof Error ? err.message : t('common.error'))

--- a/packages/app/src/renderer/components/ProjectView.tsx
+++ b/packages/app/src/renderer/components/ProjectView.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ArrowDownUp } from 'lucide-react'
-import type { ProjectGroup, Session, SessionSource, ProjectSessionSortOrder } from '@spool-lab/core'
-import SessionRow from './SessionRow.js'
+import type { ProjectGroup, Session, SessionSource, ProjectSessionSortOrder, SessionsCursor, DirectoryCount } from '@spool-lab/core'
+import VirtualSessionList, { type SessionListRow } from './VirtualSessionList.js'
 import Menu from './Menu.js'
-import { CollapsibleSection } from './LibraryLanding.js'
+import { insertSessionSorted } from '../../shared/sessionSort.js'
 import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
 import { formatRelativeDate } from '../../shared/formatDate.js'
 import { PROJECT_SORT_OPTIONS } from '../../shared/projectView.js'
@@ -18,6 +18,8 @@ type Props = {
   onShare?: (uuid: string) => void
 }
 
+const PAGE_SIZE = 50
+
 export default function ProjectView({
   identityKey,
   sortOrder,
@@ -26,7 +28,7 @@ export default function ProjectView({
   onCopySessionId,
   onShare,
 }: Props) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const projectSortLabel = (value: ProjectSessionSortOrder): string => {
     switch (value) {
       case 'recent': return t('project.sort_recent')
@@ -38,20 +40,17 @@ export default function ProjectView({
   const [group, setGroup] = useState<ProjectGroup | null>(null)
   const [sessions, setSessions] = useState<Session[] | null>(null)
   const [pinnedSessions, setPinnedSessions] = useState<Session[]>([])
+  const [directoryCounts, setDirectoryCounts] = useState<DirectoryCount[]>([])
+  const [cursor, setCursor] = useState<SessionsCursor | null>(null)
+  const [loadingMore, setLoadingMore] = useState(false)
   const [activeSources, setActiveSources] = useState<Set<SessionSource>>(new Set())
-  const [closedCwds, setClosedCwds] = useState<Set<string>>(new Set())
   const [isolatedCwd, setIsolatedCwd] = useState<string | null>(null)
-  const [reloadKey, setReloadKey] = useState(0)
+  const fetchTokenRef = useRef(0)
 
   useEffect(() => {
     setActiveSources(new Set())
-    setClosedCwds(new Set())
     setIsolatedCwd(null)
   }, [identityKey])
-
-  useEffect(() => {
-    setSessions(null)
-  }, [identityKey, sortOrder, activeSources])
 
   useEffect(() => {
     let cancelled = false
@@ -65,40 +64,158 @@ export default function ProjectView({
   }, [identityKey])
 
   useEffect(() => {
-    let cancelled = false
+    const token = ++fetchTokenRef.current
+    setSessions(null)
+    setCursor(null)
+    setLoadingMore(false)
     const sourcesArray = Array.from(activeSources)
-    const sharedOptions = {
-      ...(sourcesArray.length > 0 ? { sources: sourcesArray } : {}),
-    }
+    const sharedOptions = sourcesArray.length > 0 ? { sources: sourcesArray } : {}
     Promise.all([
       window.spool.listPinnedSessionsByIdentity(identityKey),
       window.spool.listSessionsByIdentity(identityKey, {
         sortOrder,
         excludePinned: true,
+        limit: PAGE_SIZE,
         ...sharedOptions,
       }),
+      window.spool.listProjectDirectoryCounts(identityKey, sourcesArray.length > 0 ? sourcesArray : undefined),
     ])
-      .then(([pinned, recent]) => {
-        if (cancelled) return
+      .then(([pinned, page, counts]) => {
+        if (fetchTokenRef.current !== token) return
         const filteredPinned = sourcesArray.length > 0
           ? pinned.filter(s => sourcesArray.includes(s.source))
           : pinned
         setPinnedSessions(filteredPinned)
-        setSessions(recent)
+        setSessions(page.sessions)
+        setCursor(page.nextCursor)
+        setDirectoryCounts(counts)
       })
       .catch(() => {
-        if (!cancelled) {
-          setPinnedSessions([])
-          setSessions([])
-        }
+        if (fetchTokenRef.current !== token) return
+        setPinnedSessions([])
+        setSessions([])
+        setDirectoryCounts([])
       })
-    return () => { cancelled = true }
-  }, [identityKey, sortOrder, activeSources, reloadKey])
+  }, [identityKey, sortOrder, activeSources])
+
+  const cursorRef = useRef(cursor)
+  cursorRef.current = cursor
+  const loadingRef = useRef(loadingMore)
+  loadingRef.current = loadingMore
+  const fetchArgsRef = useRef({ identityKey, sortOrder, activeSources })
+  fetchArgsRef.current = { identityKey, sortOrder, activeSources }
+  const pinnedSessionsRef = useRef<Session[]>([])
+  pinnedSessionsRef.current = pinnedSessions
+  const pinnedUuidsRef = useRef(new Set<string>())
+  pinnedUuidsRef.current = new Set(pinnedSessions.map(s => s.sessionUuid))
 
   useEffect(() => {
-    function bump() { setReloadKey(k => k + 1) }
-    window.addEventListener('spool:pin-change', bump)
-    return () => window.removeEventListener('spool:pin-change', bump)
+    // Pin events from sibling components. Diff against pinnedSessionsRef
+    // to detect what was unpinned externally and reinsert into the body
+    // list — otherwise sidebar/menu-driven unpins make sessions vanish
+    // from this view.
+    function handlePinEvent() {
+      const { identityKey: key, sortOrder: order, activeSources: srcs } = fetchArgsRef.current
+      const sourcesArray = Array.from(srcs)
+      window.spool.listPinnedSessionsByIdentity(key)
+        .then(pinned => {
+          const filtered = sourcesArray.length > 0
+            ? pinned.filter(s => sourcesArray.includes(s.source))
+            : pinned
+          const freshUuids = new Set(filtered.map(s => s.sessionUuid))
+          const newlyUnpinned = pinnedSessionsRef.current.filter(
+            s => !freshUuids.has(s.sessionUuid),
+          )
+          setPinnedSessions(filtered)
+          setSessions(prev => {
+            if (!prev) return prev
+            let acc = prev.filter(s => !freshUuids.has(s.sessionUuid))
+            for (const candidate of newlyUnpinned) {
+              // Re-respect the source filter — a pin from a filtered-out
+              // source shouldn't reappear in the body when filtered.
+              if (sourcesArray.length > 0 && !sourcesArray.includes(candidate.source)) continue
+              // exhausted=true so candidates older than the loaded range
+              // still surface; loadMore filters dedupe by uuid against
+              // already-loaded rows.
+              acc = insertSessionSorted(acc, candidate, order, true)
+            }
+            return acc
+          })
+        })
+        .catch(() => {})
+    }
+    window.addEventListener('spool:pin-change', handlePinEvent)
+    return () => window.removeEventListener('spool:pin-change', handlePinEvent)
+  }, [])
+
+  useEffect(() => {
+    // Soft-merge on sync. Always refresh directoryCounts (cheap, keeps
+    // chip badges accurate); only refresh the body list when sortOrder
+    // is 'recent', where new sessions reliably surface on the first
+    // page. For other sort orders the refetched first page wouldn't
+    // contain the new rows anyway (they're highest by startedAt, not by
+    // title/oldest/message_count), so a merge would be misleading.
+    const off = window.spool.onNewSessions(() => {
+      if (loadingRef.current) return
+      const { identityKey: key, sortOrder: order, activeSources: srcs } = fetchArgsRef.current
+      const sourcesArray = Array.from(srcs)
+      window.spool.listProjectDirectoryCounts(key, sourcesArray.length > 0 ? sourcesArray : undefined)
+        .then(setDirectoryCounts)
+        .catch(() => {})
+      if (order !== 'recent') return
+      window.spool.listSessionsByIdentity(key, {
+        sortOrder: order,
+        excludePinned: true,
+        limit: PAGE_SIZE,
+        ...(sourcesArray.length > 0 ? { sources: sourcesArray } : {}),
+      })
+        .then(page => {
+          setSessions(prev => {
+            if (prev === null) return page.sessions
+            const known = new Set(prev.map(s => s.sessionUuid))
+            const pinnedUuids = pinnedUuidsRef.current
+            const additions = page.sessions.filter(s =>
+              !known.has(s.sessionUuid) && !pinnedUuids.has(s.sessionUuid),
+            )
+            return additions.length === 0 ? prev : [...additions, ...prev]
+          })
+        })
+        .catch(() => {})
+    })
+    return () => { off() }
+  }, [])
+
+  const loadMore = useCallback(() => {
+    if (loadingRef.current || !cursorRef.current) return
+    const token = ++fetchTokenRef.current
+    setLoadingMore(true)
+    const { identityKey: key, sortOrder: order, activeSources: srcs } = fetchArgsRef.current
+    const sourcesArray = Array.from(srcs)
+    window.spool.listSessionsByIdentity(key, {
+      sortOrder: order,
+      excludePinned: true,
+      limit: PAGE_SIZE,
+      cursor: cursorRef.current,
+      ...(sourcesArray.length > 0 ? { sources: sourcesArray } : {}),
+    })
+      .then(page => {
+        if (fetchTokenRef.current !== token) return
+        setSessions(prev => {
+          const base = prev ?? []
+          // Dedupe against handlePinEvent's reinserted candidates and
+          // any pin/unpin races since the cursor was captured.
+          const seen = new Set(base.map(s => s.sessionUuid))
+          const additions = page.sessions.filter(s => !seen.has(s.sessionUuid))
+          return [...base, ...additions]
+        })
+        setCursor(page.nextCursor)
+        setLoadingMore(false)
+      })
+      .catch(() => {
+        if (fetchTokenRef.current !== token) return
+        setLoadingMore(false)
+        setCursor(null)
+      })
   }, [])
 
   function handlePinChange(sessionUuid: string, pinned: boolean) {
@@ -109,9 +226,16 @@ export default function ProjectView({
         setPinnedSessions(prev => [candidate, ...prev])
       }
     } else {
+      const candidate = pinnedSessions.find(s => s.sessionUuid === sessionUuid)
       setPinnedSessions(prev => prev.filter(s => s.sessionUuid !== sessionUuid))
+      if (candidate) {
+        // exhausted=true: see handlePinEvent for why we force this and
+        // why loadMore dedupes against already-loaded rows.
+        setSessions(prev =>
+          prev ? insertSessionSorted(prev, candidate, sortOrder, true) : prev,
+        )
+      }
     }
-    setReloadKey(k => k + 1)
   }
 
   const availableSources = group?.sources ?? []
@@ -119,30 +243,31 @@ export default function ProjectView({
     return pinnedSessions[0]?.projectDisplayPath ?? sessions?.[0]?.projectDisplayPath ?? null
   }, [pinnedSessions, sessions])
 
-  // Chip-strip groups: include pinned so counts match the project total.
+  // Bodies are grouped over loaded data so sections only show what we
+  // can render. Chip badges run off directoryCounts (full project) so
+  // their numbers stay accurate while pages stream in.
   const directoryGroups = useMemo(() => {
     if (!sessions) return null
     const map = new Map<string, Session[]>()
-    for (const s of [...pinnedSessions, ...sessions]) {
+    for (const s of sessions) {
       const key = cwdOf(s)
       const arr = map.get(key)
       if (arr) arr.push(s)
       else map.set(key, [s])
     }
     return Array.from(map.entries())
-      .map(([cwd, items]) => {
-        const lastAt = items.reduce((acc, s) => (s.startedAt > acc ? s.startedAt : acc), '')
-        return { cwd, sessions: items, lastAt }
+      .map(([cwd, unpinned]) => {
+        const lastAt = unpinned.reduce((acc, s) => (s.startedAt > acc ? s.startedAt : acc), '')
+        return { cwd, unpinned, lastAt }
       })
       .sort((a, b) => (b.lastAt > a.lastAt ? 1 : b.lastAt < a.lastAt ? -1 : 0))
-  }, [sessions, pinnedSessions])
+  }, [sessions])
 
   useEffect(() => {
-    if (!directoryGroups || isolatedCwd === null) return
-    if (!directoryGroups.some(g => g.cwd === isolatedCwd)) setIsolatedCwd(null)
-  }, [directoryGroups, isolatedCwd])
+    if (isolatedCwd === null) return
+    if (!directoryCounts.some(c => c.cwd === isolatedCwd)) setIsolatedCwd(null)
+  }, [directoryCounts, isolatedCwd])
 
-  // Render-side splits: PINNED section + grouped/isolated unpinned list.
   const visiblePinned = useMemo(() => {
     if (isolatedCwd === null) return pinnedSessions
     return pinnedSessions.filter(s => cwdOf(s) === isolatedCwd)
@@ -154,31 +279,15 @@ export default function ProjectView({
     return sessions.filter(s => cwdOf(s) === isolatedCwd)
   }, [sessions, isolatedCwd])
 
-  const unpinnedGroups = useMemo(() => {
-    if (!sessions) return null
-    const map = new Map<string, Session[]>()
-    for (const s of sessions) {
-      const key = cwdOf(s)
-      const arr = map.get(key)
-      if (arr) arr.push(s)
-      else map.set(key, [s])
-    }
-    return Array.from(map.entries())
-      .map(([cwd, items]) => {
-        const lastAt = items.reduce((acc, s) => (s.startedAt > acc ? s.startedAt : acc), '')
-        return { cwd, sessions: items, lastAt }
-      })
-      .sort((a, b) => (b.lastAt > a.lastAt ? 1 : b.lastAt < a.lastAt ? -1 : 0))
-  }, [sessions])
+  const groupByDirectory = isolatedCwd === null && (directoryGroups?.length ?? 0) >= 2
 
-  const showGrouped = (unpinnedGroups?.length ?? 0) >= 2 && isolatedCwd === null
   const looseT = t as unknown as (k: string, o?: Record<string, unknown>) => string
   const meta = useMemo(() => {
     if (!group) return null
     const lastActivity = group.lastSessionAt ? formatRelativeDate(group.lastSessionAt, { t: looseT }) : null
     return { count: group.sessionCount, lastActivity, sources: group.sources }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [group, t])
+  }, [group, i18n.language])
 
   function toggleSource(source: SessionSource) {
     setActiveSources(prev => {
@@ -188,6 +297,66 @@ export default function ProjectView({
       return next
     })
   }
+
+  // When the user isolates to one cwd we filter client-side, so the
+  // footer count must reflect what's actually visible — otherwise the
+  // "End of N sessions" line disagrees with the chip badge.
+  const totalLoaded = isolatedCwd === null
+    ? (sessions?.length ?? 0) + pinnedSessions.length
+    : visiblePinned.length + visibleUnpinned.length
+  const exhausted = sessions !== null && cursor === null
+  const pinnedLabel = useMemo(
+    () => t('library.section_pinned', { count: visiblePinned.length }),
+    [t, visiblePinned.length],
+  )
+  const rows = useMemo<SessionListRow[]>(() => {
+    const out: SessionListRow[] = []
+    if (visiblePinned.length > 0) {
+      out.push({
+        kind: 'header',
+        id: 'pinned',
+        label: pinnedLabel,
+        testId: 'project-view-pinned-header',
+      })
+      for (const s of visiblePinned) {
+        out.push({
+          kind: 'session', id: `p-${s.sessionUuid}`, session: s,
+          pinned: true, headerId: 'pinned',
+        })
+      }
+    }
+    if (groupByDirectory && directoryGroups) {
+      for (const g of directoryGroups) {
+        if (g.unpinned.length === 0) continue
+        const { name } = formatCwdLabel(g.cwd, displayPath)
+        const headerId = `cwd-${g.cwd}`
+        out.push({
+          kind: 'header',
+          id: headerId,
+          label: <DirectoryHeaderLabel name={name} count={g.unpinned.length} />,
+          testId: 'project-view-directory-group-header',
+          dataAttr: { 'data-cwd': g.cwd },
+        })
+        for (const s of g.unpinned) {
+          out.push({ kind: 'session', id: s.sessionUuid, session: s, headerId })
+        }
+      }
+    } else {
+      if (visiblePinned.length > 0 && visibleUnpinned.length > 0) {
+        out.push({
+          kind: 'header',
+          id: 'recent',
+          label: 'RECENT',
+          testId: 'project-view-recent-header',
+        })
+      }
+      for (const s of visibleUnpinned) {
+        out.push({ kind: 'session', id: s.sessionUuid, session: s, headerId: 'recent' })
+      }
+    }
+    out.push({ kind: 'footer', id: 'footer', loading: loadingMore, exhausted, total: totalLoaded })
+    return out
+  }, [visiblePinned, visibleUnpinned, groupByDirectory, directoryGroups, displayPath, loadingMore, exhausted, totalLoaded, pinnedLabel])
 
   return (
     <div data-testid="project-view" className="flex flex-col h-full overflow-hidden">
@@ -280,9 +449,9 @@ export default function ProjectView({
           </div>
         </div>
 
-        {(directoryGroups?.length ?? 0) >= 2 && directoryGroups && (
+        {directoryCounts.length >= 2 && (
           <DirectoryChipStrip
-            groups={directoryGroups}
+            counts={directoryCounts}
             isolatedCwd={isolatedCwd}
             projectDisplayPath={displayPath}
             onSelect={setIsolatedCwd}
@@ -300,227 +469,86 @@ export default function ProjectView({
         )}
       </div>
 
-      <div className="flex-1 overflow-y-auto [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]">
-        {sessions === null ? (
-          <div className="px-4 py-8 text-center text-sm text-warm-faint dark:text-dark-muted">
-            {t('common.loading')}
-          </div>
-        ) : visibleUnpinned.length === 0 && visiblePinned.length === 0 ? (
-          <div className="px-4 py-12 text-center">
-            <p className="text-sm text-warm-muted dark:text-dark-muted">{t('project.noSessions')}</p>
-            <div className="mt-2 flex items-center justify-center gap-3 text-xs">
-              {activeSources.size > 0 && (
-                <button
-                  type="button"
-                  onClick={() => setActiveSources(new Set())}
-                  className="text-accent hover:underline"
-                >
-                  {t('project.clearSourceFilter')}
-                </button>
-              )}
-              {isolatedCwd !== null && (
-                <button
-                  type="button"
-                  onClick={() => setIsolatedCwd(null)}
-                  className="text-accent hover:underline"
-                >
-                  {t('project.clearDirectoryFilter')}
-                </button>
-              )}
-            </div>
-          </div>
-        ) : (
-          <>
-            {visiblePinned.length > 0 && (
-              <CollapsibleSection
-                label={t('library.section_pinned', { count: visiblePinned.length })}
-                testId="project-view-pinned"
+      {sessions === null ? (
+        <div className="px-4 py-8 text-center text-sm text-warm-faint dark:text-dark-muted">
+          {t('common.loading')}
+        </div>
+      ) : visibleUnpinned.length === 0 && visiblePinned.length === 0 ? (
+        <div className="px-4 py-12 text-center">
+          <p className="text-sm text-warm-muted dark:text-dark-muted">{t('project.noSessions')}</p>
+          <div className="mt-2 flex items-center justify-center gap-3 text-xs">
+            {activeSources.size > 0 && (
+              <button
+                type="button"
+                onClick={() => setActiveSources(new Set())}
+                className="text-accent hover:underline"
               >
-                <div>
-                  {visiblePinned.map(session => (
-                    <SessionRow
-                      key={session.sessionUuid}
-                      session={session}
-                      pinned
-                      onPinChange={handlePinChange}
-                      onOpenSession={onOpenSession}
-                      onCopySessionId={onCopySessionId}
-                      {...(onShare ? { onShare } : {})}
-                    />
-                  ))}
-                </div>
-              </CollapsibleSection>
+                {t('project.clearSourceFilter')}
+              </button>
             )}
-            {showGrouped && unpinnedGroups ? (
-              <div data-testid="project-view-by-directory">
-                {unpinnedGroups.map(g => (
-                  <DirectoryGroupSection
-                    key={g.cwd}
-                    cwd={g.cwd}
-                    projectDisplayPath={displayPath}
-                    sessions={g.sessions}
-                    open={!closedCwds.has(g.cwd)}
-                    onToggleOpen={() => {
-                      setClosedCwds(prev => {
-                        const next = new Set(prev)
-                        if (next.has(g.cwd)) next.delete(g.cwd)
-                        else next.add(g.cwd)
-                        return next
-                      })
-                    }}
-                    onPinChange={handlePinChange}
-                    onOpenSession={onOpenSession}
-                    onCopySessionId={onCopySessionId}
-                    {...(onShare ? { onShare } : {})}
-                  />
-                ))}
-              </div>
-            ) : isolatedCwd !== null ? (
-              <div data-testid="project-view-isolated" data-cwd={isolatedCwd}>
-                {visibleUnpinned.map(session => (
-                  <SessionRow
-                    key={session.sessionUuid}
-                    session={session}
-                    onPinChange={handlePinChange}
-                    onOpenSession={onOpenSession}
-                    onCopySessionId={onCopySessionId}
-                    {...(onShare ? { onShare } : {})}
-                  />
-                ))}
-              </div>
-            ) : visiblePinned.length > 0 && visibleUnpinned.length > 0 ? (
-              <CollapsibleSection label="RECENT" testId="project-view-recent">
-                {visibleUnpinned.map(session => (
-                  <SessionRow
-                    key={session.sessionUuid}
-                    session={session}
-                    onPinChange={handlePinChange}
-                    onOpenSession={onOpenSession}
-                    onCopySessionId={onCopySessionId}
-                    {...(onShare ? { onShare } : {})}
-                  />
-                ))}
-              </CollapsibleSection>
-            ) : (
-              <div data-testid="project-view-recent">
-                {visibleUnpinned.map(session => (
-                  <SessionRow
-                    key={session.sessionUuid}
-                    session={session}
-                    onPinChange={handlePinChange}
-                    onOpenSession={onOpenSession}
-                    onCopySessionId={onCopySessionId}
-                    {...(onShare ? { onShare } : {})}
-                  />
-                ))}
-              </div>
+            {isolatedCwd !== null && (
+              <button
+                type="button"
+                onClick={() => setIsolatedCwd(null)}
+                className="text-accent hover:underline"
+              >
+                {t('project.clearDirectoryFilter')}
+              </button>
             )}
-          </>
-        )}
-      </div>
+          </div>
+        </div>
+      ) : (
+        <VirtualSessionList
+          rows={rows}
+          onEndReached={loadMore}
+          onPinChange={handlePinChange}
+          onOpenSession={onOpenSession}
+          onCopySessionId={onCopySessionId}
+          {...(onShare ? { onShare } : {})}
+          testId="project-view-scroll"
+        />
+      )}
     </div>
   )
 }
 
-function DirectoryGroupSection({
-  cwd,
-  projectDisplayPath,
-  sessions,
-  open,
-  onToggleOpen,
-  onPinChange,
-  onOpenSession,
-  onCopySessionId,
-  onShare,
-}: {
-  cwd: string
-  projectDisplayPath: string | null
-  sessions: Session[]
-  open: boolean
-  onToggleOpen: () => void
-  onPinChange: (uuid: string, pinned: boolean) => void
-  onOpenSession: (uuid: string) => void
-  onCopySessionId: (source: Session['source']) => void
-  onShare?: (uuid: string) => void
-}) {
-  const { t } = useTranslation()
-  const { name } = formatCwdLabel(cwd, projectDisplayPath)
-  const count = sessions.length
-  const tooltip = cwd === '(unknown)' ? undefined : cwd
-
+function DirectoryHeaderLabel({ name, count }: { name: string; count: number }) {
   return (
-    <div data-testid="project-view-directory-group" data-cwd={cwd}>
-      <button
-        type="button"
-        onClick={onToggleOpen}
-        aria-expanded={open}
-        aria-label={open ? t('project.collapseDirectory') : t('project.expandDirectory')}
-        title={tooltip}
-        className="group w-full flex items-center gap-2 px-6 pt-3 pb-1 text-left text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75 select-none"
-      >
-        <span className="font-mono text-[11px] font-medium truncate">
-          {name}
-        </span>
-        {count > 1 && (
-          <span className="font-mono text-[10px] tabular-nums flex-none">
-            {count}
-          </span>
-        )}
-        <svg
-          width="9"
-          height="9"
-          viewBox="0 0 9 9"
-          fill="none"
-          aria-hidden
-          className={`flex-none transition-all opacity-30 group-hover:opacity-100 ${open ? 'rotate-90' : ''}`}
-        >
-          <path d="M3 1.5L6 4.5L3 7.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      </button>
-      {open && (
-        <div>
-          {sessions.map(session => (
-            <SessionRow
-              key={session.sessionUuid}
-              session={session}
-              onPinChange={onPinChange}
-              onOpenSession={onOpenSession}
-              onCopySessionId={onCopySessionId}
-              {...(onShare ? { onShare } : {})}
-            />
-          ))}
-        </div>
+    <span className="inline-flex items-center gap-2">
+      <span className="font-mono text-[11px] font-medium truncate">{name}</span>
+      {count > 1 && (
+        <span className="font-mono text-[10px] tabular-nums flex-none">{count}</span>
       )}
-    </div>
+    </span>
   )
 }
 
 const MAX_INLINE_CHIPS = 4
 
 function DirectoryChipStrip({
-  groups,
+  counts,
   isolatedCwd,
   projectDisplayPath,
   onSelect,
 }: {
-  groups: Array<{ cwd: string; sessions: Session[] }>
+  counts: DirectoryCount[]
   isolatedCwd: string | null
   projectDisplayPath: string | null
   onSelect: (cwd: string | null) => void
 }) {
-  const totalSessions = groups.reduce((sum, g) => sum + g.sessions.length, 0)
-  const top = groups.slice(0, MAX_INLINE_CHIPS)
+  const totalSessions = counts.reduce((sum, c) => sum + c.sessionCount, 0)
+  const top = counts.slice(0, MAX_INLINE_CHIPS)
   let inline = top
   if (
     isolatedCwd !== null
-    && !top.some(g => g.cwd === isolatedCwd)
-    && groups.some(g => g.cwd === isolatedCwd)
+    && !top.some(c => c.cwd === isolatedCwd)
+    && counts.some(c => c.cwd === isolatedCwd)
   ) {
-    const active = groups.find(g => g.cwd === isolatedCwd)!
+    const active = counts.find(c => c.cwd === isolatedCwd)!
     inline = [...top.slice(0, MAX_INLINE_CHIPS - 1), active]
   }
-  const inlineSet = new Set(inline.map(g => g.cwd))
-  const overflow = groups.filter(g => !inlineSet.has(g.cwd))
+  const inlineSet = new Set(inline.map(c => c.cwd))
+  const overflow = counts.filter(c => !inlineSet.has(c.cwd))
 
   return (
     <div data-testid="project-directory-chips" className="mt-2 flex items-center gap-1 flex-wrap">
@@ -530,16 +558,16 @@ function DirectoryChipStrip({
         count={totalSessions}
         onClick={() => onSelect(null)}
       />
-      {inline.map(g => {
-        const { name } = formatCwdLabel(g.cwd, projectDisplayPath)
+      {inline.map(c => {
+        const { name } = formatCwdLabel(c.cwd, projectDisplayPath)
         return (
           <DirectoryChip
-            key={g.cwd}
-            active={isolatedCwd === g.cwd}
+            key={c.cwd}
+            active={isolatedCwd === c.cwd}
             label={name}
-            title={g.cwd === '(unknown)' ? undefined : g.cwd}
-            count={g.sessions.length}
-            onClick={() => onSelect(g.cwd)}
+            title={c.cwd === '(unknown)' ? undefined : c.cwd}
+            count={c.sessionCount}
+            onClick={() => onSelect(c.cwd)}
           />
         )
       })}
@@ -562,12 +590,12 @@ function DirectoryChipStrip({
               </svg>
             </button>
           )}
-          items={overflow.map(g => {
-            const { name } = formatCwdLabel(g.cwd, projectDisplayPath)
+          items={overflow.map(c => {
+            const { name } = formatCwdLabel(c.cwd, projectDisplayPath)
             return {
-              label: `${name} · ${g.sessions.length}`,
-              active: isolatedCwd === g.cwd,
-              onSelect: () => onSelect(g.cwd),
+              label: `${name} · ${c.sessionCount}`,
+              active: isolatedCwd === c.cwd,
+              onSelect: () => onSelect(c.cwd),
             }
           })}
         />

--- a/packages/app/src/renderer/components/SearchOverlay.tsx
+++ b/packages/app/src/renderer/components/SearchOverlay.tsx
@@ -83,10 +83,10 @@ export default function SearchOverlay({
     let cancelled = false
     const fetchRecents = scope === 'project' && scopeProjectKey
       ? window.spool.listSessionsByIdentity(scopeProjectKey, { limit: 30 })
-      : window.spool.listSessions(30)
+      : window.spool.listSessions({ limit: 30 })
     /* recents and FTS both limit to 30 for consistent footer counts */
     fetchRecents
-      .then(sessions => { if (!cancelled) setRecents(sessions) })
+      .then(page => { if (!cancelled) setRecents(page.sessions) })
       .catch(() => { if (!cancelled) setRecents([]) })
     return () => { cancelled = true }
   }, [open, showRecents, scope, scopeProjectKey])

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -56,6 +56,7 @@ export default function SessionRow({ session, pinned = false, showProject = fals
     <div
       data-testid="session-row"
       data-session-uuid={session.sessionUuid}
+      {...(pinned ? { 'data-pinned': '' } : {})}
       role="button"
       tabIndex={0}
       onClick={handleOpen}

--- a/packages/app/src/renderer/components/VirtualSessionList.tsx
+++ b/packages/app/src/renderer/components/VirtualSessionList.tsx
@@ -1,0 +1,164 @@
+import { useCallback, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
+import type { Session } from '@spool-lab/core'
+import SessionRow from './SessionRow.js'
+import type { BucketKey } from '../../shared/formatDate.js'
+
+export type SessionListRow =
+  | { kind: 'header'; id: string; label: ReactNode; testId?: string; dataAttr?: Record<string, string>; collapsible?: boolean; defaultOpen?: boolean }
+  | { kind: 'session'; id: string; session: Session; pinned?: boolean; showProject?: boolean; bucket?: BucketKey; headerId: string | null }
+  | { kind: 'footer'; id: string; loading: boolean; exhausted: boolean; total: number }
+
+type Props = {
+  rows: SessionListRow[]
+  onEndReached: () => void
+  onPinChange?: (uuid: string, pinned: boolean) => void
+  onOpenSession: (uuid: string) => void
+  onCopySessionId: (source: Session['source']) => void
+  onShare?: (uuid: string) => void
+  /** Optional test id forwarded to the scroll container. */
+  testId?: string
+  /** When true (default), bucket headers can collapse the rows beneath them. */
+  collapsibleSections?: boolean
+}
+
+/**
+ * Virtualised list that flattens pinned/bucket/directory sections into one
+ * scroll surface. Parents build the row list; this component only renders +
+ * emits endReached for infinite-scroll pagination.
+ */
+export default function VirtualSessionList({
+  rows,
+  onEndReached,
+  onPinChange,
+  onOpenSession,
+  onCopySessionId,
+  onShare,
+  testId,
+  collapsibleSections = true,
+}: Props) {
+  const virtuosoRef = useRef<VirtuosoHandle | null>(null)
+  // Tracks which collapsible headers are explicitly closed. Headers not in
+  // the set are open (we keep "closed" rather than "open" so newly arriving
+  // headers default to open without needing to pre-populate state).
+  const [closed, setClosed] = useState<Set<string>>(new Set())
+
+  const toggleHeader = useCallback((id: string) => {
+    setClosed(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const visible = useMemo<SessionListRow[]>(() => {
+    if (!collapsibleSections || closed.size === 0) return rows
+    return rows.filter(r => {
+      if (r.kind === 'session') return r.headerId == null || !closed.has(r.headerId)
+      return true
+    })
+  }, [rows, closed, collapsibleSections])
+
+  return (
+    <Virtuoso
+      ref={virtuosoRef}
+      data={visible}
+      computeItemKey={(_index, row) => row.id}
+      defaultItemHeight={64}
+      increaseViewportBy={400}
+      endReached={onEndReached}
+      data-testid={testId}
+      className="flex-1 [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]"
+      itemContent={(_index, row) => {
+        if (row.kind === 'header') {
+          const open = !closed.has(row.id)
+          return (
+            <SectionHeader
+              row={row}
+              open={open}
+              onToggle={collapsibleSections && row.collapsible !== false ? () => toggleHeader(row.id) : null}
+            />
+          )
+        }
+        if (row.kind === 'footer') return <Footer loading={row.loading} exhausted={row.exhausted} total={row.total} />
+        return (
+          <SessionRow
+            session={row.session}
+            {...(row.pinned ? { pinned: true } : {})}
+            {...(row.showProject ? { showProject: true } : {})}
+            {...(row.bucket ? { bucket: row.bucket } : {})}
+            {...(onPinChange ? { onPinChange } : {})}
+            onOpenSession={onOpenSession}
+            onCopySessionId={onCopySessionId}
+            {...(onShare ? { onShare } : {})}
+          />
+        )
+      }}
+    />
+  )
+}
+
+function SectionHeader({
+  row,
+  open,
+  onToggle,
+}: {
+  row: Extract<SessionListRow, { kind: 'header' }>
+  open: boolean
+  onToggle: (() => void) | null
+}) {
+  const content = (
+    <div
+      data-testid={row.testId}
+      {...(row.dataAttr ?? {})}
+      className="px-6 pt-3 pb-1"
+    >
+      {onToggle ? (
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={open}
+          className="group w-full flex items-center gap-1.5 text-[10px] font-semibold tracking-[0.08em] text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75 select-none"
+        >
+          <span>{row.label}</span>
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            aria-hidden
+            className={`flex-none transition-all opacity-30 group-hover:opacity-100 ${open ? 'rotate-90' : ''}`}
+          >
+            <path d="M4 2L8 6L4 10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      ) : (
+        <span className="block text-[10px] font-semibold tracking-[0.08em] text-warm-faint dark:text-dark-muted select-none">
+          {row.label}
+        </span>
+      )}
+    </div>
+  )
+  return content
+}
+
+function Footer({ loading, exhausted, total }: { loading: boolean; exhausted: boolean; total: number }) {
+  const { t } = useTranslation()
+  if (loading) {
+    return (
+      <div data-testid="session-list-loading" className="flex justify-center py-6 text-[11px] text-warm-faint dark:text-dark-muted">
+        {t('library.footer_loadingMore')}
+      </div>
+    )
+  }
+  if (exhausted && total > 0) {
+    return (
+      <div data-testid="session-list-done" className="flex justify-center py-6 text-[11px] text-warm-faint dark:text-dark-muted">
+        {t('library.footer_endOf', { count: total })}
+      </div>
+    )
+  }
+  return <div className="py-4" />
+}

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -135,7 +135,10 @@
     "bucket_yesterday": "GESTERN",
     "bucket_earlierWeek": "FRÜHER DIESE WOCHE",
     "bucket_earlierMonth": "FRÜHER DIESEN MONAT",
-    "bucket_older": "ÄLTER"
+    "bucket_older": "ÄLTER",
+    "footer_loadingMore": "Ältere Sitzungen werden geladen…",
+    "footer_endOf_one": "Ende — {{count}} Sitzung",
+    "footer_endOf_other": "Ende — {{count}} Sitzungen"
   },
   "settings": {
     "title": "Einstellungen",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -135,7 +135,10 @@
     "bucket_yesterday": "YESTERDAY",
     "bucket_earlierWeek": "EARLIER THIS WEEK",
     "bucket_earlierMonth": "EARLIER THIS MONTH",
-    "bucket_older": "OLDER"
+    "bucket_older": "OLDER",
+    "footer_loadingMore": "Loading older sessions…",
+    "footer_endOf_one": "End of {{count}} session",
+    "footer_endOf_other": "End of {{count}} sessions"
   },
   "settings": {
     "title": "Settings",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -135,7 +135,10 @@
     "bucket_yesterday": "HIER",
     "bucket_earlierWeek": "PLUS TÔT CETTE SEMAINE",
     "bucket_earlierMonth": "PLUS TÔT CE MOIS-CI",
-    "bucket_older": "PLUS ANCIEN"
+    "bucket_older": "PLUS ANCIEN",
+    "footer_loadingMore": "Chargement des sessions plus anciennes…",
+    "footer_endOf_one": "Fin — {{count}} session",
+    "footer_endOf_other": "Fin — {{count}} sessions"
   },
   "settings": {
     "title": "Paramètres",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -128,7 +128,9 @@
     "bucket_yesterday": "昨日",
     "bucket_earlierWeek": "今週",
     "bucket_earlierMonth": "今月",
-    "bucket_older": "それ以前"
+    "bucket_older": "それ以前",
+    "footer_loadingMore": "古いセッションを読み込んでいます…",
+    "footer_endOf_other": "{{count}} 件のセッション"
   },
   "settings": {
     "title": "設定",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -128,7 +128,9 @@
     "bucket_yesterday": "어제",
     "bucket_earlierWeek": "이번 주 초",
     "bucket_earlierMonth": "이번 달 초",
-    "bucket_older": "이전"
+    "bucket_older": "이전",
+    "footer_loadingMore": "이전 세션 불러오는 중…",
+    "footer_endOf_other": "총 {{count}}개 세션"
   },
   "settings": {
     "title": "설정",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -128,7 +128,9 @@
     "bucket_yesterday": "昨天",
     "bucket_earlierWeek": "本周早些时候",
     "bucket_earlierMonth": "本月早些时候",
-    "bucket_older": "更早"
+    "bucket_older": "更早",
+    "footer_loadingMore": "正在加载更早的会话…",
+    "footer_endOf_other": "共 {{count}} 个会话"
   },
   "settings": {
     "title": "设置",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -128,7 +128,9 @@
     "bucket_yesterday": "昨天",
     "bucket_earlierWeek": "本週稍早",
     "bucket_earlierMonth": "本月稍早",
-    "bucket_older": "更早"
+    "bucket_older": "更早",
+    "footer_loadingMore": "正在載入更早的工作階段…",
+    "footer_endOf_other": "共 {{count}} 個工作階段"
   },
   "settings": {
     "title": "設定",

--- a/packages/app/src/shared/sessionSort.test.ts
+++ b/packages/app/src/shared/sessionSort.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import type { Session } from '@spool-lab/core'
+import { insertSessionSorted } from './sessionSort.js'
+
+function s(partial: Partial<Session> & { sessionUuid: string; startedAt: string }): Session {
+  return {
+    id: 0,
+    projectId: 1,
+    sourceId: 1,
+    sessionUuid: partial.sessionUuid,
+    filePath: '',
+    title: partial.title ?? null,
+    startedAt: partial.startedAt,
+    endedAt: partial.startedAt,
+    messageCount: partial.messageCount ?? 1,
+    hasToolUse: false,
+    cwd: null,
+    model: null,
+    source: 'claude',
+    projectDisplayPath: '',
+    projectDisplayName: '',
+  }
+}
+
+describe('insertSessionSorted', () => {
+  it('inserts at the correct DESC position for "recent"', () => {
+    const list = [
+      s({ sessionUuid: 'a', startedAt: '2026-05-10T00:00:00Z' }),
+      s({ sessionUuid: 'b', startedAt: '2026-05-08T00:00:00Z' }),
+      s({ sessionUuid: 'c', startedAt: '2026-05-05T00:00:00Z' }),
+    ]
+    const candidate = s({ sessionUuid: 'x', startedAt: '2026-05-09T00:00:00Z' })
+    const out = insertSessionSorted(list, candidate, 'recent', true)
+    expect(out.map(r => r.sessionUuid)).toEqual(['a', 'x', 'b', 'c'])
+  })
+
+  it('drops candidate older than the last loaded row when not exhausted', () => {
+    const list = [
+      s({ sessionUuid: 'a', startedAt: '2026-05-10T00:00:00Z' }),
+      s({ sessionUuid: 'b', startedAt: '2026-05-08T00:00:00Z' }),
+    ]
+    const candidate = s({ sessionUuid: 'x', startedAt: '2026-05-01T00:00:00Z' })
+    expect(insertSessionSorted(list, candidate, 'recent', false)).toBe(list)
+  })
+
+  it('appends candidate older than the last loaded row when exhausted', () => {
+    const list = [
+      s({ sessionUuid: 'a', startedAt: '2026-05-10T00:00:00Z' }),
+      s({ sessionUuid: 'b', startedAt: '2026-05-08T00:00:00Z' }),
+    ]
+    const candidate = s({ sessionUuid: 'x', startedAt: '2026-05-01T00:00:00Z' })
+    const out = insertSessionSorted(list, candidate, 'recent', true)
+    expect(out.map(r => r.sessionUuid)).toEqual(['a', 'b', 'x'])
+  })
+
+  it('sorts by message_count then started_at for "most_messages"', () => {
+    const list = [
+      s({ sessionUuid: 'a', startedAt: '2026-05-10T00:00:00Z', messageCount: 100 }),
+      s({ sessionUuid: 'b', startedAt: '2026-05-08T00:00:00Z', messageCount: 50 }),
+      s({ sessionUuid: 'c', startedAt: '2026-05-05T00:00:00Z', messageCount: 20 }),
+    ]
+    const candidate = s({ sessionUuid: 'x', startedAt: '2026-05-09T00:00:00Z', messageCount: 80 })
+    const out = insertSessionSorted(list, candidate, 'most_messages', true)
+    expect(out.map(r => r.sessionUuid)).toEqual(['a', 'x', 'b', 'c'])
+  })
+
+  it('sorts alphabetically for "title"', () => {
+    const list = [
+      s({ sessionUuid: 'a', startedAt: '2026-05-10T00:00:00Z', title: 'alpha' }),
+      s({ sessionUuid: 'b', startedAt: '2026-05-08T00:00:00Z', title: 'charlie' }),
+    ]
+    const candidate = s({ sessionUuid: 'x', startedAt: '2026-05-09T00:00:00Z', title: 'bravo' })
+    const out = insertSessionSorted(list, candidate, 'title', true)
+    expect(out.map(r => r.sessionUuid)).toEqual(['a', 'x', 'b'])
+  })
+
+  it('uses uuid as a stable tiebreaker', () => {
+    const list = [
+      s({ sessionUuid: 'a', startedAt: '2026-05-10T00:00:00Z' }),
+      s({ sessionUuid: 'c', startedAt: '2026-05-10T00:00:00Z' }),
+    ]
+    const candidate = s({ sessionUuid: 'b', startedAt: '2026-05-10T00:00:00Z' })
+    const out = insertSessionSorted(list, candidate, 'recent', true)
+    expect(out.map(r => r.sessionUuid)).toEqual(['a', 'b', 'c'])
+  })
+})

--- a/packages/app/src/shared/sessionSort.ts
+++ b/packages/app/src/shared/sessionSort.ts
@@ -1,0 +1,51 @@
+import type { Session, ProjectSessionSortOrder } from '@spool-lab/core'
+
+/**
+ * Mirror of the SQL `ORDER BY` clauses in `listSessionsByIdentity` /
+ * `listRecentSessionsPage`. Returns negative when `a` should sort before
+ * `b`. Used for client-side reinsertion when a session moves between
+ * pinned and recent without going through a full refetch.
+ */
+export function compareSessions(a: Session, b: Session, order: ProjectSessionSortOrder): number {
+  switch (order) {
+    case 'oldest':
+      if (a.startedAt !== b.startedAt) return a.startedAt < b.startedAt ? -1 : 1
+      return a.sessionUuid < b.sessionUuid ? -1 : 1
+    case 'most_messages':
+      if (a.messageCount !== b.messageCount) return a.messageCount > b.messageCount ? -1 : 1
+      if (a.startedAt !== b.startedAt) return a.startedAt > b.startedAt ? -1 : 1
+      return a.sessionUuid < b.sessionUuid ? -1 : 1
+    case 'title': {
+      const ta = a.title ?? ''
+      const tb = b.title ?? ''
+      if (ta !== tb) return ta < tb ? -1 : 1
+      if (a.startedAt !== b.startedAt) return a.startedAt > b.startedAt ? -1 : 1
+      return a.sessionUuid < b.sessionUuid ? -1 : 1
+    }
+    case 'recent':
+    default:
+      if (a.startedAt !== b.startedAt) return a.startedAt > b.startedAt ? -1 : 1
+      return a.sessionUuid < b.sessionUuid ? -1 : 1
+  }
+}
+
+/**
+ * Re-insert a session into the already-loaded page list at its sorted
+ * position. If the candidate would sort beyond the last loaded row and
+ * we haven't paginated to the end (`exhausted=false`), drop it — the
+ * session lives in a not-yet-loaded page and will appear when scrolled.
+ */
+export function insertSessionSorted(
+  sessions: Session[],
+  candidate: Session,
+  order: ProjectSessionSortOrder,
+  exhausted: boolean,
+): Session[] {
+  const last = sessions[sessions.length - 1]
+  if (last && compareSessions(candidate, last, order) > 0 && !exhausted) {
+    return sessions
+  }
+  const idx = sessions.findIndex(s => compareSessions(candidate, s, order) <= 0)
+  if (idx === -1) return [...sessions, candidate]
+  return [...sessions.slice(0, idx), candidate, ...sessions.slice(idx)]
+}

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander'
-import { getDB, listRecentSessions } from '@spool-lab/core'
+import { getDB, listRecentSessionsPage } from '@spool-lab/core'
 import type { Session } from '@spool-lab/core'
 
 const SESSION_SOURCES = new Set(['claude', 'codex', 'gemini'])
@@ -12,7 +12,7 @@ export const listCommand = new Command('list')
   .option('--json', 'Output as JSON')
   .action((opts: { limit: string; source?: string; project?: string; json?: boolean }) => {
     const db = getDB(true)
-    let sessions = listRecentSessions(db, parseInt(opts.limit, 10) * 2)
+    let sessions = listRecentSessionsPage(db, { limit: parseInt(opts.limit, 10) * 2 }).sessions
 
     if (opts.source && SESSION_SOURCES.has(opts.source)) {
       sessions = sessions.filter(s => s.source === opts.source)

--- a/packages/core/src/db/queries.test.ts
+++ b/packages/core/src/db/queries.test.ts
@@ -6,6 +6,7 @@ import {
   getOrCreateAskProject,
   insertSpoolAuthoredSession,
   upsertSession,
+  getStatus,
 } from './queries.js'
 
 describe('getOrCreateProject (with identity)', () => {
@@ -203,5 +204,31 @@ describe('insertSpoolAuthoredSession', () => {
     expect(row.title_source).toBe('spool')
     expect(row.file_path).toBe('/Users/x/.claude/projects/-Users-x--spool-agent-search-sessions/ask-uuid-3.jsonl')
     expect(row.message_count).toBe(5)
+  })
+})
+
+describe('getStatus', () => {
+  let db: Database.Database
+  beforeEach(() => {
+    db = new Database(':memory:')
+    runMigrations(db)
+    db.exec(`
+      INSERT INTO projects (source_id, slug, display_path, display_name, identity_kind, identity_key)
+      VALUES (1, 'p', '/p', 'p', 'path', '/p');
+      INSERT INTO sessions (project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count, has_tool_use, raw_file_mtime)
+      VALUES
+        (1, 1, 'a', '/a', 'a', '2026-05-01', '2026-05-01', 5, 0, '2026-05-01'),
+        (1, 1, 'b', '/b', 'b', '2026-05-02', '2026-05-02', 0, 0, '2026-05-02'),
+        (1, 2, 'c', '/c', 'c', '2026-05-03', '2026-05-03', 3, 0, '2026-05-03'),
+        (1, 2, 'd', '/d', 'd', '2026-05-04', '2026-05-04', 0, 0, '2026-05-04');
+    `)
+  })
+
+  it('counts only sessions with message_count > 0 — matches what user-visible lists show', () => {
+    const status = getStatus(db)
+    expect(status.totalSessions).toBe(2)
+    expect(status.claudeSessions).toBe(1)
+    expect(status.codexSessions).toBe(1)
+    expect(status.geminiSessions).toBe(0)
   })
 })

--- a/packages/core/src/db/queries.ts
+++ b/packages/core/src/db/queries.ts
@@ -231,17 +231,6 @@ export const SESSION_SELECT = `
   JOIN sources src ON src.id = s.source_id
   JOIN projects p ON p.id = s.project_id`
 
-export function listRecentSessions(
-  db: Database.Database,
-  limit = 50,
-): Session[] {
-  return (db.prepare(`
-    ${SESSION_SELECT}
-    WHERE s.message_count > 0
-    ORDER BY s.started_at DESC
-    LIMIT ?
-  `).all(limit) as Array<Record<string, unknown>>).map(rowToSession)
-}
 
 export function getSessionWithMessages(
   db: Database.Database,
@@ -957,9 +946,13 @@ export function listPinnedSessions(db: Database.Database): Session[] {
 }
 
 export function getStatus(db: Database.Database): StatusInfo {
+  // Filter empty sessions so this matches every user-facing list, which
+  // all gate on message_count > 0 (aborted starts and crash files have
+  // zero messages but still occupy a row in the sessions table).
   const counts = db.prepare(`
     SELECT src.name, COUNT(*) AS cnt
     FROM sessions s JOIN sources src ON src.id = s.source_id
+    WHERE s.message_count > 0
     GROUP BY src.name
   `).all() as Array<{ name: string; cnt: number }>
 

--- a/packages/core/src/projects/sessions.test.ts
+++ b/packages/core/src/projects/sessions.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import Database from 'better-sqlite3'
 import { runMigrations } from '../db/db.js'
-import { listSessionsByIdentity } from './sessions.js'
+import { listSessionsByIdentity, listRecentSessionsPage, listProjectDirectoryCounts } from './sessions.js'
 
 describe('listSessionsByIdentity', () => {
   let db: Database.Database
@@ -24,42 +24,150 @@ describe('listSessionsByIdentity', () => {
   })
 
   it('only returns sessions matching identity_key', () => {
-    const sessions = listSessionsByIdentity(db, 'github.com/spool-lab/spool')
+    const { sessions } = listSessionsByIdentity(db, 'github.com/spool-lab/spool')
     expect(sessions).toHaveLength(3)
     expect(sessions.map(s => s.sessionUuid).sort()).toEqual(['u1', 'u2', 'u3'])
   })
 
   it('default sort is started_at DESC', () => {
-    const sessions = listSessionsByIdentity(db, 'github.com/spool-lab/spool')
+    const { sessions } = listSessionsByIdentity(db, 'github.com/spool-lab/spool')
     expect(sessions.map(s => s.sessionUuid)).toEqual(['u1', 'u2', 'u3'])
   })
 
   it('sortOrder oldest', () => {
-    const sessions = listSessionsByIdentity(db, 'github.com/spool-lab/spool', { sortOrder: 'oldest' })
+    const { sessions } = listSessionsByIdentity(db, 'github.com/spool-lab/spool', { sortOrder: 'oldest' })
     expect(sessions.map(s => s.sessionUuid)).toEqual(['u3', 'u2', 'u1'])
   })
 
   it('sortOrder most_messages', () => {
-    const sessions = listSessionsByIdentity(db, 'github.com/spool-lab/spool', { sortOrder: 'most_messages' })
+    const { sessions } = listSessionsByIdentity(db, 'github.com/spool-lab/spool', { sortOrder: 'most_messages' })
     expect(sessions.map(s => s.sessionUuid)).toEqual(['u2', 'u1', 'u3'])
   })
 
   it('sortOrder title (alphabetical)', () => {
-    const sessions = listSessionsByIdentity(db, 'github.com/spool-lab/spool', { sortOrder: 'title' })
+    const { sessions } = listSessionsByIdentity(db, 'github.com/spool-lab/spool', { sortOrder: 'title' })
     expect(sessions.map(s => s.title)).toEqual(['alpha', 'beta', 'gamma'])
   })
 
   it('source filter narrows to matching sources', () => {
-    const sessions = listSessionsByIdentity(db, 'github.com/spool-lab/spool', { sources: ['claude'] })
+    const { sessions } = listSessionsByIdentity(db, 'github.com/spool-lab/spool', { sources: ['claude'] })
     expect(sessions.map(s => s.sessionUuid).sort()).toEqual(['u1', 'u2'])
   })
 
-  it('returns empty array when identity_key has no sessions', () => {
-    expect(listSessionsByIdentity(db, 'no-such-key')).toEqual([])
+  it('returns empty result when identity_key has no sessions', () => {
+    const result = listSessionsByIdentity(db, 'no-such-key')
+    expect(result.sessions).toEqual([])
+    expect(result.nextCursor).toBeNull()
   })
 
-  it('respects limit', () => {
-    const sessions = listSessionsByIdentity(db, 'github.com/spool-lab/spool', { limit: 2 })
-    expect(sessions).toHaveLength(2)
+  it('respects limit and exposes a cursor for the next page', () => {
+    const page1 = listSessionsByIdentity(db, 'github.com/spool-lab/spool', { limit: 2 })
+    expect(page1.sessions).toHaveLength(2)
+    expect(page1.sessions.map(s => s.sessionUuid)).toEqual(['u1', 'u2'])
+    expect(page1.nextCursor).not.toBeNull()
+
+    const page2 = listSessionsByIdentity(db, 'github.com/spool-lab/spool', {
+      limit: 2,
+      cursor: page1.nextCursor!,
+    })
+    expect(page2.sessions.map(s => s.sessionUuid)).toEqual(['u3'])
+    expect(page2.nextCursor).toBeNull()
+  })
+
+  it('does not return a cursor on the final partial page', () => {
+    const { nextCursor } = listSessionsByIdentity(db, 'github.com/spool-lab/spool', { limit: 10 })
+    expect(nextCursor).toBeNull()
+  })
+
+  it('keyset pagination is stable across sortOrder=most_messages', () => {
+    const page1 = listSessionsByIdentity(db, 'github.com/spool-lab/spool', { sortOrder: 'most_messages', limit: 1 })
+    expect(page1.sessions.map(s => s.sessionUuid)).toEqual(['u2'])
+    const page2 = listSessionsByIdentity(db, 'github.com/spool-lab/spool', {
+      sortOrder: 'most_messages',
+      limit: 1,
+      cursor: page1.nextCursor!,
+    })
+    expect(page2.sessions.map(s => s.sessionUuid)).toEqual(['u1'])
+    const page3 = listSessionsByIdentity(db, 'github.com/spool-lab/spool', {
+      sortOrder: 'most_messages',
+      limit: 1,
+      cursor: page2.nextCursor!,
+    })
+    expect(page3.sessions.map(s => s.sessionUuid)).toEqual(['u3'])
+    expect(page3.nextCursor).toBeNull()
+  })
+
+  it('keyset pagination is stable across sortOrder=title', () => {
+    const collected: string[] = []
+    let cursor: ReturnType<typeof listSessionsByIdentity>['nextCursor'] = null
+    for (let i = 0; i < 5; i++) {
+      const page = listSessionsByIdentity(db, 'github.com/spool-lab/spool', {
+        sortOrder: 'title',
+        limit: 1,
+        ...(cursor ? { cursor } : {}),
+      })
+      collected.push(...page.sessions.map(s => s.title!))
+      cursor = page.nextCursor
+      if (!cursor) break
+    }
+    expect(collected).toEqual(['alpha', 'beta', 'gamma'])
+  })
+})
+
+describe('listRecentSessionsPage', () => {
+  let db: Database.Database
+  beforeEach(() => {
+    db = new Database(':memory:')
+    runMigrations(db)
+    db.exec(`
+      INSERT INTO projects (source_id, slug, display_path, display_name, identity_kind, identity_key)
+      VALUES (1,'p','/p','p','path','/p');
+      INSERT INTO sessions (project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count, has_tool_use, raw_file_mtime)
+      VALUES
+        (1,1,'a','/a','a','2026-05-01T00:00:00Z','2026-05-01T00:00:00Z',1,0,'2026-05-01T00:00:00Z'),
+        (1,1,'b','/b','b','2026-05-02T00:00:00Z','2026-05-02T00:00:00Z',1,0,'2026-05-02T00:00:00Z'),
+        (1,1,'c','/c','c','2026-05-03T00:00:00Z','2026-05-03T00:00:00Z',1,0,'2026-05-03T00:00:00Z');
+    `)
+  })
+
+  it('paginates recent sessions across the global library', () => {
+    const page1 = listRecentSessionsPage(db, { limit: 2 })
+    expect(page1.sessions.map(s => s.sessionUuid)).toEqual(['c', 'b'])
+    expect(page1.nextCursor).not.toBeNull()
+
+    const page2 = listRecentSessionsPage(db, { limit: 2, cursor: page1.nextCursor! })
+    expect(page2.sessions.map(s => s.sessionUuid)).toEqual(['a'])
+    expect(page2.nextCursor).toBeNull()
+  })
+})
+
+describe('listProjectDirectoryCounts', () => {
+  let db: Database.Database
+  beforeEach(() => {
+    db = new Database(':memory:')
+    runMigrations(db)
+    db.exec(`
+      INSERT INTO projects (source_id, slug, display_path, display_name, identity_kind, identity_key)
+      VALUES (1,'spool','/r','spool','git_remote','github.com/spool-lab/spool');
+      INSERT INTO sessions (project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count, has_tool_use, raw_file_mtime, cwd)
+      VALUES
+        (1,1,'a','/a','a','2026-05-01T00:00:00Z','2026-05-01T00:00:00Z',1,0,'2026-05-01T00:00:00Z','/r/pkg/app'),
+        (1,1,'b','/b','b','2026-05-02T00:00:00Z','2026-05-02T00:00:00Z',1,0,'2026-05-02T00:00:00Z','/r/pkg/app'),
+        (1,1,'c','/c','c','2026-05-03T00:00:00Z','2026-05-03T00:00:00Z',1,0,'2026-05-03T00:00:00Z','/r/pkg/core'),
+        (1,1,'d','/d','d','2026-05-04T00:00:00Z','2026-05-04T00:00:00Z',0,0,'2026-05-04T00:00:00Z','/r/pkg/core');
+    `)
+  })
+
+  it('returns per-cwd counts ordered by recency, skipping empty sessions', () => {
+    const counts = listProjectDirectoryCounts(db, 'github.com/spool-lab/spool')
+    expect(counts).toEqual([
+      { cwd: '/r/pkg/core', sessionCount: 1, lastSessionAt: '2026-05-03T00:00:00Z' },
+      { cwd: '/r/pkg/app', sessionCount: 2, lastSessionAt: '2026-05-02T00:00:00Z' },
+    ])
+  })
+
+  it('source filter narrows the rows that get grouped', () => {
+    const counts = listProjectDirectoryCounts(db, 'github.com/spool-lab/spool', { sources: ['codex'] })
+    expect(counts).toEqual([])
   })
 })

--- a/packages/core/src/projects/sessions.ts
+++ b/packages/core/src/projects/sessions.ts
@@ -4,19 +4,40 @@ import { SESSION_SELECT, rowToSession } from '../db/queries.js'
 
 export type ProjectSessionSortOrder = 'recent' | 'oldest' | 'most_messages' | 'title'
 
+export type SessionsCursor = {
+  startedAt: string
+  sessionUuid: string
+  messageCount: number
+  title: string
+}
+
+export type SessionsPage = {
+  sessions: Session[]
+  nextCursor: SessionsCursor | null
+}
+
 export interface ListSessionsByIdentityOptions {
   sources?: SessionSource[]
   sortOrder?: ProjectSessionSortOrder
   limit?: number
   excludePinned?: boolean
+  cursor?: SessionsCursor
 }
+
+const DEFAULT_PAGE_SIZE = 50
 
 export function listSessionsByIdentity(
   db: Database.Database,
   identityKey: string,
   options: ListSessionsByIdentityOptions = {},
-): Session[] {
-  const { sources, sortOrder = 'recent', limit = 500, excludePinned = false } = options
+): SessionsPage {
+  const {
+    sources,
+    sortOrder = 'recent',
+    limit = DEFAULT_PAGE_SIZE,
+    excludePinned = false,
+    cursor,
+  } = options
 
   const conditions: string[] = ['p.identity_key = ?', 's.message_count > 0']
   const params: unknown[] = [identityKey]
@@ -31,17 +52,68 @@ export function listSessionsByIdentity(
     conditions.push('NOT EXISTS (SELECT 1 FROM pins WHERE pins.session_uuid = s.session_uuid)')
   }
 
-  const orderBy = orderByClause(sortOrder)
-  const sql = `
-    ${SESSION_SELECT}
-    WHERE ${conditions.join(' AND ')}
-    ORDER BY ${orderBy}
-    LIMIT ?
-  `
-  params.push(limit)
+  if (cursor) {
+    const c = cursorWhere(sortOrder, cursor)
+    conditions.push(c.sql)
+    params.push(...c.params)
+  }
 
-  const rows = db.prepare(sql).all(...params) as Array<Record<string, unknown>>
-  return rows.map(rowToSession)
+  return executePage(db, conditions, params, sortOrder, limit)
+}
+
+export function listRecentSessionsPage(
+  db: Database.Database,
+  options: { limit?: number; cursor?: SessionsCursor } = {},
+): SessionsPage {
+  const { limit = DEFAULT_PAGE_SIZE, cursor } = options
+  const conditions: string[] = ['s.message_count > 0']
+  const params: unknown[] = []
+  if (cursor) {
+    const c = cursorWhere('recent', cursor)
+    conditions.push(c.sql)
+    params.push(...c.params)
+  }
+  return executePage(db, conditions, params, 'recent', limit)
+}
+
+export type DirectoryCount = {
+  cwd: string
+  sessionCount: number
+  lastSessionAt: string
+}
+
+/**
+ * Per-cwd counts across the full project. Drives the chip strip's badges
+ * so they show the true distribution rather than just the loaded page.
+ * Honors the same `sources` filter as `listSessionsByIdentity`.
+ */
+export function listProjectDirectoryCounts(
+  db: Database.Database,
+  identityKey: string,
+  options: { sources?: SessionSource[] } = {},
+): DirectoryCount[] {
+  const { sources } = options
+  const conditions: string[] = ['p.identity_key = ?', 's.message_count > 0']
+  const params: unknown[] = [identityKey]
+  if (sources && sources.length > 0) {
+    const placeholders = sources.map(() => '?').join(',')
+    conditions.push(`src.name IN (${placeholders})`)
+    params.push(...sources)
+  }
+  const sql = `
+    SELECT
+      COALESCE(NULLIF(s.cwd, ''), '(unknown)') AS cwd,
+      COUNT(*) AS cnt,
+      MAX(s.started_at) AS last_at
+    FROM sessions s
+    JOIN sources src ON src.id = s.source_id
+    JOIN projects p ON p.id = s.project_id
+    WHERE ${conditions.join(' AND ')}
+    GROUP BY cwd
+    ORDER BY MAX(s.started_at) DESC
+  `
+  const rows = db.prepare(sql).all(...params) as Array<{ cwd: string; cnt: number; last_at: string }>
+  return rows.map(r => ({ cwd: r.cwd, sessionCount: r.cnt, lastSessionAt: r.last_at }))
 }
 
 export function listPinnedSessionsByIdentity(
@@ -57,16 +129,94 @@ export function listPinnedSessionsByIdentity(
   return rows.map(rowToSession)
 }
 
+function executePage(
+  db: Database.Database,
+  conditions: string[],
+  params: unknown[],
+  sortOrder: ProjectSessionSortOrder,
+  limit: number,
+): SessionsPage {
+  const sql = `
+    ${SESSION_SELECT}
+    WHERE ${conditions.join(' AND ')}
+    ORDER BY ${orderByClause(sortOrder)}
+    LIMIT ?
+  `
+  // Fetch limit+1 so we can detect "more rows exist" without a count query.
+  const rows = db.prepare(sql).all(...params, limit + 1) as Array<Record<string, unknown>>
+  const hasMore = rows.length > limit
+  const pageRows = hasMore ? rows.slice(0, limit) : rows
+  const sessions = pageRows.map(rowToSession)
+  const last = sessions.at(-1)
+  const nextCursor = hasMore && last
+    ? {
+        startedAt: last.startedAt,
+        sessionUuid: last.sessionUuid,
+        messageCount: last.messageCount,
+        title: last.title ?? '',
+      }
+    : null
+  return { sessions, nextCursor }
+}
+
 function orderByClause(sortOrder: ProjectSessionSortOrder): string {
+  // session_uuid is the unique tiebreaker so the page boundary is deterministic
+  // and keyset pagination skips exactly the rows already shown.
   switch (sortOrder) {
     case 'oldest':
-      return 's.started_at ASC'
+      return 's.started_at ASC, s.session_uuid ASC'
     case 'most_messages':
-      return 's.message_count DESC, s.started_at DESC'
+      return 's.message_count DESC, s.started_at DESC, s.session_uuid ASC'
     case 'title':
-      return 'COALESCE(NULLIF(s.title, \'\'), \'\') ASC, s.started_at DESC'
+      return "COALESCE(NULLIF(s.title, ''), '') ASC, s.started_at DESC, s.session_uuid ASC"
     case 'recent':
     default:
-      return 's.started_at DESC'
+      return 's.started_at DESC, s.session_uuid ASC'
+  }
+}
+
+function cursorWhere(
+  sortOrder: ProjectSessionSortOrder,
+  c: SessionsCursor,
+): { sql: string; params: unknown[] } {
+  const titleExpr = "COALESCE(NULLIF(s.title, ''), '')"
+  switch (sortOrder) {
+    case 'oldest':
+      return {
+        sql: '(s.started_at > ? OR (s.started_at = ? AND s.session_uuid > ?))',
+        params: [c.startedAt, c.startedAt, c.sessionUuid],
+      }
+    case 'most_messages':
+      return {
+        sql: `(
+          s.message_count < ?
+          OR (s.message_count = ? AND s.started_at < ?)
+          OR (s.message_count = ? AND s.started_at = ? AND s.session_uuid > ?)
+        )`,
+        params: [
+          c.messageCount,
+          c.messageCount, c.startedAt,
+          c.messageCount, c.startedAt, c.sessionUuid,
+        ],
+      }
+    case 'title':
+      return {
+        sql: `(
+          ${titleExpr} > ?
+          OR (${titleExpr} = ? AND s.started_at < ?)
+          OR (${titleExpr} = ? AND s.started_at = ? AND s.session_uuid > ?)
+        )`,
+        params: [
+          c.title,
+          c.title, c.startedAt,
+          c.title, c.startedAt, c.sessionUuid,
+        ],
+      }
+    case 'recent':
+    default:
+      return {
+        sql: '(s.started_at < ? OR (s.started_at = ? AND s.session_uuid > ?))',
+        params: [c.startedAt, c.startedAt, c.sessionUuid],
+      }
   }
 }


### PR DESCRIPTION
## Summary

Drop the 200/500-row caps in Library and ProjectView and replace them with `react-virtuoso` infinite scroll backed by keyset cursors. DOM stays under ~30 rows regardless of project size; pin/unpin no longer flashes the list back to skeleton; status-bar count and list footer count now both gate on the same `message_count > 0` predicate.

Resolves the P1/P2 perf items from `project_perf_findings_session_library` and three count-consistency bugs surfaced by users with 300+ sessions.

## Approach

### Backend pagination — keyset cursors

`listSessionsByIdentity` and the new `listRecentSessionsPage` return `{ sessions, nextCursor }`. The cursor is an opaque 4-tuple `(startedAt, sessionUuid, messageCount, title)`; the WHERE clause is composed per sort order so keyset pagination is stable and deterministic across all four sort modes (`recent` / `oldest` / `most_messages` / `title`). Tiebreaker in every ORDER BY is `session_uuid ASC` so page boundaries don't oscillate when two rows share the primary sort key.

Page size 50; fetch `limit + 1` to detect "more available" without a count query. `nextCursor === null` ⇒ fully exhausted.

New `listProjectDirectoryCounts` returns the per-cwd distribution for the *entire* project so chip-strip badges are accurate even when the body has only paginated through the first page.

`getStatus` now also filters `message_count > 0` so the sidebar count matches every user-facing list.

### Renderer — one virtual list per surface

New `VirtualSessionList` (react-virtuoso, same library SessionDetail's `MessageList` already uses) flattens pinned + bucket / directory sections into a single stream of typed rows: `{ kind: 'header' | 'session' | 'footer' }`. Headers, session rows, and the end-of-list footer are all rows in one Virtuoso list; `endReached` triggers the next-page fetch. ~30 rows in the DOM at any time.

`LibraryLanding` and `ProjectView` rewritten around the new component. Pin / unpin updates local cache (no refetch) and ProjectView's `DirectoryChipStrip` pulls counts from `listProjectDirectoryCounts` instead of reducing over loaded sessions.

### Cross-component pin reconciliation

The flicker on pin came from `spool:pin-change` event listeners bumping `reloadKey` → fetch effect → `setRecentSessions(null)` → Virtuoso unmounts back to skeleton.

Replaced with a diff-based reconciliation:

1. Optimistic local update via `handlePinChange` (the row's own callback).
2. The cross-component listener fetches just the pinned list, diffs against `pinnedSessionsRef.current` to detect externally-unpinned sessions, and reinserts them into the body using `insertSessionSorted` with `exhausted=true`. Forcing `exhausted=true` matters: the unpinned candidate may sort beyond the loaded range, but we know the Session object so it deserves a slot at the end of the loaded list rather than vanishing.
3. `loadMore` dedupes the keyset query result against already-loaded UUIDs so reinserted candidates can't re-appear when the next page is fetched.

`sessionSort.ts` mirrors the SQL `ORDER BY` clauses so the reinsertion lands at the correct sorted position for any of the four sort modes. Unit tests cover insertion, the "drop when not exhausted" rule for fresh-data inserts, and the uuid tiebreaker.

### Soft merge on sync

`onNewSessions` triggers a background fetch of the first page and prepends genuinely-new UUIDs to the existing recent list, without unmounting. ProjectView additionally refreshes `directoryCounts` so chip badges stay live. Skipped while a `loadMore` page is in flight to avoid races. ProjectView only merges when `sortOrder === 'recent'` — for other sort orders, new arrivals don't reliably surface on the first page anyway, so the chip refresh is enough.

### Subtractive change

Removed `listRecentSessions` from `@spool-lab/core`. CLI updated. Any external consumer should switch to `listRecentSessionsPage(db, { limit }).sessions`.

## Test plan

- [x] `pnpm --filter @spool-lab/core test` — 189 passed
- [x] `pnpm --filter @spool/app exec tsc --noEmit` — clean
- [x] `pnpm --filter @spool/app exec vitest run --exclude='e2e/**'` — 54 passed (excluding `compose-from-session.test.ts`, pre-existing test debt around origin-kind split)
- [x] `pnpm --filter @spool-lab/cli build` — clean
- [x] `npx playwright test` — 83 passed, 1 skipped (chip-count e2e skips when fixtures lack ≥2 cwds)
- [x] Manual: pin / unpin from row, sidebar, session detail; sort change reloads from page 1; chip badges reflect DB totals before pagination completes; status bar number matches list footer; sync of new session prepends without scroll jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)