### PR TITLE
fix(core): detect agent CLIs installed via mise / interactive-rc version managers

### DIFF
--- a/packages/core/src/util/resolve-bin.test.ts
+++ b/packages/core/src/util/resolve-bin.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { wellKnownBinPaths, nvmVersionBins, miseVersionBins } from './resolve-bin.js'
+
+let tmpHome: string
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'spool-resolve-bin-'))
+})
+
+afterEach(() => {
+  try { rmSync(tmpHome, { recursive: true, force: true }) } catch { /* ignore */ }
+})
+
+function touch(path: string): void {
+  mkdirSync(join(path, '..'), { recursive: true })
+  writeFileSync(path, '')
+}
+
+describe('wellKnownBinPaths', () => {
+  it('includes standard install dirs in a stable order', () => {
+    const paths = wellKnownBinPaths('codex', tmpHome)
+    expect(paths).toContain('/usr/local/bin/codex')
+    expect(paths).toContain('/opt/homebrew/bin/codex')
+    expect(paths).toContain(`${tmpHome}/.local/bin/codex`)
+  })
+
+  it('puts extras before defaults so callers can override', () => {
+    const paths = wellKnownBinPaths('codex', tmpHome, ['/custom/codex'])
+    expect(paths[0]).toBe('/custom/codex')
+  })
+
+  it('appends mise shim path', () => {
+    const paths = wellKnownBinPaths('codex', tmpHome)
+    expect(paths).toContain(`${tmpHome}/.local/share/mise/shims/codex`)
+  })
+})
+
+describe('nvmVersionBins', () => {
+  it('returns empty when nvm dir is missing', () => {
+    expect(nvmVersionBins(tmpHome, 'node')).toEqual([])
+  })
+
+  it('lists installed node versions newest first', () => {
+    const base = join(tmpHome, '.nvm', 'versions', 'node')
+    mkdirSync(join(base, 'v18.0.0'), { recursive: true })
+    mkdirSync(join(base, 'v20.5.0'), { recursive: true })
+    mkdirSync(join(base, 'v22.1.0'), { recursive: true })
+    const bins = nvmVersionBins(tmpHome, 'node')
+    expect(bins).toEqual([
+      join(base, 'v22.1.0', 'bin', 'node'),
+      join(base, 'v20.5.0', 'bin', 'node'),
+      join(base, 'v18.0.0', 'bin', 'node'),
+    ])
+  })
+
+  it('skips non-version entries', () => {
+    const base = join(tmpHome, '.nvm', 'versions', 'node')
+    mkdirSync(join(base, 'v20.0.0'), { recursive: true })
+    mkdirSync(join(base, 'alias'), { recursive: true })
+    expect(nvmVersionBins(tmpHome, 'node')).toEqual([join(base, 'v20.0.0', 'bin', 'node')])
+  })
+})
+
+describe('miseVersionBins', () => {
+  it('returns only the shim path when mise installs dir is missing', () => {
+    expect(miseVersionBins(tmpHome, 'codex')).toEqual([
+      `${tmpHome}/.local/share/mise/shims/codex`,
+    ])
+  })
+
+  it('includes shim + installed versions, with latest first when present', () => {
+    const installs = join(tmpHome, '.local', 'share', 'mise', 'installs', 'npm-openai-codex')
+    mkdirSync(join(installs, '0.1.0'), { recursive: true })
+    mkdirSync(join(installs, '0.2.0'), { recursive: true })
+    mkdirSync(join(installs, 'latest'), { recursive: true })
+    const bins = miseVersionBins(tmpHome, 'codex')
+    expect(bins[0]).toBe(`${tmpHome}/.local/share/mise/shims/codex`)
+    expect(bins[1]).toBe(join(installs, 'latest', 'bin', 'codex'))
+    expect(bins.slice(2)).toEqual([
+      join(installs, '0.2.0', 'bin', 'codex'),
+      join(installs, '0.1.0', 'bin', 'codex'),
+    ])
+  })
+
+  it('handles multiple plugins independently', () => {
+    const root = join(tmpHome, '.local', 'share', 'mise', 'installs')
+    mkdirSync(join(root, 'npm-openai-codex', 'latest'), { recursive: true })
+    mkdirSync(join(root, 'node', '20.0.0'), { recursive: true })
+    const bins = miseVersionBins(tmpHome, 'codex')
+    expect(bins).toContain(join(root, 'npm-openai-codex', 'latest', 'bin', 'codex'))
+    expect(bins).toContain(join(root, 'node', '20.0.0', 'bin', 'codex'))
+  })
+
+  it('reproduces issue #237: mise-installed codex is discoverable via fallback', () => {
+    const codexPath = join(tmpHome, '.local', 'share', 'mise', 'installs', 'npm-openai-codex', 'latest', 'bin', 'codex')
+    touch(codexPath)
+    const paths = wellKnownBinPaths('codex', tmpHome)
+    expect(paths).toContain(codexPath)
+  })
+})

