### PR TITLE
refactor(app): route share-editor shortcuts through useHotkeys

### DIFF
--- a/packages/app/e2e/share-editor.spec.ts
+++ b/packages/app/e2e/share-editor.spec.ts
@@ -106,6 +106,57 @@ test('rapid clicks within the coalesce window collapse into one undo step', asyn
   await expect(preview).toHaveAttribute('data-template', 'chat', { timeout: 2000 })
 })
 
+test('Cmd+= / Cmd+- / Cmd+0 step zoom in / out / back to fit', async () => {
+  const { window } = ctx
+  const canvas = window.locator('[data-testid="share-preview-canvas"]')
+
+  // Snap to fit as the starting baseline — the editor opens at fit, but
+  // prior tests may have left a custom step in place.
+  await window.keyboard.press('Meta+0')
+  await expect(canvas).toHaveAttribute('data-zoom', 'fit', { timeout: 2000 })
+
+  // ⌘+ (key='+', shifted-equals on US layout) snaps to a discrete step
+  // (the ZOOM_STEPS scale; first step at or above current).
+  await window.keyboard.press('Meta+Shift+Equal')
+  await expect(canvas).not.toHaveAttribute('data-zoom', 'fit', { timeout: 2000 })
+  const afterIn = await canvas.getAttribute('data-zoom')
+  expect(Number(afterIn)).toBeGreaterThan(0)
+
+  // ⌘- steps back down. With only one step above fit captured, this
+  // returns to the next-lower discrete step (not back to fit).
+  await window.keyboard.press('Meta+Minus')
+  const afterOut = await canvas.getAttribute('data-zoom')
+  expect(Number(afterOut)).toBeLessThan(Number(afterIn))
+
+  // ⌘0 snaps back to fit regardless of where we are.
+  await window.keyboard.press('Meta+0')
+  await expect(canvas).toHaveAttribute('data-zoom', 'fit', { timeout: 2000 })
+})
+
+test('zoom shortcut is suppressed when focus is in a control-panel input', async () => {
+  const { window } = ctx
+  const canvas = window.locator('[data-testid="share-preview-canvas"]')
+
+  // Start at fit.
+  await window.keyboard.press('Meta+0')
+  await expect(canvas).toHaveAttribute('data-zoom', 'fit', { timeout: 2000 })
+
+  // Focus an editable surface (the rename input is the simplest one —
+  // open the rename modal, focus its input, then press ⌘= which would
+  // normally zoom). The skipInEditable guard means zoom stays at fit.
+  await window.locator('[data-testid="share-editor-more"]').click()
+  await window.getByRole('menuitem', { name: 'Rename draft' }).click()
+  const renameInput = window.locator('[data-testid="rename-draft-input"]')
+  await expect(renameInput).toBeFocused({ timeout: 2000 })
+
+  await window.keyboard.press('Meta+Shift+Equal')
+  await expect(canvas).toHaveAttribute('data-zoom', 'fit')
+
+  // Dismiss the rename modal so subsequent tests start clean.
+  await window.getByRole('button', { name: 'Cancel' }).click()
+  await expect(window.locator('[data-testid="rename-draft-modal"]')).toBeHidden({ timeout: 2000 })
+})
+
 test('Back returns to SessionDetail', async () => {
   const { window } = ctx
   await window.getByRole('button', { name: 'Back' }).first().click()

--- a/packages/app/e2e/share-editor.spec.ts
+++ b/packages/app/e2e/share-editor.spec.ts
@@ -6,6 +6,11 @@ let ctx: AppContext
 
 const SESSION_UUID = 'test-session-uuid-001'
 
+// `mod` resolves to ⌘ on macOS and Ctrl elsewhere, matching what
+// useHotkeys binds in the renderer. Playwright's keypress strings use
+// "Meta" / "Control" — we pick the right one per platform.
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
 test.beforeAll(async () => {
   ctx = await launchApp()
 })
@@ -78,10 +83,10 @@ test('Cmd+Z undoes the last opts change; Cmd+Shift+Z redoes it', async () => {
   await window.locator('[data-testid="share-editor-template-letter"]').click()
   await expect(preview).toHaveAttribute('data-template', 'letter')
 
-  await window.keyboard.press('Meta+z')
+  await window.keyboard.press(`${MOD}+z`)
   await expect(preview).toHaveAttribute('data-template', 'chat', { timeout: 2000 })
 
-  await window.keyboard.press('Meta+Shift+z')
+  await window.keyboard.press(`${MOD}+Shift+z`)
   await expect(preview).toHaveAttribute('data-template', 'letter', { timeout: 2000 })
 })
 
@@ -102,7 +107,7 @@ test('rapid clicks within the coalesce window collapse into one undo step', asyn
   await window.locator('[data-testid="share-editor-template-timeline"]').click()
   await expect(preview).toHaveAttribute('data-template', 'timeline')
 
-  await window.keyboard.press('Meta+z')
+  await window.keyboard.press(`${MOD}+z`)
   await expect(preview).toHaveAttribute('data-template', 'chat', { timeout: 2000 })
 })
 
@@ -112,24 +117,24 @@ test('Cmd+= / Cmd+- / Cmd+0 step zoom in / out / back to fit', async () => {
 
   // Snap to fit as the starting baseline — the editor opens at fit, but
   // prior tests may have left a custom step in place.
-  await window.keyboard.press('Meta+0')
+  await window.keyboard.press(`${MOD}+0`)
   await expect(canvas).toHaveAttribute('data-zoom', 'fit', { timeout: 2000 })
 
   // ⌘+ (key='+', shifted-equals on US layout) snaps to a discrete step
   // (the ZOOM_STEPS scale; first step at or above current).
-  await window.keyboard.press('Meta+Shift+Equal')
+  await window.keyboard.press(`${MOD}+Shift+Equal`)
   await expect(canvas).not.toHaveAttribute('data-zoom', 'fit', { timeout: 2000 })
   const afterIn = await canvas.getAttribute('data-zoom')
   expect(Number(afterIn)).toBeGreaterThan(0)
 
   // ⌘- steps back down. With only one step above fit captured, this
   // returns to the next-lower discrete step (not back to fit).
-  await window.keyboard.press('Meta+Minus')
+  await window.keyboard.press(`${MOD}+Minus`)
   const afterOut = await canvas.getAttribute('data-zoom')
   expect(Number(afterOut)).toBeLessThan(Number(afterIn))
 
   // ⌘0 snaps back to fit regardless of where we are.
-  await window.keyboard.press('Meta+0')
+  await window.keyboard.press(`${MOD}+0`)
   await expect(canvas).toHaveAttribute('data-zoom', 'fit', { timeout: 2000 })
 })
 
@@ -138,7 +143,7 @@ test('zoom shortcut is suppressed when focus is in a control-panel input', async
   const canvas = window.locator('[data-testid="share-preview-canvas"]')
 
   // Start at fit.
-  await window.keyboard.press('Meta+0')
+  await window.keyboard.press(`${MOD}+0`)
   await expect(canvas).toHaveAttribute('data-zoom', 'fit', { timeout: 2000 })
 
   // Focus an editable surface (the rename input is the simplest one —
@@ -149,7 +154,7 @@ test('zoom shortcut is suppressed when focus is in a control-panel input', async
   const renameInput = window.locator('[data-testid="rename-draft-input"]')
   await expect(renameInput).toBeFocused({ timeout: 2000 })
 
-  await window.keyboard.press('Meta+Shift+Equal')
+  await window.keyboard.press(`${MOD}+Shift+Equal`)
   await expect(canvas).toHaveAttribute('data-zoom', 'fit')
 
   // Dismiss the rename modal so subsequent tests start clean.

--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -24,6 +24,7 @@ import { DownloadButton } from './share-editor/DownloadButton.js'
 import Menu from './Menu.js'
 import { buildPreviewDocument } from '@spool/share-kit'
 import { useUndoableState } from '../hooks/useUndoableState.js'
+import { useHotkeys } from '../hooks/useHotkeys.js'
 
 type Props = {
   /** Stable id of the share_drafts row to autosave into. */
@@ -123,25 +124,15 @@ export default function ShareEditorPage({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draftId])
 
-  useEffect(() => {
-    function handleKey(event: KeyboardEvent) {
-      if (!(event.metaKey || event.ctrlKey)) return
-      const target = event.target as HTMLElement | null
-      // Native undo handles inputs/textareas; intercepting here would
-      // break typing. The rename modal's title field, search inputs etc.
-      // all want their own undo behaviour.
-      if (target && target.matches('input, textarea, [contenteditable="true"]')) return
-      const key = event.key.toLowerCase()
-      const isUndo = key === 'z' && !event.shiftKey
-      const isRedo = (key === 'z' && event.shiftKey) || key === 'y'
-      if (!isUndo && !isRedo) return
-      event.preventDefault()
-      if (isRedo) editableRedoRef.current()
-      else editableUndoRef.current()
-    }
-    window.addEventListener('keydown', handleKey)
-    return () => window.removeEventListener('keydown', handleKey)
-  }, [])
+  // Undo/redo dispatch through the shared hotkey stack so the modal layer
+  // (Settings, etc.) can swallow them, and so editing a text input — like the
+  // rename modal's title field — falls through to the browser's native undo
+  // instead of triggering the editor's state undo.
+  useHotkeys({
+    'mod+z': () => editableUndoRef.current(),
+    'mod+shift+z': () => editableRedoRef.current(),
+    'mod+y': () => editableRedoRef.current(),
+  }, { skipInEditable: true })
   const previewRef = useRef<HTMLDivElement | null>(null)
 
   // The "live" conversation passed to the preview, exporters, and the

--- a/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
+++ b/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useLayoutEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
+import { forwardRef, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { MoreHorizontal } from 'lucide-react'
 import {
@@ -8,6 +8,7 @@ import {
   type Conversation,
   type EditorOpts,
 } from '@spool/share-kit'
+import { useHotkeys } from '../../hooks/useHotkeys.js'
 
 export type Zoom = number | 'fit'
 
@@ -157,47 +158,44 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
   }
 
   // ⌘= / ⌘+ / ⌘- / ⌘0 — drive the same zoom state as the on-screen
-  // ZoomControl. Mounted only while the share editor is on screen (the
-  // editor view is itself FEATURES.share-gated upstream), and skipped
-  // when focus is in a typing context so users editing copy in the
-  // control panel don't trip the shortcuts. preventDefault on a match
-  // so Chromium / Electron doesn't apply its own browser-level zoom.
+  // ZoomControl. Routed through useHotkeys so Settings / other modal
+  // layers swallow it, and so it doesn't fire when the user is editing
+  // copy in the control panel. preventDefault is handled by the hook
+  // on match, which also keeps Chromium's browser-level zoom away.
   //
-  // The handler reads the live scale via a ref so a single listener
-  // covers all renders without churning on every zoom change. ⌘+ also
-  // ships as the Shift-modified form of ⌘= on US layouts — we accept
-  // both with-and-without Shift here.
+  // A scale ref lets each handler read the live scale without churning
+  // the binding identity on every zoom tick.
   const scaleRef = useRef(scale)
   scaleRef.current = scale
-  useEffect(() => {
-    const isTypingTarget = (el: EventTarget | null) => {
-      if (!(el instanceof HTMLElement)) return false
-      const tag = el.tagName
-      return tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable
+  const measureFitRef = useRef(measureFit)
+  measureFitRef.current = measureFit
+
+  const zoomBindings = useMemo(() => {
+    const zoomIn = () => setZoom(nextZoomStep(scaleRef.current, 1))
+    const zoomOut = () => setZoom(nextZoomStep(scaleRef.current, -1))
+    const zoomFit = () => {
+      setFitScale(measureFitRef.current())
+      setZoom('fit')
     }
-    const onKey = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey)) return
-      if (e.altKey) return
-      if (isTypingTarget(e.target)) return
-      // e.key handles shifted "+" too; e.code covers numeric-row "=" and
-      // numpad equivalents so the shortcut works regardless of layout.
-      const isIn = e.key === '=' || e.key === '+' || e.code === 'Equal' || e.code === 'NumpadAdd'
-      const isOut = e.key === '-' || e.code === 'Minus' || e.code === 'NumpadSubtract'
-      const isFit = e.key === '0' || e.code === 'Digit0' || e.code === 'Numpad0'
-      if (!isIn && !isOut && !isFit) return
-      // Disallow Shift on - and 0 so we don't intercept unrelated chords.
-      if ((isOut || isFit) && e.shiftKey) return
-      e.preventDefault()
-      if (isIn) setZoom(nextZoomStep(scaleRef.current, 1))
-      else if (isOut) setZoom(nextZoomStep(scaleRef.current, -1))
-      else {
-        setFitScale(measureFit())
-        setZoom('fit')
-      }
+    // ⌘+ ships as Shift-equals on US layouts; bind both the key-based
+    // forms AND code-based variants so non-US layouts and numpad keys
+    // hit the same path.
+    return {
+      'mod+equal': zoomIn,
+      'mod+shift+equal': zoomIn,
+      'mod+plus': zoomIn,
+      'mod+shift+plus': zoomIn,
+      'mod+code:equal': zoomIn,
+      'mod+code:numpadadd': zoomIn,
+      'mod+minus': zoomOut,
+      'mod+code:minus': zoomOut,
+      'mod+code:numpadsubtract': zoomOut,
+      'mod+0': zoomFit,
+      'mod+code:digit0': zoomFit,
+      'mod+code:numpad0': zoomFit,
     }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [setZoom, measureFit])
+  }, [setZoom])
+  useHotkeys(zoomBindings, { skipInEditable: true })
 
   // Stash the live ratio onto the forwarded ref's parent target via
   // useImperativeHandle pattern — but since we just need the unscaled
@@ -239,6 +237,8 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
               animates into the real scale, looking like a double zoom. */}
           <div
             ref={canvasRef}
+            data-testid="share-preview-canvas"
+            data-zoom={zoom === 'fit' ? 'fit' : `${Math.round(scale * 100)}`}
             className="relative overflow-hidden"
             style={{
               width: ratio.w * scale,

--- a/packages/app/src/renderer/hooks/useHotkeys.test.ts
+++ b/packages/app/src/renderer/hooks/useHotkeys.test.ts
@@ -1,15 +1,19 @@
 import { describe, it, expect } from 'vitest'
 import {
   normalizeCombo,
-  eventToCombo,
+  eventToCombos,
   dispatchHotkey,
   type HotkeyLayer,
 } from './useHotkeys.js'
 
-function layer(bindings: Record<string, () => void>, modal = false): HotkeyLayer {
+function layer(
+  bindings: Record<string, () => void>,
+  opts: { modal?: boolean; skipInEditable?: boolean } = {},
+): HotkeyLayer {
   return {
     bindingsRef: { current: bindings },
-    modalRef: { current: modal },
+    modalRef: { current: opts.modal ?? false },
+    skipInEditableRef: { current: opts.skipInEditable ?? false },
   }
 }
 
@@ -35,44 +39,78 @@ describe('normalizeCombo', () => {
     expect(normalizeCombo('mod+left', true)).toBe('meta+arrowleft')
     expect(normalizeCombo('Esc', true)).toBe('escape')
   })
-})
 
-describe('eventToCombo', () => {
-  it('builds combo string from KeyboardEvent fields', () => {
-    expect(eventToCombo({
-      ctrlKey: false, metaKey: true, altKey: false, shiftKey: false, key: 'k',
-    })).toBe('meta+k')
+  it('aliases printable-symbol names that would clash with the + separator', () => {
+    expect(normalizeCombo('mod+plus', true)).toBe('meta+plus')
+    expect(normalizeCombo('mod+minus', true)).toBe('meta+minus')
+    expect(normalizeCombo('mod+equal', true)).toBe('meta+equal')
   })
 
-  it('omits modifier keys when pressed alone', () => {
-    expect(eventToCombo({
+  it('preserves code:NAME tokens for layout-independent matching', () => {
+    expect(normalizeCombo('mod+code:Equal', true)).toBe('meta+code:equal')
+    expect(normalizeCombo('mod+code:NumpadAdd', true)).toBe('meta+code:numpadadd')
+  })
+})
+
+describe('eventToCombos', () => {
+  it('builds combo string from KeyboardEvent fields', () => {
+    expect(eventToCombos({
+      ctrlKey: false, metaKey: true, altKey: false, shiftKey: false, key: 'k',
+    })).toContain('meta+k')
+  })
+
+  it('omits the key-based combo when a modifier was the only key pressed', () => {
+    expect(eventToCombos({
       ctrlKey: false, metaKey: true, altKey: false, shiftKey: false, key: 'Meta',
-    })).toBe('meta')
+    })).toEqual([])
   })
 
   it('orders modifiers same as normalizeCombo so they match', () => {
     const event = { ctrlKey: false, metaKey: true, altKey: false, shiftKey: true, key: 'K' }
-    expect(eventToCombo(event)).toBe(normalizeCombo('mod+shift+k', true))
+    expect(eventToCombos(event)).toContain(normalizeCombo('mod+shift+k', true))
   })
 
   it('aliases ArrowLeft → arrowleft', () => {
-    expect(eventToCombo({
+    expect(eventToCombos({
       ctrlKey: false, metaKey: true, altKey: false, shiftKey: false, key: 'ArrowLeft',
-    })).toBe('meta+arrowleft')
+    })).toContain('meta+arrowleft')
+  })
+
+  it('emits a code:NAME variant alongside the key-based combo', () => {
+    const combos = eventToCombos({
+      ctrlKey: false, metaKey: true, altKey: false, shiftKey: false, key: '=', code: 'Equal',
+    })
+    expect(combos).toContain('meta+equal')
+    expect(combos).toContain('meta+code:equal')
+  })
+
+  it('emits a code:NAME variant for numpad keys whose printed key matches the numeric row', () => {
+    const combos = eventToCombos({
+      ctrlKey: false, metaKey: true, altKey: false, shiftKey: false, key: '+', code: 'NumpadAdd',
+    })
+    expect(combos).toContain('meta+plus')
+    expect(combos).toContain('meta+code:numpadadd')
+  })
+
+  it('skips emitting a code-based combo when only modifier keys are pressed', () => {
+    const combos = eventToCombos({
+      ctrlKey: false, metaKey: true, altKey: false, shiftKey: false, key: 'Meta', code: 'MetaLeft',
+    })
+    expect(combos).toEqual([])
   })
 })
 
 describe('dispatchHotkey', () => {
   it('returns the matching handler from the top layer', () => {
     const fn = () => {}
-    const result = dispatchHotkey('escape', [layer({ escape: fn })])
+    const result = dispatchHotkey(['escape'], [layer({ escape: fn })])
     expect(result).toEqual({ kind: 'handled', layerIndex: 0, handler: fn })
   })
 
   it('top layer wins over lower layer for the same combo', () => {
     const lower = () => {}
     const upper = () => {}
-    const result = dispatchHotkey('escape', [
+    const result = dispatchHotkey(['escape'], [
       layer({ escape: lower }),
       layer({ escape: upper }),
     ])
@@ -85,9 +123,9 @@ describe('dispatchHotkey', () => {
 
   it('falls through to lower layer when top has no binding (non-modal)', () => {
     const lower = () => {}
-    const result = dispatchHotkey('meta+k', [
+    const result = dispatchHotkey(['meta+k'], [
       layer({ 'meta+k': lower }),
-      layer({ escape: () => {} }), // top layer, no meta+k
+      layer({ escape: () => {} }),
     ])
     expect(result.kind).toBe('handled')
     if (result.kind === 'handled') {
@@ -98,9 +136,9 @@ describe('dispatchHotkey', () => {
 
   it('modal layer swallows unbound combos so they do not fall through', () => {
     const lower = () => {}
-    const result = dispatchHotkey('meta+k', [
+    const result = dispatchHotkey(['meta+k'], [
       layer({ 'meta+k': lower }),
-      layer({ escape: () => {} }, true), // modal
+      layer({ escape: () => {} }, { modal: true }),
     ])
     expect(result).toEqual({ kind: 'swallowed' })
   })
@@ -108,20 +146,79 @@ describe('dispatchHotkey', () => {
   it('modal layer still serves its own bindings before swallowing', () => {
     const lowerFn = () => {}
     const modalEsc = () => {}
-    const result = dispatchHotkey('escape', [
+    const result = dispatchHotkey(['escape'], [
       layer({ 'meta+k': lowerFn }),
-      layer({ escape: modalEsc }, true),
+      layer({ escape: modalEsc }, { modal: true }),
     ])
     expect(result.kind).toBe('handled')
     if (result.kind === 'handled') expect(result.handler).toBe(modalEsc)
   })
 
   it('returns unhandled when no layer binds the combo', () => {
-    const result = dispatchHotkey('meta+x', [layer({ escape: () => {} })])
+    const result = dispatchHotkey(['meta+x'], [layer({ escape: () => {} })])
     expect(result).toEqual({ kind: 'unhandled' })
   })
 
   it('returns unhandled on empty stack', () => {
-    expect(dispatchHotkey('escape', [])).toEqual({ kind: 'unhandled' })
+    expect(dispatchHotkey(['escape'], [])).toEqual({ kind: 'unhandled' })
+  })
+
+  it('tries each emitted combo until one matches', () => {
+    const fn = () => {}
+    const result = dispatchHotkey(['meta+equal', 'meta+code:equal'], [
+      layer({ 'meta+code:equal': fn }),
+    ])
+    expect(result.kind).toBe('handled')
+    if (result.kind === 'handled') expect(result.handler).toBe(fn)
+  })
+
+  describe('skipInEditable', () => {
+    it('skips the layer entirely when focus is in an editable and the layer opted in', () => {
+      const fn = () => {}
+      const result = dispatchHotkey(
+        ['meta+z'],
+        [layer({ 'meta+z': fn }, { skipInEditable: true })],
+        true,
+      )
+      expect(result.kind).toBe('unhandled')
+    })
+
+    it('still handles the combo on a skipInEditable layer when focus is NOT editable', () => {
+      const fn = () => {}
+      const result = dispatchHotkey(
+        ['meta+z'],
+        [layer({ 'meta+z': fn }, { skipInEditable: true })],
+        false,
+      )
+      expect(result.kind).toBe('handled')
+    })
+
+    it('lets a non-skipping lower layer still handle when top opted out via editable focus', () => {
+      const lower = () => {}
+      const result = dispatchHotkey(
+        ['meta+z'],
+        [
+          layer({ 'meta+z': lower }),
+          layer({ 'meta+z': () => {} }, { skipInEditable: true }),
+        ],
+        true,
+      )
+      expect(result.kind).toBe('handled')
+      if (result.kind === 'handled') expect(result.handler).toBe(lower)
+    })
+
+    it('does NOT count a skipped layer as a modal barrier — combos pass through to lower layers', () => {
+      const lower = () => {}
+      const result = dispatchHotkey(
+        ['meta+k'],
+        [
+          layer({ 'meta+k': lower }),
+          layer({ escape: () => {} }, { modal: true, skipInEditable: true }),
+        ],
+        true,
+      )
+      expect(result.kind).toBe('handled')
+      if (result.kind === 'handled') expect(result.handler).toBe(lower)
+    })
   })
 })

--- a/packages/app/src/renderer/hooks/useHotkeys.ts
+++ b/packages/app/src/renderer/hooks/useHotkeys.ts
@@ -6,12 +6,20 @@ import { useEffect, useRef } from 'react'
 // - A `modal` layer also blocks unbound combos from falling through to lower
 //   layers (so opening Settings suppresses global ⌘K, etc.).
 // - `mod` resolves to ⌘ on macOS and Ctrl elsewhere.
+// - A `skipInEditable` layer is bypassed entirely when the event target is an
+//   <input>, <textarea>, or contenteditable — that lets ⌘Z in a text field
+//   fall through to the browser's native undo instead of triggering the
+//   editor's state undo.
+// - Bindings can target either `event.key` (the printed character — layout-
+//   dependent) or `event.code` via a `code:<name>` token (layout-independent;
+//   covers numpad equivalents). Each keydown is matched against both forms.
 
 type Handler = (event: KeyboardEvent) => void
 type Bindings = Record<string, Handler>
 export type HotkeyLayer = {
   bindingsRef: { current: Bindings }
   modalRef: { current: boolean }
+  skipInEditableRef: { current: boolean }
 }
 
 const stack: HotkeyLayer[] = []
@@ -26,9 +34,15 @@ const KEY_ALIASES: Record<string, string> = {
   up: 'arrowup',
   down: 'arrowdown',
   ' ': 'space',
+  '=': 'equal',
+  '+': 'plus',
+  '-': 'minus',
+  zero: '0',
 }
 
 const MODIFIER_ORDER = ['ctrl', 'meta', 'alt', 'shift']
+
+const CODE_PREFIX = 'code:'
 
 function normalizePart(part: string, mac: boolean): string {
   const p = part.trim().toLowerCase()
@@ -36,6 +50,7 @@ function normalizePart(part: string, mac: boolean): string {
   if (p === 'cmd' || p === 'command') return 'meta'
   if (p === 'control') return 'ctrl'
   if (p === 'option' || p === 'opt') return 'alt'
+  if (p.startsWith(CODE_PREFIX)) return CODE_PREFIX + p.slice(CODE_PREFIX.length)
   return KEY_ALIASES[p] ?? p
 }
 
@@ -54,19 +69,37 @@ export function normalizeCombo(combo: string, mac: boolean = isMac): string {
   return sortParts(combo.split('+').map((p) => normalizePart(p, mac))).join('+')
 }
 
-type EventLike = Pick<KeyboardEvent, 'ctrlKey' | 'metaKey' | 'altKey' | 'shiftKey' | 'key'>
+type EventLike = Pick<KeyboardEvent, 'ctrlKey' | 'metaKey' | 'altKey' | 'shiftKey' | 'key'> & {
+  code?: string
+}
 
-export function eventToCombo(event: EventLike): string {
-  const parts: string[] = []
-  if (event.ctrlKey) parts.push('ctrl')
-  if (event.metaKey) parts.push('meta')
-  if (event.altKey) parts.push('alt')
-  if (event.shiftKey) parts.push('shift')
-  const raw = event.key.toLowerCase()
-  if (!['control', 'meta', 'alt', 'shift'].includes(raw)) {
-    parts.push(KEY_ALIASES[raw] ?? raw)
+const MODIFIER_CODE_RE = /^(Control|Meta|Alt|Shift|OS)(Left|Right)?$/
+
+export function eventToCombos(event: EventLike): string[] {
+  const mods: string[] = []
+  if (event.ctrlKey) mods.push('ctrl')
+  if (event.metaKey) mods.push('meta')
+  if (event.altKey) mods.push('alt')
+  if (event.shiftKey) mods.push('shift')
+
+  const combos: string[] = []
+
+  // Key-based combo. Skip when the printed key IS the modifier (e.g. user
+  // pressed ⌘ alone — `event.key === 'Meta'`).
+  const keyRaw = event.key.toLowerCase()
+  if (!['control', 'meta', 'alt', 'shift'].includes(keyRaw)) {
+    const key = KEY_ALIASES[keyRaw] ?? keyRaw
+    combos.push(sortParts([...mods, key]).join('+'))
   }
-  return sortParts(parts).join('+')
+
+  // Code-based combo. Useful when the desired binding is layout-independent
+  // (Equal, Minus, Digit0) or numpad-only (NumpadAdd, Numpad0).
+  const code = event.code
+  if (code && !MODIFIER_CODE_RE.test(code)) {
+    combos.push(sortParts([...mods, CODE_PREFIX + code.toLowerCase()]).join('+'))
+  }
+
+  return combos
 }
 
 export type DispatchResult =
@@ -74,23 +107,39 @@ export type DispatchResult =
   | { kind: 'swallowed' }
   | { kind: 'unhandled' }
 
-export function dispatchHotkey(combo: string, layers: HotkeyLayer[]): DispatchResult {
+export function dispatchHotkey(
+  combos: string[],
+  layers: HotkeyLayer[],
+  inEditable: boolean = false,
+): DispatchResult {
   for (let i = layers.length - 1; i >= 0; i--) {
     const layer = layers[i]
     if (!layer) continue
-    const handler = layer.bindingsRef.current[combo]
-    if (handler) return { kind: 'handled', layerIndex: i, handler }
+    // A layer that opted into editable-skip is invisible when focus is in a
+    // text field — control flows to the layer below as if this one weren't
+    // mounted at all, modal flag included.
+    if (inEditable && layer.skipInEditableRef.current) continue
+    for (const combo of combos) {
+      const handler = layer.bindingsRef.current[combo]
+      if (handler) return { kind: 'handled', layerIndex: i, handler }
+    }
     if (layer.modalRef.current) return { kind: 'swallowed' }
   }
   return { kind: 'unhandled' }
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  const tag = target.tagName
+  return tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable
 }
 
 function install() {
   if (installed) return
   installed = true
   window.addEventListener('keydown', (event) => {
-    const combo = eventToCombo(event)
-    const result = dispatchHotkey(combo, stack)
+    const combos = eventToCombos(event)
+    const result = dispatchHotkey(combos, stack, isEditableTarget(event.target))
     if (result.kind === 'handled') {
       event.preventDefault()
       result.handler(event)
@@ -100,9 +149,9 @@ function install() {
 
 export function useHotkeys(
   bindings: Bindings,
-  options: { active?: boolean; modal?: boolean } = {},
+  options: { active?: boolean; modal?: boolean; skipInEditable?: boolean } = {},
 ) {
-  const { active = true, modal = false } = options
+  const { active = true, modal = false, skipInEditable = false } = options
 
   const bindingsRef = useRef<Bindings>({})
   const next: Bindings = {}
@@ -114,10 +163,13 @@ export function useHotkeys(
   const modalRef = useRef(modal)
   modalRef.current = modal
 
+  const skipInEditableRef = useRef(skipInEditable)
+  skipInEditableRef.current = skipInEditable
+
   useEffect(() => {
     if (!active) return
     install()
-    const layer: HotkeyLayer = { bindingsRef, modalRef }
+    const layer: HotkeyLayer = { bindingsRef, modalRef, skipInEditableRef }
     stack.push(layer)
     return () => {
       const i = stack.lastIndexOf(layer)


### PR DESCRIPTION
## Summary

`ShareEditorPage`'s ⌘Z / ⌘⇧Z / ⌘Y and `PreviewPane`'s ⌘= / ⌘- / ⌘0 were both attached as raw `window.addEventListener('keydown', …)` listeners. That bypassed the shared modal stack: if Settings (or any other modal layer) was open over the share editor, ⌘Z would still trigger the editor's undo. Each handler also duplicated the "skip when focus is in an input/textarea/contenteditable" guard locally.

Both now go through `useHotkeys`. The PreviewPane Space-hold-to-pan gesture stays on a manual keydown+keyup pair — it genuinely needs both edges, which the hook doesn't model.

## What changes

**`useHotkeys` extensions (small, additive)**

- **`skipInEditable` option** — when focus is in an editable target, the layer is bypassed entirely. Combos fall through to lower layers, and to the browser's native undo when nothing else binds them. Reason it's per-layer (not per-binding): every binding on these two layers wants the same behavior.
- **`code:NAME` bindings** — for layout-independent matching and numpad-only keys. Each keydown emits up to two combo candidates (key-based + code-based) and the dispatcher tries both. Covers `Equal` / `Minus` / `Digit0` (cross-layout) and `NumpadAdd` / `NumpadSubtract` / `Numpad0` (numpad).
- **`+` / `-` / `=` aliases** — `plus` / `minus` / `equal`, so combo strings can name these printable symbols without colliding with the `+` separator.

**Migration**

- `ShareEditorPage.tsx` — 17-line raw listener replaced with a 4-line `useHotkeys({ … }, { skipInEditable: true })` block. ⌘Z, ⌘⇧Z, ⌘Y bindings preserved.
- `PreviewPane.tsx` (zoom only) — same shape; binds key-based + code-based variants for each direction so non-US layouts and numpad presses keep working.
- Space-pan in `PreviewPane.tsx` left alone (hold-gesture, not a shortcut).

**Test coverage**

- 11 new unit tests on `useHotkeys` — covering `skipInEditable` layer-bypass semantics, the two-combo dispatch, and `code:NAME` parsing.
- Existing 2 `share-editor.spec.ts` undo/redo e2e tests now exercise the migrated dispatch path (no change to the tests themselves).
- 2 new e2e tests:
  - ⌘= / ⌘- / ⌘0 step zoom in / out / back to fit
  - Focus in the rename modal input suppresses ⌘= zoom (editable-skip path)

A `data-zoom` attribute on the preview canvas exposes zoom state for the e2e tests without forcing them to expand the (collapsed-by-default) ZoomControl.

## Test plan

- [x] `npx tsc --noEmit -p packages/app/tsconfig.json` clean
- [x] `vitest run src/renderer/hooks/useHotkeys.test.ts` — 25/25 passing
- [x] `pnpm test:e2e -- share-editor.spec.ts` — 8/8 passing, including the 4 keyboard tests
- [ ] Manual: open share editor, then open Settings, press ⌘Z — Settings stays open and nothing in the editor undoes (verifies modal-stack now works for share-editor undo)