### PR TITLE
fix(app): no flash of English on first paint for non-English UI

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -93,7 +93,11 @@ export default function App() {
   const [pinnedSortOrder, setPinnedSortOrder] = useState<PinnedSortOrder>(DEFAULT_PINNED_SORT_ORDER)
   const [projectSortOrder, setProjectSortOrder] = useState<ProjectSessionSortOrder>(DEFAULT_PROJECT_SORT_ORDER)
   const [themeEditor, setThemeEditor] = useState<ThemeEditorStateV1>(() => defaultThemeEditorState())
-  const [language, setLanguage] = useState<LanguagePreference>('system')
+  // undefined until AgentsConfig has loaded — useLanguageBootstrap skips
+  // until then so the cached locale (set by the last applyLanguage call)
+  // isn't transiently overwritten by the system fallback while config IPC
+  // is still in flight. Otherwise users see zh-CN → en → zh-CN flash.
+  const [language, setLanguage] = useState<LanguagePreference | undefined>(undefined)
   useLanguageBootstrap(language)
   const themeHydrated = useRef(false)
   const deferredResults = useDeferredValue(results)
@@ -786,7 +790,7 @@ export default function App() {
             geminiCount={status?.geminiSessions ?? null}
             themeEditor={themeEditor}
             onThemeEditorChange={setThemeEditor}
-            language={language}
+            language={language ?? 'system'}
             onLanguageChange={handleLanguageChange}
           />
         )}
@@ -1021,7 +1025,7 @@ export default function App() {
           geminiCount={status?.geminiSessions ?? null}
           themeEditor={themeEditor}
           onThemeEditorChange={setThemeEditor}
-          language={language}
+          language={language ?? 'system'}
           onLanguageChange={handleLanguageChange}
         />
       )}

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react
 import { useTranslation } from 'react-i18next'
 import { Newspaper, Plus, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
+import { getMonthDayFormatter } from '../../shared/formatDate.js'
 import { useShareDrafts } from '../hooks/useShareDrafts'
 import { useSpoolDrop } from '../hooks/useSpoolDrop.js'
 import { FeaturedEmptyState, SmallEmptyState } from './EmptyState.js'
@@ -531,5 +532,5 @@ function formatRelative(iso: string, t?: RelativeT): string {
   const locale = typeof document !== 'undefined' && document.documentElement.lang
     ? document.documentElement.lang
     : undefined
-  return new Date(parsed).toLocaleDateString(locale, { month: 'short', day: 'numeric' })
+  return getMonthDayFormatter(locale, false).format(new Date(parsed))
 }

--- a/packages/app/src/renderer/i18n/index.ts
+++ b/packages/app/src/renderer/i18n/index.ts
@@ -34,6 +34,20 @@ function writeCachedLocale(locale: SupportedLocale): void {
   } catch { /* ignore */ }
 }
 