--- a/packages/core/src/util/resolve-bin.ts
+++ b/packages/core/src/util/resolve-bin.ts
@@ -7,9 +7,14 @@ import { join } from 'node:path'
  * Resolve a binary path that works in both terminal-launched and
  * GUI-launched (minimal PATH) contexts on macOS.
  *
- * Strategy: try `which` first, then login shell, then well-known paths.
+ * Strategy: process PATH → user login+interactive shell → bash fallback →
+ * well-known install locations (homebrew, ~/.local/bin, nvm, mise).
+ *
+ * The interactive (-i) flag is what picks up version managers that activate
+ * in .zshrc / .bashrc (mise, asdf, fnm, etc.) rather than only profile files.
  */
-function nvmVersionBins(home: string, name: string): string[] {
+
+export function nvmVersionBins(home: string, name: string): string[] {
   const versionsDir = join(home, '.nvm', 'versions', 'node')
   try {
     return readdirSync(versionsDir)
@@ -21,30 +26,88 @@ function nvmVersionBins(home: string, name: string): string[] {
   }
 }
 
-export function resolveSystemBinary(name: string, extraSearchPaths: string[] = []): string | null {
-  // Try shell lookup first
-  try {
-    const p = execSync(`which ${name}`, { encoding: 'utf8', timeout: 3000, stdio: ['pipe', 'pipe', 'pipe'] }).trim()
-    if (p) return p
-  } catch {}
+/**
+ * Enumerate mise-managed binary paths for a given tool name.
+ * mise installs under ~/.local/share/mise/installs/<plugin>/<version>/bin/<name>,
+ * and exposes shims at ~/.local/share/mise/shims/<name>. We check the shim first
+ * (it's a stable entry point), then scan installed versions newest-first.
+ */
+export function miseVersionBins(home: string, name: string): string[] {
+  const root = join(home, '.local', 'share', 'mise')
+  const result: string[] = [join(root, 'shims', name)]
 
-  // Try login shell — picks up nvm/fnm/etc even in GUI context
+  const installsDir = join(root, 'installs')
+  let plugins: string[]
   try {
-    const p = execSync(`bash -lc "which ${name}"`, { encoding: 'utf8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim()
-    if (p) return p
-  } catch {}
+    plugins = readdirSync(installsDir)
+  } catch {
+    return result
+  }
 
-  // Check well-known paths directly
-  const home = homedir()
-  const searchPaths = [
-    ...extraSearchPaths,
+  for (const plugin of plugins) {
+    const pluginDir = join(installsDir, plugin)
+    let versions: string[]
+    try {
+      versions = readdirSync(pluginDir)
+    } catch { continue }
+    const ordered = versions.includes('latest')
+      ? ['latest', ...versions.filter(v => v !== 'latest').sort().reverse()]
+      : versions.sort().reverse()
+    for (const v of ordered) {
+      result.push(join(pluginDir, v, 'bin', name))
+    }
+  }
+  return result
+}
+
+/** Ordered list of filesystem paths to probe for `name`. Pure. */
+export function wellKnownBinPaths(name: string, home: string, extras: string[] = []): string[] {
+  return [
+    ...extras,
     `/usr/local/bin/${name}`,
     `/opt/homebrew/bin/${name}`,
     `${home}/.local/bin/${name}`,
     `${home}/.nvm/current/bin/${name}`,
     ...nvmVersionBins(home, name),
+    ...miseVersionBins(home, name),
   ]
-  for (const p of searchPaths) {
+}
+
+function shellLookup(shell: string, flags: string, name: string, timeoutMs: number): string | null {
+  try {
+    const p = execSync(`${shell} ${flags} 'command -v ${name}'`, {
+      encoding: 'utf8',
+      timeout: timeoutMs,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim()
+    return p || null
+  } catch {
+    return null
+  }
+}
+
+export function resolveSystemBinary(name: string, extraSearchPaths: string[] = []): string | null {
+  // 1. Current process PATH — fast path for terminal-launched contexts
+  try {
+    const p = execSync(`command -v ${name}`, { encoding: 'utf8', timeout: 3000, stdio: ['pipe', 'pipe', 'pipe'] }).trim()
+    if (p) return p
+  } catch {}
+
+  // 2. User's login+interactive shell — covers mise/asdf/fnm activated in .zshrc/.bashrc
+  const userShell = process.env['SHELL']
+  if (userShell) {
+    const p = shellLookup(userShell, '-ilc', name, 5000)
+    if (p) return p
+  }
+
+  // 3. Bash fallback — in case SHELL is unset or the user's shell is broken
+  if (!userShell || !userShell.endsWith('bash')) {
+    const p = shellLookup('bash', '-lc', name, 5000)
+    if (p) return p
+  }
+
+  // 4. Well-known install locations
+  for (const p of wellKnownBinPaths(name, homedir(), extraSearchPaths)) {
     if (existsSync(p)) return p
   }
   return null


### PR DESCRIPTION
Fixes #237.

## What

Make `resolveSystemBinary` find agent CLIs (codex, claude, gemini, …) that are installed via `mise` (and other version managers activated in interactive shell rc files like `.zshrc`) when Spool is launched from Dock/Finder.

## Why

`packages/core/src/util/resolve-bin.ts` had three discovery tiers:

1. `which <name>` against the current process PATH.
2. `bash -lc "which <name>"` as a "shell that knows about nvm" fallback.
3. A hardcoded well-known-paths list.

In a Dock/Finder launch on macOS, (1) misses because Electron inherits the system minimal PATH. (2) misses for the most common modern setup — zsh + mise — because `mise activate zsh` lives in `.zshrc`, and `bash -lc` neither runs zsh nor sources interactive rc files. (3) didn't know about mise install layouts.

Net effect: a perfectly working `which codex` in the terminal showed up as "not installed" in Settings → AI Agents, as reported in #237.

## How it connects

Two layers of fix so a single broken assumption can't take detection down:

- **Shell tier**: replace `bash -lc` with `$SHELL -ilc 'command -v <name>'` (login + **interactive**), matching the strategy already used by `acp.ts:getLoginShellEnv()` for spawning agent subprocesses. Falls back to `bash -lc` only when `SHELL` is unset / non-bash and the user shell lookup failed.
- **Filesystem tier**: append mise's standard install paths to the probe list — the shim at `~/.local/share/mise/shims/<name>` and per-plugin/per-version installs under `~/.local/share/mise/installs/<plugin>/<version>/bin/<name>`, parallel to the existing `nvmVersionBins` enumeration.

Refactors candidate-path assembly into a pure `wellKnownBinPaths(name, home, extras)` helper so the discovery contract is unit-testable without mocking `execSync` or the real filesystem.

## Test plan

- [x] New `packages/core/src/util/resolve-bin.test.ts` (10 tests) covers `nvmVersionBins`, the new `miseVersionBins`, `wellKnownBinPaths` ordering + extras override, and a regression case reproducing the exact #237 install path.
- [x] Full core suite passes — `pnpm --filter @spool-lab/core test` → 199/199.
- [ ] Manual verification: install `codex` via mise, launch Spool from Dock → Settings shows it as installed.