### PR TITLE
feat(app): add undo/redo to the share editor (Cmd+Z / Cmd+Shift+Z)

### DIFF
--- a/packages/app/e2e/share-editor.spec.ts
+++ b/packages/app/e2e/share-editor.spec.ts
@@ -63,6 +63,49 @@ test('chrome toggles (masthead, colophon, avatars, hideEmptyTurns, showGaps) fli
   }
 })
 
+test('Cmd+Z undoes the last opts change; Cmd+Shift+Z redoes it', async () => {
+  const { window } = ctx
+  // Editor is left open by prior tests in this file; do not call
+  // openShareEditorFromSessionDetail (its sidebar click would be
+  // intercepted by the editor's right panel).
+  const preview = window.locator('[data-testid="share-preview-render"]')
+
+  // Settle on chat, wait past the coalesce window, change to letter.
+  // Two distinct undo entries: (chat) → (letter).
+  await window.locator('[data-testid="share-editor-template-chat"]').click()
+  await expect(preview).toHaveAttribute('data-template', 'chat')
+  await window.waitForTimeout(600)
+  await window.locator('[data-testid="share-editor-template-letter"]').click()
+  await expect(preview).toHaveAttribute('data-template', 'letter')
+
+  await window.keyboard.press('Meta+z')
+  await expect(preview).toHaveAttribute('data-template', 'chat', { timeout: 2000 })
+
+  await window.keyboard.press('Meta+Shift+z')
+  await expect(preview).toHaveAttribute('data-template', 'letter', { timeout: 2000 })
+})
+
+test('rapid clicks within the coalesce window collapse into one undo step', async () => {
+  const { window } = ctx
+  const preview = window.locator('[data-testid="share-preview-render"]')
+
+  // Settle on a known starting template; gap so the next chain begins
+  // a fresh undo entry.
+  await window.locator('[data-testid="share-editor-template-chat"]').click()
+  await expect(preview).toHaveAttribute('data-template', 'chat')
+  await window.waitForTimeout(600)
+
+  // Three rapid switches within the 500ms coalesce window collapse
+  // into a single undo step that returns to 'chat'.
+  await window.locator('[data-testid="share-editor-template-letter"]').click()
+  await window.locator('[data-testid="share-editor-template-forum"]').click()
+  await window.locator('[data-testid="share-editor-template-timeline"]').click()
+  await expect(preview).toHaveAttribute('data-template', 'timeline')
+
+  await window.keyboard.press('Meta+z')
+  await expect(preview).toHaveAttribute('data-template', 'chat', { timeout: 2000 })
+})
+
 test('Back returns to SessionDetail', async () => {
   const { window } = ctx
   await window.getByRole('button', { name: 'Back' }).first().click()

--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -23,6 +23,7 @@ import { ControlPanel } from './share-editor/ControlPanel.js'
 import { DownloadButton } from './share-editor/DownloadButton.js'
 import Menu from './Menu.js'
 import { buildPreviewDocument } from '@spool/share-kit'
+import { useUndoableState } from '../hooks/useUndoableState.js'
 
 type Props = {
   /** Stable id of the share_drafts row to autosave into. */
@@ -67,19 +68,80 @@ export default function ShareEditorPage({
   onToggleSidebar,
 }: Props) {
   const { t } = useTranslation()
-  const [opts, setOpts] = useState<EditorOpts>(initialOpts)
+  // opts + title share one undo stack — Cmd+Z reverts whichever was
+  // edited last, which matches how users think about "undo my last
+  // change" in editors. Zoom, panel collapse, save state, and modal
+  // open/close are intentionally outside the stack so undo doesn't
+  // walk back through navigation/UI noise the user didn't intend to
+  // record.
+  type EditableState = { opts: EditorOpts; title: string }
+  const editable = useUndoableState<EditableState>({
+    opts: initialOpts,
+    title: conversation.title,
+  })
+  const opts = editable.state.opts
+  const title = editable.state.title
+  const setOpts = useCallback(
+    (next: EditorOpts) => editable.set(prev => ({ ...prev, opts: next })),
+    [editable],
+  )
+  const setTitle = useCallback(
+    (next: string) => editable.set(prev => ({ ...prev, title: next })),
+    [editable],
+  )
+
   const [zoom, setZoom] = useState<Zoom>('fit')
   const [saveState, setSaveState] = useState<SaveState>('idle')
   const [pdfPreview, setPdfPreview] = useState<{ url: string; filename: string } | null>(null)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
-  // Draft title state. Mirrors share_drafts.title; we override
-  // conversation.title at save time so the snapshot stays in sync.
-  // Renamed via a modal (the Pencil button next to the title opens it).
-  // Empty strings persist as-is during the edit but resolve to a sane
-  // fallback ("Untitled") at render time so the Shares grid never shows
-  // a blank card label.
-  const [title, setTitle] = useState<string>(conversation.title)
+  // Draft title state lives in `editable.state.title` above; the rename
+  // modal still uses `title` / `setTitle` directly. Empty strings persist
+  // as-is during the edit but resolve to a sane fallback ("Untitled") at
+  // render time so the Shares grid never shows a blank card label.
   const [renaming, setRenaming] = useState(false)
+
+  // Refs hold the latest hook callbacks so the effects below can keep
+  // empty deps and avoid rebinding on every snapshot change. Without
+  // this, the keydown listener would add+remove on every edit (since
+  // `editable` is a fresh object per render).
+  const editableResetRef = useRef(editable.reset)
+  const editableUndoRef = useRef(editable.undo)
+  const editableRedoRef = useRef(editable.redo)
+  editableResetRef.current = editable.reset
+  editableUndoRef.current = editable.undo
+  editableRedoRef.current = editable.redo
+
+  // Switching to a different draft reuses this component instance (no
+  // `key={draftId}` upstream), so the undo stack would otherwise carry
+  // edits from the previous draft into the new one. Reset on draftId
+  // change captures the new initial state as the bottom of the stack.
+  useEffect(() => {
+    editableResetRef.current({ opts: initialOpts, title: conversation.title })
+    // Only fire when the draft identity changes; conversation/initialOpts
+    // identity changes within the same draft are user edits already
+    // routed through editable.set.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftId])
+
+  useEffect(() => {
+    function handleKey(event: KeyboardEvent) {
+      if (!(event.metaKey || event.ctrlKey)) return
+      const target = event.target as HTMLElement | null
+      // Native undo handles inputs/textareas; intercepting here would
+      // break typing. The rename modal's title field, search inputs etc.
+      // all want their own undo behaviour.
+      if (target && target.matches('input, textarea, [contenteditable="true"]')) return
+      const key = event.key.toLowerCase()
+      const isUndo = key === 'z' && !event.shiftKey
+      const isRedo = (key === 'z' && event.shiftKey) || key === 'y'
+      if (!isUndo && !isRedo) return
+      event.preventDefault()
+      if (isRedo) editableRedoRef.current()
+      else editableUndoRef.current()
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [])
   const previewRef = useRef<HTMLDivElement | null>(null)
 
   // The "live" conversation passed to the preview, exporters, and the

--- a/packages/app/src/renderer/hooks/useUndoableState.test.ts
+++ b/packages/app/src/renderer/hooks/useUndoableState.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import {
+  applySet,
+  applyUndo,
+  applyRedo,
+  type UndoSnapshot,
+} from './useUndoableState.js'
+
+const opts = { coalesceMs: 500, maxHistory: 5 }
+
+function snap<T>(present: T, past: T[] = [], future: T[] = []): UndoSnapshot<T> {
+  return { past, present, future }
+}
+
+describe('applySet', () => {
+  it('pushes the previous present onto past on the first set', () => {
+    const initial = snap('a')
+    const result = applySet(initial, 'b', 0, 1_000, opts)
+    expect(result.snap.past).toEqual(['a'])
+    expect(result.snap.present).toBe('b')
+    expect(result.snap.future).toEqual([])
+    expect(result.lastSetAt).toBe(1_000)
+  })
+
+  it('coalesces consecutive sets within the time window', () => {
+    const initial = snap('a')
+    const first = applySet(initial, 'b', 0, 1_000, opts)
+    const second = applySet(first.snap, 'c', first.lastSetAt, 1_200, opts)
+    // past should still be just ['a'] — the rapid 'b' → 'c' edit is one
+    // undo step that brings the user back to 'a'.
+    expect(second.snap.past).toEqual(['a'])
+    expect(second.snap.present).toBe('c')
+  })
+
+  it('starts a new entry once outside the coalesce window', () => {
+    const initial = snap('a')
+    const first = applySet(initial, 'b', 0, 1_000, opts)
+    const second = applySet(first.snap, 'c', first.lastSetAt, 2_000, opts)
+    expect(second.snap.past).toEqual(['a', 'b'])
+    expect(second.snap.present).toBe('c')
+  })
+
+  it('clears the future on a non-coalesced set', () => {
+    const initial: UndoSnapshot<string> = snap('b', ['a'], ['c'])
+    const result = applySet(initial, 'd', 0, 1_000, opts)
+    expect(result.snap.future).toEqual([])
+  })
+
+  it('preserves the future during coalescing (mid-edit chain)', () => {
+    const initial: UndoSnapshot<string> = snap('b', ['a'], ['c'])
+    const result = applySet(initial, 'b2', 800, 1_000, opts)
+    expect(result.snap.future).toEqual(['c'])
+  })
+
+  it('returns the same snapshot identity when set value matches present', () => {
+    const initial = snap('a')
+    const result = applySet(initial, 'a', 0, 1_000, opts)
+    expect(result.snap).toBe(initial)
+    expect(result.lastSetAt).toBe(0)
+  })
+
+  it('caps past at maxHistory by dropping the oldest entry', () => {
+    let s = snap('p0')
+    let last = 0
+    // 6 non-coalesced sets, so past would naturally grow to 6
+    for (let i = 0; i < 6; i++) {
+      const t = (i + 1) * 1_000
+      const result = applySet(s, `p${i + 1}`, last, t, opts)
+      s = result.snap
+      last = result.lastSetAt
+    }
+    expect(s.past).toHaveLength(5)
+    // Oldest entry 'p0' is gone; past now starts at 'p1'.
+    expect(s.past[0]).toBe('p1')
+    expect(s.present).toBe('p6')
+  })
+})
+
+describe('applyUndo', () => {
+  it('moves the latest past entry into present and stashes prior present in future', () => {
+    const s = snap('c', ['a', 'b'], [])
+    const result = applyUndo(s)
+    expect(result.past).toEqual(['a'])
+    expect(result.present).toBe('b')
+    expect(result.future).toEqual(['c'])
+  })
+
+  it('is a no-op when past is empty', () => {
+    const s = snap('a', [], ['b'])
+    expect(applyUndo(s)).toBe(s)
+  })
+})
+
+describe('applyRedo', () => {
+  it('moves the latest future entry into present and stashes prior present in past', () => {
+    const s = snap('a', [], ['c', 'b'])
+    const result = applyRedo(s)
+    expect(result.past).toEqual(['a'])
+    expect(result.present).toBe('b')
+    expect(result.future).toEqual(['c'])
+  })
+
+  it('is a no-op when future is empty', () => {
+    const s = snap('a', ['z'], [])
+    expect(applyRedo(s)).toBe(s)
+  })
+})
+
+describe('integration: edit -> undo -> redo -> edit clears redo', () => {
+  it('clears the redo stack when the user starts a fresh edit after undoing', () => {
+    let s = snap('initial')
+    let last = 0
+    let result = applySet(s, 'a', last, 1_000, opts)
+    s = result.snap; last = result.lastSetAt
+    result = applySet(s, 'b', last, 2_000, opts)
+    s = result.snap; last = result.lastSetAt
+    // Two undos take us back past 'a' to 'initial'.
+    s = applyUndo(s)            // present 'a', future ['b']
+    s = applyUndo(s)            // present 'initial', future ['b', 'a']
+    expect(s.present).toBe('initial')
+    expect(s.future).toEqual(['b', 'a'])
+    // A new edit clears the redo branch (lastSetAt reset to 0 means no
+    // coalescing, so this is a non-coalesced set).
+    result = applySet(s, 'c', 0, 5_000, opts)
+    s = result.snap
+    expect(s.present).toBe('c')
+    expect(s.future).toEqual([])
+    expect(s.past).toEqual(['initial'])
+  })
+})

--- a/packages/app/src/renderer/hooks/useUndoableState.ts
+++ b/packages/app/src/renderer/hooks/useUndoableState.ts
@@ -1,0 +1,144 @@
+import { useCallback, useRef, useState } from 'react'
+
+type UpdaterFn<T> = (prev: T) => T
+type SetArg<T> = T | UpdaterFn<T>
+
+export interface UndoSnapshot<T> {
+  past: T[]
+  present: T
+  future: T[]
+}
+
+interface NormalisedOptions {
+  coalesceMs: number
+  maxHistory: number
+}
+
+export interface UndoableOptions {
+  /** Sets within this many ms of the previous one collapse onto the
+   *  same undo entry — slider drags become one step instead of fifty.
+   *  Default 500. */
+  coalesceMs?: number
+  /** Hard cap on the past stack so unbounded edit sessions don't grow
+   *  the heap. Default 100. */
+  maxHistory?: number
+}
+
+export interface UndoableState<T> {
+  state: T
+  set: (next: SetArg<T>) => void
+  undo: () => void
+  redo: () => void
+  canUndo: boolean
+  canRedo: boolean
+  /** Discard history and start fresh. Use when the underlying record
+   *  changes identity (e.g. user switches to a different draft) so the
+   *  old undo stack doesn't carry across. */
+  reset: (newInitial: T) => void
+}
+
+const DEFAULTS: NormalisedOptions = { coalesceMs: 500, maxHistory: 100 }
+
+/** Pure transition for a `set`. Returns the new snapshot plus the new
+ *  `lastSetAt` watermark so the caller can persist it across calls. */
+export function applySet<T>(
+  snap: UndoSnapshot<T>,
+  next: T,
+  lastSetAt: number,
+  now: number,
+  options: NormalisedOptions = DEFAULTS,
+): { snap: UndoSnapshot<T>; lastSetAt: number } {
+  if (Object.is(next, snap.present)) return { snap, lastSetAt }
+  const shouldCoalesce = now - lastSetAt < options.coalesceMs
+  if (shouldCoalesce) {
+    return { snap: { ...snap, present: next }, lastSetAt: now }
+  }
+  const newPast = [...snap.past, snap.present]
+  const trimmed = newPast.length > options.maxHistory
+    ? newPast.slice(newPast.length - options.maxHistory)
+    : newPast
+  return { snap: { past: trimmed, present: next, future: [] }, lastSetAt: now }
+}
+
+export function applyUndo<T>(snap: UndoSnapshot<T>): UndoSnapshot<T> {
+  if (snap.past.length === 0) return snap
+  const previous = snap.past[snap.past.length - 1]!
+  return {
+    past: snap.past.slice(0, -1),
+    present: previous,
+    future: [...snap.future, snap.present],
+  }
+}
+
+export function applyRedo<T>(snap: UndoSnapshot<T>): UndoSnapshot<T> {
+  if (snap.future.length === 0) return snap
+  const next = snap.future[snap.future.length - 1]!
+  return {
+    past: [...snap.past, snap.present],
+    present: next,
+    future: snap.future.slice(0, -1),
+  }
+}
+
+export function useUndoableState<T>(
+  initial: T,
+  options: UndoableOptions = {},
+): UndoableState<T> {
+  const normalised: NormalisedOptions = {
+    coalesceMs: options.coalesceMs ?? DEFAULTS.coalesceMs,
+    maxHistory: options.maxHistory ?? DEFAULTS.maxHistory,
+  }
+  const [snapshot, setSnapshot] = useState<UndoSnapshot<T>>(() => ({
+    past: [],
+    present: initial,
+    future: [],
+  }))
+  // Wall-clock of the most recent `set`. Reset to 0 after undo/redo/reset
+  // so the next user edit always starts a fresh entry — we never want to
+  // coalesce a user edit with a system-driven state replacement.
+  const lastSetAtRef = useRef<number>(0)
+
+  const set = useCallback((next: SetArg<T>) => {
+    // Capture wall-clock + the watermark BEFORE entering the updater so
+    // the ref mutation stays out of the setState reducer (StrictMode
+    // double-invokes those, ref mutation there is an anti-pattern).
+    const now = Date.now()
+    const prevLastSetAt = lastSetAtRef.current
+    lastSetAtRef.current = now
+    setSnapshot(prev => {
+      const resolved = typeof next === 'function'
+        ? (next as UpdaterFn<T>)(prev.present)
+        : next
+      return applySet(prev, resolved, prevLastSetAt, now, normalised).snap
+    })
+    // `normalised` is rebuilt each render but its primitives are stable;
+    // depending on the inner numbers (rather than the wrapper object)
+    // keeps `set`'s identity stable for downstream consumers.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [normalised.coalesceMs, normalised.maxHistory])
+
+  const undo = useCallback(() => {
+    setSnapshot(applyUndo)
+    lastSetAtRef.current = 0
+  }, [])
+
+  const redo = useCallback(() => {
+    setSnapshot(applyRedo)
+    lastSetAtRef.current = 0
+  }, [])
+
+  const reset = useCallback((newInitial: T) => {
+    setSnapshot({ past: [], present: newInitial, future: [] })
+    lastSetAtRef.current = 0
+  }, [])
+
+  return {
+    state: snapshot.present,
+    set,
+    undo,
+    redo,
+    canUndo: snapshot.past.length > 0,
+    canRedo: snapshot.future.length > 0,
+    reset,
+  }
+}


### PR DESCRIPTION
## Summary

Editing a share now records every meaningful change onto a per-draft undo stack. Cmd+Z reverts the last edit, Cmd+Shift+Z (or Cmd+Y) redoes it. Covers template / paper / typeface / colorway / density, all toggle switches, the redact panel, the turn selector, and the title rename modal — anything that mutates `EditorOpts` or `title` flows through the same stack.

## Design

### Snapshot stack, not command pattern

`useUndoableState<T>` keeps a `{ past, present, future }` of full `T` snapshots. Each user edit pushes the previous `present` onto `past`; undo pops `past`, swaps with `present`, and stashes the prior `present` in `future`; redo is the inverse; any new edit clears `future`.

Snapshot won over a typed command pattern because:
- `EditorOpts` is a small plain object — snapshot memory is negligible
- The share editor has 18+ mutation points across 3 child components — wrapping each as a typed command would be a lot of code
- Adding a new opts field (which already happens regularly in share-kit) shouldn't require teaching the undo system about a new command type

Snapshots make every mutation automatically undoable for free.

### Time-window coalescing (default 500ms)

Sets within `coalesceMs` of the previous one keep the existing `past` entry and just replace `present`. Dragging the colorway slider becomes one undo step instead of fifty. The trade-off vs. per-key coalescing: rapid switches across different controls within the window also collapse, but in practice users pause >500ms between distinct controls, so the simpler API is fine. If "switch template then immediately switch paper" feedback comes in we can add a `coalesceKey: string` parameter without breaking callers.

`maxHistory` (default 100) caps the past stack so a long edit session can't grow the heap unbounded — at ~200 bytes per `EditorOpts`, the worst case is ~20KB.

### Pure transitions + thin React adapter

The state machine lives in three pure functions:
- `applySet(snap, next, lastSetAt, now, options)` — handles coalescing, future-clearing, and the maxHistory trim
- `applyUndo(snap)` and `applyRedo(snap)` — single-step rewinds

These are unit-tested directly without any React renderer or fake timers (the app package doesn't carry RTL / jsdom and didn't need to here). The `useUndoableState` hook is a thin wrapper that wires these to `useState` + a wall-clock ref.

### Combined `{opts, title}` state

`opts` and `title` share one stack rather than two parallel ones — matches the user mental model of "undo my last change", whatever flavour. The hook is generic, so callers can compose whatever shape they want into a single stack.

### Reset on `draftId` change

`ShareEditorPage` isn't keyed by draftId at the App level, so switching to a different draft re-renders the same component instance with new props. A `useEffect([draftId])` calls `editable.reset({ opts: initialOpts, title: ... })` to discard the prior draft's history. The reset callback is read through a ref so the effect's deps stay tight.

### Keyboard binding

Single `window.keydown` listener installed once (empty deps on the effect; the hook's `undo`/`redo` are read through refs to avoid rebinding per render). Skips when focus is in `input | textarea | [contenteditable]` so the rename modal's title field gets native browser undo, not the share-editor's. macOS gets Cmd+Z / Cmd+Shift+Z; Windows/Linux additionally accept Cmd+Y.

### Out-of-scope state

`zoom`, `panelOpen`, `saveState`, `pdfPreview`, `confirmingDelete`, `renaming` stay outside the stack. Walking back through "I scrolled the preview" or "I closed the rename modal" is noise — Cmd+Z should take you back to the last *content* change.

### Autosave compatibility

Undo replaces `opts` → existing autosave effect re-runs → existing debounced flush picks up the rewound state. No special wiring; the recently-landed stringify-debounce (#232) handles it.

## Test plan

- [x] `pnpm --filter @spool/app exec tsc --noEmit` — clean
- [x] `npx vitest run src/renderer/hooks/useUndoableState.test.ts` — 12 passed: `applySet` (coalesce, no-coalesce, no-op identity, maxHistory trim, future-clearing, future-preservation during coalesce), `applyUndo` / `applyRedo` (no-op on empty), and an edit→undo→undo→edit integration that verifies redo gets cleared
- [x] `npx playwright test e2e/share-editor.spec.ts e2e/share-autosave.spec.ts e2e/share-delete.spec.ts` — 11 passed including:
  - new `Cmd+Z undoes the last opts change; Cmd+Shift+Z redoes it`
  - new `rapid clicks within the coalesce window collapse into one undo step`
  - existing `unmount flush` (so undo doesn't break the autosave debounce path)
  - existing `editor topbar delete` (so undo doesn't break the `pendingInputsRef`-clearing delete path)
- [x] Manual: rename modal Cmd+Z does NOT trigger global undo while typing; closing the modal then Cmd+Z reverts the content edit that preceded the rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)