### PR TITLE
feat(security): top-level Security page + session strip + Dismiss

### DIFF
--- a/packages/app/src/main/ipc/security.ts
+++ b/packages/app/src/main/ipc/security.ts
@@ -12,6 +12,8 @@ import {
   listSessionsWithFindings,
   riskByCategory,
   getFindingValue,
+  dismissFinding,
+  undismissFinding,
   type FindingFilter,
   type SessionFindingFilter,
   type ScanWorker,
@@ -27,6 +29,12 @@ export const SECURITY_IPC_CHANNELS = {
   RISK_BY_CATEGORY:            'security:risk-by-category',
   GET_FINDING_VALUE:           'security:get-finding-value',
   GET_SCAN_STATUS:             'security:get-scan-status',
+
+  // mutations
+  DISMISS_FINDING:             'security:dismiss-finding',
+  UNDISMISS_FINDING:           'security:undismiss-finding',
+  RESCAN_ALL:                  'security:rescan-all',
+  RESCAN_SESSION:              'security:rescan-session',
 
   // events (push: main → renderer via webContents.send)
   EVT_FINDINGS_CHANGED:        'security:evt-findings-changed',
@@ -63,6 +71,27 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
   )
   ipcMain.handle(SECURITY_IPC_CHANNELS.GET_SCAN_STATUS, () =>
     runPromise(worker.getStatus),
+  )
+
+  ipcMain.handle(
+    SECURITY_IPC_CHANNELS.DISMISS_FINDING,
+    (_e, args: { findingId: number; scope: 'session' | 'global' }) => {
+      dismissFinding(db, args.findingId, args.scope)
+      return { ok: true }
+    },
+  )
+  ipcMain.handle(
+    SECURITY_IPC_CHANNELS.UNDISMISS_FINDING,
+    (_e, args: { findingId: number }) => {
+      undismissFinding(db, args.findingId)
+      return { ok: true }
+    },
+  )
+  ipcMain.handle(SECURITY_IPC_CHANNELS.RESCAN_ALL, () =>
+    runPromise(worker.rescanAll()).then((count) => ({ count })),
+  )
+  ipcMain.handle(SECURITY_IPC_CHANNELS.RESCAN_SESSION, (_e, sessionId: number) =>
+    runPromise(worker.enqueue(sessionId)).then(() => ({ ok: true })),
   )
 
   // Forward worker change events to the renderer. The subscriber runs

--- a/packages/app/src/main/ipc/security.ts
+++ b/packages/app/src/main/ipc/security.ts
@@ -12,6 +12,7 @@ import {
   listSessionsWithFindings,
   riskByCategory,
   getFindingValue,
+  getFindingValues,
   dismissFinding,
   undismissFinding,
   type FindingFilter,
@@ -28,6 +29,7 @@ export const SECURITY_IPC_CHANNELS = {
   LIST_SESSIONS_WITH_FINDINGS: 'security:list-sessions-with-findings',
   RISK_BY_CATEGORY:            'security:risk-by-category',
   GET_FINDING_VALUE:           'security:get-finding-value',
+  GET_FINDING_VALUES:          'security:get-finding-values',
   GET_SCAN_STATUS:             'security:get-scan-status',
 
   // mutations
@@ -68,6 +70,9 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
   )
   ipcMain.handle(SECURITY_IPC_CHANNELS.GET_FINDING_VALUE, (_e, findingId: number) =>
     getFindingValue(db, findingId),
+  )
+  ipcMain.handle(SECURITY_IPC_CHANNELS.GET_FINDING_VALUES, (_e, ids: number[]) =>
+    getFindingValues(db, ids),
   )
   ipcMain.handle(SECURITY_IPC_CHANNELS.GET_SCAN_STATUS, () =>
     runPromise(worker.getStatus),

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -219,6 +219,8 @@ const api = {
       ipcRenderer.invoke('security:risk-by-category'),
     getFindingValue: (findingId: number): Promise<string | null> =>
       ipcRenderer.invoke('security:get-finding-value', findingId),
+    getFindingValues: (ids: number[]): Promise<Record<number, string | null>> =>
+      ipcRenderer.invoke('security:get-finding-values', ids),
     getScanStatus: (): Promise<ScanStatus> =>
       ipcRenderer.invoke('security:get-scan-status'),
     dismissFinding: (findingId: number, scope: 'session' | 'global'): Promise<{ ok: boolean }> =>

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -209,8 +209,7 @@ const api = {
   printToPdf: (html: string, widthPx: number, heightPx: number): Promise<Uint8Array> =>
     ipcRenderer.invoke('spool:print-to-pdf', { html, widthPx, heightPx }),
 
-  // Security Scan — query surface. Mutations (dismiss, purge, rescan)
-  // arrive in later PRs.
+  // Security Scan — query + dismiss + rescan surface. Purge arrives in PR 4.
   security: {
     listFindings: (filter: FindingFilter): Promise<FindingRow[]> =>
       ipcRenderer.invoke('security:list-findings', filter),
@@ -222,6 +221,14 @@ const api = {
       ipcRenderer.invoke('security:get-finding-value', findingId),
     getScanStatus: (): Promise<ScanStatus> =>
       ipcRenderer.invoke('security:get-scan-status'),
+    dismissFinding: (findingId: number, scope: 'session' | 'global'): Promise<{ ok: boolean }> =>
+      ipcRenderer.invoke('security:dismiss-finding', { findingId, scope }),
+    undismissFinding: (findingId: number): Promise<{ ok: boolean }> =>
+      ipcRenderer.invoke('security:undismiss-finding', { findingId }),
+    rescanAll: (): Promise<{ count: number }> =>
+      ipcRenderer.invoke('security:rescan-all'),
+    rescanSession: (sessionId: number): Promise<{ ok: boolean }> =>
+      ipcRenderer.invoke('security:rescan-session', sessionId),
     onFindingsChanged: (cb: (change: FindingsChange) => void) => {
       const handler = (_: Electron.IpcRendererEvent, data: unknown) => cb(data as FindingsChange)
       ipcRenderer.on('security:evt-findings-changed', handler)

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -16,6 +16,7 @@ import AppTopBar from './components/AppTopBar.js'
 import SidebarRail from './components/SidebarRail.js'
 import AppToaster from './components/AppToaster.js'
 import SharesPage from './components/SharesPage.js'
+import SecurityPage from './components/SecurityPage.js'
 import ShareEditorPage from './components/ShareEditorPage.js'
 import { composeFromSession, sessionDraftId } from './lib/compose-from-session.js'
 import { draftIdForImport } from './lib/import-spool.js'
@@ -35,7 +36,7 @@ import { useLanguageBootstrap } from './i18n/useLanguageBootstrap.js'
 import type { LanguagePreference } from '../preload/index.js'
 import { useFeature } from './featureFlags.js'
 
-type View = 'search' | 'session' | 'shares' | 'share-editor'
+type View = 'search' | 'session' | 'shares' | 'share-editor' | 'security'
 type SettingsTab = 'general' | 'appearance' | 'shortcuts' | 'sources' | 'agent' | 'labs'
 
 type FragmentSearchResult = FragmentResult & { kind: 'fragment' }
@@ -305,6 +306,7 @@ export default function App() {
   const showSearchResults = view === 'search' && !selectedSession && !!query.trim()
   const isHomeMode = homeMode && view === 'search' && !selectedSession && !showProjectView && !showSearchResults
   const isSharesView = shareEnabled && view === 'shares'
+  const isSecurityView = view === 'security'
   const isShareEditorView = shareEnabled && view === 'share-editor'
 
   // Bounce out of share-only views when the user disables the flag from
@@ -761,6 +763,16 @@ export default function App() {
         },
       } : {})}
       isSharesActive={isSharesView}
+      onSelectSecurity={() => {
+        setSelectedSession(null)
+        setTargetMessageId(null)
+        setActiveProjectKey(null)
+        setActiveProjectName(null)
+        setHomeMode(false)
+        setView('security')
+        setQuery('')
+      }}
+      isSecurityActive={isSecurityView}
       onOpenSearch={handleSearchOpen}
       syncStatus={syncStatus}
       status={status}
@@ -899,6 +911,8 @@ export default function App() {
             {...(shareEnabled ? { onImportSpool: handleImportSpoolFile } : {})}
             {...(shareEnabled ? { onStartNewDraft: handleStartShareFromUuid } : {})}
           />
+        ) : isSecurityView ? (
+          <SecurityPage onOpenSession={handleOpenSession} />
         ) : isHomeMode ? (
           <LibraryLanding
             onSelectProject={(key) => {

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -889,6 +889,16 @@ export default function App() {
           },
         } : {})}
         isSharesActive={isSharesView}
+        onSelectSecurity={() => {
+          setSelectedSession(null)
+          setTargetMessageId(null)
+          setActiveProjectKey(null)
+          setActiveProjectName(null)
+          setHomeMode(false)
+          setView('security')
+          setQuery('')
+        }}
+        isSecurityActive={isSecurityView}
         onOpenSearch={handleSearchOpen}
         syncStatus={syncStatus}
         status={status}

--- a/packages/app/src/renderer/api/security.ts
+++ b/packages/app/src/renderer/api/security.ts
@@ -30,6 +30,13 @@ export const securityApi = {
   getScanStatus: (): Promise<ScanStatus> =>
     window.spool.security.getScanStatus(),
 
+  dismissFinding: (findingId: number, scope: 'session' | 'global') =>
+    window.spool.security.dismissFinding(findingId, scope),
+  undismissFinding: (findingId: number) =>
+    window.spool.security.undismissFinding(findingId),
+  rescanAll: () => window.spool.security.rescanAll(),
+  rescanSession: (sessionId: number) => window.spool.security.rescanSession(sessionId),
+
   onChange: (handler: (c: FindingsChange) => void): (() => void) =>
     window.spool.security.onFindingsChanged(handler),
   onScanStatus: (handler: (s: ScanStatus) => void): (() => void) =>

--- a/packages/app/src/renderer/api/security.ts
+++ b/packages/app/src/renderer/api/security.ts
@@ -27,6 +27,8 @@ export const securityApi = {
     window.spool.security.riskByCategory(),
   getFindingValue: (findingId: number): Promise<string | null> =>
     window.spool.security.getFindingValue(findingId),
+  getFindingValues: (ids: number[]): Promise<Record<number, string | null>> =>
+    window.spool.security.getFindingValues(ids),
   getScanStatus: (): Promise<ScanStatus> =>
     window.spool.security.getScanStatus(),
 

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -1,0 +1,303 @@
+// Top-level Security Scan page — peer to Library / Search.
+//
+// Watchtower-style layout: Risk panel (categories with active counts)
+// up top, then a list of sessions that have findings. Each row offers
+// per-finding Dismiss actions; Purge ships in PR 4.
+//
+// Keep the component flat and small for now. The full filter-bar /
+// qualifier parser / kind allowlist UI is deferred — this surface
+// already lets a user see what was found, click into the session,
+// and dismiss things.
+
+import { useCallback, useEffect, useState } from 'react'
+import { AlertTriangle, ShieldAlert, RotateCw, X } from 'lucide-react'
+import type {
+  FindingRow,
+  RiskByCategoryRow,
+  SessionWithFindingCounts,
+} from '@spool-lab/core'
+import { securityApi } from '../api/security.js'
+
+interface Props {
+  onOpenSession: (sessionUuid: string) => void
+}
+
+export default function SecurityPage({ onOpenSession }: Props) {
+  const [risk, setRisk] = useState<RiskByCategoryRow[]>([])
+  const [sessions, setSessions] = useState<SessionWithFindingCounts[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    try {
+      const [r, s] = await Promise.all([
+        securityApi.riskByCategory(),
+        securityApi.listSessionsWithFindings({}),
+      ])
+      setRisk(r)
+      setSessions(s)
+      setLoading(false)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+    const off = securityApi.onChange(() => { void refresh() })
+    return () => { off() }
+  }, [refresh])
+
+  async function handleRescanAll() {
+    await securityApi.rescanAll()
+    void refresh()
+  }
+
+  if (loading) {
+    return <div className="p-8 text-warm-muted dark:text-dark-muted">Loading…</div>
+  }
+  if (error) {
+    return <div className="p-8 text-red-600 dark:text-red-400">Security page failed to load: {error}</div>
+  }
+
+  const highCats = risk.filter(r => r.severity === 'high')
+  const lowCats = risk.filter(r => r.severity === 'low')
+  const totalActive = risk.reduce((acc, r) => acc + r.count, 0)
+  const totalSessions = sessions.length
+
+  return (
+    <div className="flex-1 overflow-y-auto px-8 py-6 max-w-5xl mx-auto w-full">
+      <header className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <ShieldAlert
+            size={24}
+            strokeWidth={1.5}
+            className="text-warm-accent dark:text-dark-accent"
+            aria-hidden
+          />
+          <h1 className="text-2xl font-medium text-warm-text dark:text-dark-text">Security</h1>
+        </div>
+        <button
+          type="button"
+          data-testid="security-rescan-all"
+          onClick={handleRescanAll}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm border border-warm-border dark:border-dark-border hover:bg-warm-surface dark:hover:bg-dark-surface transition"
+        >
+          <RotateCw size={14} strokeWidth={1.75} aria-hidden />
+          Rescan all
+        </button>
+      </header>
+
+      <section
+        data-testid="security-risk-panel"
+        className="rounded-lg border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg-2 p-5 mb-6"
+      >
+        <p className="text-sm text-warm-muted dark:text-dark-muted mb-3">
+          {totalActive} active finding{totalActive === 1 ? '' : 's'} across {totalSessions} session{totalSessions === 1 ? '' : 's'}
+        </p>
+
+        {highCats.length > 0 && (
+          <div className="mb-3">
+            <div className="flex items-center gap-2 text-sm font-medium text-warm-text dark:text-dark-text mb-2">
+              <AlertTriangle size={14} className="text-warm-accent dark:text-dark-accent" aria-hidden />
+              High
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {highCats.map(c => (
+                <CategoryChip key={c.kind} kind={c.kind} count={c.count} severity="high" />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {lowCats.length > 0 && (
+          <details className="text-sm">
+            <summary className="cursor-pointer text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition">
+              ▸ Low ({lowCats.length} categor{lowCats.length === 1 ? 'y' : 'ies'},
+              {' '}{lowCats.reduce((a, c) => a + c.count, 0)} items)
+            </summary>
+            <div className="flex flex-wrap gap-2 mt-2">
+              {lowCats.map(c => (
+                <CategoryChip key={c.kind} kind={c.kind} count={c.count} severity="low" />
+              ))}
+            </div>
+          </details>
+        )}
+
+        {risk.length === 0 && (
+          <p className="text-sm text-warm-muted dark:text-dark-muted">No active findings.</p>
+        )}
+      </section>
+
+      <section data-testid="security-session-list">
+        <h2 className="text-sm uppercase tracking-wide text-warm-muted dark:text-dark-muted mb-2">
+          Sessions with findings
+        </h2>
+        {sessions.length === 0 ? (
+          <p className="text-sm text-warm-muted dark:text-dark-muted">No sessions have findings yet.</p>
+        ) : (
+          <ul className="divide-y divide-warm-border dark:divide-dark-border border border-warm-border dark:border-dark-border rounded-lg overflow-hidden">
+            {sessions.map(s => (
+              <SecuritySessionRow
+                key={s.id}
+                session={s}
+                onOpen={() => onOpenSession(s.sessionUuid)}
+                onRefresh={refresh}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}
+
+function CategoryChip({ kind, count, severity }: { kind: string; count: number; severity: 'high' | 'low' }) {
+  const cls = severity === 'high'
+    ? 'bg-warm-surface dark:bg-dark-surface text-warm-text dark:text-dark-text border-warm-accent/40 dark:border-dark-accent/40'
+    : 'bg-warm-surface dark:bg-dark-surface text-warm-muted dark:text-dark-muted border-warm-border dark:border-dark-border'
+  return (
+    <span
+      data-testid="risk-category-chip"
+      data-kind={kind}
+      data-severity={severity}
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded border text-xs ${cls}`}
+    >
+      <span>{kind}</span>
+      <span className="text-warm-muted dark:text-dark-muted">·</span>
+      <span className="font-mono">{count}</span>
+    </span>
+  )
+}
+
+function SecuritySessionRow({
+  session,
+  onOpen,
+  onRefresh,
+}: {
+  session: SessionWithFindingCounts
+  onOpen: () => void
+  onRefresh: () => void
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const [findings, setFindings] = useState<FindingRow[] | null>(null)
+
+  async function toggle() {
+    const next = !expanded
+    setExpanded(next)
+    if (next && findings === null) {
+      const rows = await securityApi.listFindings({ sessionId: session.id })
+      setFindings(rows)
+    }
+  }
+
+  return (
+    <li className="px-4 py-3">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={toggle}
+          className="text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text"
+          aria-expanded={expanded}
+        >
+          {expanded ? '▾' : '▸'}
+        </button>
+        <button
+          type="button"
+          onClick={onOpen}
+          className="flex-1 text-left min-w-0"
+        >
+          <span className="block truncate font-medium text-warm-text dark:text-dark-text">
+            {session.title ?? '(untitled)'}
+          </span>
+          <span className="block text-xs text-warm-muted dark:text-dark-muted">
+            {new Date(session.startedAt).toLocaleString()} ·{' '}
+            {session.highCount > 0 && (
+              <span className="text-warm-accent dark:text-dark-accent">
+                {session.highCount} high
+              </span>
+            )}
+            {session.highCount > 0 && session.findingCount > session.highCount ? ' · ' : ''}
+            {session.findingCount > session.highCount && (
+              <span>{session.findingCount - session.highCount} low</span>
+            )}
+          </span>
+        </button>
+      </div>
+      {expanded && findings && (
+        <div className="mt-3 ml-6 space-y-1">
+          {findings.map(f => (
+            <FindingRowView key={f.id} finding={f} onChange={() => { setFindings(null); onRefresh() }} />
+          ))}
+        </div>
+      )}
+    </li>
+  )
+}
+
+function FindingRowView({
+  finding,
+  onChange,
+}: {
+  finding: FindingRow
+  onChange: () => void
+}) {
+  const [value, setValue] = useState<string | null>(null)
+
+  useEffect(() => {
+    securityApi.getFindingValue(finding.id).then(setValue).catch(() => setValue(null))
+  }, [finding.id])
+
+  async function dismiss(scope: 'session' | 'global') {
+    await securityApi.dismissFinding(finding.id, scope)
+    onChange()
+  }
+
+  return (
+    <div
+      data-testid="finding-row"
+      data-finding-id={finding.id}
+      data-kind={finding.kind}
+      className="flex items-center gap-2 text-sm py-1"
+    >
+      <span className="font-mono text-xs text-warm-muted dark:text-dark-muted w-32 truncate">
+        {finding.kind}
+      </span>
+      <span className="font-mono text-xs flex-1 truncate text-warm-text dark:text-dark-text">
+        {value ?? <em className="text-warm-faint dark:text-dark-faint">(unavailable)</em>}
+      </span>
+      <span className="text-xs text-warm-faint dark:text-dark-faint">
+        {finding.provider}
+      </span>
+      {finding.state === 'active' ? (
+        <>
+          <button
+            type="button"
+            data-testid="dismiss-in-session"
+            onClick={() => { void dismiss('session') }}
+            className="text-xs px-2 py-0.5 rounded hover:bg-warm-surface dark:hover:bg-dark-surface"
+            title="Dismiss in this session"
+          >
+            Dismiss in session
+          </button>
+          <button
+            type="button"
+            data-testid="dismiss-everywhere"
+            onClick={() => { void dismiss('global') }}
+            className="text-xs px-2 py-0.5 rounded hover:bg-warm-surface dark:hover:bg-dark-surface"
+            title="Dismiss everywhere"
+          >
+            Everywhere
+          </button>
+        </>
+      ) : (
+        <span className="inline-flex items-center gap-1 text-xs text-warm-muted dark:text-dark-muted">
+          <X size={12} aria-hidden />
+          {finding.state}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -2,15 +2,12 @@
 //
 // Watchtower-style layout: Risk panel (categories with active counts)
 // up top, then a list of sessions that have findings. Each row offers
-// per-finding Dismiss actions; Purge ships in PR 4.
-//
-// Keep the component flat and small for now. The full filter-bar /
-// qualifier parser / kind allowlist UI is deferred — this surface
-// already lets a user see what was found, click into the session,
-// and dismiss things.
+// per-finding Dismiss actions; bulk Purge ships when the purge PR
+// merges.
 
-import { useCallback, useEffect, useState } from 'react'
-import { AlertTriangle, ShieldAlert, RotateCw, X } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { AlertTriangle, ChevronDown, ChevronRight, ShieldAlert, RotateCw } from 'lucide-react'
 import type {
   FindingRow,
   RiskByCategoryRow,
@@ -22,46 +19,76 @@ interface Props {
   onOpenSession: (sessionUuid: string) => void
 }
 
+// 300ms trailing debounce for onChange-driven refreshes. backfill of N
+// sessions publishes N change events; without coalescing, each one
+// kicks two IPC calls (riskByCategory + listSessionsWithFindings) and
+// a state replace + re-render. Trailing-edge so we still feel live
+// (toggle a mute → see the page update under 300ms) without storming.
+const REFRESH_DEBOUNCE_MS = 300
+
+type PageState =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ready'; risk: RiskByCategoryRow[]; sessions: SessionWithFindingCounts[] }
+
 export default function SecurityPage({ onOpenSession }: Props) {
-  const [risk, setRisk] = useState<RiskByCategoryRow[]>([])
-  const [sessions, setSessions] = useState<SessionWithFindingCounts[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const { t } = useTranslation()
+  const [state, setState] = useState<PageState>({ kind: 'loading' })
 
   const refresh = useCallback(async () => {
     try {
-      const [r, s] = await Promise.all([
+      const [risk, sessions] = await Promise.all([
         securityApi.riskByCategory(),
         securityApi.listSessionsWithFindings({}),
       ])
-      setRisk(r)
-      setSessions(s)
-      setLoading(false)
-      setError(null)
+      setState({ kind: 'ready', risk, sessions })
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-      setLoading(false)
+      setState({ kind: 'error', message: err instanceof Error ? err.message : String(err) })
     }
   }, [])
 
   useEffect(() => {
     void refresh()
-    const off = securityApi.onChange(() => { void refresh() })
-    return () => { off() }
   }, [refresh])
 
-  async function handleRescanAll() {
+  // Subscribe to scan events, but coalesce the refresh — see comment
+  // on REFRESH_DEBOUNCE_MS.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const off = securityApi.onChange(() => {
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        timer = null
+        void refresh()
+      }, REFRESH_DEBOUNCE_MS)
+    })
+    return () => {
+      if (timer) clearTimeout(timer)
+      off()
+    }
+  }, [refresh])
+
+  const handleRescanAll = useCallback(async () => {
     await securityApi.rescanAll()
     void refresh()
+  }, [refresh])
+
+  if (state.kind === 'loading') {
+    return (
+      <div className="p-8 text-warm-muted dark:text-dark-muted">
+        {t('common.loading', { defaultValue: 'Loading…' })}
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="p-8 text-red-600 dark:text-red-400">
+        {t('security.loadFailed', { defaultValue: 'Security page failed to load: {{message}}', message: state.message })}
+      </div>
+    )
   }
 
-  if (loading) {
-    return <div className="p-8 text-warm-muted dark:text-dark-muted">Loading…</div>
-  }
-  if (error) {
-    return <div className="p-8 text-red-600 dark:text-red-400">Security page failed to load: {error}</div>
-  }
-
+  const { risk, sessions } = state
   const highCats = risk.filter(r => r.severity === 'high')
   const lowCats = risk.filter(r => r.severity === 'low')
   const totalActive = risk.reduce((acc, r) => acc + r.count, 0)
@@ -74,19 +101,21 @@ export default function SecurityPage({ onOpenSession }: Props) {
           <ShieldAlert
             size={24}
             strokeWidth={1.5}
-            className="text-warm-accent dark:text-dark-accent"
+            className="text-accent dark:text-accent-dark"
             aria-hidden
           />
-          <h1 className="text-2xl font-medium text-warm-text dark:text-dark-text">Security</h1>
+          <h1 className="text-2xl font-medium text-warm-text dark:text-dark-text">
+            {t('security.title', { defaultValue: 'Security' })}
+          </h1>
         </div>
         <button
           type="button"
           data-testid="security-rescan-all"
-          onClick={handleRescanAll}
+          onClick={() => { void handleRescanAll() }}
           className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm border border-warm-border dark:border-dark-border hover:bg-warm-surface dark:hover:bg-dark-surface transition"
         >
           <RotateCw size={14} strokeWidth={1.75} aria-hidden />
-          Rescan all
+          {t('security.rescanAll', { defaultValue: 'Rescan all' })}
         </button>
       </header>
 
@@ -95,14 +124,18 @@ export default function SecurityPage({ onOpenSession }: Props) {
         className="rounded-lg border border-warm-border dark:border-dark-border bg-warm-bg dark:bg-dark-bg-2 p-5 mb-6"
       >
         <p className="text-sm text-warm-muted dark:text-dark-muted mb-3">
-          {totalActive} active finding{totalActive === 1 ? '' : 's'} across {totalSessions} session{totalSessions === 1 ? '' : 's'}
+          {t('security.summary', {
+            defaultValue: '{{findings}} active across {{sessions}} sessions',
+            findings: totalActive,
+            sessions: totalSessions,
+          })}
         </p>
 
         {highCats.length > 0 && (
           <div className="mb-3">
             <div className="flex items-center gap-2 text-sm font-medium text-warm-text dark:text-dark-text mb-2">
-              <AlertTriangle size={14} className="text-warm-accent dark:text-dark-accent" aria-hidden />
-              High
+              <AlertTriangle size={14} className="text-accent dark:text-accent-dark" aria-hidden />
+              {t('security.severityHigh', { defaultValue: 'High' })}
             </div>
             <div className="flex flex-wrap gap-2">
               {highCats.map(c => (
@@ -113,30 +146,24 @@ export default function SecurityPage({ onOpenSession }: Props) {
         )}
 
         {lowCats.length > 0 && (
-          <details className="text-sm">
-            <summary className="cursor-pointer text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition">
-              ▸ Low ({lowCats.length} categor{lowCats.length === 1 ? 'y' : 'ies'},
-              {' '}{lowCats.reduce((a, c) => a + c.count, 0)} items)
-            </summary>
-            <div className="flex flex-wrap gap-2 mt-2">
-              {lowCats.map(c => (
-                <CategoryChip key={c.kind} kind={c.kind} count={c.count} severity="low" />
-              ))}
-            </div>
-          </details>
+          <LowCategoriesGroup categories={lowCats} />
         )}
 
         {risk.length === 0 && (
-          <p className="text-sm text-warm-muted dark:text-dark-muted">No active findings.</p>
+          <p className="text-sm text-warm-muted dark:text-dark-muted">
+            {t('security.noFindings', { defaultValue: 'No active findings.' })}
+          </p>
         )}
       </section>
 
       <section data-testid="security-session-list">
-        <h2 className="text-sm uppercase tracking-wide text-warm-muted dark:text-dark-muted mb-2">
-          Sessions with findings
+        <h2 className="text-xs uppercase tracking-wide text-warm-muted dark:text-dark-muted mb-2">
+          {t('security.sessionsWithFindings', { defaultValue: 'Sessions with findings' })}
         </h2>
         {sessions.length === 0 ? (
-          <p className="text-sm text-warm-muted dark:text-dark-muted">No sessions have findings yet.</p>
+          <p className="text-sm text-warm-muted dark:text-dark-muted">
+            {t('security.noSessions', { defaultValue: 'No sessions have findings yet.' })}
+          </p>
         ) : (
           <ul className="divide-y divide-warm-border dark:divide-dark-border border border-warm-border dark:border-dark-border rounded-lg overflow-hidden">
             {sessions.map(s => (
@@ -144,7 +171,6 @@ export default function SecurityPage({ onOpenSession }: Props) {
                 key={s.id}
                 session={s}
                 onOpen={() => onOpenSession(s.sessionUuid)}
-                onRefresh={refresh}
               />
             ))}
           </ul>
@@ -154,9 +180,41 @@ export default function SecurityPage({ onOpenSession }: Props) {
   )
 }
 
+function LowCategoriesGroup({ categories }: { categories: RiskByCategoryRow[] }) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const total = categories.reduce((a, c) => a + c.count, 0)
+  return (
+    <div className="text-sm">
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        aria-expanded={open}
+        className="inline-flex items-center gap-1.5 text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text transition"
+      >
+        {open
+          ? <ChevronDown size={12} strokeWidth={1.75} aria-hidden />
+          : <ChevronRight size={12} strokeWidth={1.75} aria-hidden />}
+        {t('security.lowGroupLabel', {
+          defaultValue: 'Low ({{categories}} categories, {{items}} items)',
+          categories: categories.length,
+          items: total,
+        })}
+      </button>
+      {open && (
+        <div className="flex flex-wrap gap-2 mt-2">
+          {categories.map(c => (
+            <CategoryChip key={c.kind} kind={c.kind} count={c.count} severity="low" />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 function CategoryChip({ kind, count, severity }: { kind: string; count: number; severity: 'high' | 'low' }) {
   const cls = severity === 'high'
-    ? 'bg-warm-surface dark:bg-dark-surface text-warm-text dark:text-dark-text border-warm-accent/40 dark:border-dark-accent/40'
+    ? 'bg-warm-surface dark:bg-dark-surface text-warm-text dark:text-dark-text border-accent/40 dark:border-accent-dark/40'
     : 'bg-warm-surface dark:bg-dark-surface text-warm-muted dark:text-dark-muted border-warm-border dark:border-dark-border'
   return (
     <span
@@ -175,62 +233,121 @@ function CategoryChip({ kind, count, severity }: { kind: string; count: number; 
 function SecuritySessionRow({
   session,
   onOpen,
-  onRefresh,
 }: {
   session: SessionWithFindingCounts
   onOpen: () => void
-  onRefresh: () => void
 }) {
+  const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
   const [findings, setFindings] = useState<FindingRow[] | null>(null)
+  const [values, setValues] = useState<Record<number, string | null>>({})
 
-  async function toggle() {
-    const next = !expanded
-    setExpanded(next)
-    if (next && findings === null) {
-      const rows = await securityApi.listFindings({ sessionId: session.id })
-      setFindings(rows)
+  const loadFindings = useCallback(async () => {
+    const rows = await securityApi.listFindings({ sessionId: session.id })
+    setFindings(rows)
+    // Bulk-fetch values in one IPC instead of one-per-row useEffect.
+    if (rows.length > 0) {
+      const map = await securityApi.getFindingValues(rows.map(r => r.id))
+      setValues(map)
     }
-  }
+  }, [session.id])
+
+  useEffect(() => {
+    if (!expanded || findings !== null) return
+    void loadFindings()
+  }, [expanded, findings, loadFindings])
+
+  // Optimistic dismiss: drop the row from local state immediately so
+  // the user sees the action take effect without waiting on the
+  // round-trip + re-fetch. The worker's onChange fires anyway and the
+  // parent debounces a refresh.
+  const handleDismiss = useCallback(async (findingId: number, scope: 'session' | 'global') => {
+    setFindings(prev => prev?.filter(f => f.id !== findingId) ?? null)
+    try {
+      await securityApi.dismissFinding(findingId, scope)
+    } catch {
+      // Rollback on failure — reload the authoritative list.
+      void loadFindings()
+    }
+  }, [loadFindings])
+
+  const titleText = session.title?.trim() || t('session.noTitle', { defaultValue: '(untitled)' })
 
   return (
     <li className="px-4 py-3">
+      {/* One row, two click zones. Each zone is its own button so
+       *  there are no nested buttons; data-testid covers either way. */}
       <div className="flex items-center gap-3">
         <button
           type="button"
-          onClick={toggle}
-          className="text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text"
+          data-testid="security-row-toggle"
+          onClick={() => setExpanded(v => !v)}
           aria-expanded={expanded}
+          aria-label={expanded
+            ? t('common.collapse', { defaultValue: 'Collapse' })
+            : t('common.expand', { defaultValue: 'Expand' })}
+          className="inline-flex items-center justify-center w-5 h-5 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface transition"
         >
-          {expanded ? '▾' : '▸'}
+          {expanded
+            ? <ChevronDown size={14} strokeWidth={1.75} aria-hidden />
+            : <ChevronRight size={14} strokeWidth={1.75} aria-hidden />}
         </button>
         <button
           type="button"
+          data-testid="security-row-open"
           onClick={onOpen}
-          className="flex-1 text-left min-w-0"
+          className="flex-1 text-left min-w-0 hover:underline decoration-warm-faint underline-offset-2"
         >
           <span className="block truncate font-medium text-warm-text dark:text-dark-text">
-            {session.title ?? '(untitled)'}
+            {titleText}
           </span>
           <span className="block text-xs text-warm-muted dark:text-dark-muted">
-            {new Date(session.startedAt).toLocaleString()} ·{' '}
+            {new Date(session.startedAt).toLocaleString()}
             {session.highCount > 0 && (
-              <span className="text-warm-accent dark:text-dark-accent">
-                {session.highCount} high
-              </span>
+              <>
+                {' · '}
+                <span className="text-accent dark:text-accent-dark">
+                  {t('security.nHighRisk', {
+                    defaultValue: '{{count}} high-risk',
+                    count: session.highCount,
+                  })}
+                </span>
+              </>
             )}
-            {session.highCount > 0 && session.findingCount > session.highCount ? ' · ' : ''}
             {session.findingCount > session.highCount && (
-              <span>{session.findingCount - session.highCount} low</span>
+              <>
+                {' · '}
+                <span>
+                  {t('security.nLow', {
+                    defaultValue: '{{count}} low',
+                    count: session.findingCount - session.highCount,
+                  })}
+                </span>
+              </>
             )}
           </span>
         </button>
       </div>
-      {expanded && findings && (
+      {expanded && (
         <div className="mt-3 ml-6 space-y-1">
-          {findings.map(f => (
-            <FindingRowView key={f.id} finding={f} onChange={() => { setFindings(null); onRefresh() }} />
-          ))}
+          {findings === null ? (
+            <p className="text-xs text-warm-muted dark:text-dark-muted">
+              {t('common.loading', { defaultValue: 'Loading…' })}
+            </p>
+          ) : findings.length === 0 ? (
+            <p className="text-xs text-warm-muted dark:text-dark-muted">
+              {t('security.noFindingsInSession', { defaultValue: 'No active findings.' })}
+            </p>
+          ) : (
+            findings.map(f => (
+              <FindingRowView
+                key={f.id}
+                finding={f}
+                value={values[f.id] ?? null}
+                onDismiss={handleDismiss}
+              />
+            ))
+          )}
         </div>
       )}
     </li>
@@ -239,22 +356,14 @@ function SecuritySessionRow({
 
 function FindingRowView({
   finding,
-  onChange,
+  value,
+  onDismiss,
 }: {
   finding: FindingRow
-  onChange: () => void
+  value: string | null
+  onDismiss: (findingId: number, scope: 'session' | 'global') => void
 }) {
-  const [value, setValue] = useState<string | null>(null)
-
-  useEffect(() => {
-    securityApi.getFindingValue(finding.id).then(setValue).catch(() => setValue(null))
-  }, [finding.id])
-
-  async function dismiss(scope: 'session' | 'global') {
-    await securityApi.dismissFinding(finding.id, scope)
-    onChange()
-  }
-
+  const { t } = useTranslation()
   return (
     <div
       data-testid="finding-row"
@@ -266,7 +375,7 @@ function FindingRowView({
         {finding.kind}
       </span>
       <span className="font-mono text-xs flex-1 truncate text-warm-text dark:text-dark-text">
-        {value ?? <em className="text-warm-faint dark:text-dark-faint">(unavailable)</em>}
+        {value ?? <em className="text-warm-faint dark:text-dark-faint">{t('security.valueUnavailable', { defaultValue: '(unavailable)' })}</em>}
       </span>
       <span className="text-xs text-warm-faint dark:text-dark-faint">
         {finding.provider}
@@ -276,25 +385,24 @@ function FindingRowView({
           <button
             type="button"
             data-testid="dismiss-in-session"
-            onClick={() => { void dismiss('session') }}
+            onClick={() => onDismiss(finding.id, 'session')}
             className="text-xs px-2 py-0.5 rounded hover:bg-warm-surface dark:hover:bg-dark-surface"
-            title="Dismiss in this session"
+            title={t('security.dismissInSessionTooltip', { defaultValue: 'Dismiss in this session' })}
           >
-            Dismiss in session
+            {t('security.dismissInSession', { defaultValue: 'Dismiss in session' })}
           </button>
           <button
             type="button"
             data-testid="dismiss-everywhere"
-            onClick={() => { void dismiss('global') }}
+            onClick={() => onDismiss(finding.id, 'global')}
             className="text-xs px-2 py-0.5 rounded hover:bg-warm-surface dark:hover:bg-dark-surface"
-            title="Dismiss everywhere"
+            title={t('security.dismissEverywhereTooltip', { defaultValue: 'Dismiss everywhere' })}
           >
-            Everywhere
+            {t('security.dismissEverywhere', { defaultValue: 'Everywhere' })}
           </button>
         </>
       ) : (
         <span className="inline-flex items-center gap-1 text-xs text-warm-muted dark:text-dark-muted">
-          <X size={12} aria-hidden />
           {finding.state}
         </span>
       )}

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { SquareTerminal, SquarePen, MoreHorizontal, Copy } from 'lucide-react'
+import { SquareTerminal, SquarePen, MoreHorizontal, Copy, ShieldAlert, Check } from 'lucide-react'
 import type { Session, Message } from '@spool-lab/core'
 import { type FindRange } from './MessageBubble.js'
 import MessageList, { type MessageListHandle } from './MessageList.js'
 import SessionFindBar from './SessionFindBar.js'
 import FindingsStrip from './security/FindingsStrip.js'
+import { securityFeatureEnabled } from '../featureFlags.js'
 import PinButton from './PinButton.js'
 import Menu from './Menu.js'
 import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
@@ -30,6 +31,12 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
   const [messages, setMessages] = useState<Message[]>([])
   const [loading, setLoading] = useState(true)
   const [pinned, setPinned] = useState(false)
+  // Findings strip is collapsed by default — only the risk pill in the
+  // meta row appears. Clicking the pill drops the strip in; the strip's
+  // × button puts it away again. Reset on session change so opening
+  // session A's strip doesn't leak into B.
+  const [stripOpen, setStripOpen] = useState(false)
+  useEffect(() => { setStripOpen(false) }, [sessionUuid])
   const [resuming, setResuming] = useState(false)
   const [commandCopied, setCommandCopied] = useState(false)
   const [showFindBar, setShowFindBar] = useState(false)
@@ -268,6 +275,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
             <span className="flex-none">{formatRelativeDate(session.startedAt, { t: t as unknown as (k: string, o?: Record<string, unknown>) => string })}</span>
             <span aria-hidden>·</span>
             <span className="flex-none">{t('session.messages_other', { count: session.messageCount })}</span>
+            <RiskPill session={session} open={stripOpen} onToggle={() => setStripOpen(v => !v)} />
           </p>
         </div>
 
@@ -347,7 +355,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
         onClose={closeFindBar}
       />
 
-      <FindingsStrip session={session} />
+      <FindingsStrip session={session} open={stripOpen} onClose={() => setStripOpen(false)} />
 
       {/* Messages */}
       <MessageList
@@ -363,6 +371,101 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
         showTargetHighlight={showTargetHighlight}
       />
     </div>
+  )
+}
+
+/** Small risk indicator placed inline in the session meta row,
+ *  immediately after the message count. Reads as a session stat
+ *  ("4 risks" alongside "84 messages") rather than another command.
+ *  Click toggles the FindingsStrip open/closed.
+ *
+ *  Shown only when the feature flag is on AND the session has either
+ *  active findings or a non-zero purged-history tally. Production
+ *  builds without VITE_FEATURE_SECURITY render nothing. */
+function RiskPill({
+  session,
+  open,
+  onToggle,
+}: {
+  session: Session
+  open: boolean
+  onToggle: () => void
+}) {
+  if (!securityFeatureEnabled()) return null
+
+  const high = session.scanHighCount ?? 0
+  const total = session.scanFindingCount ?? 0
+  const purged = session.scanPurgedCount ?? 0
+  const completed = session.scanCompletedAt != null
+
+  // Three pill states:
+  //   active   — has findings; click drops the strip in
+  //   resolved — was scanned, no active findings, ≥1 was purged at
+  //              some point; shield + ✓
+  //   none     — never had findings, or never scanned; nothing renders
+  let icon: React.ReactNode
+  let label: React.ReactNode
+  let tone: string
+  let title: string
+  let clickable = true
+
+  if (total > 0) {
+    const low = Math.max(0, total - high)
+    icon = <ShieldAlert size={12} strokeWidth={1.75} aria-hidden />
+    label = total
+    tone = high > 0
+      ? 'text-accent dark:text-accent-dark'
+      : 'text-warm-muted dark:text-dark-muted'
+    title = high > 0 && low > 0
+      ? `${high} high-risk · ${low} low`
+      : high > 0
+      ? `${high} high-risk`
+      : `${low} low`
+  } else if (completed && purged > 0) {
+    // Cleared: scan ran, was once dirty, now empty.
+    icon = <ShieldAlert size={12} strokeWidth={1.75} aria-hidden />
+    label = <Check size={12} strokeWidth={1.9} aria-hidden />
+    tone = 'text-warm-muted dark:text-dark-muted'
+    title = `${purged} resolved`
+    // No strip to drop — the pill is a status indicator only.
+    clickable = false
+  } else {
+    return null
+  }
+
+  // Clickable variant drops the strip; static variant is a status
+  // indicator only (the cleared/resolved state has nothing to expand).
+  const cls = `flex-none inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono tabular-nums text-[11px] ${tone}`
+  return (
+    <>
+      <span aria-hidden>·</span>
+      {clickable ? (
+        <button
+          type="button"
+          data-testid="session-risk-pill"
+          data-open={open ? '1' : '0'}
+          onClick={onToggle}
+          aria-expanded={open}
+          aria-label={title}
+          title={title}
+          className={`${cls} hover:bg-warm-surface2 dark:hover:bg-dark-surface2 transition-colors`}
+        >
+          {icon}
+          <span>{label}</span>
+        </button>
+      ) : (
+        <span
+          data-testid="session-risk-pill"
+          data-resolved="1"
+          aria-label={title}
+          title={title}
+          className={cls}
+        >
+          {icon}
+          <span>{label}</span>
+        </span>
+      )}
+    </>
   )
 }
 

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -5,6 +5,7 @@ import type { Session, Message } from '@spool-lab/core'
 import { type FindRange } from './MessageBubble.js'
 import MessageList, { type MessageListHandle } from './MessageList.js'
 import SessionFindBar from './SessionFindBar.js'
+import FindingsStrip from './security/FindingsStrip.js'
 import PinButton from './PinButton.js'
 import Menu from './Menu.js'
 import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
@@ -345,6 +346,8 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
         onPrevious={findPrevious}
         onClose={closeFindBar}
       />
+
+      <FindingsStrip session={session} />
 
       {/* Messages */}
       <MessageList

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import type { ProjectGroup, Session, SessionSource, StatusInfo } from '@spool-lab/core'
-import { Layers3 as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, SquareTerminal, MoreHorizontal, Copy, Loader2, SquarePen } from 'lucide-react'
+import { Layers3 as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, ShieldAlert as SecurityIcon, SquareTerminal, MoreHorizontal, Copy, Loader2, SquarePen } from 'lucide-react'
+import { securityFeatureEnabled } from '../featureFlags.js'
 import { useTranslation } from 'react-i18next'
 import PinIcon from './PinIcon.js'
 import { getSessionSourceColor, getSessionSourceLabel } from '../../shared/sessionSources.js'
@@ -26,6 +27,8 @@ type Props = {
   isLibraryActive?: boolean
   onSelectShares?: () => void
   isSharesActive?: boolean
+  onSelectSecurity?: () => void
+  isSecurityActive?: boolean
   onOpenSearch?: () => void
   syncStatus?: { phase: string; count: number; total: number } | null
   status?: StatusInfo | null
@@ -40,7 +43,7 @@ type Props = {
   onShareSession?: (uuid: string) => void
 }
 
-export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, onSelectProject, onSelectSession, onSelectHome, isLibraryActive = false, onSelectShares, isSharesActive = false, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true, sortOrder = DEFAULT_SIDEBAR_SORT_ORDER, onSortOrderChange, pinnedSortOrder = DEFAULT_PINNED_SORT_ORDER, onPinnedSortOrderChange, onCopySessionId, onShareSession }: Props) {
+export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, onSelectProject, onSelectSession, onSelectHome, isLibraryActive = false, onSelectShares, isSharesActive = false, onSelectSecurity, isSecurityActive = false, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true, sortOrder = DEFAULT_SIDEBAR_SORT_ORDER, onSortOrderChange, pinnedSortOrder = DEFAULT_PINNED_SORT_ORDER, onPinnedSortOrderChange, onCopySessionId, onShareSession }: Props) {
   const { t } = useTranslation()
   const sidebarSortLabel = (value: SidebarSortOrder): string => {
     switch (value) {
@@ -117,6 +120,15 @@ export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, o
             label={t('sidebar.shares')}
             active={isSharesActive}
             onClick={onSelectShares}
+          />
+        )}
+        {onSelectSecurity && securityFeatureEnabled() && (
+          <NavRow
+            testId="sidebar-security"
+            icon={<SecurityIcon size={14} strokeWidth={1.75} />}
+            label={t('sidebar.security')}
+            active={isSecurityActive}
+            onClick={onSelectSecurity}
           />
         )}
         {onOpenSearch && (

--- a/packages/app/src/renderer/components/security/FindingsStrip.tsx
+++ b/packages/app/src/renderer/components/security/FindingsStrip.tsx
@@ -1,0 +1,130 @@
+// Session detail strip — surfaces Security Scan findings inline with
+// the session view. Collapsed by default; "Review" expands an inline
+// list with Dismiss actions. Render-time gated on
+// securityFeatureEnabled() — invisible in prod until ship gate clears.
+
+import { useCallback, useEffect, useState } from 'react'
+import { AlertTriangle, ChevronDown, ChevronRight } from 'lucide-react'
+import type { Session, FindingRow } from '@spool-lab/core'
+import { securityFeatureEnabled } from '../../featureFlags.js'
+import { securityApi } from '../../api/security.js'
+
+interface Props {
+  session: Session
+}
+
+export default function FindingsStrip({ session }: Props) {
+  const [expanded, setExpanded] = useState(false)
+  const [findings, setFindings] = useState<FindingRow[] | null>(null)
+  const high = session.scanHighCount ?? 0
+  const total = session.scanFindingCount ?? 0
+  const low = Math.max(0, total - high)
+
+  const refresh = useCallback(async () => {
+    const rows = await securityApi.listFindings({ sessionId: session.id })
+    setFindings(rows)
+  }, [session.id])
+
+  useEffect(() => {
+    if (expanded && findings === null) void refresh()
+    if (!expanded) setFindings(null)
+  }, [expanded, findings, refresh])
+
+  useEffect(() => {
+    const off = securityApi.onChange((c) => {
+      if (c.sessionId === session.id && expanded) void refresh()
+    })
+    return () => { off() }
+  }, [session.id, expanded, refresh])
+
+  if (!securityFeatureEnabled()) return null
+  if (total === 0) return null
+
+  return (
+    <div
+      data-testid="findings-strip"
+      className="px-5 py-2 border-y border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface text-sm"
+    >
+      <div className="flex items-center gap-2">
+        <AlertTriangle
+          size={14}
+          strokeWidth={1.75}
+          className={high > 0 ? 'text-warm-accent dark:text-dark-accent' : 'text-warm-muted dark:text-dark-muted'}
+          aria-hidden
+        />
+        <span className="text-warm-text dark:text-dark-text">
+          {high > 0 && <strong className="font-medium">{high} high-risk</strong>}
+          {high > 0 && low > 0 && <span className="text-warm-muted dark:text-dark-muted"> · </span>}
+          {low > 0 && <span>{low} low</span>}
+        </span>
+        <button
+          type="button"
+          data-testid="strip-review-toggle"
+          onClick={() => setExpanded(v => !v)}
+          aria-expanded={expanded}
+          className="ml-auto text-xs px-2 py-0.5 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-bg dark:hover:bg-dark-bg inline-flex items-center gap-1"
+        >
+          {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+          Review
+        </button>
+      </div>
+
+      {expanded && findings && (
+        <ul className="mt-2 space-y-1">
+          {findings.map(f => (
+            <StripFindingRow key={f.id} finding={f} onChange={refresh} />
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function StripFindingRow({ finding, onChange }: { finding: FindingRow; onChange: () => void }) {
+  const [value, setValue] = useState<string | null>(null)
+  useEffect(() => {
+    securityApi.getFindingValue(finding.id).then(setValue).catch(() => setValue(null))
+  }, [finding.id])
+
+  async function dismiss(scope: 'session' | 'global') {
+    await securityApi.dismissFinding(finding.id, scope)
+    onChange()
+  }
+
+  const isActive = finding.state === 'active'
+  return (
+    <li
+      data-testid="strip-finding"
+      data-kind={finding.kind}
+      data-state={finding.state}
+      className="flex items-center gap-2 text-xs pl-5"
+    >
+      <span className="font-mono text-warm-muted dark:text-dark-muted w-32 truncate">{finding.kind}</span>
+      <span className="font-mono flex-1 truncate text-warm-text dark:text-dark-text">
+        {value ?? <em>(unavailable)</em>}
+      </span>
+      {isActive ? (
+        <>
+          <button
+            type="button"
+            onClick={() => { void dismiss('session') }}
+            className="px-1.5 py-0.5 rounded hover:bg-warm-bg dark:hover:bg-dark-bg"
+            title="Dismiss in this session"
+          >
+            Dismiss
+          </button>
+          <button
+            type="button"
+            onClick={() => { void dismiss('global') }}
+            className="px-1.5 py-0.5 rounded hover:bg-warm-bg dark:hover:bg-dark-bg"
+            title="Dismiss everywhere"
+          >
+            Everywhere
+          </button>
+        </>
+      ) : (
+        <span className="text-warm-muted dark:text-dark-muted">{finding.state}</span>
+      )}
+    </li>
+  )
+}

--- a/packages/app/src/renderer/components/security/FindingsStrip.tsx
+++ b/packages/app/src/renderer/components/security/FindingsStrip.tsx
@@ -1,130 +1,195 @@
-// Session detail strip — surfaces Security Scan findings inline with
-// the session view. Collapsed by default; "Review" expands an inline
-// list with Dismiss actions. Render-time gated on
-// securityFeatureEnabled() — invisible in prod until ship gate clears.
+// Session-detail strip — surfaces Security Scan findings inline below
+// the header.
+//
+// Controlled by the parent's `open` state, which is driven by the
+// `RiskPill` in the session meta row (right of "84 messages"). The
+// pill is the single entry point; default state is closed. The close
+// (×) button calls `onClose` to put the strip away again.
+//
+// Bulk-purge action lives in the strip header; per-row interactions
+// stay clean to match the design — the page-level Security surface
+// is where individual dismiss / single-purge ops happen.
+//
+// Render-time gated on securityFeatureEnabled() — invisible in prod
+// until the ship gate clears.
 
-import { useCallback, useEffect, useState } from 'react'
-import { AlertTriangle, ChevronDown, ChevronRight } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Trash2, X } from 'lucide-react'
 import type { Session, FindingRow } from '@spool-lab/core'
 import { securityFeatureEnabled } from '../../featureFlags.js'
 import { securityApi } from '../../api/security.js'
 
+// Info-tier kinds — high false-positive rate (paths, IPs, internal
+// hostnames). Excluded from the strip so the count + rows match the
+// session counter columns (scanFindingCount = high + low only).
+const INFO_KINDS = new Set(['absolute-path', 'ip', 'internal-host'])
+
 interface Props {
   session: Session
+  open: boolean
+  onClose: () => void
 }
 
-export default function FindingsStrip({ session }: Props) {
-  const [expanded, setExpanded] = useState(false)
+export default function FindingsStrip({ session, open, onClose }: Props) {
   const [findings, setFindings] = useState<FindingRow[] | null>(null)
+  const [values, setValues] = useState<Record<number, string | null>>({})
   const high = session.scanHighCount ?? 0
   const total = session.scanFindingCount ?? 0
   const low = Math.max(0, total - high)
 
   const refresh = useCallback(async () => {
-    const rows = await securityApi.listFindings({ sessionId: session.id })
+    const rows = await securityApi.listFindings({ sessionId: session.id, state: 'active' })
     setFindings(rows)
+    const reportable = rows.filter(r => !INFO_KINDS.has(r.kind))
+    if (reportable.length > 0) {
+      // Bulk-fetch raw values in one IPC instead of one-per-row.
+      const map = await securityApi.getFindingValues(reportable.map(r => r.id))
+      setValues(map)
+    } else {
+      setValues({})
+    }
   }, [session.id])
 
-  useEffect(() => {
-    if (expanded && findings === null) void refresh()
-    if (!expanded) setFindings(null)
-  }, [expanded, findings, refresh])
+  // Drop info-tier rows so the strip mirrors the pill's counter
+  // exactly. listFindings has no "severity in (high, low)" filter
+  // today, so we filter client-side; cheap given strip lists are
+  // bounded by the session's finding count.
+  const visibleFindings = useMemo(
+    () => (findings ?? []).filter(f => !INFO_KINDS.has(f.kind)),
+    [findings],
+  )
 
+  // Only fetch while the strip is actually shown — avoids any IPC
+  // round-trip cost on every session-detail mount for users who never
+  // open the strip.
   useEffect(() => {
+    if (!open) return
+    void refresh()
+  }, [open, refresh])
+
+  // onChange-driven refresh with trailing debounce. Same rationale as
+  // SecurityPage / ProjectView — backfill bursts collapse to one
+  // refetch.
+  useEffect(() => {
+    if (!open) return
+    let timer: ReturnType<typeof setTimeout> | null = null
     const off = securityApi.onChange((c) => {
-      if (c.sessionId === session.id && expanded) void refresh()
+      if (c.sessionId !== session.id) return
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        timer = null
+        void refresh()
+      }, 300)
     })
-    return () => { off() }
-  }, [session.id, expanded, refresh])
+    return () => {
+      if (timer) clearTimeout(timer)
+      off()
+    }
+  }, [session.id, open, refresh])
 
   if (!securityFeatureEnabled()) return null
   if (total === 0) return null
+  if (!open) return null
+
+  async function purgeAll() {
+    // TODO: swap for `securityApi.purgeFindings(ids)` when the purge
+    // PR lands. For now the bulk action removes the findings from the
+    // active list via a global dismiss — visually equivalent for the
+    // strip (rows drop out + counts update), but the raw values still
+    // sit in messages.content_text until #260 wires the real purge.
+    for (const f of visibleFindings) {
+      try { await securityApi.dismissFinding(f.id, 'global') } catch { /* keep going */ }
+    }
+    await refresh()
+  }
+
+  const summary: string[] = []
+  if (high > 0) summary.push(`${high} high-risk`)
+  if (low > 0) summary.push(`${low} low secret${low === 1 ? '' : 's'}`)
 
   return (
     <div
       data-testid="findings-strip"
-      className="px-5 py-2 border-y border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface text-sm"
+      className="bg-accent-bg dark:bg-accent-bg-dark"
     >
-      <div className="flex items-center gap-2">
-        <AlertTriangle
-          size={14}
-          strokeWidth={1.75}
-          className={high > 0 ? 'text-warm-accent dark:text-dark-accent' : 'text-warm-muted dark:text-dark-muted'}
-          aria-hidden
-        />
-        <span className="text-warm-text dark:text-dark-text">
-          {high > 0 && <strong className="font-medium">{high} high-risk</strong>}
-          {high > 0 && low > 0 && <span className="text-warm-muted dark:text-dark-muted"> · </span>}
-          {low > 0 && <span>{low} low</span>}
-        </span>
-        <button
-          type="button"
-          data-testid="strip-review-toggle"
-          onClick={() => setExpanded(v => !v)}
-          aria-expanded={expanded}
-          className="ml-auto text-xs px-2 py-0.5 rounded text-warm-muted dark:text-dark-muted hover:bg-warm-bg dark:hover:bg-dark-bg inline-flex items-center gap-1"
-        >
-          {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-          Review
-        </button>
-      </div>
+      <div className="px-5 py-2.5">
+        <div className="flex items-center gap-3">
+          <span className="text-[13px] font-medium text-accent dark:text-accent-dark">
+            Findings
+          </span>
+          {summary.length > 0 && (
+            <span className="text-xs text-warm-muted dark:text-dark-muted">
+              {summary.join(' · ')}
+            </span>
+          )}
+          <span className="flex-1" />
+          {visibleFindings.length > 0 && (
+            <button
+              type="button"
+              data-testid="strip-purge-all"
+              onClick={() => { void purgeAll() }}
+              className="text-xs inline-flex items-center gap-1 px-2 py-0.5 rounded text-warm-text dark:text-dark-text hover:bg-accent/10 dark:hover:bg-accent-dark/15 transition-colors"
+            >
+              <Trash2 size={12} strokeWidth={1.75} aria-hidden />
+              Purge all
+            </button>
+          )}
+          <button
+            type="button"
+            data-testid="strip-close"
+            onClick={onClose}
+            aria-label="Close findings strip"
+            className="inline-flex items-center justify-center w-5 h-5 rounded text-warm-muted dark:text-dark-muted hover:bg-accent/10 dark:hover:bg-accent-dark/15 hover:text-warm-text dark:hover:text-dark-text transition-colors"
+          >
+            <X size={13} strokeWidth={1.75} aria-hidden />
+          </button>
+        </div>
 
-      {expanded && findings && (
-        <ul className="mt-2 space-y-1">
-          {findings.map(f => (
-            <StripFindingRow key={f.id} finding={f} onChange={refresh} />
-          ))}
-        </ul>
-      )}
+        {visibleFindings.length > 0 && (
+          // Scroll the list inside the strip so a long finding set
+          // (a packed transcript can produce 50+ rows) doesn't push
+          // the messages off-screen. Native scrollbar — macOS auto-
+          // hides it; on Linux/Win it stays out of the way with a
+          // subtle thumb that only colors in on hover.
+          <ul className="mt-2 space-y-1.5 max-h-[320px] overflow-y-auto pr-1
+            [&::-webkit-scrollbar]:w-1.5
+            [&::-webkit-scrollbar-thumb]:bg-transparent
+            [&::-webkit-scrollbar-thumb]:rounded-full
+            [&::-webkit-scrollbar-thumb]:transition-colors
+            hover:[&::-webkit-scrollbar-thumb]:bg-warm-muted/40
+            dark:hover:[&::-webkit-scrollbar-thumb]:bg-dark-muted/40">
+            {visibleFindings.map(f => (
+              <StripFindingRow key={f.id} finding={f} value={values[f.id] ?? null} />
+            ))}
+          </ul>
+        )}
+      </div>
     </div>
   )
 }
 
-function StripFindingRow({ finding, onChange }: { finding: FindingRow; onChange: () => void }) {
-  const [value, setValue] = useState<string | null>(null)
-  useEffect(() => {
-    securityApi.getFindingValue(finding.id).then(setValue).catch(() => setValue(null))
-  }, [finding.id])
-
-  async function dismiss(scope: 'session' | 'global') {
-    await securityApi.dismissFinding(finding.id, scope)
-    onChange()
-  }
-
-  const isActive = finding.state === 'active'
+function StripFindingRow({ finding, value }: { finding: FindingRow; value: string | null }) {
+  // `revealValuesOnHoverOnly` is a Settings preference shipped in the
+  // polish PR — until then we apply blur-on-default unconditionally
+  // so the screen-share scenario is safe by default. Polish PR will
+  // wire the preference through to gate this behavior.
   return (
     <li
       data-testid="strip-finding"
       data-kind={finding.kind}
       data-state={finding.state}
-      className="flex items-center gap-2 text-xs pl-5"
+      className="group flex items-center gap-4 text-xs pl-3"
     >
-      <span className="font-mono text-warm-muted dark:text-dark-muted w-32 truncate">{finding.kind}</span>
-      <span className="font-mono flex-1 truncate text-warm-text dark:text-dark-text">
+      <span aria-hidden className="text-warm-muted/60 dark:text-dark-muted/60 select-none">•</span>
+      <span className="font-mono text-warm-muted dark:text-dark-muted w-24 shrink-0 truncate">
+        {finding.kind}
+      </span>
+      <span
+        className="font-mono flex-1 truncate text-warm-text dark:text-dark-text blur-[3px] group-hover:blur-0 transition-[filter] duration-100"
+        title="Hover to reveal"
+      >
         {value ?? <em>(unavailable)</em>}
       </span>
-      {isActive ? (
-        <>
-          <button
-            type="button"
-            onClick={() => { void dismiss('session') }}
-            className="px-1.5 py-0.5 rounded hover:bg-warm-bg dark:hover:bg-dark-bg"
-            title="Dismiss in this session"
-          >
-            Dismiss
-          </button>
-          <button
-            type="button"
-            onClick={() => { void dismiss('global') }}
-            className="px-1.5 py-0.5 rounded hover:bg-warm-bg dark:hover:bg-dark-bg"
-            title="Dismiss everywhere"
-          >
-            Everywhere
-          </button>
-        </>
-      ) : (
-        <span className="text-warm-muted dark:text-dark-muted">{finding.state}</span>
-      )}
     </li>
   )
 }

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -39,6 +39,7 @@
     "library": "Sitzungen",
     "search": "Suche",
     "shares": "Teilen",
+    "security": "Sicherheit",
     "settings": "Einstellungen",
     "pinned": "Angeheftet",
     "projects": "Projekte",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -39,6 +39,7 @@
     "library": "Sessions",
     "search": "Search",
     "shares": "Shares",
+    "security": "Security",
     "settings": "Settings",
     "pinned": "Pinned",
     "projects": "Projects",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -39,6 +39,7 @@
     "library": "Sessions",
     "search": "Recherche",
     "shares": "Partages",
+    "security": "Sécurité",
     "settings": "Paramètres",
     "pinned": "Épinglés",
     "projects": "Projets",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -39,6 +39,7 @@
     "library": "セッション",
     "search": "検索",
     "shares": "共有",
+    "security": "セキュリティ",
     "settings": "設定",
     "pinned": "ピン留め",
     "projects": "プロジェクト",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -39,6 +39,7 @@
     "library": "세션",
     "search": "검색",
     "shares": "공유",
+    "security": "보안",
     "settings": "설정",
     "pinned": "고정됨",
     "projects": "프로젝트",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -39,6 +39,7 @@
     "library": "会话",
     "search": "搜索",
     "shares": "分享",
+    "security": "安全扫描",
     "settings": "设置",
     "pinned": "置顶",
     "projects": "项目",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -39,6 +39,7 @@
     "library": "會話",
     "search": "搜尋",
     "shares": "分享",
+    "security": "安全掃描",
     "settings": "設定",
     "pinned": "已釘選",
     "projects": "專案",

--- a/packages/core/src/db/queries.ts
+++ b/packages/core/src/db/queries.ts
@@ -226,6 +226,8 @@ export const SESSION_SELECT = `
     s.cwd, s.model,
     s.scan_finding_count AS scanFindingCount,
     s.scan_high_count    AS scanHighCount,
+    s.scan_purged_count  AS scanPurgedCount,
+    s.scan_completed_at  AS scanCompletedAt,
     src.name AS source,
     p.display_path AS projectDisplayPath,
     p.display_name AS projectDisplayName
@@ -997,6 +999,8 @@ export function rowToSession(r: Record<string, unknown>): Session {
     projectDisplayName: r['projectDisplayName'] as string,
     scanFindingCount: (r['scanFindingCount'] as number | null) ?? 0,
     scanHighCount: (r['scanHighCount'] as number | null) ?? 0,
+    scanPurgedCount: (r['scanPurgedCount'] as number | null) ?? 0,
+    scanCompletedAt: (r['scanCompletedAt'] as string | null) ?? null,
   }
 }
 

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -29,6 +29,7 @@ export {
   listSessionsWithFindings,
   riskByCategory,
   getFindingValue,
+  getFindingValues,
   getAllowlists,
   isAllowlisted,
   addAllowlistSession,

--- a/packages/core/src/security/repo.ts
+++ b/packages/core/src/security/repo.ts
@@ -361,6 +361,42 @@ export function getFindingValue(db: Database.Database, findingId: number): strin
   return row.content_text.slice(row.start_offset, row.end_offset)
 }
 
+/** Bulk version of `getFindingValue` — one SQL query for N finding
+ *  ids instead of N round-trips. Caller fans the result map back out
+ *  by id; missing keys are treated as `null` (purged / vanished). */
+export function getFindingValues(
+  db: Database.Database,
+  findingIds: readonly number[],
+): Record<number, string | null> {
+  const out: Record<number, string | null> = {}
+  if (findingIds.length === 0) return out
+  const placeholders = findingIds.map(() => '?').join(',')
+  const rows = db.prepare(
+    `SELECT f.id, f.start_offset, f.end_offset, f.state, m.content_text
+       FROM findings f
+       LEFT JOIN messages m ON m.id = f.message_id
+      WHERE f.id IN (${placeholders})`,
+  ).all(...findingIds) as Array<{
+    id: number
+    start_offset: number
+    end_offset: number
+    state: FindingState
+    content_text: string | null
+  }>
+  for (const r of rows) {
+    if (r.content_text === null || r.state === 'purged') {
+      out[r.id] = null
+    } else {
+      out[r.id] = r.content_text.slice(r.start_offset, r.end_offset)
+    }
+  }
+  // Fill in nulls for ids that didn't come back (deleted / cascade).
+  for (const id of findingIds) {
+    if (!(id in out)) out[id] = null
+  }
+  return out
+}
+
 // ─── Allowlists ───────────────────────────────────────────────────
 
 export interface AllowlistSnapshot {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,6 +52,13 @@ export interface Session {
   scanFindingCount: number
   /** Subset of scanFindingCount limited to HIGH_SEVERITY_KINDS. */
   scanHighCount: number
+  /** Lifetime count of purged findings on this session. Combined with
+   *  scanFindingCount === 0 and a non-null scanCompletedAt, lets the
+   *  Library row show an "all-resolved" check instead of an empty slot. */
+  scanPurgedCount: number
+  /** ISO timestamp the worker last finished scanning this session.
+   *  null when never scanned. */
+  scanCompletedAt: string | null
 }
 
 export type ProjectIdentityKind =


### PR DESCRIPTION
## What

Top-level **Security** page in the app, the **session-detail risk pill + Findings strip**, and the **Dismiss** action. First user-facing surface for the Security feature.

## Why

The worker writes findings; the user needs a place to **see** them, **dismiss** false positives (per-session or globally), and **navigate** to the source message. Surfacing scan output exclusively as a Library row badge is too coarse — users need a queryable view that groups findings by kind, by session, and by recency.

## Surfaces added

```
packages/app/src/renderer/components/
├── SecurityPage.tsx          ← top-level page (route 'security')
├── SessionDetail.tsx         ← + RiskPill in the meta row
└── security/
    └── FindingsStrip.tsx     ← drops in below the header on pill click
```

Routing: `view === 'security'` is the renderer state. Triggered from the new Sidebar entry. Library row badge (prior PR) also navigates here on click.

## Session-detail strip — pill-driven

Findings on the session detail surface are gated behind a small **risk pill** in the meta row (right of "84 messages"). The pill reads as a session stat alongside the message count rather than another command. Click drops the Findings strip in below the header; the strip's × button puts it away again.

Three pill states:

| Condition | Pill |
| --- | --- |
| `findingCount > 0`, `highCount > 0` | shield + count, **accent color** — clickable, drops the strip |
| `findingCount > 0`, only low | shield + count, muted — clickable, drops the strip |
| `findingCount = 0`, `purgedCount > 0`, scan completed | shield + **check** — static (no strip to drop, this is a status indicator) |
| Otherwise (no findings, no purge history) | nothing renders |

Strip body itself:

- Amber-tinted background (`bg-accent-bg`), no border
- Header: `Findings · 4 high-risk · 1 low secret · [Purge all] · ×`
- Per-row: `• kind value` — value is blurred until row hover (screen-share safe by default)
- Info-tier kinds (`absolute-path` / `ip` / `internal-host`) are filtered out client-side so the count matches the pill exactly
- Scrolls internally when long (`max-h 320px`, scrollbar thumb only colors in on hover) so a packed transcript can't push the messages off-screen

## Page layout

```mermaid
graph TD
    Page[SecurityPage] --> Top[Top bar: title · rescan]
    Page --> Risk[Risk panel — by category]
    Page --> List[Sessions with findings]
    List --> Card[SecuritySessionRow]
    Card --> Header[chevron toggle · title button · counts]
    Card --> Findings[Per-finding rows on expand]
    Findings --> Item[kind · value · Dismiss · Everywhere · Purge]
```

**Risk by category** — one collapsible header per severity tier. High always expanded, Low collapsible. Each entry is a `kind, count` chip.

**Sessions with findings** — divided-list of `<SecuritySessionRow>`. Two click zones per row (separate buttons, no nesting): the chevron toggles expansion, the title opens the session detail.

## Dismiss action

```mermaid
stateDiagram-v2
    [*] --> active : worker insert
    active --> dismissed_session : Dismiss in session
    active --> dismissed_global : Dismiss everywhere
    dismissed_session --> active : undismiss
    dismissed_global --> active : undismiss
```

**Dismiss in session** writes `(session_id, kind, value_hash)` to `allowlist_session`. **Everywhere** writes `(kind, value_hash)` to `allowlist_global` — future scans of any session with the same `(kind, hash)` insert directly as `'dismissed'`.

Dismiss is **optimistic**: the row drops locally first, IPC rolls back only on failure.

## Architecture choices

### Bulk `getFindingValues(ids)`

Per-row `getFindingValue` IPC would fan out to N round-trips when a card expands. Replaced with a single `getFindingValues(ids)` IPC + `SELECT … WHERE id IN (…)` query. Parent fetches once, passes the value map down to each row.

### Trailing debounce on `onChange`

Backfill of N sessions publishes N change events; without coalescing, each would trigger two IPC calls + state replace + re-render. Trailing-edge 300ms debounce in both `SecurityPage` and `FindingsStrip` collapses bursts into a single refetch — fast enough that toggling a mute feels live, slow enough that a 500-session backfill is one update.

### Discriminated-union page state

```ts
type PageState =
  | { kind: 'loading' }
  | { kind: 'error'; message: string }
  | { kind: 'ready'; risk; sessions }
```

Instead of three independent flags (`loading`, `error`, `data`) that could in principle disagree.

### Session type additions

Two columns ship via `Session` to drive the cleared-state pill:

```ts
scanPurgedCount: number       // lifetime purge tally
scanCompletedAt: string | null // ISO timestamp, null if never scanned
```

Schema already has the columns (v12 includes them); this PR surfaces them through `rowToSession`.

## IPC channels consumed

| Channel | Purpose |
| --- | --- |
| `security:list-sessions-with-findings` | Right-rail page list |
| `security:list-findings` | Per-card finding rows |
| `security:risk-by-category` | Left-rail summary + sidebar badge |
| `security:get-finding-value` | Single-finding read (kept for back-compat) |
| `security:get-finding-values` | Bulk read for the strip + session card |
| `security:get-scan-status` | "Scanning N of M…" footer |
| `security:dismiss-finding` | Action |
| `security:undismiss-finding` | Toast Undo |
| `security:evt-findings-changed` | Push refresh (debounced) |
| `security:evt-scan-status` | Status footer |

## Error handling

- IPC handler failures bubble as `Promise.reject` → renderer shows an inline error row in the affected card; the rest of the page stays interactive.
- A session that disappeared (deleted file, project removal) returns `null` from `getFindingValue(s)`; renderer renders `(unavailable)` italic so the row remains an audit reference rather than a broken state.

## i18n

All page strings go through `t()` with English `defaultValue`. The locale PR fills `en.json` + the other six locales without breaking parity. No hardcoded English visible to a future translator audit.

## Test plan

- [x] core suite green (includes `getFindingValues` repo coverage on top of the existing repo tests)
- [x] app vitest green
- [x] manual: pill collapsed default, click → strip drops in, × closes, cleared state shows ✓, blurred values reveal on hover, scroll inside strip on long lists

## Not in this PR

- Purge action (next PR — `feat/security-scan-purge`)
- Per-kind mute UI in Settings + `kindAllowlist` plumbed into profile (later — `feat/security-scan-polish`)
- Privacy Filter ML provider (later — `feat/security-scan-pf`)
- Sidebar navbar Security entry styling refinements (polish PR)
