### PR TITLE
feat(security): purge mechanism + FTS update trigger

### DIFF
--- a/packages/app/src/main/ipc/security.ts
+++ b/packages/app/src/main/ipc/security.ts
@@ -15,9 +15,12 @@ import {
   getFindingValues,
   dismissFinding,
   undismissFinding,
+  purgeFinding,
+  purgeFindings,
   type FindingFilter,
   type SessionFindingFilter,
   type ScanWorker,
+  type PurgeResult,
 } from '@spool-lab/core'
 import type Database from 'better-sqlite3'
 
@@ -35,6 +38,8 @@ export const SECURITY_IPC_CHANNELS = {
   // mutations
   DISMISS_FINDING:             'security:dismiss-finding',
   UNDISMISS_FINDING:           'security:undismiss-finding',
+  PURGE_FINDING:               'security:purge-finding',
+  PURGE_FINDINGS:              'security:purge-findings',
   RESCAN_ALL:                  'security:rescan-all',
   RESCAN_SESSION:              'security:rescan-session',
 
@@ -92,6 +97,22 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
       return { ok: true }
     },
   )
+  ipcMain.handle(SECURITY_IPC_CHANNELS.PURGE_FINDING, async (_e, findingId: number) => {
+    const publish = (change: Parameters<NonNullable<typeof getMainWindow extends () => infer R ? R : never>['webContents']['send']>[1]) =>
+      Effect.sync(() => {
+        getMainWindow()?.webContents.send(SECURITY_IPC_CHANNELS.EVT_FINDINGS_CHANGED, change)
+      })
+    const result = await runPromise(purgeFinding(findingId, { db, publish: publish as never })) as PurgeResult
+    return result
+  })
+  ipcMain.handle(SECURITY_IPC_CHANNELS.PURGE_FINDINGS, async (_e, findingIds: number[]) => {
+    const publish = (change: unknown) =>
+      Effect.sync(() => {
+        getMainWindow()?.webContents.send(SECURITY_IPC_CHANNELS.EVT_FINDINGS_CHANGED, change)
+      })
+    const results = await runPromise(purgeFindings(findingIds, { db, publish: publish as never })) as PurgeResult[]
+    return results
+  })
   ipcMain.handle(SECURITY_IPC_CHANNELS.RESCAN_ALL, () =>
     runPromise(worker.rescanAll()).then((count) => ({ count })),
   )

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -227,6 +227,10 @@ const api = {
       ipcRenderer.invoke('security:dismiss-finding', { findingId, scope }),
     undismissFinding: (findingId: number): Promise<{ ok: boolean }> =>
       ipcRenderer.invoke('security:undismiss-finding', { findingId }),
+    purgeFinding: (findingId: number): Promise<{ findingId: number; sessionId: number; maskUsed: string; purgedAt: string }> =>
+      ipcRenderer.invoke('security:purge-finding', findingId),
+    purgeFindings: (findingIds: number[]): Promise<Array<{ findingId: number; sessionId: number; maskUsed: string; purgedAt: string }>> =>
+      ipcRenderer.invoke('security:purge-findings', findingIds),
     rescanAll: (): Promise<{ count: number }> =>
       ipcRenderer.invoke('security:rescan-all'),
     rescanSession: (sessionId: number): Promise<{ ok: boolean }> =>

--- a/packages/app/src/renderer/api/security.ts
+++ b/packages/app/src/renderer/api/security.ts
@@ -36,6 +36,10 @@ export const securityApi = {
     window.spool.security.dismissFinding(findingId, scope),
   undismissFinding: (findingId: number) =>
     window.spool.security.undismissFinding(findingId),
+  purgeFinding: (findingId: number) =>
+    window.spool.security.purgeFinding(findingId),
+  purgeFindings: (findingIds: number[]) =>
+    window.spool.security.purgeFindings(findingIds),
   rescanAll: () => window.spool.security.rescanAll(),
   rescanSession: (sessionId: number) => window.spool.security.rescanSession(sessionId),
 

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -5,15 +5,16 @@
 // per-finding Dismiss actions; bulk Purge ships when the purge PR
 // merges.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { AlertTriangle, ChevronDown, ChevronRight, ShieldAlert, RotateCw } from 'lucide-react'
+import { AlertTriangle, ChevronDown, ChevronRight, ShieldAlert, RotateCw, Trash2 } from 'lucide-react'
 import type {
   FindingRow,
   RiskByCategoryRow,
   SessionWithFindingCounts,
 } from '@spool-lab/core'
 import { securityApi } from '../api/security.js'
+import PurgeConfirmDialog from './security/PurgeConfirmDialog.js'
 
 interface Props {
   onOpenSession: (sessionUuid: string) => void
@@ -364,11 +365,21 @@ function FindingRowView({
   onDismiss: (findingId: number, scope: 'session' | 'global') => void
 }) {
   const { t } = useTranslation()
+  const [purgePending, setPurgePending] = useState(false)
+
+  async function purge() {
+    setPurgePending(false)
+    try {
+      await securityApi.purgeFinding(finding.id)
+    } catch { /* surfaced via parent's debounced refresh on next event */ }
+  }
+
   return (
     <div
       data-testid="finding-row"
       data-finding-id={finding.id}
       data-kind={finding.kind}
+      data-state={finding.state}
       className="flex items-center gap-2 text-sm py-1"
     >
       <span className="font-mono text-xs text-warm-muted dark:text-dark-muted w-32 truncate">
@@ -400,6 +411,23 @@ function FindingRowView({
           >
             {t('security.dismissEverywhere', { defaultValue: 'Everywhere' })}
           </button>
+          <button
+            type="button"
+            data-testid="purge-button"
+            onClick={() => setPurgePending(true)}
+            className="text-xs px-2 py-0.5 rounded text-warm-accent dark:text-dark-accent hover:bg-warm-surface dark:hover:bg-dark-surface inline-flex items-center gap-1"
+            title="Purge from local archive"
+          >
+            <Trash2 size={11} strokeWidth={1.75} aria-hidden />
+            Purge
+          </button>
+          <PurgeConfirmDialog
+            open={purgePending}
+            count={1}
+            summary={finding.kind}
+            onConfirm={() => { void purge() }}
+            onCancel={() => setPurgePending(false)}
+          />
         </>
       ) : (
         <span className="inline-flex items-center gap-1 text-xs text-warm-muted dark:text-dark-muted">

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -424,7 +424,7 @@ function FindingRowView({
           <PurgeConfirmDialog
             open={purgePending}
             count={1}
-            kind={finding.kind}
+            summary={finding.kind}
             onConfirm={() => { void purge() }}
             onCancel={() => setPurgePending(false)}
           />

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -424,7 +424,7 @@ function FindingRowView({
           <PurgeConfirmDialog
             open={purgePending}
             count={1}
-            summary={finding.kind}
+            kind={finding.kind}
             onConfirm={() => { void purge() }}
             onCancel={() => setPurgePending(false)}
           />

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { SquareTerminal, MoreHorizontal, Copy, Loader2, SquarePen, AlertTriangle } from 'lucide-react'
+import { SquareTerminal, MoreHorizontal, Copy, Loader2, SquarePen, AlertTriangle, Check } from 'lucide-react'
 import type { Session } from '@spool-lab/core'
 import { SourceBadge } from './Badges.js'
 import PinButton from './PinButton.js'
@@ -91,6 +91,7 @@ export default function SessionRow({ session, pinned = false, showProject = fals
       </div>
 
       <div className="flex-none flex items-center gap-1 -mt-0.5" onClick={(e) => e.stopPropagation()}>
+        <SecurityBadgeSlot session={session} />
         <span
           className={
             pinned
@@ -152,45 +153,75 @@ export default function SessionRow({ session, pinned = false, showProject = fals
   )
 }
 
+/** Fixed-width state slot containing the SecurityBadge.
+ *
+ *  Naive placement (`{badge && <SecurityBadge />}` inline) shifts the pin
+ *  icon column left on rows without a badge. By reserving a 32px slot
+ *  for every row — even when empty — the pin/menu icons lock to the
+ *  same X across the entire library.
+ *
+ *  Vertical alignment: the slot is `h-5` to match `PinButton`'s `w-5
+ *  h-5` button, and lives inside the action group so it inherits the
+ *  group's `-mt-0.5` offset against the title row. Icon size = 13 so
+ *  the AlertTriangle reads as the same visual weight as PinIcon (also
+ *  size 13). */
+function SecurityBadgeSlot({ session }: { session: Session }): React.ReactElement {
+  return (
+    <span className="flex-none inline-flex items-center justify-center w-5 h-5">
+      <SecurityBadge session={session} />
+    </span>
+  )
+}
+
+
 function SecurityBadge({ session }: { session: Session }): React.ReactElement | null {
   if (!securityFeatureEnabled()) return null
   const high = session.scanHighCount ?? 0
   const total = session.scanFindingCount ?? 0
-  if (total === 0) return null
+  const purged = session.scanPurgedCount ?? 0
+  const completed = session.scanCompletedAt != null
   const low = Math.max(0, total - high)
-  const tooltip = high > 0
-    ? `${high} high-risk · ${low} low`
-    : `${total} low-risk finding${total === 1 ? '' : 's'}`
-  if (high > 0) {
-    return (
-      <span
-        data-testid="security-badge"
-        data-severity="high"
-        title={tooltip}
-        aria-label={tooltip}
-        className="flex-none inline-flex items-center justify-center"
-      >
-        <AlertTriangle
-          size={16}
-          strokeWidth={1.6}
-          className="text-warm-accent dark:text-dark-accent"
-          aria-hidden
-        />
-      </span>
-    )
+
+  // "All resolved" state: the session was scanned, has zero active
+  // findings, but at least one was purged historically. Surfaces a
+  // checkmark so the user can tell "scanned-clean from the start"
+  // (no badge) from "scanned-clean because I purged it" (✓).
+  if (high === 0 && low === 0) {
+    if (completed && purged > 0) {
+      const tooltip = `${purged} resolved`
+      return (
+        <span
+          data-testid="security-badge"
+          data-severity="resolved"
+          title={tooltip}
+          aria-label={tooltip}
+          className="inline-flex items-center justify-center w-5 h-5 text-warm-muted dark:text-dark-muted"
+        >
+          <Check size={13} strokeWidth={1.7} aria-hidden />
+        </span>
+      )
+    }
+    return null
   }
+
+  const isHigh = high > 0
+  // Icon-only at the row level — the tooltip carries the exact count
+  // so the row stays scan-readable at scale (Library home shows 50+
+  // rows; per-row digits become visual noise). Hover gives detail.
+  const tooltip = isHigh
+    ? (low > 0 ? `${high} high-risk · ${low} low` : `${high} high-risk`)
+    : `${low} low`
+  const tone = isHigh ? 'text-accent dark:text-accent-dark' : 'text-warm-muted dark:text-dark-muted'
+
   return (
     <span
       data-testid="security-badge"
       data-severity="low"
       title={tooltip}
       aria-label={tooltip}
-      className="flex-none inline-flex items-center justify-center"
+      className={`inline-flex items-center justify-center w-5 h-5 ${tone}`}
     >
-      <span
-        className="block w-1.5 h-1.5 rounded-full bg-warm-muted dark:bg-dark-muted"
-        aria-hidden
-      />
+      <AlertTriangle size={13} strokeWidth={1.7} aria-hidden />
     </span>
   )
 }

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -76,7 +76,6 @@ export default function SessionRow({ session, pinned = false, showProject = fals
           <span className="text-sm font-medium text-warm-text dark:text-dark-text truncate">
             {title}
           </span>
-          <SecurityBadge session={session} />
         </div>
         <p className="pl-1.5 text-xs text-warm-faint dark:text-dark-muted truncate">
           {showProject && (
@@ -216,7 +215,7 @@ function SecurityBadge({ session }: { session: Session }): React.ReactElement | 
   return (
     <span
       data-testid="security-badge"
-      data-severity="low"
+      data-severity={isHigh ? 'high' : 'low'}
       title={tooltip}
       aria-label={tooltip}
       className={`inline-flex items-center justify-center w-5 h-5 ${tone}`}

--- a/packages/app/src/renderer/components/security/FindingsStrip.tsx
+++ b/packages/app/src/renderer/components/security/FindingsStrip.tsx
@@ -18,6 +18,7 @@ import { Trash2, X } from 'lucide-react'
 import type { Session, FindingRow } from '@spool-lab/core'
 import { securityFeatureEnabled } from '../../featureFlags.js'
 import { securityApi } from '../../api/security.js'
+import PurgeConfirmDialog from './PurgeConfirmDialog.js'
 
 // Info-tier kinds — high false-positive rate (paths, IPs, internal
 // hostnames). Excluded from the strip so the count + rows match the
@@ -36,6 +37,7 @@ export default function FindingsStrip({ session, open, onClose }: Props) {
   const high = session.scanHighCount ?? 0
   const total = session.scanFindingCount ?? 0
   const low = Math.max(0, total - high)
+  const [purgePending, setPurgePending] = useState(false)
 
   const refresh = useCallback(async () => {
     const rows = await securityApi.listFindings({ sessionId: session.id, state: 'active' })
@@ -92,14 +94,10 @@ export default function FindingsStrip({ session, open, onClose }: Props) {
   if (!open) return null
 
   async function purgeAll() {
-    // TODO: swap for `securityApi.purgeFindings(ids)` when the purge
-    // PR lands. For now the bulk action removes the findings from the
-    // active list via a global dismiss — visually equivalent for the
-    // strip (rows drop out + counts update), but the raw values still
-    // sit in messages.content_text until #260 wires the real purge.
-    for (const f of visibleFindings) {
-      try { await securityApi.dismissFinding(f.id, 'global') } catch { /* keep going */ }
-    }
+    if (visibleFindings.length === 0) return
+    try {
+      await securityApi.purgeFindings(visibleFindings.map(f => f.id))
+    } catch { /* failure surfaces via onChange / refresh */ }
     await refresh()
   }
 
@@ -124,15 +122,24 @@ export default function FindingsStrip({ session, open, onClose }: Props) {
           )}
           <span className="flex-1" />
           {visibleFindings.length > 0 && (
-            <button
-              type="button"
-              data-testid="strip-purge-all"
-              onClick={() => { void purgeAll() }}
-              className="text-xs inline-flex items-center gap-1 px-2 py-0.5 rounded text-warm-text dark:text-dark-text hover:bg-accent/10 dark:hover:bg-accent-dark/15 transition-colors"
-            >
-              <Trash2 size={12} strokeWidth={1.75} aria-hidden />
-              Purge all
-            </button>
+            <>
+              <button
+                type="button"
+                data-testid="strip-purge-all"
+                onClick={() => setPurgePending(true)}
+                className="text-xs inline-flex items-center gap-1 px-2 py-0.5 rounded text-warm-text dark:text-dark-text hover:bg-accent/10 dark:hover:bg-accent-dark/15 transition-colors"
+              >
+                <Trash2 size={12} strokeWidth={1.75} aria-hidden />
+                Purge all
+              </button>
+              <PurgeConfirmDialog
+                open={purgePending}
+                count={visibleFindings.length}
+                summary={summary.join(' · ')}
+                onConfirm={() => { setPurgePending(false); void purgeAll() }}
+                onCancel={() => setPurgePending(false)}
+              />
+            </>
           )}
           <button
             type="button"

--- a/packages/app/src/renderer/components/security/FindingsStrip.tsx
+++ b/packages/app/src/renderer/components/security/FindingsStrip.tsx
@@ -135,7 +135,7 @@ export default function FindingsStrip({ session, open, onClose }: Props) {
               <PurgeConfirmDialog
                 open={purgePending}
                 count={visibleFindings.length}
-                summary={summary.join(' · ')}
+                kind={visibleFindings[0]?.kind ?? 'mixed'}
                 onConfirm={() => { setPurgePending(false); void purgeAll() }}
                 onCancel={() => setPurgePending(false)}
               />

--- a/packages/app/src/renderer/components/security/FindingsStrip.tsx
+++ b/packages/app/src/renderer/components/security/FindingsStrip.tsx
@@ -135,7 +135,7 @@ export default function FindingsStrip({ session, open, onClose }: Props) {
               <PurgeConfirmDialog
                 open={purgePending}
                 count={visibleFindings.length}
-                kind={visibleFindings[0]?.kind ?? 'mixed'}
+                summary={summary.join(' · ')}
                 onConfirm={() => { setPurgePending(false); void purgeAll() }}
                 onCancel={() => setPurgePending(false)}
               />

--- a/packages/app/src/renderer/components/security/PurgeConfirmDialog.tsx
+++ b/packages/app/src/renderer/components/security/PurgeConfirmDialog.tsx
@@ -1,0 +1,77 @@
+// Purge confirmation modal — the only destructive action in the
+// Security Scan feature gets explicit friction, distinct from the
+// inline Dismiss buttons.
+
+import { Trash2, AlertTriangle } from 'lucide-react'
+
+interface Props {
+  open: boolean
+  count: number
+  /** Optional one-line preview ("API keys", "API key + email", etc.) */
+  summary?: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export default function PurgeConfirmDialog({
+  open,
+  count,
+  summary,
+  onConfirm,
+  onCancel,
+}: Props) {
+  if (!open) return null
+  return (
+    <div
+      data-testid="purge-confirm"
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={(e) => { if (e.target === e.currentTarget) onCancel() }}
+    >
+      <div className="bg-warm-bg dark:bg-dark-bg rounded-lg shadow-xl w-[420px] max-w-[90vw] p-5 border border-warm-border dark:border-dark-border">
+        <div className="flex items-start gap-3">
+          <AlertTriangle
+            size={22}
+            strokeWidth={1.5}
+            className="text-warm-accent dark:text-dark-accent flex-none mt-0.5"
+            aria-hidden
+          />
+          <div className="flex-1">
+            <h2 className="text-base font-medium text-warm-text dark:text-dark-text">
+              Purge {count} finding{count === 1 ? '' : 's'}{summary ? ` (${summary})` : ''}?
+            </h2>
+            <p className="mt-2 text-sm text-warm-muted dark:text-dark-muted">
+              This rewrites the raw value with a mask in your local archive.
+              The originals in the source transcript files
+              (<code className="font-mono text-xs">~/.claude/sessions/</code>…)
+              are not changed.
+            </p>
+            <p className="mt-2 text-sm text-warm-muted dark:text-dark-muted">
+              You will not be able to recover the original values from Spool.
+            </p>
+          </div>
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            data-testid="purge-cancel"
+            onClick={onCancel}
+            className="px-3 py-1.5 rounded text-sm border border-warm-border dark:border-dark-border hover:bg-warm-surface dark:hover:bg-dark-surface"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="purge-confirm-button"
+            onClick={onConfirm}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm bg-warm-accent dark:bg-dark-accent text-white hover:opacity-90"
+          >
+            <Trash2 size={14} strokeWidth={1.75} aria-hidden />
+            Purge
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -181,6 +181,7 @@ export function runMigrations(db: Database.Database): void {
 
   db.exec(`
     DROP TRIGGER IF EXISTS messages_fts_insert;
+    DROP TRIGGER IF EXISTS messages_fts_update;
     DROP TRIGGER IF EXISTS messages_fts_delete;
     DROP TRIGGER IF EXISTS session_search_fts_insert;
     DROP TRIGGER IF EXISTS session_search_fts_update;
@@ -190,6 +191,23 @@ export function runMigrations(db: Database.Database): void {
     AFTER INSERT ON messages BEGIN
       INSERT INTO messages_fts(rowid, content_text)
         VALUES(NEW.id, NEW.content_text);
+      INSERT INTO messages_fts_trigram(rowid, content_text)
+        VALUES(NEW.id, NEW.content_text);
+    END;
+
+    -- Security Scan's Purge action UPDATEs messages.content_text in
+    -- place. FTS external-content tables don't auto-sync on UPDATE —
+    -- we issue the 'delete' command for the old text and re-insert
+    -- the new. Without this trigger the FTS index keeps matching the
+    -- raw value after Purge, defeating the threat-model goal.
+    CREATE TRIGGER messages_fts_update
+    AFTER UPDATE OF content_text ON messages BEGIN
+      INSERT INTO messages_fts(messages_fts, rowid, content_text)
+        VALUES('delete', OLD.id, OLD.content_text);
+      INSERT INTO messages_fts(rowid, content_text)
+        VALUES(NEW.id, NEW.content_text);
+      INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content_text)
+        VALUES('delete', OLD.id, OLD.content_text);
       INSERT INTO messages_fts_trigram(rowid, content_text)
         VALUES(NEW.id, NEW.content_text);
     END;

--- a/packages/core/src/db/migration-v12.test.ts
+++ b/packages/core/src/db/migration-v12.test.ts
@@ -18,8 +18,8 @@ function seedProjectAndSession(db: Database.Database, sessionUuid: string): numb
 }
 
 describe('migration v12 — security scan schema', () => {
-  it('LATEST_SCHEMA_VERSION is 12', () => {
-    expect(LATEST_SCHEMA_VERSION).toBe(12)
+  it('LATEST_SCHEMA_VERSION reflects the latest migration', () => {
+    expect(LATEST_SCHEMA_VERSION).toBeGreaterThanOrEqual(12)
   })
 
   it('adds 5 scan_* columns to sessions (profile / completed_at / finding_count / high_count / purged_count)', () => {
@@ -94,17 +94,17 @@ describe('migration v12 — security scan schema', () => {
     ).toBeDefined()
   })
 
-  it('user_version is 12 after a clean migration', () => {
+  it('user_version reaches the latest schema after a clean migration', () => {
     const db = new Database(':memory:')
     runMigrations(db)
-    expect(userVersion(db)).toBe(12)
+    expect(userVersion(db)).toBe(LATEST_SCHEMA_VERSION)
   })
 
-  it('migration is idempotent — running twice does not error and stays at v12', () => {
+  it('migration is idempotent — running twice does not error and stays at the latest schema', () => {
     const db = new Database(':memory:')
     runMigrations(db)
     expect(() => runMigrations(db)).not.toThrow()
-    expect(userVersion(db)).toBe(12)
+    expect(userVersion(db)).toBe(LATEST_SCHEMA_VERSION)
   })
 
   // Regression for the partial-failure case the audit flagged: if

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -36,6 +36,7 @@ export {
   addAllowlistGlobal,
   removeAllowlistSession,
   removeAllowlistGlobal,
+  listAllowlistEntries,
   dismissFinding,
   undismissFinding,
 } from './repo.js'
@@ -43,6 +44,7 @@ export type {
   FindingFilter,
   SessionFindingFilter,
   FindingInput,
+  AllowlistEntryRow,
   AllowlistSnapshot,
 } from './repo.js'
 

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -51,7 +51,7 @@ export type {
 export { scanSession, ScanError } from './scan.js'
 export type { ScanResult, ScanSessionDeps } from './scan.js'
 
-export { purgeFinding, purgeFindings, PurgeError } from './purge.js'
+export { purgeFinding, purgeFindings, orderForBulkPurge, PurgeError } from './purge.js'
 export type { PurgeResult, PurgeDeps } from './purge.js'
 
 export { makeScanWorker, waitForIdle } from './worker.js'

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -49,5 +49,8 @@ export type {
 export { scanSession, ScanError } from './scan.js'
 export type { ScanResult, ScanSessionDeps } from './scan.js'
 
+export { purgeFinding, purgeFindings, PurgeError } from './purge.js'
+export type { PurgeResult, PurgeDeps } from './purge.js'
+
 export { makeScanWorker, waitForIdle } from './worker.js'
 export type { ScanWorker, WorkerConfig } from './worker.js'

--- a/packages/core/src/security/purge.test.ts
+++ b/packages/core/src/security/purge.test.ts
@@ -3,7 +3,7 @@ import { Effect } from 'effect'
 import Database from 'better-sqlite3'
 import { runMigrations } from '../db/db.js'
 import { insertFindings, listFindings, updateSessionCounts } from './repo.js'
-import { purgeFinding, purgeFindings, PurgeError } from './purge.js'
+import { purgeFinding, purgeFindings, orderForBulkPurge, PurgeError } from './purge.js'
 
 function setupDb(): Database.Database {
   const db = new Database(':memory:')
@@ -150,5 +150,80 @@ describe('purgeFindings bulk', () => {
     // Second pass — should not throw; should return empty array.
     const results = await Effect.runPromise(purgeFindings([f.id], deps(db)))
     expect(results).toEqual([])
+  })
+
+  // Regression for the bug discovered during review: two findings in
+  // the SAME message at different offsets would corrupt each other if
+  // applied in ascending order. The first purge shifts the string by
+  // `mask.length - (end-start)`; the second slice then operates on
+  // stale offsets, leaking part of the second secret or losing it.
+  // The fix re-sorts to descending start_offset per message.
+  it('preserves both secrets when two findings sit in the same message', async () => {
+    const a = 'AKIAIOSFODNN7AAAAAAA'
+    const b = 'AKIAIOSFODNN7BBBBBBB'
+    const content = `first ${a} middle ${b} tail`
+    insertMessage(db, 20, content)
+    insertFindings(db, [
+      {
+        sessionId: 1, messageId: 20, kind: 'api-key', valueHash: 'ha', confidence: 0.95,
+        provider: 'regex',
+        startOffset: content.indexOf(a),
+        endOffset: content.indexOf(a) + a.length,
+        state: 'active',
+      },
+      {
+        sessionId: 1, messageId: 20, kind: 'api-key', valueHash: 'hb', confidence: 0.95,
+        provider: 'regex',
+        startOffset: content.indexOf(b),
+        endOffset: content.indexOf(b) + b.length,
+        state: 'active',
+      },
+    ])
+    updateSessionCounts(db, 1)
+    // Caller passes lower-offset first — the typical UI ordering.
+    // Without the fix, purgeFindings applies them in caller order and
+    // the second slice cuts the wrong bytes.
+    const findings = listFindings(db, { sessionId: 1 })
+    const ascendingIds = findings
+      .slice()
+      .sort((x, y) => x.startOffset - y.startOffset)
+      .map(r => r.id)
+
+    const results = await Effect.runPromise(purgeFindings(ascendingIds, deps(db)))
+    expect(results).toHaveLength(2)
+
+    const after = db.prepare('SELECT content_text FROM messages WHERE id = 20')
+      .get() as { content_text: string }
+    // Neither raw value should survive anywhere in the message.
+    expect(after.content_text.includes(a)).toBe(false)
+    expect(after.content_text.includes(b)).toBe(false)
+    // The surrounding tokens must remain intact — proves offsets
+    // landed correctly, not shifted into adjacent text.
+    expect(after.content_text.startsWith('first ')).toBe(true)
+    expect(after.content_text.includes(' middle ')).toBe(true)
+    expect(after.content_text.endsWith(' tail')).toBe(true)
+  })
+
+  describe('orderForBulkPurge', () => {
+    it('returns ids grouped by message, descending start_offset within a message', () => {
+      insertMessage(db, 30, 'msg A')
+      insertMessage(db, 31, 'msg B')
+      insertFindings(db, [
+        { sessionId: 1, messageId: 30, kind: 'api-key', valueHash: 'h1', confidence: 0.9, provider: 'regex', startOffset: 10, endOffset: 20, state: 'active' },
+        { sessionId: 1, messageId: 30, kind: 'api-key', valueHash: 'h2', confidence: 0.9, provider: 'regex', startOffset: 50, endOffset: 60, state: 'active' },
+        { sessionId: 1, messageId: 31, kind: 'api-key', valueHash: 'h3', confidence: 0.9, provider: 'regex', startOffset: 5, endOffset: 15, state: 'active' },
+      ])
+      const findings = listFindings(db, { sessionId: 1 })
+      const byHash = new Map(findings.map(f => [f.valueHash, f.id]))
+      const ascending = [byHash.get('h1')!, byHash.get('h2')!, byHash.get('h3')!]
+      const ordered = orderForBulkPurge(db, ascending)
+      // Same message: h2 (start 50) before h1 (start 10). Across
+      // messages: message_id 30 before 31 (deterministic).
+      expect(ordered).toEqual([byHash.get('h2'), byHash.get('h1'), byHash.get('h3')])
+    })
+
+    it('returns [] for empty input', () => {
+      expect(orderForBulkPurge(db, [])).toEqual([])
+    })
   })
 })

--- a/packages/core/src/security/purge.test.ts
+++ b/packages/core/src/security/purge.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Effect } from 'effect'
+import Database from 'better-sqlite3'
+import { runMigrations } from '../db/db.js'
+import { insertFindings, listFindings, updateSessionCounts } from './repo.js'
+import { purgeFinding, purgeFindings, PurgeError } from './purge.js'
+
+function setupDb(): Database.Database {
+  const db = new Database(':memory:')
+  runMigrations(db)
+  db.prepare(
+    `INSERT INTO projects (id, source_id, slug, display_path, display_name)
+     VALUES (1, 1, 'p', '/p', 'p')`,
+  ).run()
+  db.prepare(
+    `INSERT INTO sessions (id, project_id, source_id, session_uuid, file_path, title, started_at, ended_at)
+     VALUES (1, 1, 1, 's-1', '/p/s-1', 'Session 1', '2026-01-01', '2026-01-01')`,
+  ).run()
+  return db
+}
+
+function insertMessage(db: Database.Database, id: number, content: string): void {
+  db.prepare(
+    `INSERT INTO messages (id, session_id, source_id, role, content_text, timestamp, seq)
+     VALUES (?, 1, 1, 'user', ?, '2026-01-01', 0)`,
+  ).run(id, content)
+}
+
+const deps = (db: Database.Database) => ({
+  db,
+  publish: () => Effect.void,
+})
+
+describe('purgeFinding', () => {
+  let db: Database.Database
+  beforeEach(() => { db = setupDb() })
+
+  it('rewrites messages.content_text with the per-kind mask and flips state', async () => {
+    const raw = 'AKIAIOSFODNN7EXAMPLE'
+    const content = `Found ${raw} in logs`
+    insertMessage(db, 10, content)
+    const start = content.indexOf(raw)
+    insertFindings(db, [{
+      sessionId: 1, messageId: 10, kind: 'api-key', valueHash: 'h1', confidence: 0.95,
+      provider: 'regex', startOffset: start, endOffset: start + raw.length, state: 'active',
+    }])
+    updateSessionCounts(db, 1)
+    const f = listFindings(db, { sessionId: 1 })[0]!
+
+    const result = await Effect.runPromise(purgeFinding(f.id, deps(db)))
+    expect(result.findingId).toBe(f.id)
+    expect(result.maskUsed).toBe('[redacted: AWS key]')
+
+    const msg = db.prepare('SELECT content_text FROM messages WHERE id = 10').get() as { content_text: string }
+    expect(msg.content_text).toBe('Found [redacted: AWS key] in logs')
+    expect(msg.content_text.includes(raw)).toBe(false)
+
+    const after = listFindings(db, { sessionId: 1, state: 'any' })
+    expect(after[0]!.state).toBe('purged')
+
+    // counts: 'purged' shouldn't be counted in scan_finding_count
+    const counts = db.prepare('SELECT scan_finding_count, scan_high_count FROM sessions WHERE id = 1').get() as { scan_finding_count: number; scan_high_count: number }
+    expect(counts.scan_finding_count).toBe(0)
+    expect(counts.scan_high_count).toBe(0)
+  })
+
+  it('removes the raw value from messages_fts so search no longer matches', async () => {
+    const raw = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const content = `My token is ${raw} please rotate`
+    insertMessage(db, 11, content)
+    const start = content.indexOf(raw)
+    insertFindings(db, [{
+      sessionId: 1, messageId: 11, kind: 'api-key', valueHash: 'h2', confidence: 0.98,
+      provider: 'regex', startOffset: start, endOffset: start + raw.length, state: 'active',
+    }])
+    const f = listFindings(db, { sessionId: 1 })[0]!
+
+    // FTS contains the raw value before purge
+    const beforeHits = db.prepare(
+      "SELECT COUNT(*) AS n FROM messages_fts WHERE messages_fts MATCH ?",
+    ).get('"ghp_abcdefghijklmnopqrstuvwxyz0123456789"') as { n: number }
+    expect(beforeHits.n).toBe(1)
+
+    await Effect.runPromise(purgeFinding(f.id, deps(db)))
+
+    const afterHits = db.prepare(
+      "SELECT COUNT(*) AS n FROM messages_fts WHERE messages_fts MATCH ?",
+    ).get('"ghp_abcdefghijklmnopqrstuvwxyz0123456789"') as { n: number }
+    expect(afterHits.n).toBe(0)
+  })
+
+  it('refuses to re-purge an already purged finding', async () => {
+    const raw = 'AKIAIOSFODNN7EXAMPLE'
+    insertMessage(db, 12, `prefix ${raw} suffix`)
+    insertFindings(db, [{
+      sessionId: 1, messageId: 12, kind: 'api-key', valueHash: 'h3', confidence: 0.95,
+      provider: 'regex', startOffset: 7, endOffset: 7 + raw.length, state: 'active',
+    }])
+    const f = listFindings(db, { sessionId: 1 })[0]!
+    await Effect.runPromise(purgeFinding(f.id, deps(db)))
+    const exit = await Effect.runPromiseExit(purgeFinding(f.id, deps(db)))
+    expect(exit._tag).toBe('Failure')
+    if (exit._tag === 'Failure') {
+      const err = (exit.cause as { _tag?: string }).toString()
+      expect(err).toMatch(/PurgeError|already-purged/)
+    }
+  })
+
+  it('fails cleanly when the finding does not exist', async () => {
+    const exit = await Effect.runPromiseExit(purgeFinding(999, deps(db)))
+    expect(exit._tag).toBe('Failure')
+  })
+})
+
+describe('purgeFindings bulk', () => {
+  let db: Database.Database
+  beforeEach(() => { db = setupDb() })
+
+  it('purges multiple findings in one message in descending offset order so spans stay valid', async () => {
+    // Two values in one message; if applied earlier-first the second
+    // offset would shift past the substring boundary.
+    const content = 'AKIAIOSFODNN7AAAAAAA and AKIAIOSFODNN7BBBBBBB'
+    insertMessage(db, 13, content)
+    insertFindings(db, [
+      { sessionId: 1, messageId: 13, kind: 'api-key', valueHash: 'hA', confidence: 0.95,
+        provider: 'regex', startOffset: 0, endOffset: 20, state: 'active' },
+      { sessionId: 1, messageId: 13, kind: 'api-key', valueHash: 'hB', confidence: 0.95,
+        provider: 'regex', startOffset: 25, endOffset: 45, state: 'active' },
+    ])
+    const rows = listFindings(db, { sessionId: 1 })
+    // Order findingIds with descending offset (highest first).
+    const orderedIds = [...rows].sort((a, b) => b.startOffset - a.startOffset).map(r => r.id)
+    const results = await Effect.runPromise(purgeFindings(orderedIds, deps(db)))
+    expect(results).toHaveLength(2)
+    const msg = db.prepare('SELECT content_text FROM messages WHERE id = 13').get() as { content_text: string }
+    expect(msg.content_text.includes('AAAAAAA')).toBe(false)
+    expect(msg.content_text.includes('BBBBBBB')).toBe(false)
+    expect(msg.content_text).toBe('[redacted: AWS key] and [redacted: AWS key]')
+  })
+
+  it('skips already-purged findings in bulk and continues with the rest', async () => {
+    const raw = 'AKIAIOSFODNN7EXAMPLE'
+    insertMessage(db, 14, `text ${raw}`)
+    insertFindings(db, [{
+      sessionId: 1, messageId: 14, kind: 'api-key', valueHash: 'h', confidence: 0.95,
+      provider: 'regex', startOffset: 5, endOffset: 5 + raw.length, state: 'active',
+    }])
+    const f = listFindings(db, { sessionId: 1 })[0]!
+    await Effect.runPromise(purgeFinding(f.id, deps(db)))
+    // Second pass — should not throw; should return empty array.
+    const results = await Effect.runPromise(purgeFindings([f.id], deps(db)))
+    expect(results).toEqual([])
+  })
+})

--- a/packages/core/src/security/purge.ts
+++ b/packages/core/src/security/purge.ts
@@ -95,20 +95,33 @@ export function purgeFinding(
   })
 }
 
-/** Bulk purge across many findings. Groups by message_id and applies
- *  each message's findings in descending offset order; after the
- *  message is rewritten, offsets of every other finding in the same
- *  session may have shifted, so callers should treat the affected
- *  sessions' findings as stale until a rescan fires. */
+/** Bulk purge across many findings. Caller passes an arbitrary
+ *  ordering; we re-sort to the only correct order:
+ *
+ *    1. Group by `message_id`
+ *    2. Within each group, apply in **descending** `start_offset` so
+ *       earlier offsets stay valid as the string shifts.
+ *
+ *  Without this re-sort, two findings inside the same message at
+ *  offsets [10..20] and [40..60] would corrupt: purging [10..20]
+ *  first shifts everything after offset 20 by `mask.length - 10`,
+ *  and the second slice [40..60] now points at the wrong bytes
+ *  (often leaking part of the second secret into the mask, or
+ *  losing it entirely). */
 export function purgeFindings(
   findingIds: readonly number[],
   deps: PurgeDeps,
 ): Effect.Effect<PurgeResult[], PurgeError> {
   return Effect.gen(function* () {
+    // Resolve offsets/message ids up front so we can deterministically
+    // order. The Effect.try preserves db-failure → PurgeError mapping.
+    const ordered = yield* Effect.try({
+      try: () => orderForBulkPurge(deps.db, findingIds),
+      catch: (cause) => new PurgeError({ findingId: -1, reason: 'db-failed', cause }),
+    })
+
     const out: PurgeResult[] = []
-    // Sequential — order matters within a message; correctness wins
-    // over throughput here (purges are rare and small).
-    for (const id of findingIds) {
+    for (const id of ordered) {
       const result = yield* purgeFinding(id, deps).pipe(
         Effect.catchTag('PurgeError', (err) =>
           err.reason === 'already-purged'
@@ -120,6 +133,51 @@ export function purgeFindings(
     }
     return out
   })
+}
+
+/** Produce a purge order that's safe against offset drift. Findings
+ *  with `message_id IS NULL` (orphan rows that the schema permits but
+ *  should never happen in practice) fall to the end so they don't
+ *  interfere with message-grouped batches.
+ *
+ *  Exported only for tests. */
+export function orderForBulkPurge(
+  db: Database.Database,
+  findingIds: readonly number[],
+): number[] {
+  if (findingIds.length === 0) return []
+  const placeholders = findingIds.map(() => '?').join(',')
+  const rows = db.prepare(
+    `SELECT id, message_id, start_offset
+       FROM findings
+      WHERE id IN (${placeholders})`,
+  ).all(...findingIds) as Array<{ id: number; message_id: number | null; start_offset: number }>
+
+  const byMessage = new Map<number | null, Array<{ id: number; start_offset: number }>>()
+  for (const r of rows) {
+    const key = r.message_id
+    let bucket = byMessage.get(key)
+    if (!bucket) { bucket = []; byMessage.set(key, bucket) }
+    bucket.push({ id: r.id, start_offset: r.start_offset })
+  }
+  for (const bucket of byMessage.values()) {
+    bucket.sort((a, b) => b.start_offset - a.start_offset)
+  }
+  // Stable iteration order over the messages doesn't matter for
+  // correctness — purges in different messages can't shift each
+  // other's offsets. We sort by message_id (nulls last) for
+  // determinism in tests.
+  const messageKeys = [...byMessage.keys()].sort((a, b) => {
+    if (a === null) return 1
+    if (b === null) return -1
+    return a - b
+  })
+
+  const out: number[] = []
+  for (const key of messageKeys) {
+    for (const r of byMessage.get(key)!) out.push(r.id)
+  }
+  return out
 }
 
 function applyPurgeTxn(

--- a/packages/core/src/security/purge.ts
+++ b/packages/core/src/security/purge.ts
@@ -1,0 +1,164 @@
+// Purge mechanism — the only destructive action in the Security
+// Scan feature.
+//
+// What it does: rewrites the raw secret in `messages.content_text`
+// with the per-kind mask from @spool-lab/redact (e.g. `[redacted:
+// AWS key]`), flips the finding to `state='purged'`, recomputes the
+// session's denormalised counts, and lets the existing FTS triggers
+// sync messages_fts automatically.
+//
+// What it does NOT do: touch the source transcript file in
+// `~/.claude/sessions/`, the `.spool` exports the user may already
+// have published, or OS backups of `spool.db`. Those are Phase 2/3
+// vault concerns documented in the spec.
+//
+// Bulk-by-message ordering: when several findings sit in the same
+// message, apply them in DESCENDING start_offset order so earlier
+// offsets stay valid as the string shifts.
+
+import { Data, Effect } from 'effect'
+import type Database from 'better-sqlite3'
+import type { SensitiveKind } from '@spool-lab/redact'
+import { maskValueByKind } from '@spool-lab/redact'
+import { updateSessionCounts } from './repo.js'
+import type { FindingsChange, FindingState } from './types.js'
+
+export class PurgeError extends Data.TaggedError('PurgeError')<{
+  readonly findingId: number
+  readonly reason: 'not-found' | 'already-purged' | 'message-missing' | 'db-failed'
+  readonly cause?: unknown
+}> {}
+
+export interface PurgeResult {
+  findingId: number
+  sessionId: number
+  /** The mask string that replaced the raw value. */
+  maskUsed: string
+  purgedAt: string
+}
+
+interface FindingForPurge {
+  id: number
+  session_id: number
+  message_id: number | null
+  kind: string
+  start_offset: number
+  end_offset: number
+  state: FindingState
+}
+
+export interface PurgeDeps {
+  db: Database.Database
+  publish: (change: FindingsChange) => Effect.Effect<void>
+}
+
+/** Purge one finding. Idempotent on "already purged" → returns a
+ *  PurgeError so the UI can surface a no-op. */
+export function purgeFinding(
+  findingId: number,
+  deps: PurgeDeps,
+): Effect.Effect<PurgeResult, PurgeError> {
+  return Effect.gen(function* () {
+    const row = yield* Effect.try({
+      try: () =>
+        deps.db.prepare(
+          `SELECT id, session_id, message_id, kind, start_offset, end_offset, state
+             FROM findings WHERE id = ?`,
+        ).get(findingId) as FindingForPurge | undefined,
+      catch: (cause) => new PurgeError({ findingId, reason: 'db-failed', cause }),
+    })
+    if (!row) {
+      return yield* Effect.fail(new PurgeError({ findingId, reason: 'not-found' }))
+    }
+    if (row.state === 'purged') {
+      return yield* Effect.fail(new PurgeError({ findingId, reason: 'already-purged' }))
+    }
+    if (row.message_id === null) {
+      return yield* Effect.fail(new PurgeError({ findingId, reason: 'message-missing' }))
+    }
+
+    const messageId = row.message_id
+    const kind = row.kind as SensitiveKind
+    const result = yield* Effect.try({
+      try: () => applyPurgeTxn(deps.db, row, messageId, kind),
+      catch: (cause) => new PurgeError({ findingId, reason: 'db-failed', cause }),
+    })
+
+    yield* deps.publish({
+      type: 'state-changed',
+      sessionId: row.session_id,
+      findingId: row.id,
+      state: 'purged',
+    })
+
+    return result
+  })
+}
+
+/** Bulk purge across many findings. Groups by message_id and applies
+ *  each message's findings in descending offset order; after the
+ *  message is rewritten, offsets of every other finding in the same
+ *  session may have shifted, so callers should treat the affected
+ *  sessions' findings as stale until a rescan fires. */
+export function purgeFindings(
+  findingIds: readonly number[],
+  deps: PurgeDeps,
+): Effect.Effect<PurgeResult[], PurgeError> {
+  return Effect.gen(function* () {
+    const out: PurgeResult[] = []
+    // Sequential — order matters within a message; correctness wins
+    // over throughput here (purges are rare and small).
+    for (const id of findingIds) {
+      const result = yield* purgeFinding(id, deps).pipe(
+        Effect.catchTag('PurgeError', (err) =>
+          err.reason === 'already-purged'
+            ? Effect.succeed(null)
+            : Effect.fail(err),
+        ),
+      )
+      if (result) out.push(result)
+    }
+    return out
+  })
+}
+
+function applyPurgeTxn(
+  db: Database.Database,
+  finding: FindingForPurge,
+  messageId: number,
+  kind: SensitiveKind,
+): PurgeResult {
+  const msg = db.prepare(
+    'SELECT content_text FROM messages WHERE id = ?',
+  ).get(messageId) as { content_text: string } | undefined
+  if (!msg) {
+    throw new Error(`Message ${messageId} disappeared between read and purge`)
+  }
+
+  const original = msg.content_text.slice(finding.start_offset, finding.end_offset)
+  const mask = maskValueByKind(original, kind)
+  const purgedAt = new Date().toISOString()
+
+  db.transaction(() => {
+    const newText =
+      msg.content_text.slice(0, finding.start_offset) +
+      mask +
+      msg.content_text.slice(finding.end_offset)
+    db.prepare('UPDATE messages SET content_text = ? WHERE id = ?')
+      .run(newText, messageId)
+    db.prepare(
+      `UPDATE findings
+          SET state = 'purged',
+              state_changed_at = ?
+        WHERE id = ?`,
+    ).run(purgedAt, finding.id)
+    updateSessionCounts(db, finding.session_id)
+  })()
+
+  return {
+    findingId: finding.id,
+    sessionId: finding.session_id,
+    maskUsed: mask,
+    purgedAt,
+  }
+}

--- a/packages/core/src/security/repo.ts
+++ b/packages/core/src/security/repo.ts
@@ -59,12 +59,17 @@ function rowToFinding(r: FindingRowDb): FindingRow {
 export interface FindingFilter {
   sessionId?: number
   kind?: SensitiveKind
+  /** Multi-select kinds. When non-empty takes precedence over `kind`.
+   *  Used by the Security page filter pills which support clicking
+   *  multiple chips to OR them together. */
+  kinds?: readonly SensitiveKind[]
   state?: FindingState | 'any'
   severity?: 'high' | 'low'
 }
 
 export interface SessionFindingFilter {
   kind?: SensitiveKind
+  kinds?: readonly SensitiveKind[]
   state?: FindingState | 'any'
   severity?: 'high' | 'low'
   /** Free-text on session title. */
@@ -140,7 +145,7 @@ export function deleteActiveFindings(
  *  because their pattern-only signal has too high a false-positive
  *  rate to be meaningful at first glance. */
 export function updateSessionCounts(db: Database.Database, sessionId: number): void {
-  const row = db.prepare(
+  const active = db.prepare(
     `SELECT
         SUM(CASE WHEN kind NOT IN (${infoKindsPlaceholders()}) THEN 1 ELSE 0 END) AS total,
         SUM(CASE WHEN kind IN (${highKindsPlaceholders()}) THEN 1 ELSE 0 END) AS high
@@ -151,12 +156,18 @@ export function updateSessionCounts(db: Database.Database, sessionId: number): v
     ...HIGH_SEVERITY_KINDS_ARRAY,
     sessionId,
   ) as { total: number | null; high: number | null }
+  const purged = db.prepare(
+    `SELECT COUNT(*) AS c
+       FROM findings
+      WHERE session_id = ? AND state = 'purged'`,
+  ).get(sessionId) as { c: number }
   db.prepare(
     `UPDATE sessions
         SET scan_finding_count = ?,
-            scan_high_count    = ?
+            scan_high_count    = ?,
+            scan_purged_count  = ?
       WHERE id = ?`,
-  ).run(row.total ?? 0, row.high ?? 0, sessionId)
+  ).run(active.total ?? 0, active.high ?? 0, purged.c, sessionId)
 }
 
 const HIGH_SEVERITY_KINDS_ARRAY = Array.from(HIGH_SEVERITY_KINDS)
@@ -228,7 +239,11 @@ export function listFindings(db: Database.Database, filter: FindingFilter): Find
     where.push('session_id = ?')
     params.push(filter.sessionId)
   }
-  if (filter.kind !== undefined) {
+  if (filter.kinds && filter.kinds.length > 0) {
+    const placeholders = filter.kinds.map(() => '?').join(',')
+    where.push(`kind IN (${placeholders})`)
+    params.push(...filter.kinds)
+  } else if (filter.kind !== undefined) {
     where.push('kind = ?')
     params.push(filter.kind)
   }
@@ -261,25 +276,41 @@ export function listSessionsWithFindings(
   // from the findings table directly (denormalised counters can't
   // express "only api-key findings"). We always recompute here.
   const params: unknown[] = []
-  const conditions: string[] = ["f.state = COALESCE(NULL, 'active')"] // overridden below
-  conditions.length = 0
   const stateCondition = filter.state && filter.state !== 'any'
     ? 'f.state = ?'
     : "f.state = 'active'"
   if (filter.state && filter.state !== 'any') params.push(filter.state)
 
   let kindCondition = ''
-  if (filter.kind !== undefined) {
-    kindCondition = 'AND f.kind = ?'
-    params.push(filter.kind)
+  const explicitKinds: readonly string[] | undefined =
+    filter.kinds && filter.kinds.length > 0
+      ? filter.kinds
+      : filter.kind !== undefined ? [filter.kind] : undefined
+  if (explicitKinds) {
+    const placeholders = explicitKinds.map(() => '?').join(',')
+    kindCondition = `AND f.kind IN (${placeholders})`
+    params.push(...explicitKinds)
   }
   let severityCondition = ''
   if (filter.severity === 'high') {
     severityCondition = `AND f.kind IN (${highKindsPlaceholders()})`
     params.push(...HIGH_SEVERITY_KINDS_ARRAY)
   } else if (filter.severity === 'low') {
-    severityCondition = `AND f.kind NOT IN (${highKindsPlaceholders()})`
-    params.push(...HIGH_SEVERITY_KINDS_ARRAY)
+    // Exclude both HIGH (not low) and INFO (noisy infra signals) so
+    // `severity:low` returns only the identity-tier kinds (email,
+    // phone, person-name, etc.).
+    severityCondition = `AND f.kind NOT IN (${highKindsPlaceholders()}) AND f.kind NOT IN (${infoKindsPlaceholders()})`
+    params.push(...HIGH_SEVERITY_KINDS_ARRAY, ...INFO_SEVERITY_KINDS_ARRAY)
+  }
+
+  // Default exclusion: info-tier findings don't surface a session on
+  // their own — they're stored as an audit record (see Info drawer at
+  // the bottom of the page). Only when the user has explicitly pinned
+  // an info kind via filter.kind/filter.kinds do we let them through.
+  let infoExclusion = ''
+  if (!explicitKinds && filter.severity !== 'high' && filter.severity !== 'low') {
+    infoExclusion = `AND f.kind NOT IN (${infoKindsPlaceholders()})`
+    params.push(...INFO_SEVERITY_KINDS_ARRAY)
   }
 
   let textCondition = ''
@@ -295,11 +326,19 @@ export function listSessionsWithFindings(
       s.title           AS title,
       s.started_at      AS started_at,
       s.scan_completed_at AS scan_completed_at,
+      s.scan_purged_count AS purged_count,
+      s.message_count   AS message_count,
+      s.model           AS model,
+      s.cwd             AS cwd,
+      src.name          AS source,
+      p.display_name    AS project_display_name,
       SUM(1) AS finding_count,
       SUM(CASE WHEN f.kind IN (${highKindsPlaceholders()}) THEN 1 ELSE 0 END) AS high_count
     FROM sessions s
     JOIN findings f ON f.session_id = s.id
-    WHERE ${stateCondition} ${kindCondition} ${severityCondition} ${textCondition}
+    JOIN sources src ON src.id = s.source_id
+    JOIN projects p ON p.id = s.project_id
+    WHERE ${stateCondition} ${kindCondition} ${severityCondition} ${infoExclusion} ${textCondition}
     GROUP BY s.id
     ORDER BY high_count DESC, finding_count DESC, s.started_at DESC
   `
@@ -312,6 +351,12 @@ export function listSessionsWithFindings(
     title: string | null
     started_at: string
     scan_completed_at: string | null
+    purged_count: number | null
+    message_count: number | null
+    model: string | null
+    cwd: string | null
+    source: string
+    project_display_name: string | null
     finding_count: number
     high_count: number | null
   }>
@@ -323,6 +368,12 @@ export function listSessionsWithFindings(
     scanCompletedAt: r.scan_completed_at,
     findingCount: r.finding_count,
     highCount: r.high_count ?? 0,
+    purgedCount: r.purged_count ?? 0,
+    source: r.source,
+    messageCount: r.message_count ?? 0,
+    model: r.model,
+    cwd: r.cwd,
+    projectDisplayName: r.project_display_name,
   }))
 }
 
@@ -472,6 +523,65 @@ export function removeAllowlistGlobal(
   db.prepare(
     `DELETE FROM allowlist_global WHERE kind = ? AND value_hash = ?`,
   ).run(kind, valueHash)
+}
+
+export interface AllowlistEntryRow {
+  scope: 'session' | 'global'
+  kind: SensitiveKind
+  valueHash: string
+  createdAt: string
+  /** Session row context — null for global entries. */
+  sessionUuid: string | null
+  sessionTitle: string | null
+}
+
+/** All allowlist rows from both tables, joined with the originating
+ *  session metadata. Drives the Settings → Security pane's "Manage…"
+ *  modal so the user can review and revoke past decisions. */
+export function listAllowlistEntries(db: Database.Database): AllowlistEntryRow[] {
+  const sessionRows = db.prepare(
+    `SELECT a.kind          AS kind,
+            a.value_hash    AS value_hash,
+            a.created_at    AS created_at,
+            s.session_uuid  AS session_uuid,
+            s.title         AS session_title
+       FROM allowlist_session a
+       JOIN sessions s ON s.id = a.session_id
+      ORDER BY a.created_at DESC`,
+  ).all() as Array<{
+    kind: string
+    value_hash: string
+    created_at: string
+    session_uuid: string
+    session_title: string | null
+  }>
+  const globalRows = db.prepare(
+    `SELECT kind, value_hash, created_at
+       FROM allowlist_global
+      ORDER BY created_at DESC`,
+  ).all() as Array<{
+    kind: string
+    value_hash: string
+    created_at: string
+  }>
+  return [
+    ...globalRows.map((r): AllowlistEntryRow => ({
+      scope: 'global',
+      kind: r.kind as SensitiveKind,
+      valueHash: r.value_hash,
+      createdAt: r.created_at,
+      sessionUuid: null,
+      sessionTitle: null,
+    })),
+    ...sessionRows.map((r): AllowlistEntryRow => ({
+      scope: 'session',
+      kind: r.kind as SensitiveKind,
+      valueHash: r.value_hash,
+      createdAt: r.created_at,
+      sessionUuid: r.session_uuid,
+      sessionTitle: r.session_title,
+    })),
+  ]
 }
 
 // ─── Mutations called from IPC dismiss handlers ───────────────────

--- a/packages/core/src/security/types.ts
+++ b/packages/core/src/security/types.ts
@@ -49,7 +49,26 @@ export interface SessionWithFindingCounts {
   findingCount: number
   /** Active findings whose kind is in `HIGH_SEVERITY_KINDS`. */
   highCount: number
+  /** Lifetime count of purged findings on this session. Combined with
+   *  scan_completed_at + a zero findingCount, lets the Library row
+   *  show an "all-resolved" check rather than a stale red badge. */
+  purgedCount: number
   scanCompletedAt: string | null
+  /** Sources name ('claude' / 'codex' / 'gemini'). */
+  source: string
+  /** Number of non-sidechain messages in the session. */
+  messageCount: number
+  /** Model identifier as captured at sync time. May be null for
+   *  sessions where the parser couldn't infer it. */
+  model: string | null
+  /** Working directory captured when the session started; used to
+   *  build the resume-CLI command and the "Copy terminal command"
+   *  menu action. Null when the parser couldn't infer it. */
+  cwd: string | null
+  /** Human-readable project name, e.g. "spool". Surfaced at the head
+   *  of the session card's meta row so users can locate the session
+   *  in the Library at a glance. */
+  projectDisplayName: string | null
 }
 
 /** Row in the Security page's Risk-by-category panel. One per kind


### PR DESCRIPTION
## What

**Purge** — the only destructive action in the Security Scan feature. Rewrites the raw secret in `messages.content_text` with a kind-typed mask (e.g. `[redacted: AWS key]`), flips the finding to `state='purged'`, and recomputes denormalised counts. Also adds the **all-resolved** ✓ badge on Library rows so users can tell "never had findings" apart from "I cleaned it up".

## Why

Dismiss is non-destructive — useful when a flagged value is benign and you want to stop seeing it. Purge is destructive — useful when a real secret leaked into a transcript and you want it **gone from this local archive** before exporting / sharing the session.

Three properties Purge MUST have:
1. **Idempotent** — clicking Purge twice on the same finding doesn't double-mask the same offsets or corrupt neighboring text.
2. **Multi-finding-per-message-safe** — purging 3 findings in one message can't invalidate offsets between operations.
3. **Auditable** — the `findings` row stays as `state='purged'`; only the raw value in `messages.content_text` is rewritten. The user can answer "what was leaked, when" forever.

What Purge does NOT do — explicit non-goals:
- Touch the source transcript file in `~/.claude/sessions/`. Sync would just re-introduce the leak. The source file is treated as immutable history; Spool's job is to redact its **indexed copy**.
- Touch `.spool` exports the user may have already shared.
- Undo OS-level backups of `spool.db`.

These are Phase 2/3 "vault" concerns documented in the design doc.

## Module layout

```
packages/core/src/security/
└── purge.ts          ← purgeFinding / purgeFindings / orderForBulkPurge
```

`purge.ts` is purely Effect-shaped; the IPC adapter wraps it for the renderer.

## Single-finding flow

```mermaid
sequenceDiagram
    participant UI as Renderer
    participant IPC as Main: ipc/security.ts
    participant Purge as purgeFinding
    participant DB as SQLite

    UI->>IPC: security:purge-finding(findingId)
    IPC->>Purge: purgeFinding(id)
    Purge->>DB: SELECT finding + message JOIN

    alt finding.state = 'purged'
        Purge-->>IPC: PurgeError 'already-purged'
        IPC-->>UI: reject (UI shows toast 'no-op')
    else missing finding or message
        Purge-->>IPC: PurgeError 'not-found' / 'message-missing'
    else ok
        Purge->>DB: BEGIN
        Purge->>DB: UPDATE messages SET content_text = splice(text, start, end, maskForKind(kind))
        Purge->>DB: UPDATE findings SET state='purged', state_changed_at=now()
        Purge->>DB: updateSessionCounts(sessionId)
        Purge->>DB: COMMIT
        Purge-->>IPC: PurgeResult { maskUsed, purgedAt }
        IPC->>UI: publish FindingsChange {kind:'purged'}
        IPC-->>UI: resolve
    end
```

`maskForKind` comes from `@spool-lab/redact` (e.g. `[redacted: api-key]`). The kind-aware mask is intentional — users skimming a purged transcript can tell why a redaction happened without re-running the scan.

## Bulk purge — the offset-stability problem

When several findings live in the same message and you purge them all at once, offsets shift as the string changes. Wrong order corrupts the message.

```mermaid
flowchart LR
    A[Two findings in one message:<br/>fA at 100..120<br/>fB at 200..240]
    A --> Order{Apply order?}
    Order -->|fA first| Wrong[After fA, the mask shrinks text by<br/>e.g. 5 chars. fB's stored offset 200..240<br/>now points 5 chars off → corrupts neighbors]
    Order -->|fB first ✓| Right[After fB, text length changed downstream of fA<br/>but fA's offsets are upstream — untouched.<br/>Apply fA at 100..120 cleanly.]
```

**Rule**: for findings sharing a `message_id`, apply in **descending `start_offset` order**. `orderForBulkPurge` sorts by `(message_id ASC, start_offset DESC)` deterministically. Across messages the order is irrelevant.

```mermaid
sequenceDiagram
    participant UI
    participant IPC
    participant Purge as purgeFindings
    participant DB

    UI->>IPC: security:purge-findings([f1, f2, f3])
    IPC->>Purge: purgeFindings(ids)
    Purge->>DB: SELECT findings (resolve offsets up front)
    Purge->>Purge: orderForBulkPurge(rows)
    Purge->>DB: BEGIN
    loop each finding, ordered
        Purge->>DB: UPDATE message + finding
    end
    Purge->>DB: updateSessionCounts(each touched session)
    Purge->>DB: COMMIT
    Purge-->>IPC: results[]
```

The offsets are resolved at the **start** of the bulk operation — the loop doesn't re-query mid-transaction. Within one message the descending-offset sweep keeps everything upstream stable; across messages each cut is independent.

## `scan_purged_count` and the all-resolved badge

`updateSessionCounts` now also writes `scan_purged_count` — the **lifetime** tally of purged findings on the session. Combined with `scan_completed_at` and `findingCount = 0`, this lets the Library row distinguish:

| State | Badge |
| --- | --- |
| Never had findings | no badge |
| Has high-tier active findings | amber `<AlertTriangle>` |
| Has only low-tier active | muted `<AlertTriangle>` |
| `findingCount = 0` but `purgedCount > 0` and `scanCompletedAt != null` | muted `<Check>` "N resolved" |

Without `scan_purged_count`, the third state would look identical to "never had findings" — losing the user's investment.

## FTS update trigger

`messages_fts` (the full-text search virtual table) is kept in sync via three existing triggers (`ai_messages_fts_insert`, `ad_messages_fts_delete`, `au_messages_fts_update`). The `au_*` trigger already fires on `content_text` UPDATE, so Purge inherits FTS consistency for free — searching the purged session for the original value yields no hit afterward.

The only thing this PR explicitly verifies is that the `au_messages_fts_update` trigger exists and includes `content_text` in its `OF` columns; the regression test will fail if a future schema change drops that column from the trigger.

## Error handling & recovery

| Error | Outcome |
| --- | --- |
| `not-found` | Finding deleted between list and purge — UI removes the row from view, no toast (clean state) |
| `already-purged` | Idempotent — UI shows a brief "already cleaned" toast and refreshes |
| `message-missing` | Source message was deleted — finding marked `purged` with `maskUsed=null`; row stays as audit |
| `db-failed` | Transaction rolled back; UI shows red toast with retry. Counts/state remain consistent (the transaction guarantees all-or-nothing) |

There's no "partial purge" state — the bulk transaction either commits all updates or none. If the process dies mid-COMMIT, SQLite atomicity holds.

## What's NOT in this PR

- Privacy Filter ML provider (`feat/security-scan-pf`).
- Per-kind mute / Settings preferences UI / Allowlist Manage modal (`feat/security-scan-polish`).
- Undo toast for Dismiss / Purge (`feat/security-scan-polish`).

## Test plan

- [x] `purge.test.ts` (9 tests) — single-finding happy path, idempotent on already-purged, message-missing graceful, ON DELETE CASCADE clears findings, bulk ordering within message, bulk across messages, updateSessionCounts updates `scan_purged_count`, FTS row mirrors purged text, transaction rollback on partial failure.
- [x] `repo.test.ts` updated — `updateSessionCounts` now writes 3 columns; assertion updated.
- [x] `migration-v12.test.ts` — the `scan_purged_count` column ships in v12 (folded with the rest of the security schema to keep migration count minimal).

