### PR TITLE
feat(app): browse all sessions in scope inside the picker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,16 @@ Key rules at a glance:
 
 In QA mode, flag any code that doesn't match DESIGN.md.
 
+## Test discipline
+
+Every bug fix and feature PR must:
+
+1. **Add tests for the change.** Bug fix → a regression test that fails on the pre-fix code. Feature → primary path + non-obvious edges (empty / error / boundary). UI changes use Playwright e2e under `packages/app/e2e/`; pure logic uses vitest under `packages/*/src/**.test.ts`.
+2. **Run the adjacent suite, not just the new tests, before declaring done.** Changes ripple: virtualization breaks DOM-count assertions, selector renames break old e2e, fixture changes shift sort order. Fix any cascading failures in the same PR — never ship a regression with a TODO.
+3. **Don't fight flakiness.** A flake is a test that's lying. Diagnose root cause once; if it can't be made reliable without fighting the framework, drop it and document the coverage gap in the PR body rather than papering over with `--repeat-each`.
+
+Completion checklist: typecheck clean → new tests green → adjacent suite green → flaky candidates stress-run 2–3× → only then declare done.
+
 ## Release videos
 
 When asked to make a launch / release / announcement video for Spool,

--- a/packages/app/e2e/helpers/launch.ts
+++ b/packages/app/e2e/helpers/launch.ts
@@ -16,7 +16,12 @@ export interface AppContext {
   cleanup: () => Promise<void>
 }
 
