### PR TITLE
fix(app): expand draggable top-bar region beyond the toggle gutter

### DIFF
--- a/packages/app/src/renderer/components/AppTopBar.tsx
+++ b/packages/app/src/renderer/components/AppTopBar.tsx
@@ -68,10 +68,13 @@ export default function AppTopBar({ sidebarCollapsed, onToggleSidebar, children 
           ].join(' ')}
           aria-hidden="true"
         />
+        {/* Slot inherits `drag` from the bar so whitespace around page
+            chrome remains a drag handle. Interactive elements injected
+            into this slot must opt out individually with
+            `WebkitAppRegion: 'no-drag'`. */}
         <div
           data-testid="app-top-bar-slot"
           className="flex-1 min-w-0 flex items-stretch"
-          style={noDragStyle}
         >
           {children}
         </div>

--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -411,6 +411,9 @@ export default function ShareEditorPage({
     }
   }, [beginSaving, liveConversation, opts])
 
+  // The AppTopBar slot inherits `drag` so whitespace remains a window
+  // drag handle — interactive elements must opt out individually.
+  const noDragStyle = { WebkitAppRegion: 'no-drag' } as React.CSSProperties
   const topBarContent = (
     <div className="flex-1 min-w-0 flex items-center gap-2 px-3">
       <button
@@ -419,6 +422,7 @@ export default function ShareEditorPage({
         aria-label={t('common.back')}
         title={t('common.back')}
         className="flex-none flex items-center justify-center w-5 h-5 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
+        style={noDragStyle}
       >
         <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
           <path d="M8 3L4 6.5L8 10" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
@@ -442,6 +446,7 @@ export default function ShareEditorPage({
               aria-label={t('shareEditor.moreOptions')}
               title={t('shareEditor.moreOptions')}
               className="flex-none inline-flex items-center justify-center w-5 h-5 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
+              style={noDragStyle}
             >
               <MoreHorizontal size={13} strokeWidth={1.6} aria-hidden />
             </button>
@@ -477,6 +482,7 @@ export default function ShareEditorPage({
         aria-label={panelOpen ? t('shareEditor.hidePanel') : t('shareEditor.showPanel')}
         aria-pressed={panelOpen}
         className="flex-none inline-flex items-center justify-center w-5 h-5 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
+        style={noDragStyle}
       >
         <PanelRight size={13} strokeWidth={1.75} />
       </button>

--- a/packages/app/src/renderer/components/share-editor/DownloadButton.tsx
+++ b/packages/app/src/renderer/components/share-editor/DownloadButton.tsx
@@ -70,7 +70,12 @@ export function DownloadButton({ saving, onExport }: Props) {
   }
 
   return (
-    <div ref={rootRef} className="relative flex flex-none" data-testid="share-editor-download">
+    <div
+      ref={rootRef}
+      className="relative flex flex-none"
+      data-testid="share-editor-download"
+      style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+    >
       {/* Primary action: always "Download". The button width never
        *  reflows on format switch or while saving — only the icon
        *  swaps (Download → spinner) and the OS tooltip carries the


### PR DESCRIPTION
## What

`AppTopBar`'s right slot was blanket-marked `WebkitAppRegion: 'no-drag'`,
so once a page injected chrome the whole right half of the title bar
stopped acting as a window drag handle. With the sidebar collapsed
only the ~25px gutter between the traffic lights and the fold button
remained draggable.

Flip to the standard Electron pattern:

- `AppTopBar` slot inherits `drag` from the bar.
- Interactive elements in the slot opt out with `no-drag` individually.

Touched the only consumer that actually injects chrome — `ShareEditorPage` (back / more / panel-toggle buttons + `DownloadButton` root). Pages with no `topBar` content (Library, Search, Project, Session) automatically get the whole bar back as a drag handle.

## Why

The previous behavior made the macOS window feel "stuck" — the drag affordance was hidden in a tiny strip the user had to aim for, and shrank further when the sidebar was collapsed. Standard Electron title bars are fully draggable except over interactive controls; matching that convention restores normal window-management ergonomics.

## How it connects

`BrowserWindow` uses `titleBarStyle: 'hiddenInset'` (`packages/app/src/main/index.ts`), so the renderer-painted top bar is the only drag surface for moving the window. The bar already handled `no-drag` correctly on the left (sidebar toggle); this PR applies the same discipline to the right slot.

## Test plan

- [x] Library / Search / Project / Session pages: dragging anywhere on the top bar (except the fold button) moves the window, with sidebar both expanded and collapsed.
- [x] Share Editor: back button, More menu, Download button + dropdown, and right-panel toggle all remain clickable.
- [x] Share Editor: whitespace between buttons and the title text are draggable.
- [x] Typecheck passes (`pnpm exec tsc --noEmit` in `packages/app`).