### PR TITLE
perf(app): debounce ShareEditorPage's autosave stringify

### DIFF
--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -101,19 +101,35 @@ export default function ShareEditorPage({
   // produces a new conversation/opts object reference with no actual
   // change in content.
   //
-  // pendingRef holds the most recent un-flushed payload so the unmount
-  // / window-close handlers below can write it immediately rather than
-  // losing the last 400ms of edits when the user clicks Back or quits
-  // the app. The debounce timer also reads through this ref so a stale
-  // queued upsert turns into a no-op once another path (delete, flush)
-  // has cleared the pending state.
+  // pendingInputsRef stamps the *inputs* needed to build a payload, not
+  // the payload itself. The expensive part — `buildSpoolDocument` plus
+  // two `JSON.stringify` calls — is moved into `flushPendingSave` so it
+  // only runs once per debounce window (and once on unmount), instead
+  // of synchronously on every opts change. For a 1000+ msg share that
+  // saves ~hundreds of ms per click on the render thread.
   const didMountRef = useRef(false)
-  type UpsertPayload = Parameters<NonNullable<NonNullable<typeof window.spool>['shareDraft']>['upsert']>[0]
-  const pendingRef = useRef<UpsertPayload | null>(null)
+  type AutosaveInputs = {
+    draftId: string
+    sourceKind: ShareDraftSourceKind
+    sourceOrigin: string | null
+    effectiveTitle: string
+    liveConversation: Conversation
+    opts: EditorOpts
+  }
+  const pendingInputsRef = useRef<AutosaveInputs | null>(null)
   const flushPendingSave = useCallback(() => {
-    const payload = pendingRef.current
-    if (!payload) return
-    pendingRef.current = null
+    const inputs = pendingInputsRef.current
+    if (!inputs) return
+    pendingInputsRef.current = null
+    const doc = buildSpoolDocument(inputs.liveConversation, inputs.opts)
+    const payload = {
+      draft_id: inputs.draftId,
+      source_kind: inputs.sourceKind,
+      source_origin: inputs.sourceOrigin,
+      title: inputs.effectiveTitle,
+      snapshot_json: JSON.stringify(doc),
+      preview_json: JSON.stringify(buildPreviewDocument(doc)),
+    }
     void window.spool?.shareDraft?.upsert(payload).catch((err) =>
       console.error('Flush share draft autosave failed:', err),
     )
@@ -124,25 +140,15 @@ export default function ShareEditorPage({
       didMountRef.current = true
       return
     }
-    const doc = buildSpoolDocument(liveConversation, opts)
-    const payload: UpsertPayload = {
-      draft_id: draftId,
-      source_kind: sourceKind,
-      source_origin: sourceOrigin,
-      title: effectiveTitle,
-      snapshot_json: JSON.stringify(doc),
-      preview_json: JSON.stringify(buildPreviewDocument(doc)),
+    pendingInputsRef.current = {
+      draftId, sourceKind, sourceOrigin, effectiveTitle, liveConversation, opts,
     }
-    pendingRef.current = payload
-
-    const handle = window.setTimeout(() => {
-      // Identity check guards against the window where another path
-      // (delete, explicit flush) has cleared / replaced the pending
-      // payload between scheduling and firing.
-      if (pendingRef.current === payload) {
-        flushPendingSave()
-      }
-    }, 400)
+    // The cleanup below clears any in-flight timer when a new edit
+    // arrives or the component unmounts, so only the latest stamped
+    // inputs ever feed flushPendingSave. If `handleDelete` has cleared
+    // pendingInputsRef in the meantime, flushPendingSave returns a
+    // no-op when it reads the ref.
+    const handle = window.setTimeout(flushPendingSave, 400)
     return () => window.clearTimeout(handle)
   }, [opts, liveConversation, draftId, sourceKind, sourceOrigin, effectiveTitle, flushPendingSave])
 
@@ -279,7 +285,7 @@ export default function ShareEditorPage({
     // Cancel any queued autosave first — otherwise the unmount-flush
     // (or a still-queued setTimeout) would re-insert the row we're
     // about to delete.
-    pendingRef.current = null
+    pendingInputsRef.current = null
     try {
       await window.spool.shareDraft.delete(draftId)
     } catch (err) {


### PR DESCRIPTION
## Summary

Move `buildSpoolDocument` + the two `JSON.stringify` calls in ShareEditorPage's autosave from the effect body into the 400 ms `setTimeout` callback. A rapid sequence of opts changes (colorway slider, template paging) now collapses into one build per debounce window instead of running the full serialize on every click.

For a 1000+ message share that's the difference between ~hundreds of ms blocking the render thread per click and one build per debounce window.

## Approach

Replace `pendingRef` (which held a fully-built `UpsertPayload`) with `pendingInputsRef` (just the inputs needed to build one). Stamping the inputs is O(1) and stays in the effect body so unmount-flush still captures the latest user state. The actual build happens in `flushPendingSave`, which both the debounce timer and the unmount cleanup call.

The original identity check (`pendingRef.current === payload`) is no longer needed: the effect cleanup already cancels stale timers, and `flushPendingSave` returns a no-op when the ref has been cleared (which is what `handleDelete` does to prevent re-inserting a just-deleted draft).

Unmount-flush now does pay the build cost once on Back / navigation, where it used to read a pre-built payload — acceptable trade-off because unmount is a single event vs. per-keystroke before.

## Test plan

- [x] `pnpm --filter @spool/app exec tsc --noEmit` — clean
- [x] `npx playwright test e2e/share-autosave.spec.ts e2e/share-editor.spec.ts e2e/share-delete.spec.ts` — 9 passed, including:
  - `share-autosave.spec.ts:84` — unmount flush after immediate Back
  - `share-delete.spec.ts:47` — editor delete clears pending autosave
- [x] Manual: real conversation with hundreds of messages — dragging the colorway slider and switching templates rapidly no longer stalls the render thread; final state still autosaves and persists across an app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)