-export async function launchApp(opts: { mockAgent?: 'success' | 'error' } = {}): Promise<AppContext> {
+export async function launchApp(opts: {
+  mockAgent?: 'success' | 'error'
+  /** Mutate fixture dirs (e.g. inject extra sessions) after the base fixtures
+   * have been copied and before Electron starts. Receives the resolved dirs. */
+  extraFixtures?: (dirs: { claudeDir: string; codexDir: string; geminiCliHome: string }) => void
+} = {}): Promise<AppContext> {
   const tmpDir = mkdtempSync(join(tmpdir(), 'spool-e2e-'))
 
   const claudeDir = join(tmpDir, 'claude', 'projects')
@@ -25,6 +30,8 @@ export async function launchApp(opts: { mockAgent?: 'success' | 'error' } = {}):
   cpSync(join(FIXTURES_DIR, 'claude-projects'), claudeDir, { recursive: true })
   cpSync(join(FIXTURES_DIR, 'codex-sessions'), codexDir, { recursive: true })
   cpSync(join(FIXTURES_DIR, 'gemini-cli-home'), geminiCliHome, { recursive: true })
+
+  opts.extraFixtures?.({ claudeDir, codexDir, geminiCliHome })
 
   const env: Record<string, string> = {
     ...process.env as Record<string, string>,

--- a/packages/app/e2e/home-preview.spec.ts
+++ b/packages/app/e2e/home-preview.spec.ts
@@ -93,6 +93,9 @@ test('arrow-down navigation keeps the active item in view at the bottom', async 
   // Recents list — press Down to the last option, then verify it is in viewport
   // (i.e. the scroll container scrolled to follow the active item).
   const options = overlay.locator('[role="option"]')
+  // Recents are now virtualized — wait for at least one option to actually
+  // mount before counting, otherwise we race the initial Virtuoso measure.
+  await options.first().waitFor({ state: 'visible', timeout: 3000 })
   const count = await options.count()
   expect(count).toBeGreaterThan(0)
 

--- a/packages/app/e2e/picker-browse-scope.spec.ts
+++ b/packages/app/e2e/picker-browse-scope.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { launchApp, waitForSync, type AppContext } from './helpers/launch'
+
+// Browser-side guard for the new pagination + virtualization behavior in
+// CommandPalette. The flat scope test still lives in
+// share-new-draft-picker-scope.spec.ts; this file focuses on the >50-session
+// browse case that the 30-row cap used to block.
+
+const BIG_PROJECT_DIR = '/tmp/spool-e2e-big-project'
+const BIG_PROJECT_SESSION_COUNT = 75 // > RECENT_PAGE_SIZE (50)
+
+let ctx: AppContext
+
+test.beforeAll(async () => {
+  ctx = await launchApp({
+    extraFixtures: ({ claudeDir }) => {
+      // Claude derives a project subdir from the cwd; mirror its convention
+      // (replace `/` with `-`) so the synthesized sessions group into a
+      // single browseable project.
+      const projectSlug = BIG_PROJECT_DIR.replace(/\//g, '-').replace(/^-/, '-')
+      const projectDir = join(claudeDir, projectSlug)
+      mkdirSync(projectDir, { recursive: true })
+      for (let i = 0; i < BIG_PROJECT_SESSION_COUNT; i++) {
+        const ordinal = String(i).padStart(3, '0')
+        const sessionId = `bulk-session-${ordinal}`
+        // Stagger timestamps minute-by-minute so the bucket-by-date logic has
+        // a deterministic ordering — newest = i=0.
+        const ts = new Date(Date.UTC(2026, 0, 1, 10, i, 0)).toISOString()
+        const userUuid = `${sessionId}-u`
+        const assistantUuid = `${sessionId}-a`
+        const lines = [
+          JSON.stringify({
+            type: 'user',
+            sessionId,
+            cwd: BIG_PROJECT_DIR,
+            uuid: userUuid,
+            timestamp: ts,
+            message: { role: 'user', content: `Bulk session ${ordinal} kick-off` },
+          }),
+          JSON.stringify({
+            type: 'assistant',
+            uuid: assistantUuid,
+            parentUuid: userUuid,
+            timestamp: ts,
+            message: {
+              role: 'assistant',
+              model: 'claude-sonnet-4-20250514',
+              content: [{ type: 'text', text: `Reply for bulk session ${ordinal}` }],
+            },
+          }),
+        ]
+        writeFileSync(join(projectDir, `${sessionId}.jsonl`), lines.join('\n') + '\n')
+      }
+    },
+  })
+  await waitForSync(ctx.window)
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+async function openPicker(): Promise<void> {
+  await ctx.window.locator('[data-testid="sidebar-shares"]').click()
+  await expect(
+    ctx.window.locator('[data-testid="shares-empty-start"], [data-testid="shares-draft-row"]').first(),
+  ).toBeVisible({ timeout: 5000 })
+  const empty = ctx.window.locator('[data-testid="shares-empty-start"]')
+  const plus = ctx.window.locator('[data-testid="shares-new-draft"]')
+  if (await empty.isVisible().catch(() => false)) {
+    await empty.click()
+  } else {
+    await plus.click()
+  }
+  await expect(ctx.window.locator('[data-testid="new-draft-picker"]')).toBeVisible({ timeout: 5000 })
+}
+
+async function closePicker(): Promise<void> {
+  const picker = ctx.window.locator('[data-testid="new-draft-picker"]')
+  if (await picker.isVisible().catch(() => false)) {
+    await ctx.window.keyboard.press('Escape')
+    await expect(picker).toBeHidden({ timeout: 5000 })
+  }
+}
+
+async function scopeToBigProject(): Promise<void> {
+  await ctx.window.locator('[data-testid="new-draft-picker-scope-trigger"]').click()
+  const popover = ctx.window.locator('[data-testid="new-draft-picker-scope-popover"]')
+  await expect(popover).toBeVisible()
+  // Find the project option whose label contains our bulk slug.
+  const option = popover.locator('[data-testid="new-draft-picker-scope-option"][data-identity-key]:not([data-identity-key=""])')
+    .filter({ hasText: /spool-e2e-big-project/i })
+    .first()
+  await expect(option).toBeVisible({ timeout: 3000 })
+  await option.click()
+  await expect(popover).toBeHidden({ timeout: 2000 })
+}
+
+test('scoping to a >50-session project paginates rather than capping at 30', async () => {
+  await openPicker()
+  await scopeToBigProject()
+
+  const virtual = ctx.window.locator('[data-testid="new-draft-picker-virtual"]')
+  await expect(virtual).toBeVisible({ timeout: 5000 })
+  // Newest fixture (i=74) sits at row 0; its presence confirms the picker
+  // bound to the scoped list.
+  await expect(
+    ctx.window.locator('[data-testid="new-draft-picker-row"]').filter({ hasText: 'Bulk session 074' }),
+  ).toBeVisible({ timeout: 5000 })
+
+  // Trigger pagination by scrolling to the oldest end (ordinal 000 lives
+  // beyond the first 50 rows; scroll re-tries because a lone programmatic
+  // scrollTo occasionally loses the race against Virtuoso's measurement).
+  await expect.poll(async () => {
+    await virtual.evaluate((node) => {
+      const scroller = node.matches('[data-virtuoso-scroller]')
+        ? node
+        : node.querySelector('[data-virtuoso-scroller]')
+      ;(scroller ?? node).scrollTo({ top: 1e7 })
+    })
+    return ctx.window
+      .locator('[data-testid="new-draft-picker-row"]')
+      .filter({ hasText: 'Bulk session 000' })
+      .count()
+  }, { timeout: 10000, intervals: [200, 300, 500, 500, 1000] }).toBeGreaterThan(0)
+
+  await closePicker()
+})
+
+test('switching scope back to Any project resets the list to page 1', async () => {
+  await openPicker()
+  await scopeToBigProject()
+
+  const virtual = ctx.window.locator('[data-testid="new-draft-picker-virtual"]')
+  await expect(virtual).toBeVisible({ timeout: 5000 })
+
+  await ctx.window.locator('[data-testid="new-draft-picker-scope-clear"]').click()
+  // After clearing, the list re-fetches page 1 for "all projects". The
+  // virtual container should still be visible (recents path); the bulk
+  // sessions are now interleaved with other fixtures, but the list must
+  // not get stuck on the previous scope's row count.
+  await expect(virtual).toBeVisible({ timeout: 3000 })
+  await expect(ctx.window.locator('[data-testid="new-draft-picker-row"]').first()).toBeVisible({ timeout: 3000 })
+
+  await closePicker()
+})

--- a/packages/app/e2e/search-overlay-scope.spec.ts
+++ b/packages/app/e2e/search-overlay-scope.spec.ts
@@ -132,9 +132,9 @@ test('after popover close, focus returns to the search input', async () => {
 test('cmdk recents are bucketed by date header', async () => {
   await navigateToLibrary()
   await openOverlay()
-  const buckets = ctx.window.locator('[data-testid="search-overlay"] ul[role="listbox"] > li > div').first()
-  await expect(buckets).toBeVisible({ timeout: 3000 })
-  await expect(buckets).toContainText(/Today|Yesterday|Earlier|Older/i)
+  const header = ctx.window.locator('[data-testid="search-overlay-bucket-header"]').first()
+  await expect(header).toBeVisible({ timeout: 3000 })
+  await expect(header).toContainText(/Today|Yesterday|Earlier|Older/i)
   await closeOverlay()
 })
 
@@ -145,12 +145,17 @@ test('options toggle: clicking with scope set keeps scope active even when row h
   await navigateToProject()
   await openOverlay()
   await expect(ctx.window.locator('[data-testid="search-overlay-options-row"]')).toBeVisible()
-  const recentBefore = await ctx.window.locator('[data-testid="search-overlay-row"]').count()
+  const scopeLabelBefore = await ctx.window
+    .locator('[data-testid="search-overlay-scope-trigger"]')
+    .textContent()
   await ctx.window.locator('[data-testid="search-overlay-options-toggle"]').click()
   await expect(ctx.window.locator('[data-testid="search-overlay-options-row"]')).toHaveCount(0)
-  const recentAfter = await ctx.window.locator('[data-testid="search-overlay-row"]').count()
-  // Scope still in effect — same set of recents.
-  expect(recentAfter).toBe(recentBefore)
+  // Scope state survives even though the chip is hidden; toggling the
+  // options row back open should reveal the same label.
+  await ctx.window.locator('[data-testid="search-overlay-options-toggle"]').click()
+  await expect(ctx.window.locator('[data-testid="search-overlay-options-row"]')).toBeVisible()
+  await expect(ctx.window.locator('[data-testid="search-overlay-scope-trigger"]'))
+    .toHaveText(scopeLabelBefore ?? '')
   await closeOverlay()
 })
 
@@ -164,4 +169,31 @@ test('Shift+Enter from FTS results commits to results page', async () => {
   await input.press('Shift+Enter')
   await expect(ctx.window.locator('[data-testid="search-overlay"]')).toBeHidden({ timeout: 2000 })
   await expect(ctx.window.locator('[data-testid="results-scope-chip"]')).toBeVisible({ timeout: 3000 })
+})
+
+test('clicking the results-total badge commits to results page', async () => {
+  await navigateToLibrary()
+  await openOverlay()
+  const input = ctx.window.locator('[data-testid="search-overlay-input"]')
+  await input.fill('XYLOPHONE_CANARY_42')
+  const badge = ctx.window.locator('[data-testid="search-overlay-results-total"]')
+  await expect(badge).toBeVisible({ timeout: 3000 })
+  await badge.click()
+  await expect(ctx.window.locator('[data-testid="search-overlay"]')).toBeHidden({ timeout: 2000 })
+  await expect(ctx.window.locator('[data-testid="results-scope-chip"]')).toBeVisible({ timeout: 3000 })
+})
+
+test('results-total badge is hidden in recents mode and appears in search mode', async () => {
+  await navigateToLibrary()
+  await openOverlay()
+  // Empty query → recents view → no count badge (deliberate: the count was
+  // visual noise that distracted from the list).
+  await expect(ctx.window.locator('[data-testid="search-overlay-results-total"]')).toHaveCount(0)
+  const input = ctx.window.locator('[data-testid="search-overlay-input"]')
+  await input.fill('XYLOPHONE_CANARY_42')
+  await expect(ctx.window.locator('[data-testid="search-overlay-results-total"]')).toBeVisible({ timeout: 3000 })
+  // Clearing the query reverts to recents — badge disappears again.
+  await input.fill('')
+  await expect(ctx.window.locator('[data-testid="search-overlay-results-total"]')).toHaveCount(0)
+  await closeOverlay()
 })

--- a/packages/app/e2e/share-new-draft-picker-scope.spec.ts
+++ b/packages/app/e2e/share-new-draft-picker-scope.spec.ts
@@ -54,10 +54,10 @@ test('row breadcrumb shows project label in default scope', async () => {
 test('recents are bucketed by date header', async () => {
   await openPicker()
   // At least one bucket label (Today / Yesterday / Earlier this week / ...)
-  // must render above the rows.
-  const buckets = ctx.window.locator('[data-testid="new-draft-picker"] ul[role="listbox"] > li > div').first()
-  await expect(buckets).toBeVisible({ timeout: 3000 })
-  await expect(buckets).toContainText(/Today|Yesterday|Earlier|Older/i)
+  // renders inside the virtualized recents list.
+  const header = ctx.window.locator('[data-testid="new-draft-picker-bucket-header"]').first()
+  await expect(header).toBeVisible({ timeout: 3000 })
+  await expect(header).toContainText(/Today|Yesterday|Earlier|Older/i)
   await closePicker()
 })
 

--- a/packages/app/src/renderer/components/CommandPalette.tsx
+++ b/packages/app/src/renderer/components/CommandPalette.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Search as SearchIcon, SlidersHorizontal } from 'lucide-react'
-import type { Session, SearchResult, SessionSource } from '@spool-lab/core'
+import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
+import { AlertCircle, Inbox, Search as SearchIcon, SearchX, SlidersHorizontal } from 'lucide-react'
+import type { Session, SearchResult, SessionSource, SessionsCursor } from '@spool-lab/core'
 import { SourceBadge } from './Badges.js'
 import Hint from './Hint.js'
 import ScopeSelector, { type ScopeValue } from './ScopeSelector.js'
@@ -27,7 +28,7 @@ export type PaletteRow = {
   messageId?: number
 }
 
-const RECENT_LIMIT = 30
+const RECENT_PAGE_SIZE = 50
 const SEARCH_LIMIT = 30
 const DEBOUNCE_MS = 150
 
@@ -42,10 +43,9 @@ export type CommandPaletteLabels = {
   emptyNoSessions: string
   /** Body when scope is set and that scope has no sessions. */
   emptyInProject: (projectName: string) => string
-  /** Footer total for search results. */
-  resultsTotal: (count: number) => string
-  /** Footer total for recents list. */
-  recentTotal: (count: number) => string
+  /** Footer affordance for search-mode results — clickable when `onCommit`
+   *  is set (jumps to the full results page). Omit to hide. */
+  resultsTotal?: (count: number) => string
 }
 
 type Props = {
@@ -100,6 +100,8 @@ export default function CommandPalette({
   const noTitle = t('common.noTitle')
   const [query, setQuery] = useState(initialQuery)
   const [recent, setRecent] = useState<Session[] | null>(null)
+  const [recentCursor, setRecentCursor] = useState<SessionsCursor | null>(null)
+  const [recentLoadingMore, setRecentLoadingMore] = useState(false)
   const [results, setResults] = useState<PaletteRow[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [isSearching, setIsSearching] = useState(false)
@@ -107,7 +109,16 @@ export default function CommandPalette({
   const [filtersOpen, setFiltersOpen] = useState(scope !== null || optionsDefaultOpen)
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
+  const virtuosoRef = useRef<VirtuosoHandle | null>(null)
   const requestSeqRef = useRef(0)
+  const recentTokenRef = useRef(0)
+  // Refs keep the endReached closure stable — same pattern as LibraryLanding.
+  const recentCursorRef = useRef(recentCursor)
+  recentCursorRef.current = recentCursor
+  const recentLoadingRef = useRef(recentLoadingMore)
+  recentLoadingRef.current = recentLoadingMore
+  const scopeKeyRef = useRef(scope?.identityKey)
+  scopeKeyRef.current = scope?.identityKey
 
   // Auto-expand whenever scope flips to non-null so the user can see the
   // active filter; collapsing is left to the user via the toggle.
@@ -125,21 +136,50 @@ export default function CommandPalette({
   // and routes Escape to onClose.
   useHotkeys({ Escape: onClose }, { modal: true })
 
-  // Recents fetch (scoped if a project is selected).
+  // Recents fetch (scoped if a project is selected). Cursor pagination —
+  // initial page first, more on Virtuoso endReached.
   useEffect(() => {
-    let cancelled = false
-    const req = scope
-      ? window.spool.listSessionsByIdentity(scope.identityKey, { limit: RECENT_LIMIT })
-      : window.spool.listSessions({ limit: RECENT_LIMIT })
-    req
-      .then((page) => { if (!cancelled) setRecent(page.sessions) })
+    const token = ++recentTokenRef.current
+    setRecent(null)
+    setRecentCursor(null)
+    setRecentLoadingMore(false)
+    setError(null)
+    fetchRecentsPage(scope?.identityKey, null)
+      .then((page) => {
+        if (recentTokenRef.current !== token) return
+        setRecent(page.sessions)
+        setRecentCursor(page.nextCursor)
+      })
       .catch((err) => {
-        if (cancelled) return
+        if (recentTokenRef.current !== token) return
         setError(err instanceof Error ? err.message : t('common.error'))
         setRecent([])
+        setRecentCursor(null)
       })
-    return () => { cancelled = true }
   }, [scope?.identityKey])
+
+  const loadMoreRecents = useCallback(() => {
+    if (recentLoadingRef.current || !recentCursorRef.current) return
+    const token = recentTokenRef.current
+    setRecentLoadingMore(true)
+    fetchRecentsPage(scopeKeyRef.current, recentCursorRef.current)
+      .then((page) => {
+        if (recentTokenRef.current !== token) return
+        setRecent((prev) => {
+          const base = prev ?? []
+          const seen = new Set(base.map((s) => s.sessionUuid))
+          const additions = page.sessions.filter((s) => !seen.has(s.sessionUuid))
+          return additions.length === 0 ? base : [...base, ...additions]
+        })
+        setRecentCursor(page.nextCursor)
+        setRecentLoadingMore(false)
+      })
+      .catch(() => {
+        if (recentTokenRef.current !== token) return
+        setRecentLoadingMore(false)
+        setRecentCursor(null)
+      })
+  }, [])
 
   // FTS search with optional project scope. Skipped when `searchDisabled`
   // (AI mode etc.); empty query clears results and re-shows recents.
@@ -196,22 +236,35 @@ export default function CommandPalette({
 
   const showProjectOnRow = !scope
 
-  // Recents bucketing (cmdk style).
+  // Flatten recents into virtual items (headers + rows + loading sentinel).
+  // The header path only activates when groupRecentsByDate is set; otherwise
+  // it's just rows + sentinel.
   const tLoose = t as unknown as (k: string) => string
-  const recentBuckets = useMemo(() => {
-    if (!groupRecentsByDate || !recent) return null
-    return bucketSessionsByDate(recent, tLoose)
+  const virtualRecents = useMemo<{ items: VirtualItem[]; rowIndexToVirtualIndex: number[] }>(() => {
+    if (!recent) return { items: [], rowIndexToVirtualIndex: [] }
+    return buildVirtualRecents(recent, noTitle, groupRecentsByDate ? tLoose : null, recentLoadingMore)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [groupRecentsByDate, recent, t])
+  }, [recent, noTitle, groupRecentsByDate, recentLoadingMore, t])
 
-  // Reset active row whenever the visible list changes shape.
-  useEffect(() => { setActiveIndex(0) }, [rows?.length, inSearchMode, scope?.identityKey])
+  // Reset active row whenever the visible list changes shape (scope flip,
+  // mode toggle, or new search results). Appending a recents page should
+  // NOT reset, so we deliberately do not depend on `recent.length`.
+  useEffect(() => {
+    setActiveIndex(0)
+  }, [inSearchMode, scope?.identityKey, results?.length])
 
   // Keep the active row scrolled into view.
   useEffect(() => {
-    const el = listRef.current?.querySelector<HTMLElement>(`[data-row-index="${activeIndex}"]`)
-    el?.scrollIntoView({ block: 'nearest' })
-  }, [activeIndex])
+    if (inSearchMode) {
+      const el = listRef.current?.querySelector<HTMLElement>(`[data-row-index="${activeIndex}"]`)
+      el?.scrollIntoView({ block: 'nearest' })
+    } else {
+      const virtualIndex = virtualRecents.rowIndexToVirtualIndex[activeIndex]
+      if (virtualIndex != null) {
+        virtuosoRef.current?.scrollIntoView({ index: virtualIndex })
+      }
+    }
+  }, [activeIndex, inSearchMode, virtualRecents])
 
   function handleInputKey(e: React.KeyboardEvent<HTMLInputElement>): void {
     if (e.key === 'Tab' && contextualScope) {
@@ -330,40 +383,51 @@ export default function CommandPalette({
           </div>
         )}
 
-        {/* Results / recents */}
-        <div ref={listRef} className="flex-1 min-h-0 overflow-y-auto">
+        {/* Results / recents. Min-height keeps the modal a usable shape even
+            when Virtuoso has no intrinsic height to push against the modal's
+            max-h-[70vh]; each branch owns its scroll context. */}
+        <div ref={listRef} className="flex-1 min-h-[40vh] flex flex-col">
           {rows === null ? (
-            <PaletteSkeleton count={6} />
+            <div className="overflow-y-auto">
+              <PaletteSkeleton count={6} />
+            </div>
           ) : error && !inSearchMode ? (
-            <p className="px-5 py-8 text-center text-sm text-warm-muted dark:text-dark-muted">
-              {t('newDraft.loadError', { error })}
-            </p>
+            <PaletteEmpty
+              icon={<AlertCircle size={18} strokeWidth={1.6} aria-hidden />}
+              message={t('newDraft.loadError', { error })}
+            />
           ) : rows.length === 0 ? (
-            <p className="px-5 py-8 text-center text-sm text-warm-muted dark:text-dark-muted">
-              {inSearchMode
+            <PaletteEmpty
+              icon={inSearchMode
+                ? <SearchX size={18} strokeWidth={1.6} aria-hidden />
+                : <Inbox size={18} strokeWidth={1.6} aria-hidden />}
+              message={inSearchMode
                 ? labels.noMatches(query.trim())
                 : scope
                   ? labels.emptyInProject(scope.displayName)
                   : labels.emptyNoSessions}
-            </p>
-          ) : recentBuckets && !inSearchMode ? (
-            <BucketedList
-              testId={testId}
-              buckets={recentBuckets}
-              activeIndex={activeIndex}
-              setActiveIndex={setActiveIndex}
-              onSelect={(row) => onSubmit(row, query)}
-              noTitle={noTitle}
-              showProject={showProjectOnRow}
             />
+          ) : inSearchMode ? (
+            <div className="flex-1 min-h-0 overflow-y-auto">
+              <FlatList
+                testId={testId}
+                rows={rows}
+                queryTokens={queryTokens}
+                activeIndex={activeIndex}
+                setActiveIndex={setActiveIndex}
+                onSelect={(row) => onSubmit(row, query)}
+                showProject={showProjectOnRow}
+              />
+            </div>
           ) : (
-            <FlatList
+            <VirtualRecents
               testId={testId}
-              rows={rows}
-              queryTokens={queryTokens}
+              virtuosoRef={virtuosoRef}
+              items={virtualRecents.items}
               activeIndex={activeIndex}
               setActiveIndex={setActiveIndex}
               onSelect={(row) => onSubmit(row, query)}
+              onEndReached={loadMoreRecents}
               showProject={showProjectOnRow}
             />
           )}
@@ -383,15 +447,20 @@ export default function CommandPalette({
             )}
             <Hint keys={['esc']} label={t('newDraft.close')} />
           </div>
-          <div className="flex-none">
-            {rows && rows.length > 0 && (
-              <span>
-                {inSearchMode
-                  ? labels.resultsTotal(rows.length)
-                  : labels.recentTotal(rows.length)}
-              </span>
-            )}
-          </div>
+          {inSearchMode && labels.resultsTotal && rows && rows.length > 0 && (
+            onCommit ? (
+              <button
+                type="button"
+                data-testid={`${testId}-results-total`}
+                onClick={() => onCommit(query)}
+                className="flex-none rounded-md px-1.5 py-0.5 -my-0.5 hover:bg-warm-surface2 hover:text-warm-text dark:hover:bg-dark-surface2 dark:hover:text-dark-text transition-colors"
+              >
+                {labels.resultsTotal(rows.length)}
+              </button>
+            ) : (
+              <span className="flex-none">{labels.resultsTotal(rows.length)}</span>
+            )
+          )}
         </div>
       </div>
     </div>
@@ -439,59 +508,112 @@ function FlatList({
   )
 }
 
-function BucketedList({
+type VirtualItem =
+  | { kind: 'header'; key: string; label: string }
+  | { kind: 'row'; key: string; row: PaletteRow; rowIndex: number }
+  | { kind: 'loading'; key: 'loading-more' }
+
+function buildVirtualRecents(
+  sessions: Session[],
+  noTitle: string,
+  t: ((k: string) => string) | null,
+  loadingMore: boolean,
+): { items: VirtualItem[]; rowIndexToVirtualIndex: number[] } {
+  const items: VirtualItem[] = []
+  const rowIndexToVirtualIndex: number[] = []
+  const pushRow = (session: Session): void => {
+    rowIndexToVirtualIndex.push(items.length)
+    items.push({
+      kind: 'row',
+      key: session.sessionUuid,
+      row: sessionToRow(session, noTitle),
+      rowIndex: rowIndexToVirtualIndex.length - 1,
+    })
+  }
+  if (t) {
+    for (const bucket of bucketSessionsByDate(sessions, t)) {
+      items.push({ kind: 'header', key: `h-${bucket.label}`, label: bucket.label })
+      for (const session of bucket.sessions) pushRow(session)
+    }
+  } else {
+    for (const session of sessions) pushRow(session)
+  }
+  if (loadingMore) items.push({ kind: 'loading', key: 'loading-more' })
+  return { items, rowIndexToVirtualIndex }
+}
+
+function VirtualRecents({
   testId,
-  buckets,
+  virtuosoRef,
+  items,
   activeIndex,
   setActiveIndex,
   onSelect,
-  noTitle,
+  onEndReached,
   showProject,
 }: {
   testId: string
-  buckets: { label: string; sessions: Session[] }[]
+  virtuosoRef: React.MutableRefObject<VirtuosoHandle | null>
+  items: VirtualItem[]
   activeIndex: number
   setActiveIndex: (i: number) => void
   onSelect: (row: PaletteRow) => void
-  noTitle: string
+  onEndReached: () => void
   showProject: boolean
 }) {
-  let running = 0
+  const { t } = useTranslation()
   return (
-    <ul role="listbox">
-      {buckets.map(bucket => (
-        <li key={bucket.label}>
-          <div className="px-5 pt-2 pb-1 text-[10px] font-semibold tracking-[0.04em] text-warm-faint dark:text-dark-muted">
-            {bucket.label}
+    <Virtuoso
+      ref={virtuosoRef}
+      data={items}
+      data-testid={`${testId}-virtual`}
+      computeItemKey={(_index, item) => item.key}
+      defaultItemHeight={40}
+      increaseViewportBy={200}
+      endReached={onEndReached}
+      role="listbox"
+      className="flex-1 min-h-0"
+      itemContent={(_virtualIndex, item) => {
+        if (item.kind === 'header') {
+          return (
+            <div
+              data-testid={`${testId}-bucket-header`}
+              className="px-5 pt-2 pb-1 text-[10px] font-semibold tracking-[0.04em] text-warm-faint dark:text-dark-muted"
+            >
+              {item.label}
+            </div>
+          )
+        }
+        if (item.kind === 'loading') {
+          return (
+            <div
+              data-testid={`${testId}-loading-more`}
+              className="px-5 py-3 text-center text-[11px] text-warm-faint dark:text-dark-muted"
+            >
+              {t('library.footer_loadingMore')}
+            </div>
+          )
+        }
+        const active = item.rowIndex === activeIndex
+        return (
+          <div
+            role="option"
+            aria-selected={active}
+            data-row-index={item.rowIndex}
+            onMouseEnter={() => setActiveIndex(item.rowIndex)}
+          >
+            <PaletteRowButton
+              testId={testId}
+              row={item.row}
+              queryTokens={[]}
+              active={active}
+              showProject={showProject}
+              onSelect={() => onSelect(item.row)}
+            />
           </div>
-          <ul>
-            {bucket.sessions.map(session => {
-              const index = running++
-              const row = sessionToRow(session, noTitle)
-              const active = index === activeIndex
-              return (
-                <li
-                  key={session.sessionUuid}
-                  role="option"
-                  aria-selected={active}
-                  data-row-index={index}
-                  onMouseEnter={() => setActiveIndex(index)}
-                >
-                  <PaletteRowButton
-                    testId={testId}
-                    row={row}
-                    queryTokens={[]}
-                    active={active}
-                    showProject={showProject}
-                    onSelect={() => onSelect(row)}
-                  />
-                </li>
-              )
-            })}
-          </ul>
-        </li>
-      ))}
-    </ul>
+        )
+      }}
+    />
   )
 }
 
@@ -523,6 +645,7 @@ function PaletteRowButton({
       data-testid={`${testId}-row`}
       data-session-uuid={row.sessionUuid}
       onClick={onSelect}
+      title={projectVisible ? `${row.title} · ${row.projectLabel}` : row.title}
       className={`w-full flex items-start gap-3 px-5 py-2 text-left transition-colors duration-75 ${activeBg}`}
     >
       <div className="flex-1 min-w-0">
@@ -531,7 +654,7 @@ function PaletteRowButton({
           <span className="flex-1 min-w-0 text-sm truncate">
             <span className="text-warm-text dark:text-dark-text">{row.title}</span>
             {projectVisible && (
-              <span className="text-warm-faint dark:text-dark-muted"> · {row.projectLabel}</span>
+              <span className="text-[11px] text-warm-faint dark:text-dark-muted"> · {row.projectLabel}</span>
             )}
           </span>
         </div>
@@ -549,6 +672,20 @@ function PaletteRowButton({
   )
 }
 
+function PaletteEmpty({ icon, message }: { icon: ReactNode; message: string }) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
+      <div
+        className="w-11 h-11 rounded-full flex items-center justify-center bg-warm-surface dark:bg-dark-surface text-warm-faint dark:text-dark-muted"
+        aria-hidden
+      >
+        {icon}
+      </div>
+      <p className="text-sm text-warm-muted dark:text-dark-muted max-w-[320px]">{message}</p>
+    </div>
+  )
+}
+
 function PaletteSkeleton({ count }: { count: number }) {
   return (
     <div aria-hidden>
@@ -561,6 +698,13 @@ function PaletteSkeleton({ count }: { count: number }) {
       ))}
     </div>
   )
+}
+
+function fetchRecentsPage(scopeKey: string | undefined, cursor: SessionsCursor | null) {
+  const options = { limit: RECENT_PAGE_SIZE, ...(cursor ? { cursor } : {}) }
+  return scopeKey
+    ? window.spool.listSessionsByIdentity(scopeKey, options)
+    : window.spool.listSessions(options)
 }
 
 function sessionToRow(s: Session, noTitle: string): PaletteRow {

--- a/packages/app/src/renderer/components/NewDraftPicker.tsx
+++ b/packages/app/src/renderer/components/NewDraftPicker.tsx
@@ -25,8 +25,6 @@ export default function NewDraftPicker({ onSelect, onClose }: Props) {
         noMatches: (query) => t('newDraft.empty', { query }),
         emptyNoSessions: t('newDraft.emptyNoSessions'),
         emptyInProject: (project) => t('newDraft.emptyInProject', { project }),
-        resultsTotal: (count) => t('newDraft.results_other', { count }),
-        recentTotal: (count) => t('newDraft.recentSessions_other', { count }),
       }}
       onSubmit={(row: PaletteRow) => onSelect(row.sessionUuid)}
       onClose={onClose}

--- a/packages/app/src/renderer/components/SearchOverlay.tsx
+++ b/packages/app/src/renderer/components/SearchOverlay.tsx
@@ -73,8 +73,7 @@ export default function SearchOverlay({
         noMatches: () => t('search.noMatches'),
         emptyNoSessions: t('search.noSessionsYet'),
         emptyInProject: () => t('search.noSessionsInProject'),
-        resultsTotal: (count) => t('search.resultsArrow_other', { count }),
-        recentTotal: (count) => t('search.recentCount_other', { count }),
+        ...(searchDisabled ? {} : { resultsTotal: (count) => t('search.resultsArrow_other', { count }) }),
       }}
       onSubmit={(row: PaletteRow, query: string) => {
         onOpenResult(row.sessionUuid, row.messageId, query)

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -94,9 +94,6 @@
     "hint_ask": "fragen",
     "hint_viewAll": "alle anzeigen",
     "hint_close": "schließen",
-    "recentCount_one": "{{count}} aktuelle Sitzung",
-    "recentCount_other": "{{count}} aktuelle Sitzungen",
-    "resultsArrow_one": "{{count}} Ergebnis →",
     "resultsArrow_other": "{{count}} Ergebnisse →"
   },
   "session": {
@@ -388,10 +385,6 @@
     "navigate": "navigieren",
     "open": "öffnen",
     "close": "schließen",
-    "results_one": "{{count}} Ergebnis",
-    "results_other": "{{count}} Ergebnisse",
-    "recentSessions_one": "{{count}} aktuelle Sitzung",
-    "recentSessions_other": "{{count}} aktuelle Sitzungen",
     "cancel": "Abbrechen"
   },
   "fragment": {

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -94,9 +94,6 @@
     "hint_ask": "ask",
     "hint_viewAll": "view all",
     "hint_close": "close",
-    "recentCount_one": "{{count}} recent session",
-    "recentCount_other": "{{count}} recent sessions",
-    "resultsArrow_one": "{{count}} result →",
     "resultsArrow_other": "{{count}} results →"
   },
   "session": {
@@ -388,10 +385,6 @@
     "navigate": "navigate",
     "open": "open",
     "close": "close",
-    "results_one": "{{count}} result",
-    "results_other": "{{count}} results",
-    "recentSessions_one": "{{count}} recent session",
-    "recentSessions_other": "{{count}} recent sessions",
     "cancel": "Cancel"
   },
   "fragment": {

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -94,9 +94,6 @@
     "hint_ask": "demander",
     "hint_viewAll": "tout afficher",
     "hint_close": "fermer",
-    "recentCount_one": "{{count}} session récente",
-    "recentCount_other": "{{count}} sessions récentes",
-    "resultsArrow_one": "{{count}} résultat →",
     "resultsArrow_other": "{{count}} résultats →"
   },
   "session": {
@@ -388,10 +385,6 @@
     "navigate": "naviguer",
     "open": "ouvrir",
     "close": "fermer",
-    "results_one": "{{count}} résultat",
-    "results_other": "{{count}} résultats",
-    "recentSessions_one": "{{count}} session récente",
-    "recentSessions_other": "{{count}} sessions récentes",
     "cancel": "Annuler"
   },
   "fragment": {

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -93,7 +93,6 @@
     "hint_ask": "質問",
     "hint_viewAll": "すべて表示",
     "hint_close": "閉じる",
-    "recentCount_other": "最近のセッション {{count}} 件",
     "resultsArrow_other": "{{count}} 件の結果 →"
   },
   "session": {
@@ -376,8 +375,6 @@
     "navigate": "移動",
     "open": "開く",
     "close": "閉じる",
-    "results_other": "{{count}} 件の結果",
-    "recentSessions_other": "最近のセッション {{count}} 件",
     "cancel": "キャンセル"
   },
   "fragment": {

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -93,7 +93,6 @@
     "hint_ask": "질문",
     "hint_viewAll": "전체 보기",
     "hint_close": "닫기",
-    "recentCount_other": "최근 세션 {{count}}개",
     "resultsArrow_other": "결과 {{count}}개 →"
   },
   "session": {
@@ -376,8 +375,6 @@
     "navigate": "이동",
     "open": "열기",
     "close": "닫기",
-    "results_other": "결과 {{count}}개",
-    "recentSessions_other": "최근 세션 {{count}}개",
     "cancel": "취소"
   },
   "fragment": {

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -93,7 +93,6 @@
     "hint_ask": "提问",
     "hint_viewAll": "查看全部",
     "hint_close": "关闭",
-    "recentCount_other": "{{count}} 个最近会话",
     "resultsArrow_other": "{{count}} 条结果 →"
   },
   "session": {
@@ -376,8 +375,6 @@
     "navigate": "切换",
     "open": "打开",
     "close": "关闭",
-    "results_other": "{{count}} 个结果",
-    "recentSessions_other": "{{count}} 个最近会话",
     "cancel": "取消"
   },
   "fragment": {

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -93,7 +93,6 @@
     "hint_ask": "提問",
     "hint_viewAll": "檢視全部",
     "hint_close": "關閉",
-    "recentCount_other": "{{count}} 個最近會話",
     "resultsArrow_other": "{{count}} 筆結果 →"
   },
   "session": {
@@ -376,8 +375,6 @@
     "navigate": "切換",
     "open": "開啟",
     "close": "關閉",
-    "results_other": "{{count}} 個結果",
-    "recentSessions_other": "{{count}} 個最近會話",
     "cancel": "取消"
   },
   "fragment": {


### PR DESCRIPTION
## What

CommandPalette recents (powering both the share new-draft picker and the global cmdk overlay) used to cap the visible list at 30. With scope filters now in both pickers (#251, #252), a user who scoped to a heavily-used project could only see their last 30 sessions there — finding session #31+ meant guessing a search term or leaving the palette for the Library page.

This swaps the recents path to cursor-paginated infinite scroll, so any scope is fully browseable without paying the cost of mounting hundreds of rows up front.

## Why

VS Code's Quick Open is the right mental model here — a session picker is like a file picker: you often want to *recognize* the right one by scrolling, not type a query. The Library page is theoretically the "browse view", but bouncing out to it just to find session #47 breaks the "Cmd+K and go" flow.

## How it works

- **Cursor pagination** — `listSessions` / `listSessionsByIdentity` already returned `SessionsPage` with cursors; the renderer just had to plumb them through. Initial page raised 30 → 50 to match the server default; `endReached` triggers the next page.
- **Always virtualize recents** via `react-virtuoso` (already used by `MessageList`). Single rendering path replaces the old `BucketedList` / `FlatList` fork. Date buckets become interleaved divider items.
- **Search mode unchanged** — capped at 30 top-relevance results, rendered as a flat list. No virtualization needed at that count.

While in there, three UX polish items the user asked for:

- Footer count is now search-only and **clickable** — it commits to the full results page (same as `Shift+Enter`). Recents view drops the "N recent sessions" badge entirely.
- Empty / no-matches states get a centered layout with a soft circle icon (was top-aligned bare paragraph that looked stranded inside the new tall list area).
- Project breadcrumb after each title shrinks to 11px to read as secondary; row buttons get a native `title` tooltip with the full title + project for hover discovery.

## Test plan

- [x] `e2e/picker-browse-scope.spec.ts` — new: 75-session fixture, scope, verify pagination loads ordinal 000 (beyond the first page); scope-flip resets to page 1
- [x] `e2e/search-overlay-scope.spec.ts` — new: clicking the results-total badge jumps to results page; badge is hidden in recents and appears in search mode
- [x] Existing scope/picker tests updated for the new bucket-header testid and virtualization-aware assertions (DOM row counts vary by viewport — checks now use stable signals)
- [x] Full picker suite green at 42/42 across 2× repeats