### PR TITLE
fix(app): include cd <cwd> prefix in Copy Resume Command everywhere

### DIFF
--- a/packages/app/e2e/copy-resume-command.spec.ts
+++ b/packages/app/e2e/copy-resume-command.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, search, waitForSync, type AppContext } from './helpers/launch'
+
+// Regression coverage for issue #248: every "Copy resume command" menu item
+// must produce `cd '<cwd>' && <cli> --resume '<uuid>'`, never the bare
+// resume command (which would launch the agent in the wrong directory).
+
+let ctx: AppContext
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+async function installClipboardSpy() {
+  const { window } = ctx
+  await window.evaluate(() => {
+    const w = window as unknown as { __copiedTexts: string[] }
+    w.__copiedTexts = []
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: async (text: string) => {
+          w.__copiedTexts.push(text)
+        },
+        readText: async () => '',
+      },
+    })
+  })
+}
+
+async function readCopied(): Promise<string[]> {
+  const { window } = ctx
+  return window.evaluate(() => (window as unknown as { __copiedTexts: string[] }).__copiedTexts)
+}
+
+test('SessionRow Copy resume command includes cd <cwd> prefix', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+  await installClipboardSpy()
+
+  await window.locator('[data-testid="sidebar-project-row"]').first().click()
+  const row = window.locator('[data-testid="session-row"]').first()
+  await expect(row).toBeVisible({ timeout: 5000 })
+  await row.hover()
+  await row.getByRole('button', { name: 'More actions' }).click()
+  await window.getByRole('menuitem', { name: /Copy resume command/ }).click()
+
+  const copied = await readCopied()
+  expect(copied).toHaveLength(1)
+  expect(copied[0]).toMatch(/^cd '[^']+' && (claude|codex|gemini) /)
+})
+
+test('SessionDetail Copy resume command includes cd <cwd> prefix', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+  await installClipboardSpy()
+
+  await window.locator('[data-testid="sidebar-project-row"]').first().click()
+  await window.locator('[data-testid="session-row"]').first().click()
+  await expect(window.locator('[data-testid="session-detail"]')).toBeVisible({ timeout: 5000 })
+
+  await window.locator('[data-testid="detail-actions-menu"] button').first().click()
+  await window.getByRole('menuitem', { name: /Copy resume command/ }).click()
+
+  const copied = await readCopied()
+  expect(copied).toHaveLength(1)
+  expect(copied[0]).toMatch(/^cd '[^']+' && (claude|codex|gemini) /)
+})
+
+test('Sidebar pinned row Copy resume command includes cd <cwd> prefix', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+  await installClipboardSpy()
+
+  // Pin a session from the project view, then surface its sidebar entry.
+  await window.locator('[data-testid="sidebar-project-row"]').first().click()
+  const firstRow = window.locator('[data-testid="session-row"]').first()
+  await expect(firstRow).toBeVisible({ timeout: 5000 })
+  const uuid = await firstRow.getAttribute('data-session-uuid')
+  expect(uuid).toBeTruthy()
+  await firstRow.hover()
+  await firstRow.locator('[data-testid="pin-button"]').click()
+
+  const pinnedRow = window.locator(`[data-testid="sidebar-pinned-row"][data-session-uuid="${uuid}"]`)
+  await expect(pinnedRow).toBeVisible({ timeout: 5000 })
+  await pinnedRow.hover()
+  await pinnedRow.locator('[data-testid="sidebar-pinned-menu-trigger"]').click()
+  await window.getByRole('menuitem', { name: /Copy resume command/ }).click()
+
+  const copied = await readCopied()
+  expect(copied).toHaveLength(1)
+  expect(copied[0]).toMatch(/^cd '[^']+' && (claude|codex|gemini) /)
+
+  // Cleanup: unpin so other tests in this file aren't affected.
+  await pinnedRow.hover()
+  await pinnedRow.locator('[data-testid="sidebar-pinned-unpin"]').click()
+})
+
+test('Fragment row Copy resume command includes cd <cwd> prefix', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+  await installClipboardSpy()
+
+  await search(window, 'XYLOPHONE_CANARY_42')
+  const row = window.locator('[data-testid="fragment-row"]').first()
+  await expect(row).toBeVisible({ timeout: 5000 })
+  await row.hover()
+  await row.getByRole('button', { name: 'More actions' }).click()
+  await window.getByRole('menuitem', { name: /Copy resume command/ }).click()
+
+  const copied = await readCopied()
+  expect(copied).toHaveLength(1)
+  expect(copied[0]).toMatch(/^cd '[^']+' && (claude|codex|gemini) /)
+})

