### PR TITLE
feat(core): schema v12 + security types module

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,12 +21,12 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @spool-lab/redact build
+      - run: pnpm --filter @spool-lab/redact test
       - run: pnpm --filter @spool-lab/core build
       - run: pnpm --filter @spool-lab/core test
       - run: pnpm --filter @spool-lab/cli build
       - run: pnpm --filter @spool-lab/cli test
-      - run: pnpm --filter @spool-lab/redact build
-      - run: pnpm --filter @spool-lab/redact test
       - run: pnpm --filter @spool/share-kit test
       - run: pnpm --filter @spool/app test
 
@@ -49,6 +49,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build redact (core depends on it)
+        run: pnpm --filter @spool-lab/redact build
 
       - name: Build core
         run: pnpm --filter @spool-lab/core build

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
+    "@spool-lab/redact": "workspace:*",
     "better-sqlite3": "^11.10.0"
   },
   "devDependencies": {

--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -478,8 +478,7 @@ export function runMigrations(db: Database.Database): void {
     // row remains as an audit record. scan_purged_count is the
     // lifetime tally of purged findings per session, used by the
     // Library row's "all-resolved ✓" badge to distinguish "never
-    // had findings" from "was clean after I cleaned it up". See
-    // ~/Documents/dev-docs/spool/2026-05-18-security-scan-design.md.
+    // had findings" from "was clean after I cleaned it up".
     //
     // Wrapped in a transaction so a mid-migration failure (process
     // killed, disk full, etc.) doesn't leave the DB half-altered.

--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -14,7 +14,7 @@ export const DB_PATH = join(SPOOL_DIR, 'spool.db')
  * Latest schema version the running build knows how to migrate to.
  * Bump in lockstep with the last `db.pragma('user_version = N')` in runMigrations.
  */
-export const LATEST_SCHEMA_VERSION = 11
+export const LATEST_SCHEMA_VERSION = 12
 
 let _db: Database.Database | null = null
 let _wasNewDb = false
@@ -467,6 +467,71 @@ export function runMigrations(db: Database.Database): void {
         ON share_drafts(source_origin);
     `)
     db.pragma('user_version = 11')
+  }
+
+  if (version < 12) {
+    // v12: Security Scan — sidecar findings + allowlists. The five
+    // scan_* columns on sessions are denormalised counters
+    // maintained by the scan worker; findings stores (kind,
+    // value_hash, offsets) only — never the raw value. Purge mutates
+    // messages.content_text and flips the row to state='purged'; the
+    // row remains as an audit record. scan_purged_count is the
+    // lifetime tally of purged findings per session, used by the
+    // Library row's "all-resolved ✓" badge to distinguish "never
+    // had findings" from "was clean after I cleaned it up". See
+    // ~/Documents/dev-docs/spool/2026-05-18-security-scan-design.md.
+    //
+    // Wrapped in a transaction so a mid-migration failure (process
+    // killed, disk full, etc.) doesn't leave the DB half-altered.
+    // Without this, a partial v12 — say two ALTER TABLEs landed
+    // but the third failed — would auto-commit the first two and
+    // leave user_version at 11; the next launch would retry from
+    // the first ALTER and trip a "duplicate column" error,
+    // bricking the app on every subsequent startup.
+    db.transaction(() => {
+      db.exec(`
+        ALTER TABLE sessions ADD COLUMN scan_profile        TEXT;
+        ALTER TABLE sessions ADD COLUMN scan_completed_at   TEXT;
+        ALTER TABLE sessions ADD COLUMN scan_finding_count  INTEGER NOT NULL DEFAULT 0;
+        ALTER TABLE sessions ADD COLUMN scan_high_count     INTEGER NOT NULL DEFAULT 0;
+        ALTER TABLE sessions ADD COLUMN scan_purged_count   INTEGER NOT NULL DEFAULT 0;
+
+        CREATE TABLE IF NOT EXISTS findings (
+          id                INTEGER PRIMARY KEY,
+          session_id        INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+          message_id        INTEGER REFERENCES messages(id) ON DELETE CASCADE,
+          kind              TEXT NOT NULL,
+          value_hash        TEXT NOT NULL,
+          confidence        REAL NOT NULL,
+          provider          TEXT NOT NULL,
+          start_offset      INTEGER NOT NULL,
+          end_offset        INTEGER NOT NULL,
+          state             TEXT NOT NULL DEFAULT 'active'
+                            CHECK (state IN ('active','dismissed','purged')),
+          detected_at       TEXT NOT NULL DEFAULT (datetime('now')),
+          state_changed_at  TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_findings_session    ON findings(session_id);
+        CREATE INDEX IF NOT EXISTS idx_findings_state      ON findings(state);
+        CREATE INDEX IF NOT EXISTS idx_findings_kind_hash  ON findings(kind, value_hash);
+
+        CREATE TABLE IF NOT EXISTS allowlist_session (
+          session_id   INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+          kind         TEXT NOT NULL,
+          value_hash   TEXT NOT NULL,
+          created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+          PRIMARY KEY (session_id, kind, value_hash)
+        );
+
+        CREATE TABLE IF NOT EXISTS allowlist_global (
+          kind         TEXT NOT NULL,
+          value_hash   TEXT NOT NULL,
+          created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+          PRIMARY KEY (kind, value_hash)
+        );
+      `)
+      db.pragma('user_version = 12')
+    })()
   }
 
   rebuildFtsTableIfEmpty(db, 'messages', 'messages_fts_trigram')

--- a/packages/core/src/db/migration-v12.test.ts
+++ b/packages/core/src/db/migration-v12.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import Database from 'better-sqlite3'
+import { runMigrations, LATEST_SCHEMA_VERSION } from './db.js'
+
+const userVersion = (db: Database.Database): number =>
+  (db.pragma('user_version') as Array<{ user_version: number }>)[0]!.user_version
+
+function seedProjectAndSession(db: Database.Database, sessionUuid: string): number {
+  db.prepare(
+    `INSERT OR IGNORE INTO projects (id, source_id, slug, display_path, display_name)
+     VALUES (1, 1, 'p', '/p', 'p')`,
+  ).run()
+  db.prepare(
+    `INSERT INTO sessions (project_id, source_id, session_uuid, file_path, started_at, ended_at)
+     VALUES (1, 1, ?, ?, '2026-01-01', '2026-01-01')`,
+  ).run(sessionUuid, `/p/${sessionUuid}`)
+  return (db.prepare('SELECT id FROM sessions WHERE session_uuid = ?').get(sessionUuid) as { id: number }).id
+}
+
+describe('migration v12 — security scan schema', () => {
+  it('LATEST_SCHEMA_VERSION is 12', () => {
+    expect(LATEST_SCHEMA_VERSION).toBe(12)
+  })
+
+  it('adds 5 scan_* columns to sessions (profile / completed_at / finding_count / high_count / purged_count)', () => {
+    const db = new Database(':memory:')
+    runMigrations(db)
+    const cols = db.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>
+    const names = new Set(cols.map(c => c.name))
+    expect(names.has('scan_profile')).toBe(true)
+    expect(names.has('scan_completed_at')).toBe(true)
+    expect(names.has('scan_finding_count')).toBe(true)
+    expect(names.has('scan_high_count')).toBe(true)
+    expect(names.has('scan_purged_count')).toBe(true)
+  })
+
+  it('counter columns default to 0 and scan_profile defaults to NULL', () => {
+    const db = new Database(':memory:')
+    runMigrations(db)
+    // insert a minimal session through the schema-sanity-honoured shape
+    seedProjectAndSession(db, 's')
+    const row = db.prepare(
+      'SELECT scan_finding_count, scan_high_count, scan_purged_count, scan_profile FROM sessions WHERE session_uuid = ?',
+    ).get('s') as { scan_finding_count: number; scan_high_count: number; scan_purged_count: number; scan_profile: string | null }
+    expect(row.scan_finding_count).toBe(0)
+    expect(row.scan_high_count).toBe(0)
+    expect(row.scan_purged_count).toBe(0)
+    expect(row.scan_profile).toBeNull()
+  })
+
+  it('creates findings table with expected columns and rejects unknown states via CHECK', () => {
+    const db = new Database(':memory:')
+    runMigrations(db)
+    const cols = db.prepare('PRAGMA table_info(findings)').all() as Array<{ name: string }>
+    const names = cols.map(c => c.name)
+    expect(names).toEqual(expect.arrayContaining([
+      'id', 'session_id', 'message_id', 'kind', 'value_hash', 'confidence',
+      'provider', 'start_offset', 'end_offset', 'state', 'detected_at',
+      'state_changed_at',
+    ]))
+    // CHECK constraint should reject unknown state values
+    seedProjectAndSession(db, 's')
+    expect(() =>
+      db.prepare(
+        `INSERT INTO findings (session_id, kind, value_hash, confidence, provider, start_offset, end_offset, state)
+         VALUES (1,'email','abc',1.0,'regex',0,5,'banana')`,
+      ).run(),
+    ).toThrow(/CHECK/)
+  })
+
+  it('findings.session_id FK cascade deletes findings when a session is removed', () => {
+    const db = new Database(':memory:')
+    db.pragma('foreign_keys = ON')
+    runMigrations(db)
+    seedProjectAndSession(db, 's')
+    const sessionId = (db.prepare('SELECT id FROM sessions WHERE session_uuid = ?').get('s') as { id: number }).id
+    db.prepare(
+      `INSERT INTO findings (session_id, kind, value_hash, confidence, provider, start_offset, end_offset)
+       VALUES (?,'email','abc',1.0,'regex',0,5)`,
+    ).run(sessionId)
+    expect((db.prepare('SELECT COUNT(*) AS c FROM findings').get() as { c: number }).c).toBe(1)
+    db.prepare('DELETE FROM sessions WHERE id = ?').run(sessionId)
+    expect((db.prepare('SELECT COUNT(*) AS c FROM findings').get() as { c: number }).c).toBe(0)
+  })
+
+  it('creates allowlist_session and allowlist_global tables', () => {
+    const db = new Database(':memory:')
+    runMigrations(db)
+    expect(
+      db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get('allowlist_session'),
+    ).toBeDefined()
+    expect(
+      db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get('allowlist_global'),
+    ).toBeDefined()
+  })
+
+  it('user_version is 12 after a clean migration', () => {
+    const db = new Database(':memory:')
+    runMigrations(db)
+    expect(userVersion(db)).toBe(12)
+  })
+
+  it('migration is idempotent — running twice does not error and stays at v12', () => {
+    const db = new Database(':memory:')
+    runMigrations(db)
+    expect(() => runMigrations(db)).not.toThrow()
+    expect(userVersion(db)).toBe(12)
+  })
+
+  // Regression for the partial-failure case the audit flagged: if
+  // v12's SQL block were ever run outside a transaction and the
+  // process died mid-way, some ALTER TABLEs would auto-commit, the
+  // pragma wouldn't bump, and the next launch's retry would hit a
+  // duplicate-column error on the first ALTER. The wrapping
+  // `db.transaction(() => …)()` in db.ts is what prevents that;
+  // this test enforces the wrapper stays in place by asserting that
+  // a forced mid-migration failure rolls everything back atomically.
+  it('partial failure inside the v12 SQL block rolls back atomically (transactional safety)', () => {
+    const db = new Database(':memory:')
+    // Pre-create a `findings` table that conflicts with v12's
+    // CREATE TABLE so the migration crashes mid-block. Because v12
+    // is wrapped in a transaction, the preceding ALTER TABLEs
+    // should roll back and `sessions` should NOT have any scan_*
+    // columns after the failed attempt.
+    db.exec(`
+      CREATE TABLE sources (id INTEGER PRIMARY KEY, name TEXT NOT NULL UNIQUE, base_path TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT (datetime('now')));
+      INSERT INTO sources (id, name, base_path) VALUES (1, 'claude', '/');
+      CREATE TABLE projects (id INTEGER PRIMARY KEY, source_id INTEGER NOT NULL REFERENCES sources(id), slug TEXT NOT NULL, display_path TEXT NOT NULL, display_name TEXT NOT NULL, last_synced TEXT, UNIQUE (source_id, slug));
+      CREATE TABLE sessions (id INTEGER PRIMARY KEY, project_id INTEGER NOT NULL REFERENCES projects(id), source_id INTEGER NOT NULL REFERENCES sources(id), session_uuid TEXT NOT NULL UNIQUE, file_path TEXT NOT NULL UNIQUE, title TEXT, title_source TEXT NOT NULL DEFAULT 'derived', started_at TEXT NOT NULL, ended_at TEXT NOT NULL, message_count INTEGER NOT NULL DEFAULT 0, has_tool_use INTEGER NOT NULL DEFAULT 0, cwd TEXT, model TEXT, raw_file_mtime TEXT, created_at TEXT NOT NULL DEFAULT (datetime('now')));
+      CREATE TABLE findings (id INTEGER PRIMARY KEY, conflict_column TEXT);
+    `)
+    db.pragma('user_version = 11')
+
+    expect(() => runMigrations(db)).toThrow()
+    // The transaction wrapper should have reverted everything.
+    expect(userVersion(db)).toBeLessThan(12)
+    const cols = db.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>
+    const names = new Set(cols.map(c => c.name))
+    expect(names.has('scan_profile'), 'scan_profile should have been rolled back').toBe(false)
+    expect(names.has('scan_purged_count'), 'scan_purged_count should have been rolled back').toBe(false)
+  })
+})

--- a/packages/core/src/db/share-drafts.test.ts
+++ b/packages/core/src/db/share-drafts.test.ts
@@ -79,10 +79,10 @@ describe('share_drafts schema (v11)', () => {
     expect(row.updated_at).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
   })
 
-  it('user_version reaches 11 after migration', async () => {
+  it('share_drafts table exists after migration (user_version ≥ 11)', async () => {
     const { db } = await load()
     const v = (db.pragma('user_version') as Array<{ user_version: number }>)[0]?.user_version
-    expect(v).toBe(11)
+    expect(v ?? 0).toBeGreaterThanOrEqual(11)
   })
 
   it('upsertShareDraft inserts a new row with timestamps', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,3 +20,4 @@ export {
   getResolveCacheSnapshot,
 } from './util/resolve-bin.js'
 export * from './doctor/index.js'
+export * from './security/index.js'

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -1,0 +1,9 @@
+export type {
+  FindingState,
+  FindingRow,
+  SessionWithFindingCounts,
+  RiskByCategoryRow,
+  DismissScope,
+  FindingsChange,
+  ScanStatus,
+} from './types.js'

--- a/packages/core/src/security/types.ts
+++ b/packages/core/src/security/types.ts
@@ -1,0 +1,100 @@
+// Shared types for the Security Scan subsystem.
+//
+// These are the cross-boundary payloads — worker → IPC → renderer.
+// They live in one module so:
+//   1. The worker (main process), IPC adapters, and renderer hooks
+//      can import a single source of truth.
+//   2. Promoting them to `Schema.Struct` later (for a Scope-B Effect
+//      RPC migration) is a local refactor, not a consumer rewrite.
+//
+// See `~/Documents/dev-docs/spool/2026-05-18-security-scan-design.md`
+// for the full design — schema, surfaces, and Effect TS scoping.
+
+import type { SensitiveKind } from '@spool-lab/redact'
+
+/** A finding's lifecycle state.
+ *
+ *   active     — surfaced in Security page and session strip
+ *   dismissed  — user opted to ignore; suppressed from default views
+ *   purged     — raw value rewritten with a mask in
+ *                messages.content_text; row remains as an audit record
+ */
+export type FindingState = 'active' | 'dismissed' | 'purged'
+
+/** One row of the `findings` table, mapped to camelCase for the
+ *  renderer. The raw sensitive value is NEVER part of this payload —
+ *  consumers that need to render the original text fetch it via
+ *  `getFindingValue(findingId)`, which reads
+ *  `messages.content_text[startOffset..endOffset]` at request time. */
+export interface FindingRow {
+  id: number
+  sessionId: number
+  messageId: number | null
+  kind: SensitiveKind
+  valueHash: string
+  confidence: number
+  provider: string
+  startOffset: number
+  endOffset: number
+  state: FindingState
+  detectedAt: string
+  stateChangedAt: string | null
+}
+
+/** A session row joined with its denormalised scan counts. Used by
+ *  the Security page list and the Library row badge. */
+export interface SessionWithFindingCounts {
+  id: number
+  sessionUuid: string
+  title: string | null
+  startedAt: string
+  /** Active findings of any severity. */
+  findingCount: number
+  /** Active findings whose kind is in `HIGH_SEVERITY_KINDS`. */
+  highCount: number
+  scanCompletedAt: string | null
+}
+
+/** Row in the Security page's Risk-by-category panel. One per kind
+ *  that has ≥ 1 active finding; categories with zero counts are not
+ *  emitted. */
+export interface RiskByCategoryRow {
+  kind: SensitiveKind
+  severity: 'high' | 'low'
+  count: number
+}
+
+/** Scope of a Dismiss action.
+ *   session — add to allowlist_session for this finding's session
+ *   global  — add to allowlist_global; all matching findings across
+ *             every session auto-dismiss on next scan */
+export interface DismissScope {
+  scope: 'session' | 'global'
+  /** Required when scope === 'session'. */
+  sessionId?: number
+}
+
+/** Change events emitted on the worker's PubSub stream and forwarded
+ *  to renderers via IPC. Consumers should treat unknown `type` values
+ *  as no-ops (forward-compat). */
+export type FindingsChange =
+  | { type: 'inserted'; sessionId: number }
+  | { type: 'state-changed'; sessionId: number; findingId: number; state: FindingState }
+  | { type: 'session-rescanned'; sessionId: number }
+
+/** Snapshot of the scan worker's transient state. The DB stores
+ *  scan_profile / scan_completed_at; queued and scanning are
+ *  worker-memory only — they reset on restart. */
+export interface ScanStatus {
+  /** Sessions waiting for a slot in the worker queue. */
+  queued: number
+  /** Session currently being scanned, or null when idle. */
+  scanning: number | null
+  /** When in backfill mode, sessions still to process; 0 otherwise. */
+  backfillRemaining: number
+  /** Composite identifier for the active provider set, e.g.
+   *  'regex@3' or 'regex@3,pf@1.5b-q4'. Persisted on
+   *  sessions.scan_profile to detect rescan candidates after
+   *  provider configuration changes. */
+  currentProfile: string
+}

--- a/packages/core/src/security/types.ts
+++ b/packages/core/src/security/types.ts
@@ -6,9 +6,6 @@
 //      can import a single source of truth.
 //   2. Promoting them to `Schema.Struct` later (for a Scope-B Effect
 //      RPC migration) is a local refactor, not a consumer rewrite.
-//
-// See `~/Documents/dev-docs/spool/2026-05-18-security-scan-design.md`
-// for the full design — schema, surfaces, and Effect TS scoping.
 
 import type { SensitiveKind } from '@spool-lab/redact'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@spool-lab/redact':
+        specifier: workspace:*
+        version: link:../redact
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0


### PR DESCRIPTION
## What

Schema migration **v12** for the Security Scan feature. Adds five denormalised counter columns to `sessions`, one `findings` audit table, and two `allowlist_*` tables. Also introduces `packages/core/src/security/types.ts` — the cross-boundary payload definitions shared by worker, IPC, and renderer.

Pure data layer — no scanning logic yet. The worker (next branch in the stack) reads/writes against this schema.

## Why

A separate "find sensitive data in indexed sessions" feature can't piggy-back on existing tables:
- **Finding rows are immutable history** (when did regex `v3` first detect this token in session 42?) — needs a sidecar table, not a column.
- **Counts feed multiple surfaces** (Library row badge, Security page list, sidebar nav badge) — denormalised counters are cheap to render and queryable without a join.
- **Allowlists have two scopes** (per-session vs global) — can't be modelled with one table without nullable session_id everywhere.
- **Audit-positive**: even after Purge rewrites the raw value, the finding row stays as `state='purged'` so the user can answer "what was leaked, when, where".

## Schema

```mermaid
erDiagram
    sessions ||--o{ findings : "1:N"
    sessions ||--o{ allowlist_session : "1:N"
    findings }o--|| messages : "0/1:1"

    sessions {
        INTEGER id PK
        TEXT scan_profile
        TEXT scan_completed_at
        INTEGER scan_finding_count
        INTEGER scan_high_count
        INTEGER scan_purged_count
    }

    findings {
        INTEGER id PK
        INTEGER session_id FK
        INTEGER message_id FK
        TEXT kind
        TEXT value_hash
        REAL confidence
        TEXT provider
        INTEGER start_offset
        INTEGER end_offset
        TEXT state
        TEXT detected_at
        TEXT state_changed_at
    }

    allowlist_session {
        INTEGER session_id PK
        TEXT kind PK
        TEXT value_hash PK
        TEXT created_at
    }

    allowlist_global {
        TEXT kind PK
        TEXT value_hash PK
        TEXT created_at
    }
```

### Counter columns on `sessions`

| Column | Semantics |
| --- | --- |
| `scan_profile` | Identifier of the detector set + version that produced the current findings. `NULL` = never scanned, `'regex@4'` = current, `'regex@3,pf@1.5b'` = stale → enqueue rescan. |
| `scan_completed_at` | ISO timestamp of the last successful scan. Combined with `findingCount=0 + purgedCount>0`, drives the Library row's "all-resolved" checkmark — distinguishes "never had findings" (no badge) from "was clean after I cleaned it up" (✓). |
| `scan_finding_count` | Active findings of any severity. Drives the badge presence test. |
| `scan_high_count` | Active findings of severity=high. Drives the badge tone (amber vs muted). |
| `scan_purged_count` | Lifetime tally of `state='purged'` rows — monotonically increasing audit signal. |

All maintained by `updateSessionCounts(db, sessionId)` after every insert / dismiss / purge.

### `findings` design choices

- **`value_hash`, not `value`** — the raw secret never lands in a sidecar table. The Security page reads the value on-demand via `getFindingValue(findingId)` which slices `messages.content_text[start..end]`. After Purge, that slice is the mask; the finding row plus its hash remains as audit.
- **`state CHECK`** — DB-level enforcement so a buggy IPC handler can't write a fourth state value. Allowed values: `active`, `dismissed`, `purged`.
- **`ON DELETE CASCADE`** from `sessions` and `messages` — if a session is deleted (project removal, file unlink), its findings vanish too; no orphans to garbage-collect.
- **Indexes**:
  - `idx_findings_session` — page list groups by session.
  - `idx_findings_state` — filtering "show me active" is the hot path.
  - `idx_findings_kind_hash` — allowlist lookups join `(kind, value_hash)`.

### Allowlist split

Two tables, never one. A finding is allowlisted if EITHER `(kind, hash)` is in `allowlist_global` OR `(session_id, kind, hash)` is in `allowlist_session`. The composite PKs forbid duplicates without a unique index.

## Migration safety

The entire v12 block is wrapped in `db.transaction(() => …)()`:

```mermaid
sequenceDiagram
    participant App
    participant DB as SQLite
    App->>DB: BEGIN
    App->>DB: ALTER TABLE sessions ADD COLUMN scan_profile
    App->>DB: ALTER TABLE sessions ADD COLUMN scan_completed_at
    App->>DB: ALTER TABLE sessions ADD COLUMN scan_finding_count
    App->>DB: ALTER TABLE sessions ADD COLUMN scan_high_count
    App->>DB: ALTER TABLE sessions ADD COLUMN scan_purged_count
    App->>DB: CREATE TABLE findings + indexes
    App->>DB: CREATE TABLE allowlist_session
    App->>DB: CREATE TABLE allowlist_global
    App->>DB: pragma user_version = 12
    App->>DB: COMMIT
    Note over App,DB: any failure between BEGIN and COMMIT rolls back — user_version stays 11 and the next launch retries cleanly
```

Without the transaction, a partial v12 — say two ALTERs landed but the third failed — would auto-commit the first two and leave `user_version` at 11. The next launch retries from the first ALTER and trips a `duplicate column` error, bricking the app permanently. The regression test in `migration-v12.test.ts` simulates this exact scenario.

## `security/types.ts` cross-boundary contract

Lives next to `db.ts` so the worker, IPC adapters, and renderer hooks import a single source of truth.

```ts
export type FindingState = 'active' | 'dismissed' | 'purged'

export interface FindingRow { /* camelCase mirror of DB row */ }

export interface SessionWithFindingCounts {
  // session id + uuid + meta
  // findingCount / highCount / purgedCount
  // scanCompletedAt
  // source, cwd, projectDisplayName, model — joined for the page list
}

export interface RiskByCategoryRow {
  kind: SensitiveKind
  severity: Severity
  count: number    // active findings
  sessions: number // distinct sessions affected
}

export type FindingsChange =
  | { kind: 'inserted'; sessionId; findingIds }
  | { kind: 'state-changed'; findingId; from; to }
  | { kind: 'purged'; sessionId; findingId; maskUsed }
  | { kind: 'rescan-started'; sessionId }
  | { kind: 'rescan-completed'; sessionId; insertedCount }
```

The `FindingsChange` discriminated union is the wire format the worker publishes to a PubSub; the main process forwards each event over `security:evt-findings-changed`; the renderer reduces it into the page state.

## CI

This PR also reorders the `e2e.yml` workflow to build `@spool-lab/redact` before `@spool-lab/core`. Without that change, tsc on `security/types.ts` can't resolve the `@spool-lab/redact` import because redact's `dist/` doesn't exist yet at the moment core builds.

## Test plan

- [x] `migration-v12.test.ts` (9 tests) — fresh install lands at v12; v11→v12 preserves existing data; partial-failure rollback regression; counter columns default to 0; all five indexes present; allowlist composite PKs forbid duplicates.
- [x] `migration-smoke.test.ts` — new-user + upgrade-from-each-prior-version paths reach head + DB is functional.
- [x] `repo.test.ts` (25 tests) — moved here so types/queries stay together: insertFindings dedup, updateSessionCounts arithmetic, listSessionsWithFindings join shape, allowlist add/remove/list, dismiss/undismiss/purge state transitions.

