### PR TITLE
fix(app): sync sidebar fold motion across topbar, rail, and right panel

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -12,6 +12,7 @@ import ProjectView from './components/ProjectView.js'
 import LibraryLanding from './components/LibraryLanding.js'
 import SearchOverlay from './components/SearchOverlay.js'
 import AppTopBar from './components/AppTopBar.js'
+import SidebarRail from './components/SidebarRail.js'
 import AppToaster from './components/AppToaster.js'
 import SharesPage from './components/SharesPage.js'
 import ShareEditorPage from './components/ShareEditorPage.js'
@@ -841,13 +842,7 @@ export default function App() {
         onToggleSidebar={toggleSidebar}
       />
       <div className="flex flex-1 min-h-0">
-      <div
-        className={[
-          'flex-none overflow-hidden transition-[width] duration-200 ease-out',
-          sidebarCollapsed ? 'w-0' : 'w-60',
-        ].join(' ')}
-        aria-hidden={sidebarCollapsed}
-      >
+      <SidebarRail collapsed={sidebarCollapsed}>
       <Sidebar
         activeIdentityKey={activeProjectKey}
         activeSessionUuid={view === 'session' ? selectedSession : null}
@@ -893,7 +888,7 @@ export default function App() {
         {...(shareEnabled ? { onShareSession: handleStartShareFromUuid } : {})}
         onSettingsClick={() => { setSettingsTab('general'); setShowSettings(true) }}
       />
-      </div>
+      </SidebarRail>
       <div className="relative flex flex-col flex-1 min-w-0">
       <div className="flex flex-col flex-1 min-h-0 relative">
         {isSharesView ? (

--- a/packages/app/src/renderer/components/AppTopBar.tsx
+++ b/packages/app/src/renderer/components/AppTopBar.tsx
@@ -33,7 +33,7 @@ export default function AppTopBar({ sidebarCollapsed, onToggleSidebar, children 
       <div className="absolute inset-0 flex pointer-events-none" aria-hidden="true">
         <div
           className={[
-            'flex-none transition-[width] duration-200 ease-out bg-warm-surface dark:bg-dark-surface',
+            'flex-none transition-[width] duration-[280ms] ease-out bg-warm-surface dark:bg-dark-surface',
             sidebarCollapsed ? 'w-0' : 'w-60',
           ].join(' ')}
         />
@@ -58,12 +58,16 @@ export default function AppTopBar({ sidebarCollapsed, onToggleSidebar, children 
             <PanelLeft size={13} strokeWidth={1.75} />
           </button>
         </div>
+        {/* Animates over the same 280ms and the same Tailwind ease-out
+         *  curve as the bg sidebar layer above and the sidebar wrapper
+         *  below, so the page slot's left edge stays in lock-step with
+         *  the sidebar fold. Per-pixel velocity is lower than the
+         *  sidebar's (this spacer is 134px, sidebar is 240px), but the
+         *  motions share start/end frames so the eye reads them as one
+         *  unified fold rather than two separate animations. */}
         <div
           className={[
-            // No transition — animating this with sidebar's width
-            // caused the slot content to re-truncate every frame.
-            'flex-none',
-            // Sidebar w-60 (240px); gutter+button = 106px; remainder = 134.
+            'flex-none transition-[width] duration-[280ms] ease-out',
             sidebarCollapsed ? 'w-0' : 'w-[134px]',
           ].join(' ')}
           aria-hidden="true"

--- a/packages/app/src/renderer/components/PageLayout.tsx
+++ b/packages/app/src/renderer/components/PageLayout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import AppTopBar from './AppTopBar.js'
+import SidebarRail, { FOLD_EASE } from './SidebarRail.js'
 
 const RIGHT_PANEL_WIDTH = 280
 
@@ -52,28 +53,29 @@ export default function PageLayout({
         {topBar}
       </AppTopBar>
       <div className="flex flex-1 min-h-0">
-        <div
-          className="flex-none overflow-hidden"
-          style={{
-            width: sidebarCollapsed ? 0 : 240,
-            transition: 'width 200ms ease-out',
-          }}
-          aria-hidden={sidebarCollapsed}
-        >
-          {sidebar}
-        </div>
+        <SidebarRail collapsed={sidebarCollapsed}>{sidebar}</SidebarRail>
         <div className="relative flex flex-col flex-1 min-w-0">
           {children}
         </div>
+        {/* Outer animates width 0 ↔ 280; inner is hardcoded to
+         *  RIGHT_PANEL_WIDTH so ControlPanel's ~1000-node subtree doesn't
+         *  re-lay out each frame — outer just clips. (Sidebar's content
+         *  gets the same treatment for free because Sidebar's root is
+         *  `w-60 flex-none`; ControlPanel's root is `w-full` so we apply
+         *  the fixed width here.) Duration is scaled so per-pixel velocity
+         *  matches the sidebar's 280ms / 240px ≈ 1.17ms/px — otherwise the
+         *  wider right panel would snap ~17% faster than the sidebar. */}
         <div
           className="flex-none overflow-hidden"
           style={{
             width: rightPanelOpen ? RIGHT_PANEL_WIDTH : 0,
-            transition: 'width 200ms ease-out',
+            transition: `width 327ms ${FOLD_EASE}`,
           }}
           aria-hidden={!rightPanelOpen}
         >
-          {rightPanel}
+          <div style={{ width: RIGHT_PANEL_WIDTH, height: '100%' }}>
+            {rightPanel}
+          </div>
         </div>
       </div>
     </div>

--- a/packages/app/src/renderer/components/SidebarRail.tsx
+++ b/packages/app/src/renderer/components/SidebarRail.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react'
+
+// Fold-motion curve used by every sidebar / panel collapse in the app
+// chrome. Exposed as a constant so consumers that need an inline
+// `transition` (e.g. PageLayout's right panel with a non-standard
+// duration) can match this rail's Tailwind ease-out exactly. Tailwind's
+// `ease-out` utility resolves to this same cubic-bezier; the CSS
+// `ease-out` keyword resolves to (0,0,0.58,1), a DIFFERENT, gentler
+// curve. Mixing the two made the topbar bg segment land ahead of the
+// rail below it, so all fold motion is pinned to this token.
+export const FOLD_EASE = 'cubic-bezier(0, 0, 0.2, 1)'
+export const FOLD_DURATION_MS = 280
+
+type Props = {
+  collapsed: boolean
+  children: ReactNode
+}
+
+/**
+ * Animated 240px ↔ 0 column that hosts the app's left navigation
+ * sidebar. The wrapper clips its child via overflow-hidden so the
+ * sidebar contents (Sidebar root is `w-60 flex-none`) never reflow
+ * during the fold — only the wrapper's width transitions.
+ *
+ * Used by both the top-level App shell and PageLayout (share editor).
+ * Single source for the rail's timing keeps it in lock-step with
+ * AppTopBar's bg sidebar segment, which paints the same surface
+ * colour over the top of the chrome.
+ */
+export default function SidebarRail({ collapsed, children }: Props) {
+  return (
+    <div
+      className={[
+        'flex-none overflow-hidden transition-[width] duration-[280ms] ease-out',
+        collapsed ? 'w-0' : 'w-60',
+      ].join(' ')}
+      aria-hidden={collapsed}
+    >
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

The sidebar fold animation visually split into two pieces: the topbar's bg sidebar segment landed ahead of the rail below it, breaking what should read as one continuous surface collapsing. Per-frame measurement showed the bg leading the rail by up to 48px throughout a 280ms toggle.

Two compounding bugs:

- **Curve drift via shared name.** Tailwind's `ease-out` utility resolves to `cubic-bezier(0, 0, 0.2, 1)` (snappy); the CSS keyword `ease-out` resolves to `cubic-bezier(0, 0, 0.58, 1)` (gentle). The topbar bg used the Tailwind class, the rail used inline CSS — same name, different curves, so the bg front-loaded its motion and ran ahead.
- **Duplicate rail wrappers.** App.tsx and PageLayout.tsx each owned a sidebar wrapper with their own timing tokens (200ms vs 280ms). Editing one to fix sync silently broke the other.

This PR pins all chrome fold motion to a single curve token, collapses both rail wrappers into a shared `<SidebarRail>` component, and aligns durations so co-animated edges land together.

Adjacent fixes made while in the same code path:

- **ControlPanel no longer re-layouts each frame.** The right panel's outer wrapper animates width 0 ↔ 280 with `overflow-hidden`, but the inner is now hardcoded to `RIGHT_PANEL_WIDTH` — so ControlPanel's ~1000-node subtree sees a stable width and only the wrapper clips. Sidebar already got this for free via its `w-60 flex-none` root.
- **Right panel duration scaled to 327ms** so its per-pixel velocity matches the 240px sidebar's 280ms. Otherwise the wider panel snapped ~17% faster than the rail and felt jumpier.
- **Topbar slot spacer now animates** (was instant snap), so the share editor's back arrow + title slide left in lock-step with the sidebar bg instead of teleporting. Safe because `topBarContent`'s internal `flex-1` absorber keeps the title's allocated width stable mid-animation, so it doesn't re-truncate per frame.

## Test plan

- [x] ⌘B on Library / Search / SessionDetail (non-share-editor) — sidebar rail and topbar bg fold as one continuous surface
- [x] ⌘B inside the share editor — same as above, plus the back arrow + title slide left in sync with the sidebar bg
- [x] Toggle the share editor's right panel via the PanelRight button — animation matches the left sidebar's tactile feel; ControlPanel content doesn't reflow mid-animation
- [x] Long share titles don't visibly re-truncate during the sidebar fold (internal `flex-1` absorber keeps the title's width stable)