--- a/packages/app/src/renderer/components/ContinueActions.tsx
+++ b/packages/app/src/renderer/components/ContinueActions.tsx
@@ -20,7 +20,7 @@ export default function ContinueActions({ result, onOpenSession, onCopySessionId
   const [copiedId, setCopiedId] = useState(false)
   const [copiedCommand, setCopiedCommand] = useState(false)
   const [resuming, setResuming] = useState(false)
-  const resumeCommand = getSessionResumeCommand(result.source, result.sessionUuid)
+  const resumeCommand = getSessionResumeCommand(result.source, result.sessionUuid, result.cwd)
 
   async function handleCopyId() {
     await navigator.clipboard.writeText(result.sessionUuid)

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -46,7 +46,7 @@ export default function SessionRow({ session, pinned = false, showProject = fals
     onCopySessionId(session.source)
   }
 
-  const resumeCommand = getSessionResumeCommand(session.source, session.sessionUuid)
+  const resumeCommand = getSessionResumeCommand(session.source, session.sessionUuid, session.cwd)
   async function handleCopyCommand() {
     if (!resumeCommand) return
     await navigator.clipboard.writeText(resumeCommand)

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -596,7 +596,7 @@ function PinnedRow({
   const [unpinning, setUnpinning] = useState(false)
   const title = session.title?.trim() || t('common.noTitle')
   const projectName = session.projectDisplayName || session.projectDisplayPath
-  const resumeCommand = getSessionResumeCommand(session.source, session.sessionUuid)
+  const resumeCommand = getSessionResumeCommand(session.source, session.sessionUuid, session.cwd)
 
   async function handleResume() {
     setResuming(true)


### PR DESCRIPTION
## What

Pass `session.cwd` (or `result.cwd`) into `getSessionResumeCommand` from every menu surface that copies a resume command, and add e2e coverage asserting all four surfaces produce the full `cd '<path>' && <cli> --resume '<uuid>'` form.

## Why

`SessionRow`, `Sidebar` pinned row, and `ContinueActions` all called `getSessionResumeCommand(session.source, session.sessionUuid)` without the third `cwd` argument. The shared helper happily returned the bare command, so the clipboard ended up with `claude --resume 'abc'` instead of `cd '/Users/.../repo' && claude --resume 'abc'`. Running the pasted command from a random shell launched the agent in the wrong working directory, which is what users actually need the resume helper to preserve.

`SessionDetail` was the only call site doing it right. Now all surfaces match it.

## How it connects

- `SessionRow.tsx` — Library / project session list ⋯ menu
- `Sidebar.tsx` — sidebar pinned-row ⋯ menu
- `ContinueActions.tsx` — fragment / search-result ⋯ menu
- `SessionDetail.tsx` — already correct; covered by the new spec as a regression guard

`getSessionResumeCommand` is unchanged. Its existing unit tests already cover the `cwd` / no-`cwd` branches; the new `e2e/copy-resume-command.spec.ts` stubs `navigator.clipboard.writeText`, drives the menu on each surface, and asserts the captured text starts with `cd '<path>' && (claude|codex|gemini) `.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm exec vitest run src/shared/resumeCommand.test.ts` (existing unit coverage)
- [x] `npx playwright test e2e/copy-resume-command.spec.ts` — 4/4 pass

Fixes #248