### PR TITLE
docs(skill/launch-video): incorporate v0.5.0 production learnings

### DIFF
--- a/.claude/skills/launch-video/SKILL.md
+++ b/.claude/skills/launch-video/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 argument-hint: "[version (e.g. v0.5.0)]"
 ---
 
-Build a release video for a Spool version. The output is a 1080p MP4 plus a poster JPG, intended for X / Twitter. Total runtime ≈ 20s, four feature beats + brand outro.
+Build a release video for a Spool version. The output is a 1080p MP4 plus a poster JPG, intended for X / Twitter. Runtime scales with feature count: 20–40s, 3–8 feature beats + brand outro, optionally an "artifact" payoff scene before the outro for releases whose centrepiece is a tangible export (PDFs, share-files, etc).
 
 ## Mental model
 
@@ -14,7 +14,9 @@ A release video for Spool has two halves running in parallel on screen:
 1. **Left third** — a text panel that introduces the current scene (kicker `01 / 04 — POLISH`, a 2-line headline, a 1–2 line sub).
 2. **Right two-thirds** — the real Spool app, recorded as a native macOS window. The camera (CSS `transform-origin + scale` on the `.window`) zooms into the specific UI region for each feature.
 
-Amber annotation rectangles, positioned inside `.window` so they track the camera, call out the new feature region (`PINNED · 2 sessions` strip, `Update available` banner, etc).
+Focus on the active feature is carried by one of two devices:
+- **Amber annotation rectangles** inside `.window` that track the camera — good for "look at this strip" callouts. Cheap and precise when the feature is a single bounded region.
+- **Spotlight mask** — an SVG overlay that dims everything except 1–2 transparent "holes" punched through. Softer falloff means small coordinate drift disappears into the dim instead of reading as a misaligned outline. Dual holes let you keep the preview bright while a control on the right side lights up in sync with a click. See `references/spotlight.md`.
 
 This is **not** a PPT: text panel and demo coexist continuously, with hard match-cuts between feature clips. Don't reintroduce slide-style title cards.
 
@@ -22,9 +24,11 @@ This is **not** a PPT: text panel and demo coexist continuously, with hard match
 
 Read these references before you start composing. They are not optional — each captures hard-won decisions from prior releases.
 
-- `references/composition.md` — the proven layout, dimensions, drop-shadow recipe, panel + annotation timing patterns, beat-sync approach
-- `references/capture.md` — how to record native macOS windows of the Electron app, helper functions to use, per-release seed authoring
-- `references/pitfalls.md` — things we tried that look bad in motion (faked cursor, decorative chrome, smooth camera drifts, etc.) and why
+- `references/composition.md` — the proven layout, dimensions, drop-shadow recipe, panel + annotation timing patterns, beat-sync approach, the panel-leads-spotlight rhythm rule, the optional artifact-fan payoff scene
+- `references/capture.md` — how to record native macOS windows of the Electron app, helper functions to use, per-release seed authoring, the feature-flag-at-build-time gotcha
+- `references/cursor-overlay.md` — synthetic cursor that tracks Playwright mouse + visualises clicks. Solves "Playwright doesn't move the OS cursor and screencapture only films pixels"; required whenever a scene's whole point is a click
+- `references/spotlight.md` — SVG-mask focus technique; single-hole for one target, dual-hole for cause-effect (preview always bright + active control bright); the payoff pattern (collapse secondary to redirect the eye)
+- `references/pitfalls.md` — things we tried that look bad in motion (decorative chrome, smooth camera drifts, pre-clip resets, clip-boundary gaps, etc.) and why
 - `references/poster.md` — the `tpad clone` trick so Twitter's auto-thumbnail grabs the hero frame instead of a leading black frame
 
 ## End-to-end checklist
@@ -33,15 +37,20 @@ Read these references before you start composing. They are not optional — each
 2. **Author a per-release seed.** Write a `ProjectSeed[]` array (see `packages/app/e2e/helpers/demo-fixtures.ts` for the type). Titles should be English-only and **must not reference real user sessions** — invent plausible session titles relevant to the release theme.
 3. **Write an ad-hoc capture spec.** A Playwright spec under `packages/app/e2e/` (not committed) that:
    - Calls `launchDemoApp(seed)` + `setDemoWindowBounds(ctx, 1080, 740)`
+   - Calls `installCursorOverlay(ctx.window)` (from `helpers/cursor-overlay.ts`) before any clip is recorded so the synthetic cursor is in frame from t=0
    - Records one `.mov` per feature via `recordNativeWindow()` from `helpers/native-window-capture.ts`
+   - Uses `cursorClick(window, selector, opts)` / `cursorTo(...)` / `cursorPark(x, y)` from the same helper instead of bare `.click()` so the cursor's path is visibly filmed
    - Outputs to `videos/spool-vX.Y.Z/assets/live/` (gitignored)
+   - If your release gates a feature behind a Vite flag, build the app with `VITE_FEATURE_<NAME>=1 pnpm --filter @spool/app run build:electron` *before* running the spec — `import.meta.env.VITE_FEATURE_<NAME>` is inlined at build time, not read at runtime
+   - Bump `--global-timeout` if pacing is relaxed: Playwright's default 300s isn't enough for 7-beat spec runs (~50s of `screencapture -V` plus warmup)
 4. **Copy `videos/launch-template/` to `videos/spool-vX.Y.Z/`.**
 5. **Customise the composition** (`index.html`):
