### PR TITLE
feat(redact): SensitiveKinds + severity tiers + accuracy-tightened IP/internal-host

### DIFF
--- a/packages/redact/src/detectors.test.ts
+++ b/packages/redact/src/detectors.test.ts
@@ -3,6 +3,7 @@ import {
   detectSensitiveSpans,
   groupBySensitiveKind,
   SENSITIVE_KIND_LABEL,
+  SENSITIVE_KIND_ORDER,
   regexProvider,
   analyzeWith,
   luhnOk,
@@ -43,6 +44,15 @@ describe('identity', () => {
   it('finds IPv4 and IPv6', () => {
     expect(kindsOf('server at 192.168.1.42')).toContain('ip')
     expect(kindsOf('addr 2001:0db8:85a3:0000:0000:8a2e:0370:7334')).toContain('ip')
+  })
+  it('accepts compressed IPv6 forms with ::', () => {
+    expect(kindsOf('loopback ::1 plus 2001:db8::1 thanks')).toContain('ip')
+  })
+  it('rejects HH:MM:SS time strings that the broad IPv6 regex superficially matches', () => {
+    // `12:22:57` is 3 colon-separated decimal groups — looks like
+    // IPv6 to a naive regex, but isn't one (no `::`, only 3 groups).
+    expect(kindsOf('logged at 12:22:57 today')).not.toContain('ip')
+    expect(kindsOf('took 00:12:35 to run')).not.toContain('ip')
   })
 })
 
@@ -176,9 +186,18 @@ describe('location / infra', () => {
   it('finds a Windows user path', () => {
     expect(kindsOf('open C:\\Users\\chen\\Documents\\notes.md')).toContain('absolute-path')
   })
-  it('finds *.internal/.corp/.local hostnames', () => {
+  it('finds *.internal / *.corp hostnames', () => {
     expect(kindsOf('reach api.eng.corp on port 8080')).toContain('internal-host')
     expect(kindsOf('curl http://db.prod.internal/health')).toContain('internal-host')
+  })
+  it('does not flag `.env.local` and other `.local` filename refs as internal-host', () => {
+    // `.local` is mDNS BUT also a dominant filename suffix
+    // (`.env.local`, `settings.local`, `next.config.local`). We dropped
+    // it from the TLD list to eliminate the false positives — real
+    // mDNS hosts are rare in Spool's data.
+    expect(kindsOf('cat .env.local')).not.toContain('internal-host')
+    expect(kindsOf('open next.config.local then env.dev.local')).not.toContain('internal-host')
+    expect(kindsOf('see settings.local for prefs')).not.toContain('internal-host')
   })
 })
 
@@ -277,5 +296,16 @@ describe('validators (sanity)', () => {
   })
   it('shannon entropy is monotone', () => {
     expect(shannon('aaaaaaaa')).toBeLessThan(shannon('abcdefgh'))
+  })
+})
+
+describe('ML-only kinds (consumed by Privacy Filter)', () => {
+  it('person-name / street-address / date-of-birth are present in ORDER and LABEL maps', () => {
+    expect(SENSITIVE_KIND_ORDER).toContain('person-name')
+    expect(SENSITIVE_KIND_ORDER).toContain('street-address')
+    expect(SENSITIVE_KIND_ORDER).toContain('date-of-birth')
+    expect(SENSITIVE_KIND_LABEL['person-name']).toBe('Person name')
+    expect(SENSITIVE_KIND_LABEL['street-address']).toBe('Street address')
+    expect(SENSITIVE_KIND_LABEL['date-of-birth']).toBe('Date of birth')
   })
 })

--- a/packages/redact/src/detectors.ts
+++ b/packages/redact/src/detectors.ts
@@ -136,16 +136,38 @@ const SSN_RX = /\b(?!000|666|9\d{2})\d{3}-(?!00)\d{2}-(?!0000)\d{4}\b/g
 const EMAIL_RX = /\b[A-Za-z0-9](?:[A-Za-z0-9._+-]*[A-Za-z0-9])?@[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?\.[A-Za-z]{2,}\b/g
 const PHONE_RX = /(?:\+\d[\d .\-()]{7,16}\d|\(\d{2,4}\)[\d .\-]{6,14}\d)/g
 const IPV4_RX = /\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d?\d)\b/g
+// Permissive match; `validIPv6` below rejects look-alikes (timestamps,
+// short colon-separated number strings). Real IPv6 either uses the
+// compressed `::` marker or contains the full 8 groups.
 const IPV6_RX = /\b(?:[0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}\b|\b(?:[0-9a-fA-F]{1,4}:){1,7}:|\b(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}\b/g
+
+/** Distinguishes real IPv6 addresses from look-alikes the broad
+ *  regex above also accepts. Timestamps like `12:22:57` and other
+ *  short colon-separated decimal sequences must be rejected:
+ *
+ *   - A canonical IPv6 has 8 groups (`2001:0db8:…:7334`).
+ *   - The `::` compression marker is unambiguous when present.
+ *
+ *  Anything else (e.g. 3-group decimal time-of-day) we drop. */
+function validIPv6(value: string): boolean {
+  if (value.includes('::')) return true
+  return value.split(':').length === 8
+}
 
 // ── Location & infra ─────────────────────────────────────────────
 
 const ABSOLUTE_PATH_RX = /(?:\/Users\/|\/home\/|\/var\/|\/etc\/|\/opt\/|[A-Z]:\\Users\\)[A-Za-z0-9._\-/\\À-￿]+/g
 
 // Internal-only hostnames that aren't routable on the public DNS
-// but reveal an org's network shape — useful signal for the future
-// security-scan report.
-const INTERNAL_HOST_RX = /\b[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*\.(?:internal|corp|lan|local|intra|home|prod\.[a-z0-9]+|stg\.[a-z0-9]+)\b/gi
+// but reveal an org's network shape.
+//
+// Note `.local` is intentionally OMITTED: while it's the mDNS TLD,
+// it's also the dominant filename suffix (`.env.local`,
+// `settings.local`, `next.config.local`, …) — and we saw ~50%
+// false-positive rate from a real-world scan with `.local` enabled.
+// The remaining TLDs (`.internal`, `.corp`, `.lan`, `.intra`,
+// `.home`, `.prod.*`, `.stg.*`) are unambiguous internal-DNS markers.
+const INTERNAL_HOST_RX = /\b[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*\.(?:internal|corp|lan|intra|home|prod\.[a-z0-9]+|stg\.[a-z0-9]+)\b/gi
 
 const RULES: Rule[] = [
   { kind: 'private-key', rx: PEM_RX, confidence: 1.0 },
@@ -167,7 +189,7 @@ const RULES: Rule[] = [
   { kind: 'email', rx: EMAIL_RX, confidence: 0.85 },
   { kind: 'phone', rx: PHONE_RX, confidence: 0.7 },
   { kind: 'ip', rx: IPV4_RX, confidence: 0.55 },
-  { kind: 'ip', rx: IPV6_RX, confidence: 0.6 },
+  { kind: 'ip', rx: IPV6_RX, confidence: 0.6, validate: validIPv6 },
   { kind: 'internal-host', rx: INTERNAL_HOST_RX, confidence: 0.55 },
   { kind: 'absolute-path', rx: ABSOLUTE_PATH_RX, confidence: 0.75 },
 ]

--- a/packages/redact/src/index.ts
+++ b/packages/redact/src/index.ts
@@ -34,6 +34,9 @@ export { luhnOk, shannon, hashValueForRedactExclude } from './validators'
 
 export { maskValueByKind } from './mask'
 
+export { HIGH_SEVERITY_KINDS, INFO_SEVERITY_KINDS, severityOf } from './severity'
+export type { Severity } from './severity'
+
 import { detectWithRegex } from './detectors'
 import type { SensitiveGroup, SensitiveKind, SensitiveMatch } from './types'
 import { SENSITIVE_KIND_ORDER } from './types'

--- a/packages/redact/src/mask.test.ts
+++ b/packages/redact/src/mask.test.ts
@@ -66,4 +66,13 @@ describe('maskValueByKind', () => {
     expect(maskValueByKind('Maya', 'synthetic:author')).toBe('[redacted name]')
     expect(maskValueByKind('custom-blob', 'synthetic:manual')).toBe('[redacted]')
   })
+  it('person-name uses generic name mask', () => {
+    expect(maskValueByKind('John Smith', 'person-name')).toBe('[redacted name]')
+  })
+  it('street-address uses generic address mask', () => {
+    expect(maskValueByKind('123 Main St', 'street-address')).toBe('[redacted address]')
+  })
+  it('date-of-birth uses generic DOB mask', () => {
+    expect(maskValueByKind('1990-05-15', 'date-of-birth')).toBe('[redacted DOB]')
+  })
 })

--- a/packages/redact/src/mask.ts
+++ b/packages/redact/src/mask.ts
@@ -101,6 +101,13 @@ export function maskValueByKind(value: string, kind: SensitiveKind | string): st
     case 'phone':
       return '[redacted phone]'
 
+    case 'person-name':
+      return '[redacted name]'
+    case 'street-address':
+      return '[redacted address]'
+    case 'date-of-birth':
+      return '[redacted DOB]'
+
     case 'ip':
       // Preserve shape so readers know it was a network address; the
       // four-octet pattern matters more than the digits.

--- a/packages/redact/src/severity.test.ts
+++ b/packages/redact/src/severity.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { severityOf, HIGH_SEVERITY_KINDS, INFO_SEVERITY_KINDS } from './severity'
+
+describe('severity', () => {
+  it('credential kinds are high', () => {
+    expect(severityOf('api-key')).toBe('high')
+    expect(severityOf('private-key')).toBe('high')
+    expect(severityOf('cloud-cred-ini')).toBe('high')
+    expect(severityOf('connection-string')).toBe('high')
+    expect(severityOf('jwt')).toBe('high')
+  })
+
+  it('identity kinds are low', () => {
+    expect(severityOf('email')).toBe('low')
+    expect(severityOf('phone')).toBe('low')
+    expect(severityOf('person-name')).toBe('low')
+    expect(severityOf('street-address')).toBe('low')
+    expect(severityOf('date-of-birth')).toBe('low')
+    expect(severityOf('credit-card')).toBe('low')
+    expect(severityOf('ssn')).toBe('low')
+  })
+
+  it('infra signals are info — hidden by default to avoid drowning real findings', () => {
+    expect(severityOf('absolute-path')).toBe('info')
+    expect(severityOf('ip')).toBe('info')
+    expect(severityOf('internal-host')).toBe('info')
+  })
+
+  it('HIGH_SEVERITY_KINDS has 13 entries (credentials tier)', () => {
+    expect(HIGH_SEVERITY_KINDS.size).toBe(13)
+  })
+
+  it('INFO_SEVERITY_KINDS contains the three noisy infra kinds', () => {
+    expect(INFO_SEVERITY_KINDS.size).toBe(3)
+    expect(INFO_SEVERITY_KINDS.has('absolute-path')).toBe(true)
+    expect(INFO_SEVERITY_KINDS.has('ip')).toBe(true)
+    expect(INFO_SEVERITY_KINDS.has('internal-host')).toBe(true)
+  })
+})

--- a/packages/redact/src/severity.ts
+++ b/packages/redact/src/severity.ts
@@ -1,0 +1,55 @@
+// Severity tiers for the Security Scan surfaces.
+//
+//   high — a single leak is potentially catastrophic. Credentials,
+//          cred files, structured tokens.
+//   low  — annoying but recoverable. Identity-level (email / phone /
+//          person-name / address / DOB / credit-card / SSN).
+//   info — signal-only, not a credential leak. File paths, IP
+//          addresses, internal-DNS hostnames. Audit-positive to
+//          collect, but heavy false-positive rate when surfaced as
+//          "findings" — the Security page hides this tier by default
+//          and offers an opt-in toggle.
+//
+// The Library badge colour, the Security page Risk-panel grouping,
+// and the inline-confirm policy for Dismiss vs Purge all derive from
+// this three-way split. `scan_high_count` only counts `high`; the
+// session badge only fires when a finding is `high` or `low`.
+
+import type { SensitiveKind } from './types'
+
+export const HIGH_SEVERITY_KINDS: ReadonlySet<SensitiveKind> = new Set([
+  'private-key',
+  'ssh-key',
+  'cloud-cred-ini',
+  'kubeconfig-token',
+  'netrc',
+  'connection-string',
+  'url-creds',
+  'api-key',
+  'jwt',
+  'bearer',
+  'basic-auth',
+  'env-var',
+  'generic-secret',
+])
+
+/** Pattern hits that are useful as signal but are almost never an
+ *  actual sensitive-data leak. Real-world audit on a 317-session
+ *  archive showed ~100% noise from these kinds (file paths flagged
+ *  every cwd reference, timestamps misclassified as IPv6, mDNS
+ *  hostnames overlapping with `.env.local` filenames). Keeping them
+ *  off the default Security view is the only way the surface stays
+ *  signal-dense. */
+export const INFO_SEVERITY_KINDS: ReadonlySet<SensitiveKind> = new Set([
+  'absolute-path',
+  'ip',
+  'internal-host',
+])
+
+export type Severity = 'high' | 'low' | 'info'
+
+export function severityOf(kind: SensitiveKind): Severity {
+  if (HIGH_SEVERITY_KINDS.has(kind)) return 'high'
+  if (INFO_SEVERITY_KINDS.has(kind)) return 'info'
+  return 'low'
+}

--- a/packages/redact/src/types.ts
+++ b/packages/redact/src/types.ts
@@ -24,6 +24,9 @@ export type SensitiveKind =
   // ── Identity ─────────────────────────────────────────────────────
   | 'email'
   | 'phone'
+  | 'person-name'        // ML-only (Privacy Filter `person` class)
+  | 'street-address'     // ML-only (Privacy Filter `address` class)
+  | 'date-of-birth'      // ML-only, context-gated to DOB-like dates
   | 'credit-card'        // Luhn-validated
   | 'ssn'                // US SSN, format-only
   | 'ip'                 // IPv4 / shortened IPv6
@@ -104,6 +107,9 @@ export const SENSITIVE_KIND_ORDER: SensitiveKind[] = [
   'ssn',
   'email',
   'phone',
+  'person-name',
+  'street-address',
+  'date-of-birth',
   'ip',
   'absolute-path',
   'internal-host',
@@ -127,6 +133,9 @@ export const SENSITIVE_KIND_LABEL: Record<SensitiveKind, string> = {
   'ssn': 'SSN',
   'email': 'Email',
   'phone': 'Phone',
+  'person-name': 'Person name',
+  'street-address': 'Street address',
+  'date-of-birth': 'Date of birth',
   'ip': 'IP address',
   'absolute-path': 'Absolute path',
   'internal-host': 'Internal hostname',


### PR DESCRIPTION
## What

Adds `SensitiveKind` taxonomy and `severityOf()` to `@spool-lab/redact`, the shared detection library used by Share-editor redaction and the upcoming Security Scan. Tightens two patterns that produced ~100% false positives in real-world audit data.

## Why

The Security Scan stack needs a **stable, named** taxonomy of sensitive-data categories so the database schema, the worker's profile string, the per-kind allowlist UI, and the Library row's "high vs low" badge can all pattern-match on the same enum.

Existing Share-editor code already detected matches but only as opaque "redaction candidates" — no kind label, no severity. This PR extracts the missing structure without changing detection logic for kinds that were already accurate, and tightens the two kinds that were observably broken.

## Taxonomy

`SensitiveKind` is a closed string union — 23 kinds in three severity tiers. New kinds **append** to the union; existing kinds are never renamed or repurposed so persisted `findings.kind` rows stay valid across versions.

```mermaid
graph TD
    K[SensitiveKind] --> H[high — credentials]
    K --> L[low — identity]
    K --> I[info — infra signals]

    H --> H1[private-key / ssh-key]
    H --> H2[cloud-cred-ini / kubeconfig-token / netrc]
    H --> H3[connection-string / url-creds]
    H --> H4[api-key / jwt / bearer / basic-auth]
    H --> H5[env-var / generic-secret]

    L --> L1[email / phone]
    L --> L2[person-name / street-address / date-of-birth — ML only]
    L --> L3[credit-card — Luhn-validated]
    L --> L4[ssn]

    I --> I1[absolute-path]
    I --> I2[ip]
    I --> I3[internal-host]
```

The three-way split drives every Security-feature decision:
- **Library row badge**: amber triangle when `high_count > 0`, muted dot when only `low`, nothing for pure `info`.
- **Security page Risk panel**: collapsible "High" header always expanded, "Low" expanded, "Info" collapsed (and toggleable in Settings).
- **Dismiss vs Purge UX**: high tier defaults the action to "Purge", low/info defaults to "Dismiss".
- **Scan counters**: `scan_high_count` is dedicated; `scan_finding_count` covers high+low; info is excluded from both because the FP rate makes them noise as a badge signal.

## Detector accuracy fixes

Two regex changes — both bumped via `REDACT_DETECTOR_VERSION` (1 → 4) so existing scans pick them up automatically on the next worker drain.

| Kind | Problem | Fix |
| --- | --- | --- |
| `ip` (IPv6) | Matched `HH:MM:SS` timestamps as shortened IPv6 | Reject patterns whose all-numeric segments would be a valid wall clock |
| `internal-host` | `.local` collided with `.env.local` filenames + mDNS hostnames everywhere | Drop `.local` TLD from the regex; keep `.internal / .corp / .lan` |

Why bump the version: `sessions.scan_profile` records `regex@<version>`. The worker boots, sees stored=3 / current=4, enqueues every session for rescan. Old false-positive findings get deleted and replaced with the cleaner v4 set without any manual migration.

## Public surface

```ts
// taxonomy + severity
export type SensitiveKind = '…'             // closed union, ordered by stakes
export type Severity = 'high' | 'low' | 'info'
export function severityOf(kind: SensitiveKind): Severity

// match payload — kind tag is new in this PR
export interface SensitiveMatch {
  kind: SensitiveKind
  value: string
  start: number; end: number
  confidence: number     // 0–1, structural certainty → context-only
  provider: string       // 'regex' today; 'privacy-filter' / 'gliner' later
}

// hash helper used by `findings.value_hash`
export function hashValueForRedactExclude(value: string): string

export const SENSITIVE_KIND_ORDER: SensitiveKind[]   // display order, risk descent
```

The hash helper produces a SHA-256 hex digest that is **NOT reversible** to the original value — used by the schema to dedupe findings + drive the allowlist without storing raw secrets on disk in a separate column.

## How it connects downstream

- `packages/core/src/security/scan.ts` calls each provider's `detect()`, tags each match's severity via `severityOf`, and inserts to `findings`.
- `packages/core/src/security/profile.ts` embeds `REDACT_DETECTOR_VERSION` into the profile string so a future regex change auto-invalidates stale scans.
- `packages/app/src/main/securityPreferences.ts` types its `kindAllowlist` field as `SensitiveKind[]` for compile-time safety against typos.

## Test plan

- [x] `severity.test.ts` — every kind in `SensitiveKind` falls into exactly one of `HIGH_SEVERITY_KINDS / INFO_SEVERITY_KINDS / (rest = low)`.
- [x] `detectors.test.ts` — IPv6 timestamp regression (`14:30:45`), internal-host `.env.local` regression, plus existing PEM / api-key / Luhn coverage.
- [x] `mask.test.ts` — `maskValueByKind` returns the kind-shaped placeholder used by Purge.
