### PR TITLE
fix(app/i18n): align zh-CN sidebar pinned label

### DIFF
--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -40,7 +40,7 @@
     "search": "搜索",
     "shares": "分享",
     "settings": "设置",
-    "pinned": "已置顶",
+    "pinned": "置顶",
     "projects": "项目",
     "collapse": "收起侧栏",
     "expand": "展开侧栏",


### PR DESCRIPTION
## Summary

The simplified-Chinese sidebar section header read **"已置顶"** while every other surface in the same locale (Library section, pin action menu, sort options, settings labels) uses just **"置顶"**. The screenshot the user reported shows the mismatch side-by-side: sidebar reads *已置顶*, the library list to the right of it reads *置顶 · 2 个会话*.

This PR changes a single key — `sidebar.pinned` in `zh-CN.json` — from "已置顶" to "置顶".

## Why this term and not the other way

- "置顶" is the verb/noun stem already used by `pin`, `unpin`, `pinToProject`, `pinnedSessions`, `section_pinned_other`, `pinnedSortOrder`, `sort_recent_pinned`, `noPinned`.
- "已置顶" (past-participle "is pinned") would have required changing 9 places to align. Updating the one outlier is the smaller, safer move.
- Other locales were spot-checked and are already internally consistent (en uses "Pinned", zh-TW "已釘選", ko "고정됨", fr "Épinglés" — same stem across surfaces).

## Test plan

- [ ] In zh-CN, open the sidebar — the pinned section header reads **"置顶"**.
- [ ] Verify it visually matches the library page's **"置顶 · N 个会话"** header.
- [ ] Other locales unchanged.