-   - Update `<video>` `data-start`, `data-duration`, `src` per clip
+   - Update `<video>` `data-start`, `data-duration`, `src` per clip. Verify each pair satisfies `prev.data_start + prev.data_duration ≥ next.data_start + 0.10` — gaps where neither clip is playing render as a dark frame and read as a full-screen flash (see `pitfalls.md` #11)
    - Author one text panel per scene (kicker + headline + sub)
-   - **Measure annotation coords fresh** from your raw `.mov` frames — last release's `top: 15%` is wrong for this release
+   - **Measure focus-region coords fresh** from your raw `.mov` frames — last release's coords are wrong for this release
+   - Time the panel `~0.3–0.4s ahead of the spotlight retarget` so the headline anchors before the action starts (see `composition.md` on panel-leads-spotlight)
    - Update the brand-mark version + outro version strings
-6. **Drop in BGM** at `assets/bgm.mp3`. Identify strong beats with `ffmpeg silencedetect`; align scene cuts or camera punches to them.
+6. **Drop in BGM** at `assets/bgm.mp3`. Identify strong beats with `ffmpeg silencedetect` (for tracks with clear silences) OR `aubiotrack` (more reliable for steady-state atmospheric pieces); align scene cuts or camera punches to them. If your video needs to be longer than the source BGM, stretch with `atempo` — 0.85 is the comfortable floor (subtle pitch drop, no audible quality loss), 0.79 still acceptable, below 0.75 starts to degrade. Add a 0.6–0.8s `afade=t=out` tail so the music decays into the lockup instead of cutting off.
 7. **Iterate with drafts.**
    ```
    cd videos/spool-vX.Y.Z
@@ -58,16 +67,17 @@ Read these references before you start composing. They are not optional — each
 
 ## Hard rules
 
-- **No simulated cursor.** Real screen recordings show real interactions; faked GSAP cursors look uncanny. If a click is invisible in the clip, use an amber annotation to call out the *result*, not the action.
+- **Synthetic cursor is allowed but must track real input.** A floating GSAP cursor that arrives at random places looks uncanny — that rule from prior releases stands. What's *not* uncanny is the cursor-overlay technique in `references/cursor-overlay.md`: a DOM cursor injected into the page that follows Playwright's actual `mouse.move()` and pulses on `mousedown`. If a scene's whole point is a click, draw the cursor. Don't draw a cursor for scenes where nothing's being clicked.
+- **Chain state across clips. Don't reset between recordings.** If clip 3 ends with the editor in `Timeline / Bone / Walnut`, clip 4 starts there. Pre-clip state resets (clicking different templates / papers between recordings) cause a visible "flash" at the clipCut boundary even though both clips show editor pixels. If the export beat needs a specific final look, get to it *inside* the recording (the user sees the click) or land it earlier in the chain so it's the natural state by the export beat.
 - **First frame must be the full hero state.** Brand mark + panel 1 + UI window all visible at `t=0`, not faded in. Twitter's auto-thumbnail grabs this frame.
-- **Annotations live inside `.window`**, not on the outer canvas. They must move with the camera transform.
+- **Annotations and spotlights live inside `.window`**, not on the outer canvas. They must move with the camera transform.
 - **No decorative chrome.** No vignette, callsign, progress bar, or trailer-style overlay flashes. The UI is the protagonist.
-- **No "pull back to neutral" before the outro.** End scene 4 on its feature focus, then hard-cut/fade to the Spool lockup.
+- **No "pull back to neutral" before the outro.** End the last feature beat on its focus, then hard-cut/fade to the Spool lockup (or to the artifact-fan scene if the release earns it).
 
 ## Files this skill touches
 
-- Reads: `packages/app/e2e/helpers/{demo-fixtures,demo-launch,demo-interactions,native-window-capture}.ts`
+- Reads: `packages/app/e2e/helpers/{demo-fixtures,demo-launch,demo-interactions,native-window-capture,cursor-overlay}.ts`
 - Reads: `videos/launch-template/`
 - Creates: `videos/spool-vX.Y.Z/` (new release directory)
-- Creates: a temporary Playwright spec under `packages/app/e2e/` (do not commit)
+- Creates: a temporary Playwright spec under `packages/app/e2e/` (do not commit; delete or gitignore after the release ships)
 - Outputs: `videos/spool-vX.Y.Z/renders/spool-vX.Y.Z-final.mp4` and `.jpg` poster (both gitignored)

--- a/.claude/skills/launch-video/references/capture.md
+++ b/.claude/skills/launch-video/references/capture.md
@@ -14,6 +14,8 @@ Solution: capture the rectangular region the macOS window occupies via `screenca
 - `captureNativeWindow(app, path)` — single PNG (uses `screencapture -l <id>`).
 - `recordNativeWindow(app, path, seconds, perform)` — runs `screencapture -V <seconds> -R <rect>` while `perform()` drives the app concurrently.
 - `launchDemoApp(seed)` + `setDemoWindowBounds(ctx, 1080, 740)` — boot Electron with programmatic fixtures, force dark, set canonical size.
+- `installCursorOverlay(window)` — inject the synthetic DOM cursor that tracks Playwright's `mouse.move()` and pulses on `mousedown`. Call once after `waitForDemoSync(window)`; see `cursor-overlay.md` for details.
+- `cursorTo(window, selector, opts)` / `cursorClick(window, selector, opts)` / `cursorPark(window, x, y)` — replace bare `.click()` so the cursor's path is visibly filmed.
 - `emitUpdateStatus(app, payload)` — push updater banner state via IPC.
 - `pinFirstRowInProject(window, name)` — hover + pin first session row.
 
@@ -58,6 +60,7 @@ Structure:
 import { test } from '@playwright/test'
 import { launchDemoApp, setDemoWindowBounds, waitForDemoSync } from './helpers/demo-launch'
 import { recordNativeWindow } from './helpers/native-window-capture'
+import { installCursorOverlay, cursorClick, cursorPark } from './helpers/cursor-overlay'
 import { emitUpdateStatus, pinFirstRowInProject } from './helpers/demo-interactions'
 
 const PROJECTS = [/* per-release seed */]
@@ -65,15 +68,20 @@ const PROJECTS = [/* per-release seed */]
 const OUT_DIR = path.join(__dirname, '../../../videos/spool-vX.Y.Z/assets/live')
 
 test('record release clips', async () => {
-  test.setTimeout(180_000)
+  test.setTimeout(540_000)  // ~9min — relaxed pacing across 7 beats can take longer than the default 30s test timeout
 
   const ctx = await launchDemoApp(PROJECTS)
   await setDemoWindowBounds(ctx, 1080, 740)
   await waitForDemoSync(ctx.window)
+  await installCursorOverlay(ctx.window)         // synthetic cursor for the rest of the spec
+  await cursorPark(ctx.window, 120, 360)          // park off to the side before clip 1
 
   await recordNativeWindow(ctx.app, path.join(OUT_DIR, '01-home.mov'), 4.0, async () => {
-    // Drive the app for ~4s while screencapture records.
-    // e.g. ctx.window.mouse.wheel(0, 900)
+    await ctx.window.waitForTimeout(500)         // settle so the cursor is in the first filmed frame
+    await cursorClick(ctx.window, '[data-testid="sidebar-shares"]', {
+      preClickPause: 260, postClickPause: 280,
+    })
+    // ... drive the rest of the scene
   })
 
   // ... more clips per feature
@@ -85,7 +93,16 @@ test('record release clips', async () => {
 Run with:
 
 ```bash
-pnpm --filter @spool/app exec playwright test e2e/release-capture.spec.ts --workers=1
+pnpm --filter @spool/app exec playwright test e2e/release-capture.spec.ts \
+  --workers=1 --global-timeout=900000 --retries=0
+```
+
+`--global-timeout` is required for relaxed-pacing releases — Playwright's config default is 300s and a 7-beat spec with relaxed `postClickPause` values can easily exceed that. `--retries=0` because a flaky capture (Electron failing to focus, screencapture permission glitch) on first run can spawn a second Electron whose window overlaps the first — the capture then records the wrong app state. Better to fail loudly and re-run by hand than auto-retry and ship wrong frames.
+
+If the feature being demoed is behind a build-time flag (e.g. `VITE_FEATURE_SHARE`), build the app with the flag *before* running the spec — `import.meta.env.VITE_FEATURE_<NAME>` is inlined at build time:
+
+```bash
+VITE_FEATURE_SHARE=1 pnpm --filter @spool/app run build:electron
 ```
 
 ## Capture-time constants
@@ -95,11 +112,13 @@ pnpm --filter @spool/app exec playwright test e2e/release-capture.spec.ts --work
 | Window logical size | 1080×740 | Matches app default (`packages/app/src/main/index.ts`); the composition assumes this aspect |
 | Theme | dark forced | `nativeTheme.themeSource = 'dark'` in `setDemoWindowBounds()` |
 | GPU | disabled | `ELECTRON_DISABLE_GPU=1` for deterministic frames |
-| `screencapture` cursor | off | Default. Add `-C` to args if you want the system cursor in frame — usually you don't, the simulated cursors look unnatural |
+| `screencapture` cursor | off | Default; don't add `-C`. The real OS cursor doesn't move with Playwright, so capturing it would film a stationary system arrow in some corner. Use the synthetic DOM cursor from `cursor-overlay.md` instead |
 
 ## Common capture issues
 
 - **Window not found.** `screencapture -R` failures usually mean the Electron window hasn't focused. Call `app.focus({steal: true})` + `win.focus()` before recording.
-- **Playwright `mouse.click()` does NOT move the OS cursor.** It dispatches DOM events directly. If you need cursor-in-frame, drive the OS cursor separately (e.g. `cliclick`) — but this is usually a sign you should drop the cursor entirely and let the UI change carry the story.
+- **Playwright `mouse.click()` does NOT move the OS cursor.** It dispatches DOM events directly. If you need cursor-in-frame, install the synthetic DOM cursor from `cursor-overlay.md` — a real cursor that tracks Playwright input + a click pulse. Don't try to drive `cliclick` to move the real OS cursor; the timing is fiddly and the result still looks unnatural.
 - **First-frame black pixels in the output `.mov`.** `screencapture -V` has ~21ms latency before the first frame lands. Padded out at composition time via `tpad` (see `poster.md`).
 - **Timing slips between perform() and screencapture.** `recordNativeWindow` starts the recording, then runs `perform()`. There's a ~500ms lead-in where you can `waitForTimeout` to settle before the first action.
+- **Captures show test-suite fixtures instead of demo seed.** Symptom: clip 1 records the wrong Electron window's content (e.g. test-project fixtures with XYLOPHONE_CANARY data). Cause: a previous test left an Electron process running and Playwright auto-retried after a flake, spawning a second Electron whose Quartz window-id won the `nativeWindowInfo()` match. Fix: `pkill -9 -f Electron` before the spec, and run with `--retries=0` so flakes don't silently double up.
+- **Build-time feature flag not applied.** Symptom: test fails to find a feature-gated selector (e.g. `[data-testid="sidebar-shares"]`) even though the smoke test passes for unrelated selectors. Cause: built the app without `VITE_FEATURE_<NAME>=1`. Vite inlines `import.meta.env.VITE_FEATURE_<NAME>` at build time, not runtime, so setting the env var when running playwright is too late. Rebuild with the flag.

--- a/.claude/skills/launch-video/references/composition.md
+++ b/.claude/skills/launch-video/references/composition.md
@@ -70,18 +70,105 @@ Fade the annotation in **after** the feature is fully visible in the clip, not w
 
 Fade out **with the scene**, not after. When the panel exits and the camera transitions, the annotation goes with them.
 
+## Spotlight focus (alternative to amber rectangles)
+
+For releases where the action is "user clicks control X, preview Y changes" — i.e. cause-and-effect, not "look at this strip" — use a spotlight mask instead of amber rectangles. See `spotlight.md` for the full pattern. Brief summary:
+
+- SVG mask with 1–2 transparent holes punched through a dim overlay
+- Holes' coords retarget via `tl.set` (hard snaps, no morph)
+- Single hole for one-target scenes; dual hole for "preview + control" scenes
+- Soft alpha falloff at hole edges hides ±10px coordinate drift — much more forgiving than amber outlines, which read as misaligned at ±3px
+
+A single composition can mix both: amber rectangles for "look here" scenes, spotlight for "watch this control move that preview" scenes.
+
+## Panel-leads-spotlight timing
+
+The single most impactful rule for readability. When `panelIn()` and the spotlight retarget (or annotation reveal) fire at the same instant, the viewer's eyes don't know whether to read or watch — they end up doing neither.
+
+Stagger them:
+
+```
+t=0.00s   panelIn()                           ← headline anchors first
+t=0.40s   spotlightSnap(...) or annotation    ← eye guided to focal region
+t=0.80s   click / state change                ← action lands
+```
+
+The 0.4s lead is the natural-feel range. Anything below 0.25s reads as simultaneous; above 0.6s reads as a delay.
+
+If your scene has only one panel-led beat per scene, this is automatic. For multi-click scenes where the spotlight retargets per click, only the *first* spotlight needs the lead — subsequent retargets can fire ~0.3–0.4s before each click.
+
 ## Beat sync
 
-Run `ffmpeg -i bgm.mp3 -af "highpass=200,lowpass=4000,silencedetect=n=-30dB:d=0.05" -f null -` to find strong beats in the BGM (look at `silence_end` timestamps). Align:
+Two tools, pick by BGM type:
 
-- Scene cuts (clip swap) — to a beat if possible
+- `ffmpeg -i bgm.mp3 -af "highpass=200,lowpass=4000,silencedetect=n=-30dB:d=0.05" -f null -` — finds silence boundaries, good for tracks with clear gaps between phrases
+- `brew install aubio && aubiotrack bgm.mp3 | awk 'NR % 4 == 0 || NR == 1'` — beat-tracks the music itself, returns timestamps every 4 beats (~half-phrase). More reliable for atmospheric or sustained tracks where `silencedetect` returns nothing
+
+Align:
+
+- Scene cuts (clip swap) — to a beat / phrase boundary if possible
 - Camera punches — to a beat
+- Outro fade-in — to a phrase boundary (the lockup landing on a musical resolution feels intentional)
 - Annotation fade-ins — slightly after a beat (so it lands as an answer to the beat, not on it)
 
 The video doesn't need to be tightly beat-locked — just lining up the major moments to phrase boundaries makes the whole thing feel intentional.
+
+## BGM duration mismatch
+
+If your video needs to be longer than the source BGM (e.g. a 39s 7-beat video on a 30s track), stretch the audio with `atempo`:
+
+```bash
+ffmpeg -i source.mp3 -filter:a "atempo=0.85,afade=t=out:st=37.9:d=0.8" -t 38.75 -b:a 192k out.mp3
+```
+
+Quality floor by tempo factor:
+
+- **0.85** — slight pitch drop, no audible quality loss. The comfortable default for ~15% extension.
+- **0.79** — still acceptable, mild "underwater" feel on percussive tracks; fine for atmospheric.
+- **< 0.75** — starts to degrade. Either find a longer BGM or split the video.
+
+Always append a 0.6–0.8s `afade=t=out` tail so the music decays into the lockup instead of stopping flat.
+
+## Artifact fan (optional capstone scene)
+
+For releases whose centrepiece produces a tangible export (PDFs, share files, etc), an optional scene *between* the final feature beat and the brand outro: four document cards materialise centre-stage as a stylised fan, each pairing a paper × template combo with a format tag.
+
+Why it works:
+
+- The Export scene shows the *mechanism* (open a dropdown, see 4 formats). The artifact scene shows the *outcome* (here are 4 documents leaving the editor). Together they close the "tune → publish" arc.
+- Cards are pure CSS — no new captures, no fake browsers, no fake Twitter / Slack screenshots. The documents themselves are the demo.
+
+Composition:
+
+- 4 cards, 220×300px each, arranged in a subtle fan: rotations roughly -10° / -3° / +3° / +10°, slight Y arc (corner cards drop ~30px below middle cards)
+- Each card has: paper background colour (mirrors `share-kit`'s `PaperDef`), header with `Spool.` mark + template name, body in template-faithful style, bottom-left format tag (mono uppercase), bottom-right meta line (page count, image dimensions, file type)
+- Body styles are stylised per template: chat bubbles for Chat, threaded posts with avatars for Forum, vertical rail with markers for Timeline, monospace `# heading > quote` source view for Markdown (the MD card deliberately shows source code, not rendered output — that's what an .md file actually is, and the visual contrast against the other three keeps the formats distinct)
+- Stagger in 0.10–0.15s apart over ~0.55s each, hold 0.7–1.5s, fade out
+- Total scene: 3–4s including transitions
+
+Skip this scene if the release isn't export-focused — it adds runtime and would feel forced for, say, a sidebar polish release. Earned only when the export itself is the headline.
 
 ## Panel + annotation animations
 
 Already encoded in the template as `panelIn()`, `panelOut()`, `zoomTo()`, `clipFade()` GSAP helpers. Don't rewrite them per release; just call them with new timing values.
 
+The `clipCut(outSel, inSel, at)` helper that swaps videos should use the v0.5.0 timings — incoming clip opacity 1 at `at - 0.20`, outgoing opacity 0 at `at + 0.10` — so the renderer has time to decode the incoming clip's first frame before the outgoing one disappears. A tighter overlap can produce a one-frame dark gap that reads as a flash. See `pitfalls.md` #11.
+
 Word-by-word stagger on `panel-headline` is the one place where motion is *allowed* to be slightly playful — keeps the text from feeling like a static slide.
+
+## End-of-timeline anchor
+
+The composition's last frame must be the lockup, not a fade-to-blank. GSAP's `fromTo` keeps a tween at its end-state after completion, but at the timeline's natural end the renderer may revert to the from-state if you don't pin the final state explicitly. Add zero-duration `.to()` tweens just before the composition boundary:
+
+```js
+tl.fromTo("#outro-lockup",
+  { y: 10, opacity: 0, scale: 0.98 },
+  { y: 0, opacity: 1, scale: 1, duration: 0.55, ease: "power3.out" }, 33.80);
+// Anchor the held state at the composition boundary so the last
+// frame is the lockup, not a fade-to-blank.
+tl.to("#outro-lockup", { opacity: 1, y: 0, scale: 1, duration: 0.001 }, 35.49);
+tl.to("#outro",        { opacity: 1, duration: 0.001 }, 35.49);
+tl.to("#outro-fade",   { opacity: 1, duration: 0.001 }, 35.49);
+```
+
+The composition `data-duration` is 35.50 in this example; the anchor tweens fire at 35.49 to guarantee the last rendered frame holds the lockup's full opacity.

--- a/.claude/skills/launch-video/references/cursor-overlay.md
+++ b/.claude/skills/launch-video/references/cursor-overlay.md
@@ -1,0 +1,118 @@
+# Cursor overlay
+
+A synthetic DOM cursor that tracks Playwright's mouse position and pulses on click. Required for scenes whose whole point is a click.
+
+## Why it's needed
+
+Two facts about the capture pipeline:
+
+1. **Playwright's `page.mouse.move()` / `mouse.click()` don't move the OS cursor.** They dispatch DOM events directly into the renderer. The real OS cursor stays where it was when you ran the spec.
+2. **`screencapture -V` films native pixels.** Whatever the OS shows is what ends up in the `.mov`. Even with `-C`, only the *real* OS cursor would be captured, and it's not moving.
+
+So a scene like "click the + button, watch the picker open" reads as "the picker just appeared on its own" — no agency, no cause. The viewer doesn't see the click happen.
+
+Prior releases (v0.4.11 era) solved this by deleting the cursor entirely and using amber annotations to call out the *result* of the action ("the new pinned section appeared"). That works for changes that are visible at scale, but it falls apart when:
+
+- The same UI region keeps appearing with different contents (Templates list cycling)
+- The click is on a tiny target (a + button, a tab)
+- There are multiple consecutive clicks the viewer needs to follow
+
+The cursor-overlay technique fixes this. The trick is that the cursor must track real input — a cursor that floats by itself looks more uncanny than no cursor at all.
+
+## What it is
+
+`packages/app/e2e/helpers/cursor-overlay.ts` exports four functions:
+
+```ts
+import {
+  installCursorOverlay, // call once after the page is ready
+  cursorClick,          // move + pause + click + pulse ring
+  cursorTo,             // move only (no click)
+  cursorPark,           // move to absolute (x, y) coords — for idle parking
+} from './helpers/cursor-overlay'
+```
+
+`installCursorOverlay(page)` injects a fixed-position DOM element with:
+
+- An SVG arrow (Apple-style filled white with 1.2px dark stroke)
+- A `mousemove` listener (capture phase, passive) that repositions the arrow
+- A `mousedown` listener that briefly adds `.pulse` to a sibling ring `<span>` for a 420ms expanding click animation
+
+It registers via `page.addInitScript()` so it survives any unexpected page navigations, and is also injected immediately into the current page so it shows up before the first clip records.
+
+## How to use it
+
+In the per-release capture spec, after `launchDemoApp(seed)` and `setDemoWindowBounds(ctx, 1080, 740)`:
+
+```ts
+import { installCursorOverlay, cursorClick, cursorTo, cursorPark } from './helpers/cursor-overlay'
+
+await waitForDemoSync(ctx.window)
+await installCursorOverlay(ctx.window)
+await cursorPark(ctx.window, 120, 360) // off to the side before clip 1 starts recording
+
+await recordNativeWindow(ctx.app, OUT_DIR + '/01-foo.mov', 5.2, async () => {
+  await ctx.window.waitForTimeout(550)
+  await cursorClick(ctx.window, '[data-testid="sidebar-shares"]', {
+    preClickPause: 260,
+    postClickPause: 280,
+  })
+  await cursorPark(ctx.window, 700, 480, 22) // park on grid card, NOT on next clip's target
+  await ctx.window.waitForTimeout(2600)
+})
+```
+
+### `cursorTo(window, selector, opts)`
+
+Moves the synthetic cursor to the centre of the selector. Options:
+
+- `steps` (default 16) — number of intermediate `mousemove` events Playwright dispatches. The DOM listener treats each as a frame; higher steps = smoother motion. 16–22 is the sweet spot. Above 30 the cursor feels syrupy.
+- `settle` (default 0) — `waitForTimeout` after the move completes. Use a small value (200–250ms) when you want a beat between "cursor arrives" and "cursor clicks".
+
+### `cursorClick(window, selector, opts)`
+
+`cursorTo()` + `.click()` + optional post-click pause. Options:
+
+- `steps` (default 16) — same as `cursorTo`
+- `preClickPause` (default 220) — pause between arriving on target and firing the click. **This is the single biggest knob for natural-feel.** 220–280ms reads as "the user looked, then clicked". Below 150 feels robotic. Above 350 starts to feel hesitant.
+- `postClickPause` (default 0) — pause after the click before returning. Use this when you want the result of the click to settle on screen before the next action.
+
+### `cursorPark(window, x, y, steps = 14)`
+
+Moves to absolute viewport coordinates (CSS pixels). Use to:
+
+- Place the cursor in a "neutral" spot before the first recording so it's visible in frame 0
+- Move it off a clickable element between scenes so it doesn't read as "about to click that"
+
+**Important parking rules:**
+
+- Don't park on the *next* clip's click target. A cursor that sits on `+` for 2s and then "clicks" reads as a delayed action — viewers parse it as a missed click. Park elsewhere (on an interior card, in empty chrome).
+- Park on real content, not gutters. If your park position lands between cards or in empty grey space, the cursor looks abandoned. Aim for the centre of a visible element.
+
+## Timing rules of thumb
+
+Synthetic cursor moves are essentially **instant** from a wall-clock perspective — Playwright dispatches `mousemove` events without delay between them. The motion the viewer sees is the DOM listener catching all those events and repositioning the arrow over a single browser paint frame. So:
+
+- `steps` controls path smoothness, not duration
+- `preClickPause` is the only thing that controls "how long the cursor sits before clicking"
+- A natural-feel beat is roughly:
+  - 200–500ms idle / settle
+  - 16–22 `steps` move (~one paint frame, but smoothed)
+  - 220–280ms `preClickPause`
+  - click (instant)
+  - 1000–1500ms `postClickPause` to let the result settle
+
+## Hard rules
+
+- **One cursor only.** Don't draw your own additional cursor on top of the overlay. The cursor in the captured `.mov` should be the synthetic one and nothing else (no `screencapture -C`).
+- **Install once, before any recording.** If you install it mid-spec, the first clip's first frame might be cursor-less.
+- **Click pulse must come from a real `mousedown`.** Don't fire fake click animations — the pulse must trace a real input event, otherwise it'll drift out of sync with what the UI actually does.
+- **Don't draw the cursor in scenes where nothing's clicked.** If a scene is just "look at this grid", park the cursor on a card and let it sit. Don't make it move for the sake of moving.
+
+## What the overlay looks like
+
+The arrow is a 22×22 white SVG path with a dark 1.2px stroke — visually close enough to the macOS cursor that viewers don't notice it's synthetic. The click ring is a 42×42 circle with a 2px white border that scales from 0.35 to 1.55 over 420ms with opacity fading 0.95 → 0.
+
+Both have a subtle drop-shadow so they read against light and dark UI surfaces.
+
+The DOM structure is `#spool-demo-cursor` with one child `<svg>` (arrow) and one `<span class="ring">` (pulse). z-index is `2147483647` so nothing in the renderer can occlude it. `pointer-events: none` so it never blocks a real click target.

--- a/.claude/skills/launch-video/references/pitfalls.md
+++ b/.claude/skills/launch-video/references/pitfalls.md
@@ -2,19 +2,22 @@
 
 What we tried during v0.4.11 that looked bad in motion, and what to do instead. Read this **before** improvising on the proven layout.
 
-## 1. Faked cursors look uncanny
+## 1. Cursors that don't track real input look uncanny
 
-We built three iterations of an overlaid SVG cursor that flew across the screen to "click" buttons. Every version felt wrong:
+We built three iterations of a *standalone* GSAP cursor that flew across the screen on its own to "click" buttons. Every version felt wrong:
 
 - Linear motion → robotic
 - Bezier + overshoot → bouncy in a video-game way
-- Designed amber dot with click pulse → still felt artificial because it wasn't synced to anything physical in the clip
+- Designed amber dot with click pulse → still artificial because it wasn't synced to anything physical in the clip
 
-**Why:** the real clip has no cursor. Adding one creates a disconnect between the cursor's "intent" and the UI's actual response timing.
+**Why:** a cursor with no input event behind it is the problem. The viewer's brain reads "this isn't a real interaction" within ~100ms.
 
-**Do instead:** drop the cursor entirely. Use amber annotation rectangles to call out the *result* of an interaction (the new pinned section, the status banner change). The viewer doesn't need to see the click — they see the effect.
+**Do instead, depending on the scene:**
 
-If you absolutely need to show a click for clarity, a single amber pulse ring at the click point (no cursor) is the most you should add.
+- **No cursor at all** — for scenes where the change carries the story (new pinned strip appears, updater banner flips state). Use amber annotation rectangles to call out the *result*.
+- **Synthetic cursor that tracks Playwright** — for scenes where the *click* is the story (clicking + opens a picker; clicking a template re-flows the preview). Inject a DOM cursor that follows real `mousemove` events and pulses on real `mousedown`. See `cursor-overlay.md`. The cursor is now driven by genuine input, so the click rhythm matches the UI's response. This was the v0.5.0 fix and it works.
+
+The hard rule is: **a cursor in frame must trace real input.** A cursor that floats on its own is worse than no cursor at all.
 
 ## 2. Decorative chrome adds nothing
 
@@ -74,3 +77,71 @@ The video has ~6–8 strong beats from the BGM. Don't try to land every scene cu
 Early v0.4.11 attempts (livecut v1–v6) used a hand-built HTML mockup of the Spool UI inside the composition. It iterated for hours and still looked uncanny — wrong row heights, wrong icons, wrong rhythm.
 
 **Lesson:** always record the real Electron app. The capture pipeline exists for a reason. Don't try to recreate the UI in HTML, ever.
+
+(Exception: an *artifact* scene — a stylised post-demo card showing what the export "looks like" — is fine because the cards are explicitly not the app UI; they're documents. See `composition.md` § Artifact fan.)
+
+## 11. Clip-boundary gap (the silent full-screen flash)
+
+The most insidious bug from v0.5.0. Two adjacent video clips, both showing visually identical editor states at the boundary, *should* swap invisibly. But on rendered output we'd see a single frame of near-black at the exact cut, reading as a full-screen flash.
+
+**Root cause:** clip A's `data-duration` ended before clip B's `data-start` began. Even by 0.13s. During that gap, neither video element was "playing" — clip A had ended (browsers show a frozen last frame, but the HyperFrames renderer may release the buffer), clip B wasn't seekable yet. The result was a frame the renderer composed against an empty video element.
+
+**The math you have to satisfy:**
+
+```
+prev_clip.data_start + prev_clip.data_duration ≥ next_clip.data_start + 0.10
+```
+
+In English: the previous clip must still be playing when the next clip starts to take over. Aim for ≥ 0.20s overlap. Tighten the next clip's `data-start` earlier rather than extending the previous clip's `data-duration` past the end of the actual `.mov` file (a video element past its natural end may render unpredictably).
+
+**Bonus fix in the `clipCut` helper:** bring the incoming clip's opacity up *before* the boundary, not at it:
+
+```js
+function clipCut(outSel, inSel, at) {
+  tl.set(inSel,  { opacity: 1 }, at - 0.20);  // ← lead by 0.20s
+  tl.set(outSel, { opacity: 0 }, at + 0.10);  // ← outgoing lags 0.10s
+}
+```
+
+This gives the renderer time to decode the incoming clip's first frame before the outgoing one disappears. The 0.30s overlap is invisible because both clips show identical editor state at the boundary anyway.
+
+## 12. Pre-clip state resets cause a flash at the cut
+
+Between recording clip 3 and clip 4 in v0.5.0 we tried to "reset" the editor to a clean baseline (clicking different template / paper / typeface / colorway). When the composition cut from clip 3's end-state to clip 4's start-state, the editor visibly jumped from `Timeline / Bone / Walnut` to `Chat / Snow / Amber`. The viewer's brain registered it as a glitch even though both states were technically valid.
+
+**Why:** the reset clicks happened *outside* the recordings, so the viewer never saw the cause. A state change with no cause reads as a bug.
+
+**Do instead, in order of preference:**
+
+1. **Chain state.** Clip A ends with whatever state, clip B starts there. No reset between recordings. Design the demo flow so the natural state at each beat is what you want.
+2. **Reset *inside* a recording.** If you must change state mid-demo (e.g. to get back to Chat for the export beat), do it via visible cursor clicks during a recorded clip — the viewer sees the user making the choice.
+3. **Never** reset between clips and hope the panel transition will mask it. It won't.
+
+For the v0.5.0 export beat, the fix was to cycle Chat → Timeline → Chat *inside* clip 3, so by the time clips 4–7 ran, the editor was already on Chat and stayed there.
+
+## 13. Cognitive budget per scene
+
+A 5-second scene shows the viewer two channels in parallel: a panel headline + sub on the left, a demo action sequence on the right. You can fit either:
+
+- **One action + a full panel read** — cursor moves, one click, result settles. Viewer reads kicker + 2-line headline + 2-line sub.
+- **Up to 2 actions + a partial panel read** — cursor moves, click, settle ~1s, click again, settle. Viewer reads kicker + headline; the sub gets skimmed.
+
+**You cannot fit 3 actions in 5s with a panel.** The viewer's eyes can't track three template clicks on the right while reading a paragraph on the left. The third action might as well not exist.
+
+v0.5.0's original scene 3 cycled Chat → Letter → Forum → Timeline (3 clicks). The viewer absorbed the first and last; Letter and Forum slipped by uncounted. We trimmed it to Chat → Timeline → Chat (2 clicks across a longer beat) and the scene immediately read better.
+
+**Rule:** ≤ 2 clicks per scene if the panel has a sub. If you absolutely need to demo more variations, give it its own scene with a shorter panel.
+
+## 14. Panel must lead the spotlight by ~0.4s
+
+Synchronising `panelIn()` and `spotlightSnap()` at the same instant means the viewer's eyes have nowhere to land first — text on the left and a region lighting up on the right both demand attention, and they end up tracking neither.
+
+**Do:** fire `panelIn(...)` first, then `spotlightSnap(...)` 0.3–0.4s later, then the click another 0.3–0.5s after that. The viewer reads the headline → finds where to look → sees the action.
+
+```js
+panelIn("#panel4", 14.85);                          // 0.00s: text anchors
+spotlightSnap(F.editorPreview, 15.25, F.paperRow);  // 0.40s: highlight arrives
+// clip 04's paper-bone click happens at ~16.16     // ~1.30s: action lands
+```
+
+This is the single most impactful timing rule for readability. Without it the video reads as "everything happening at once and I can't follow." With it the video has a natural rhythm.

--- a/.claude/skills/launch-video/references/spotlight.md
+++ b/.claude/skills/launch-video/references/spotlight.md
@@ -1,0 +1,153 @@
+# Spotlight focus
+
+An SVG-mask overlay that dims everything outside 1–2 transparent "holes". An alternative to amber annotation rectangles for directing the eye.
+
+## When to use spotlight vs amber rectangle
+
+Both techniques live inside `.window` so the camera transform applies to them. Pick based on what you want the viewer to do:
+
+| Goal | Use |
+|---|---|
+| "Look at this strip" (specific feature region, no ambiguity) | Amber rectangle (precise, geometric) |
+| "Read this preview while also watching this control" | Dual spotlight (preview hole always bright, control hole retargets) |
+| "Focus tightens as the click happens" | Spotlight retarget (single hole moves) |
+| The amber outline keeps reading as "misaligned" no matter how you measure | Spotlight (soft falloff hides drift) |
+
+Amber rectangles are unforgiving about pixel alignment — if your measured coords are 4px off, the outline reads as "wrong". Spotlight holes have a dim falloff around their edge that absorbs small drift; you can be ±10px and the eye still lands where you want it.
+
+## The mask structure
+
+A single SVG covers the window. Inside is a `<mask>` with a white "shows everything" rect and 1–2 black "punches a hole" rects. The output rectangle is filled with the dim colour and references the mask, so wherever the mask is black, the dim is *not* applied (those holes show the video underneath at full brightness).
+
+```html
+<svg id="spotlight" viewBox="0 0 100 100" preserveAspectRatio="none"
+     style="position:absolute; inset:0; z-index:18; pointer-events:none; opacity:0">
+  <defs>
+    <mask id="spotlight-holes" maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
+      <rect width="100" height="100" fill="white"/>
+      <rect id="hole-primary"   x="50" y="50" width="0" height="0" rx="0.8" ry="0.8" fill="black"/>
+      <rect id="hole-secondary" x="50" y="50" width="0" height="0" rx="0.8" ry="0.8" fill="black"/>
+    </mask>
+  </defs>
+  <rect width="100" height="100" fill="#121210" fill-opacity="0.70" mask="url(#spotlight-holes)"/>
+</svg>
+```
+
+Coordinates are in viewBox units 0–100 (percentages of the `.window`'s logical 1000×685 box). `preserveAspectRatio="none"` lets the percentages map directly to width/height without aspect-ratio distortion. `maskUnits="userSpaceOnUse"` is required — without it the mask uses object bounding box and you'll spend an afternoon wondering why your rects render at the wrong scale.
+
+Each hole's default size is 0×0 (invisible). GSAP retargets them via `attr` tweens.
+
+## GSAP helpers
+
+These belong in the composition script next to `panelIn` / `clipCut`:
+
+```js
+const NULL_HOLE = { x: 50, y: 50, w: 0, h: 0 };
+
+function setHole(sel, rect, at) {
+  const r = rect || NULL_HOLE;
+  tl.set(sel, { attr: { x: r.x, y: r.y, width: r.w, height: r.h } }, at);
+}
+function spotlightOn(primary, at, secondary) {
+  setHole("#hole-primary",   primary,   at);
+  setHole("#hole-secondary", secondary, at);
+  tl.set("#spotlight", { opacity: 1 }, at);
+}
+function spotlightOff(at) {
+  tl.set("#spotlight", { opacity: 0 }, at);
+}
+function spotlightSnap(primary, at, secondary) {
+  // Retarget without changing the overall on/off state.
+  setHole("#hole-primary",   primary,   at);
+  setHole("#hole-secondary", secondary, at);
+}
+```
+
+Define your focus rectangles once near the top of the script, in `% of .window`:
+
+```js
+const F = {
+  sidebarShares: { x: 0.6,  y: 10.0, w: 20,   h: 3.4 },
+  templates:     { x: 71.5, y: 11,   w: 26.5, h: 41 },
+  editorPreview: { x: 1,    y: 1,    w: 68,   h: 98 },
+  // ...
+};
+```
+
+Then in scene code:
+
+```js
+spotlightOn(F.sidebarShares, 0.45);          // single, dim everything else
+spotlightSnap(F.draftsGrid, 1.55);            // retarget, still on
+spotlightSnap(F.editorPreview, 10.15, F.templates); // dual: preview + control
+spotlightSnap(F.editorPreview, 30.15);        // collapse secondary, single again
+spotlightOff(34.50);
+```
+
+## Hard snaps only — no morph
+
+Spotlight retargets are `tl.set()`, never `tl.to()`. A morphing spotlight (interpolating x/y/w/h between rects over 200ms) reads as a "moving frame" — the eye tracks the motion and gets distracted from the underlying content change.
+
+A snap, paired with a click happening 100–200ms later, reads as "the eye is already there waiting" — which is the whole point.
+
+## Single vs dual hole
+
+**Single** — for scenes where one region matters at a time:
+
+- Sidebar click target
+- Drafts grid contents
+- A dropdown opening
+
+**Dual** — for cause-and-effect scenes where two regions need to be readable at the same time:
+
+- "User clicks Letter template, preview reflows" → primary = preview, secondary = template list
+- "User toggles Privacy bulk, masked pills update" → primary = preview, secondary = privacy summary
+- "User clicks Bone paper, preview restyles" → primary = preview, secondary = paper row
+
+The convention: **primary = preview / result**, **secondary = control / cause**. The secondary retargets per click; the primary stays fixed on the preview throughout the scene.
+
+## The payoff pattern
+
+When the cause-and-effect has played its loop, collapse the secondary to `NULL_HOLE`. With the right side suddenly dim, the viewer's eye has only the preview to look at — and that's exactly when the preview's change is the payoff.
+
+```js
+// Scene 6 (Privacy): preview + privacy panel both bright, user toggles masks.
+spotlightSnap(F.editorPreview, 25.65, F.privacyPanel);
+// After the re-mask click, kill the secondary.
+// Now the preview's redacted pills are the only thing lit.
+spotlightSnap(F.editorPreview, 29.65);
+```
+
+This is a deliberate 0.5–1.0s moment of "look here, this is the answer." Particularly useful for features whose payoff is subtle (mask states, gap markers, accent shifts) and could get lost in a busy dual-spotlight frame.
+
+## Measuring hole coordinates
+
+Same workflow as amber rectangles, but with one advantage: spotlight is forgiving. If you measure roughly and the rect is 5–10px off, the dim falloff absorbs it. Don't sweat sub-pixel measurement — measure once to within ~1% and move on.
+
+1. Extract a raw `.mov` frame where the target is fully visible.
+2. Crop to the target region with `ffmpeg -i frame.png -vf "crop=W:H:X:Y" cropped.png`.
+3. Measure the bounding box in source pixels (typically the captured `.mov` is 2160×1480 retina).
+4. Convert to viewBox units: `x_vb = x_px / 21.6`, `y_vb = y_px / 14.8`, `w_vb = w_px / 21.6`, `h_vb = h_px / 14.8` (for a 1000×685 window).
+5. Add 0.5–1% padding on each side so the bright zone has breathing room.
+
+## clipCut interaction
+
+`spotlightSnap` doesn't change which clip is visible — it just moves the holes. When a scene changes underlying clips (clip 3 → clip 4 etc.), the spotlight coords usually don't need to change since the layout is the same (right-panel controls in the same place, preview in the same place). Retarget only when the *active control* changes — Templates list → Paper row → Typeface row, etc.
+
+Order of operations at scene boundaries:
+
+```js
+// Panel anchors first (0.4s lead — see composition.md on panel-leads-spotlight)
+panelIn("#panel4", 14.85);
+// Clip swaps next
+clipCut("#clip-templates", "#clip-style", 14.65);
+// Spotlight retargets last
+spotlightSnap(F.editorPreview, 15.25, F.paperRow);
+```
+
+## Common pitfalls
+
+- **The mask rect coords are in viewBox units, not CSS pixels.** If your hole is 220px wide on a 1000px-wide window, that's `w: 22`. Not `w: 220`.
+- **`maskUnits="userSpaceOnUse"` is mandatory.** Without it the mask renders at object bounding box and you'll see no holes (or holes at 100× scale).
+- **The dim fill colour and opacity together set the "how dark" feel.** `#121210` at `fill-opacity="0.70"` gives a strong dim that still lets shapes read through; `0.85` gets close to "obscured" which can feel too aggressive for steady-state scenes.
+- **No border on the bright zone.** A coloured outline around the spotlight makes the holes feel like "frames" and any coordinate drift becomes glaring. The soft falloff at the alpha boundary is the whole point.

--- a/packages/app/e2e/helpers/cursor-overlay.ts
+++ b/packages/app/e2e/helpers/cursor-overlay.ts
@@ -1,0 +1,123 @@
+/**
+ * Demo cursor overlay for launch-video captures.
+ *
+ * Playwright's `page.mouse.move/click` dispatch synthetic DOM events but
+ * don't move the real OS cursor, and `screencapture -V` films native
+ * pixels — so there's no pointer in frame unless we draw one ourselves.
+ *
+ * This installs a DOM-rendered arrow that tracks the synthetic mouse
+ * position via a capture-phase `mousemove` listener, plus a brief ring
+ * pulse on `mousedown` so clicks read as clicks rather than as state
+ * changes that "just happen". Pointer events stay off so the overlay
+ * never intercepts a real click target.
+ */
+import type { Page } from '@playwright/test'
+
+const OVERLAY_SCRIPT = `
+(function () {
+  if (window.__spoolDemoCursorInstalled) return
+  window.__spoolDemoCursorInstalled = true
+
+  function install() {
+    if (document.getElementById('spool-demo-cursor')) return
+    const style = document.createElement('style')
+    style.textContent = [
+      '#spool-demo-cursor{position:fixed;left:0;top:0;width:22px;height:22px;',
+      'pointer-events:none;z-index:2147483647;will-change:transform;',
+      'transition:transform 60ms linear}',
+      '#spool-demo-cursor svg{display:block;width:100%;height:100%;',
+      'filter:drop-shadow(0 1.5px 2.5px rgba(0,0,0,0.55))}',
+      '#spool-demo-cursor .ring{position:absolute;left:-10px;top:-10px;',
+      'width:42px;height:42px;border-radius:50%;border:2px solid rgba(255,255,255,0.95);',
+      'opacity:0;pointer-events:none;box-shadow:0 0 0 1px rgba(0,0,0,0.35)}',
+      '#spool-demo-cursor .ring.pulse{animation:spool-cursor-pulse 0.42s ease-out forwards}',
+      '@keyframes spool-cursor-pulse{',
+      '0%{transform:scale(0.35);opacity:0.95}',
+      '70%{opacity:0.4}',
+      '100%{transform:scale(1.55);opacity:0}}'
+    ].join('')
+    document.head.appendChild(style)
+
+    const root = document.createElement('div')
+    root.id = 'spool-demo-cursor'
+    root.innerHTML = [
+      '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">',
+      '<path d="M3 2 L3 18 L7.2 13.8 L9.6 19.4 L12.2 18.3 L9.8 12.7 L15.4 12.7 Z" ',
+      'fill="#ffffff" stroke="#181818" stroke-width="1.2" stroke-linejoin="round"/>',
+      '</svg>',
+      '<span class="ring"></span>'
+    ].join('')
+    document.body.appendChild(root)
+
+    const ring = root.querySelector('.ring')
+    let x = window.innerWidth / 2
+    let y = window.innerHeight / 2
+    function place() {
+      root.style.transform = 'translate(' + (x - 2) + 'px,' + (y - 2) + 'px)'
+    }
+    place()
+
+    document.addEventListener('mousemove', function (e) {
+      x = e.clientX
+      y = e.clientY
+      place()
+    }, { capture: true, passive: true })
+
+    document.addEventListener('mousedown', function () {
+      if (!ring) return
+      ring.classList.remove('pulse')
+      void ring.offsetWidth
+      ring.classList.add('pulse')
+    }, { capture: true, passive: true })
+  }
+
+  if (document.body) install()
+  else document.addEventListener('DOMContentLoaded', install)
+})()
+`
+
+export async function installCursorOverlay(window: Page): Promise<void> {
+  await window.addInitScript(OVERLAY_SCRIPT)
+  await window.evaluate(OVERLAY_SCRIPT)
+}
+
+export interface MoveOptions {
+  steps?: number
+  settle?: number
+}
+
+export interface MoveAndClickOptions extends MoveOptions {
+  preClickPause?: number
+  postClickPause?: number
+}
+
+async function centerOf(window: Page, selector: string): Promise<{ x: number; y: number }> {
+  const locator = window.locator(selector).first()
+  await locator.waitFor({ state: 'visible', timeout: 6000 })
+  const box = await locator.boundingBox()
+  if (!box) throw new Error(`No bounding box for ${selector}`)
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+}
+
+export async function cursorTo(window: Page, selector: string, opts: MoveOptions = {}): Promise<void> {
+  const { x, y } = await centerOf(window, selector)
+  await window.mouse.move(x, y, { steps: opts.steps ?? 16 })
+  if (opts.settle) await window.waitForTimeout(opts.settle)
+}
+
+export async function cursorClick(
+  window: Page,
+  selector: string,
+  opts: MoveAndClickOptions = {},
+): Promise<void> {
+  await cursorTo(window, selector, { steps: opts.steps, settle: opts.preClickPause ?? 220 })
+  await window.locator(selector).first().click()
+  if (opts.postClickPause) await window.waitForTimeout(opts.postClickPause)
+}
+
+/** Park the cursor at an idle position so it doesn't sit on top of the
+ *  next clickable element awkwardly between beats. Coords are in CSS
+ *  pixels of the renderer window. */
+export async function cursorPark(window: Page, x: number, y: number, steps = 14): Promise<void> {
+  await window.mouse.move(x, y, { steps })
+}

--- a/packages/app/e2e/helpers/demo-fixtures.ts
+++ b/packages/app/e2e/helpers/demo-fixtures.ts
@@ -19,6 +19,11 @@ export interface LeadSession {
   source: SessionSource
   /** ISO 8601 timestamp. Determines sort order in Recent. */
   iso: string
+  /** Optional explicit turn list. When omitted, the default 2-turn stub is
+   *  used (`Help me with: <title>` + a single assistant reply). Provide
+   *  this to demo a richer conversation in the share editor. Each turn's
+   *  timestamp is derived from `iso + (i * 30s)`. */
+  turns?: Array<{ role: 'user' | 'assistant'; text: string }>
 }
 
 export interface ProjectSeed {
@@ -58,6 +63,11 @@ function toUuid(counter: number): string {
 }
 
 function workspacePath(tmpDir: string, name: string): string {
+  void tmpDir
+  return `/Users/demo/Code/${name}`
+}
+
+function fixtureWorkspaceDir(tmpDir: string, name: string): string {
   return join(tmpDir, 'workspaces', name)
 }
 
@@ -71,43 +81,55 @@ function writeText(path: string, value: string) {
   writeFileSync(path, value, 'utf8')
 }
 
-function makeClaudeSession(sessionId: string, cwd: string, title: string, iso: string): string {
-  const followupIso = new Date(Date.parse(iso) + 45_000).toISOString()
-  return [
+function makeClaudeSession(
+  sessionId: string,
+  cwd: string,
+  title: string,
+  iso: string,
+  turns?: Array<{ role: 'user' | 'assistant'; text: string }>,
+): string {
+  const lines: string[] = [
     JSON.stringify({
       type: 'custom-title',
       sessionId,
       cwd,
       customTitle: title,
     }),
-    JSON.stringify({
-      type: 'user',
+  ]
+
+  const dialog = turns ?? [
+    { role: 'user' as const, text: `Help me with: ${title}` },
+    {
+      role: 'assistant' as const,
+      text: `Working through ${title} with the latest shell and sidebar assumptions.`,
+    },
+  ]
+
+  let parentUuid: string | undefined
+  dialog.forEach((turn, i) => {
+    const uuid = `${sessionId}-${turn.role[0]}${i + 1}`
+    const timestamp = new Date(Date.parse(iso) + i * 30_000).toISOString()
+    const entry: Record<string, unknown> = {
+      type: turn.role,
       sessionId,
       cwd,
-      uuid: `${sessionId}-u1`,
-      timestamp: iso,
-      message: {
-        role: 'user',
-        content: `Help me with: ${title}`,
-      },
-    }),
-    JSON.stringify({
-      type: 'assistant',
-      uuid: `${sessionId}-a1`,
-      parentUuid: `${sessionId}-u1`,
-      timestamp: followupIso,
-      message: {
-        role: 'assistant',
-        model: 'claude-sonnet-4.20250514',
-        content: [
-          {
-            type: 'text',
-            text: `Working through ${title} with the latest shell and sidebar assumptions.`,
-          },
-        ],
-      },
-    }),
-  ].join('\n') + '\n'
+      uuid,
+      timestamp,
+      message:
+        turn.role === 'user'
+          ? { role: 'user', content: turn.text }
+          : {
+              role: 'assistant',
+              model: 'claude-sonnet-4.20250514',
+              content: [{ type: 'text', text: turn.text }],
+            },
+    }
+    if (parentUuid) entry.parentUuid = parentUuid
+    lines.push(JSON.stringify(entry))
+    parentUuid = uuid
+  })
+
+  return lines.join('\n') + '\n'
 }
 
 function makeCodexSession(sessionId: string, cwd: string, title: string, iso: string): string {
@@ -154,6 +176,7 @@ export function buildDemoFixtures(
 
   const fillerTopics = options.fillerTopics ?? DEFAULT_FILLER_TOPICS
   let sessionCounter = options.sessionCounterStart ?? 1
+  let fillerTitleIndex = 0
 
   mkdirSync(claudeDir, { recursive: true })
   mkdirSync(codexDir, { recursive: true })
@@ -169,7 +192,7 @@ export function buildDemoFixtures(
 
   for (const project of projects) {
     const cwd = workspacePath(tmpDir, project.name)
-    mkdirSync(cwd, { recursive: true })
+    mkdirSync(fixtureWorkspaceDir(tmpDir, project.name), { recursive: true })
 
     const sessions: LeadSession[] = [...project.leadSessions]
     const fillerCount = Math.max(0, project.total - project.leadSessions.length)
@@ -178,11 +201,16 @@ export function buildDemoFixtures(
       const dayOffset = 3 + Math.floor(i / 4)
       const hour = 17 - (i % 6)
       const minute = (i * 7) % 60
+      const topicIndex = fillerTitleIndex % fillerTopics.length
+      const wrapCount = Math.floor(fillerTitleIndex / fillerTopics.length)
+      const topic = fillerTopics[topicIndex] ?? `Follow-up task ${fillerTitleIndex + 1}`
+      const title = wrapCount > 0 ? `${topic} ${wrapCount + 1}` : topic
       sessions.push({
-        title: `${fillerTopics[i % fillerTopics.length]} ${i + 1}`,
+        title,
         source,
         iso: new Date(Date.UTC(2026, 4, Math.max(1, 10 - dayOffset), hour, minute, 0)).toISOString(),
       })
+      fillerTitleIndex += 1
     }
 
     sessions.forEach((session, index) => {
@@ -190,7 +218,7 @@ export function buildDemoFixtures(
       if (session.source === 'claude') {
         const relDir = join(claudeDir, project.name.toLowerCase())
         const filePath = join(relDir, `${project.name.toLowerCase()}-${String(index + 1).padStart(3, '0')}.jsonl`)
-        writeText(filePath, makeClaudeSession(sessionId, cwd, session.title, session.iso))
+        writeText(filePath, makeClaudeSession(sessionId, cwd, session.title, session.iso, session.turns))
         return
       }
 

--- a/packages/app/e2e/smoke-demo-launch.spec.ts
+++ b/packages/app/e2e/smoke-demo-launch.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test'
+import { launchDemoApp, setDemoWindowBounds, waitForDemoSync } from './helpers/demo-launch'
+import type { ProjectSeed } from './helpers/demo-fixtures'
+
+const PROJECTS: ProjectSeed[] = [
+  {
+    name: 'spool',
+    total: 5,
+    leadSessions: [{ title: 'Hello', source: 'claude', iso: '2026-05-14T15:42:00Z' }],
+    fillerSources: ['claude'],
+  },
+]
+
+test('demo app launches', async () => {
+  test.setTimeout(120_000)
+  console.log('[smoke] launching')
+  const ctx = await launchDemoApp(PROJECTS)
+  console.log('[smoke] launched')
+  await setDemoWindowBounds(ctx, 1080, 740)
+  console.log('[smoke] bounds set')
+  await waitForDemoSync(ctx.window)
+  console.log('[smoke] synced')
+  await expect(ctx.window.locator('[data-testid="sidebar-project-row"]').first()).toBeVisible()
+  console.log('[smoke] project visible')
+  await ctx.cleanup()
+})


### PR DESCRIPTION
## Summary

Updates the launch-video skill with patterns earned while building the v0.5.0 Share-feature launch video. Two main reversals from prior guidance, plus four new pitfalls, plus a handful of practical helpers the next release will pick up automatically.

## Reversals

- **Synthetic cursor is now allowed** when it tracks real Playwright input. The original "no faked cursors" rule was about *standalone* GSAP cursors with no input event behind them — those still look uncanny. A DOM cursor injected via `addInitScript` that follows real `mousemove` and pulses on real `mousedown` reads naturally because the click rhythm matches the UI's actual response. `references/cursor-overlay.md` documents the architecture and the timing knobs (preClickPause is the single biggest natural-feel lever).
- **Spotlight mask is an alternative to amber rectangles** for cause-and-effect scenes. SVG mask with 1–2 transparent holes punched through a dim overlay. Dual holes keep the preview bright while a control retargets per click. Soft falloff at hole edges is forgiving of ±10px coordinate drift where amber rectangles need pixel-perfect alignment. `references/spotlight.md` explains the mask structure, the GSAP helpers, single-vs-dual semantics, and the payoff pattern (collapse secondary to redirect the eye at the moment of resolution).

## Four new pitfalls

- **Clip-boundary gap** — clip A's `data_start + data_duration` must overlap clip B's `data_start` by ≥ 0.10s, or the renderer composites against an empty video element and the boundary frame goes near-black. Includes the corrected `clipCut` helper that brings the incoming clip up 0.20s *before* the boundary so the renderer has time to decode its first frame.
- **Pre-clip state resets cause boundary flash** — clip A ends in one state, you reset between recordings, clip B starts in a different state. The composition cuts from one to the other and the viewer sees a glitch with no visible cause. Chain state across clips instead, or change state via visible clicks *inside* a recording.
- **Cognitive budget per scene** — a 5s scene with a panel sub can absorb 1 action with full panel read, or 2 actions with partial panel read. Three actions is the slip threshold. (The v0.5.0 templates scene originally cycled four templates and Letter + Forum slipped by uncounted; trimmed to Chat → Timeline → Chat and it instantly read better.)
- **Panel must lead spotlight retarget by ~0.4s** — anything tighter means the viewer's eyes have nowhere to land first and they end up tracking neither the headline nor the action. Single most impactful timing rule for readability.

## Surface changes

`SKILL.md`:
- Runtime broadened from "≈ 20s, 4 feature beats" to "20–40s, 3–8 beats + optional artifact-fan capstone scene"
- Hard rules updated: synthetic-cursor rule refined, new "chain state across clips" rule
- Build-time feature flag gotcha (`VITE_FEATURE_<NAME>=1` must be at build time, not runtime)
- `--global-timeout` callout for relaxed-pacing specs

`composition.md`:
- Adds spotlight focus section + panel-leads-spotlight timing rule
- BGM `atempo` stretching with quality floor (0.85 comfortable, 0.79 acceptable, < 0.75 degrades)
- `aubiotrack` as alternative to `silencedetect` for atmospheric BGMs
- Optional artifact-fan capstone scene pattern (skip unless the release earns it)
- End-of-timeline anchor tweens so the last frame is the lockup, not a fade-to-blank

`capture.md`:
- Documents the cursor-overlay helpers in the helpers list and the spec skeleton
- `--global-timeout=900000 --retries=0` invocation explained (auto-retry on flakes can produce two Electrons and capture the wrong window)
- Two new "common capture issues" entries (stray Electron + missing build-time flag)

## Infrastructure that ships with this PR

The next release-video build will pick these up automatically:

- `packages/app/e2e/helpers/cursor-overlay.ts` — the synthetic cursor module
- `packages/app/e2e/helpers/demo-fixtures.ts` — optional `turns?` on `LeadSession` for multi-turn demo conversations; better filler-title deduping when topic list wraps; display `cwd` becomes a stable fake demo path
- `packages/app/e2e/smoke-demo-launch.spec.ts` — minimal smoke test for the demo-launch infrastructure; run before any per-release capture to confirm health on the current build

## How it connects

Per-release capture specs and built `videos/spool-vX.Y.Z/` artifacts stay gitignored (deliberately). This PR is purely the durable infrastructure + skill docs.

## Test plan

- [ ] `pnpm --filter @spool/app exec playwright test e2e/smoke-demo-launch.spec.ts --workers=1 --retries=0` passes on current main
- [ ] Read-through of the new refs (`cursor-overlay.md` + `spotlight.md`) — checked for instructions that match the actual helper implementations
- [ ] Spot-check that the pitfalls.md updates don't contradict any rule still in force from earlier releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)