+// Initial language: cached value if available, else en. The renderer will
+// call `applyLanguage` once it resolves the user's preference.
+const initialLocale: SupportedLocale = readCachedLocale() ?? 'en'
+
+// Set <html lang> synchronously here so anything that reads it on first
+// paint (Intl.DateTimeFormat in formatDate.ts, CSS `:lang(...)`, ATs) sees
+// the right locale immediately. Otherwise dates render under the browser
+// default and only switch to the cached locale once `applyLanguage` runs
+// for the first time, which is visible as a flash + a beachball on CJK
+// locales where V8 has to instantiate ICU data on the main thread.
+if (typeof document !== 'undefined' && document.documentElement.lang !== initialLocale) {
+  document.documentElement.lang = initialLocale
+}
+
 i18n
   .use(initReactI18next)
   .init({
@@ -46,9 +60,7 @@ i18n
       de: { translation: de },
       fr: { translation: fr },
     },
-    // Initial language: cached value if available, else en. The renderer
-    // will call `applyLanguage` once it resolves the user's preference.
-    lng: readCachedLocale() ?? 'en',
+    lng: initialLocale,
     fallbackLng: 'en',
     supportedLngs: SUPPORTED_LOCALES,
     interpolation: { escapeValue: false },

--- a/packages/app/src/renderer/i18n/useLanguageBootstrap.ts
+++ b/packages/app/src/renderer/i18n/useLanguageBootstrap.ts
@@ -6,9 +6,16 @@ import { applyLanguage, resolveLocale, type LanguagePreference, type SupportedLo
  * their preference. Reads `AgentsConfig.language` (a `LanguagePreference` —
  * `'system'` or one of the supported locales) from main, falls back to the
  * OS locale exposed by `spool:get-system-locale`, and applies it to i18next.
+ *
+ * Pass `undefined` while the preference is still loading — the hook will
+ * no-op so the locale picked up from the localStorage cache during i18n init
+ * stays in place. Applying with `'system'` before the config has loaded
+ * would otherwise momentarily flip the UI to the OS locale, causing a flash
+ * (e.g. zh-CN → en → zh-CN for a Chinese user on an English macOS).
  */
 export function useLanguageBootstrap(preference: LanguagePreference | undefined): void {
   useEffect(() => {
+    if (preference === undefined) return
     let cancelled = false
     const apply = async () => {
       let systemLocale: SupportedLocale = 'en'

--- a/packages/app/src/shared/formatDate.ts
+++ b/packages/app/src/shared/formatDate.ts
@@ -19,6 +19,23 @@ const fallbackT: LooseT = (key, opts) => {
   }
 }
 
+// Intl.DateTimeFormat instantiation is expensive on CJK locales (V8 has to
+// load ICU data on the main thread), and the home view calls this once per
+// session row. Memoize by (locale, shape) so we pay the cost once per
+// locale switch, not once per row.
+const formatterCache = new Map<string, Intl.DateTimeFormat>()
+export function getMonthDayFormatter(locale: string | undefined, withYear: boolean): Intl.DateTimeFormat {
+  const key = `${locale ?? ''}|${withYear ? 'ymd' : 'md'}`
+  let fmt = formatterCache.get(key)
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat(locale, withYear
+      ? { month: 'short', day: 'numeric', year: 'numeric' }
+      : { month: 'short', day: 'numeric' })
+    formatterCache.set(key, fmt)
+  }
+  return fmt
+}
+
 export function formatRelativeDate(
   iso: string,
   opts?: { bucket?: BucketKey | undefined; t?: LooseT | undefined },
@@ -44,10 +61,7 @@ export function formatRelativeDate(
     const locale = typeof document !== 'undefined' && document.documentElement.lang
       ? document.documentElement.lang
       : undefined
-    if (d.getFullYear() === now.getFullYear()) {
-      return new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric' }).format(d)
-    }
-    return new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric', year: 'numeric' }).format(d)
+    return getMonthDayFormatter(locale, d.getFullYear() !== now.getFullYear()).format(d)
   } catch {
     return iso.slice(0, 10)
   }


### PR DESCRIPTION
## Summary

Returning users on a non-English UI saw the app chrome and visible dates flash through English for ~1s on every launch, plus a brief main-thread stall as V8 instantiated CJK `Intl.DateTimeFormat` data for every session row at once. Two independent causes, fixed together because they manifest as one symptom.

## What's changing

**1. Don't speculatively resolve \`'system'\` before AgentsConfig arrives.**

\`App.tsx\` initialised the language preference to \`'system'\` and ran \`useLanguageBootstrap\` immediately on mount. With the config IPC still in flight, the bootstrap effect resolved \`'system'\` to the OS locale (\`en\` for users on an English macOS) and called \`applyLanguage('en')\` — overwriting the locale i18next had already loaded from the localStorage cache. When config eventually returned \`'zh-CN'\`, the effect re-ran and flipped back. Visible as a brief en → zh-CN flash of all chrome text.

The preference state is now \`undefined\` until \`refreshAgents\` returns, and \`useLanguageBootstrap\` no-ops while it is undefined. The cached locale stays in place through initial mount.

**2. Set \`<html lang>\` synchronously at i18n init.**

\`formatDate.ts\` reads \`document.documentElement.lang\` to pick its locale, but the attribute was only written from inside \`applyLanguage\`. That meant the first painted frame had no \`lang\` attribute set, \`Intl.DateTimeFormat(undefined, …)\` fell back to the browser default, and dates rendered in English even when the cached i18next locale was already \`zh-CN\`. The later \`applyLanguage('zh-CN')\` call would then flip the attribute and trigger a date re-render storm, instantiating a fresh CJK formatter for every session row at once — the source of the brief main-thread stall.

Now \`document.documentElement.lang\` is written from the same cached locale i18next uses for its \`lng\` option, before \`i18next.init()\` runs. Dates and text agree from the first frame.

**3. Memoise \`Intl.DateTimeFormat\` by \`(locale, shape)\`.**

Even with the lang attribute fixed, the home view still allocated a fresh \`Intl.DateTimeFormat\` per session row, and \`SharesPage\` allocated one per draft card. \`formatDate.ts\` now exports a \`getMonthDayFormatter(locale, withYear)\` helper backed by a process-level cache; \`SharesPage.formatRelative\` reuses it.

## How it connects

These changes only touch the renderer and only affect locale and date formatting. No behaviour change for users whose preference matches their OS locale on an English macOS — they see the same thing as before. Users on a non-default UI language stop seeing the flash and stop paying the ICU instantiation cost on launch.

First-launch users with an empty localStorage cache still see one English paint before \`AgentsConfig\` resolves and the language flips. Fixing that would require synchronously knowing the user's preference before render, which is not available from the renderer; out of scope here.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` clean
- [x] Verified bundled output contains the early-return + synchronous \`html.lang\` write
- [x] Built signed mac arm64 \`.app\`, installed locally, confirmed dates and chrome are Chinese from first painted frame for a user with \`language: 'zh-CN'\` in AgentsConfig
- [x] First-launch behaviour with no cache unchanged: one English paint, then resolves to system locale
- [ ] Switching language in Settings still applies immediately (cache write + re-render)