### PR TITLE
feat(security): Privacy Filter ML scaffold

### DIFF
--- a/packages/app/src/main/security/class-mapping.test.ts
+++ b/packages/app/src/main/security/class-mapping.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import type { SensitiveMatch } from '@spool-lab/redact'
+import { mapPfMatch, mapPfMatches, type PfRawMatch } from './class-mapping.js'
+
+const regex = (kind: SensitiveMatch['kind'], start: number, end: number): SensitiveMatch => ({
+  kind, value: '', start, end, confidence: 0.95, provider: 'regex',
+})
+
+describe('class mapping — direct mappings', () => {
+  it('person → person-name', () => {
+    const pf: PfRawMatch = { class: 'person', value: 'Maya', start: 0, end: 4, score: 0.9 }
+    const out = mapPfMatch(pf, { regexMatches: [], fullText: 'Maya' })
+    expect(out?.kind).toBe('person-name')
+    expect(out?.provider).toBe('pf')
+  })
+  it('email → email', () => {
+    const pf: PfRawMatch = { class: 'email', value: 'a@b.c', start: 0, end: 5, score: 0.95 }
+    expect(mapPfMatch(pf, { regexMatches: [], fullText: 'a@b.c' })?.kind).toBe('email')
+  })
+  it('phone → phone', () => {
+    const pf: PfRawMatch = { class: 'phone', value: '+1234567890', start: 0, end: 11, score: 0.92 }
+    expect(mapPfMatch(pf, { regexMatches: [], fullText: '+1234567890' })?.kind).toBe('phone')
+  })
+  it('address → street-address', () => {
+    const pf: PfRawMatch = { class: 'address', value: '1 Main St', start: 0, end: 9, score: 0.88 }
+    expect(mapPfMatch(pf, { regexMatches: [], fullText: '1 Main St' })?.kind).toBe('street-address')
+  })
+})
+
+describe('class mapping — suppression rules', () => {
+  it('url with no overlapping regex url-creds is suppressed', () => {
+    const pf: PfRawMatch = { class: 'url', value: 'https://example.com', start: 0, end: 19, score: 0.9 }
+    expect(mapPfMatch(pf, { regexMatches: [], fullText: 'https://example.com' })).toBeNull()
+  })
+  it('url overlapping a regex url-creds match → url-creds (boost)', () => {
+    const pf: PfRawMatch = { class: 'url', value: 'https://u:p@x.com', start: 0, end: 17, score: 0.9 }
+    const out = mapPfMatch(pf, {
+      regexMatches: [regex('url-creds', 0, 17)],
+      fullText: 'https://u:p@x.com',
+    })
+    expect(out?.kind).toBe('url-creds')
+  })
+
+  it('account_number is always suppressed', () => {
+    const pf: PfRawMatch = { class: 'account_number', value: '4111 1111 1111 1111', start: 0, end: 19, score: 0.95 }
+    expect(mapPfMatch(pf, { regexMatches: [], fullText: '4111 1111 1111 1111' })).toBeNull()
+  })
+
+  it('secret with no regex generic-secret nearby is suppressed', () => {
+    const pf: PfRawMatch = { class: 'secret', value: 'abc', start: 0, end: 3, score: 0.7 }
+    expect(mapPfMatch(pf, { regexMatches: [], fullText: 'abc' })).toBeNull()
+  })
+
+  it('secret overlapping a regex generic-secret → generic-secret (boost)', () => {
+    const pf: PfRawMatch = { class: 'secret', value: 'xyz', start: 5, end: 8, score: 0.7 }
+    const out = mapPfMatch(pf, {
+      regexMatches: [regex('generic-secret', 0, 20)],
+      fullText: 'token = "xyz" plus extra',
+    })
+    expect(out?.kind).toBe('generic-secret')
+  })
+
+  it('date alone is suppressed', () => {
+    const pf: PfRawMatch = { class: 'date', value: '1990-05-15', start: 0, end: 10, score: 0.85 }
+    expect(mapPfMatch(pf, { regexMatches: [], fullText: 'random text 1990-05-15 nothing here' })).toBeNull()
+  })
+
+  it('date with DOB context → date-of-birth', () => {
+    const pf: PfRawMatch = { class: 'date', value: '1990-05-15', start: 14, end: 24, score: 0.85 }
+    const out = mapPfMatch(pf, {
+      regexMatches: [],
+      fullText: 'date of birth 1990-05-15 from form',
+    })
+    expect(out?.kind).toBe('date-of-birth')
+  })
+
+  it('date with DOB-like prefix is gated case-insensitively', () => {
+    const pf: PfRawMatch = { class: 'date', value: '2002-11-09', start: 5, end: 15, score: 0.85 }
+    const out = mapPfMatch(pf, {
+      regexMatches: [],
+      fullText: 'DOB: 2002-11-09',
+    })
+    expect(out?.kind).toBe('date-of-birth')
+  })
+})
+
+describe('mapPfMatches', () => {
+  it('drops suppressed entries while keeping the rest', () => {
+    const pf: PfRawMatch[] = [
+      { class: 'person', value: 'Maya', start: 0, end: 4, score: 0.9 },
+      { class: 'account_number', value: '0123456', start: 10, end: 17, score: 0.95 },
+      { class: 'email', value: 'a@b.c', start: 20, end: 25, score: 0.9 },
+    ]
+    const out = mapPfMatches(pf, { regexMatches: [], fullText: 'Maya       0123456    a@b.c' })
+    expect(out.map(m => m.kind)).toEqual(['person-name', 'email'])
+  })
+})

--- a/packages/app/src/main/security/class-mapping.ts
+++ b/packages/app/src/main/security/class-mapping.ts
@@ -1,0 +1,124 @@
+// Privacy Filter class mapping.
+//
+// OpenAI Privacy Filter emits 8 classes; we map them to Spool's
+// SensitiveKind. Some classes need suppression rules to avoid the
+// model out-shouting the regex detector for things the regex
+// already covers with checksums.
+//
+// Spec: ~/Documents/dev-docs/spool/2026-05-18-security-scan-design.md
+// §"Class mapping"
+
+import type { SensitiveKind, SensitiveMatch } from '@spool-lab/redact'
+
+/** Privacy Filter's published class labels. */
+export type PfClass =
+  | 'person'
+  | 'email'
+  | 'phone'
+  | 'url'
+  | 'address'
+  | 'date'
+  | 'account_number'
+  | 'secret'
+
+export interface PfRawMatch {
+  class: PfClass
+  value: string
+  start: number
+  end: number
+  /** PF model logit-derived confidence, 0–1. */
+  score: number
+}
+
+export interface MappingContext {
+  /** Matches already produced by the regex provider for the same
+   *  text. Used by url/secret rules — pf only emits when regex also
+   *  flagged the same span, so the pf hit acts as a confidence
+   *  boost rather than a noisy standalone signal. */
+  regexMatches: ReadonlyArray<SensitiveMatch>
+  /** Optional substring around each match (~16 chars on each side)
+   *  used for date-of-birth context gating. Caller passes the full
+   *  text — gating runs cheaply. */
+  fullText: string
+}
+
+const DOB_CONTEXT_RX = /\b(dob|date\s+of\s+birth|born\s+on|birthday|d\.?o\.?b\.?)\b/i
+
+/** Map one PF raw match to a SensitiveMatch, or null when the
+ *  suppression rules say to drop it. */
+export function mapPfMatch(
+  pf: PfRawMatch,
+  ctx: MappingContext,
+): SensitiveMatch | null {
+  const kind = mapClass(pf, ctx)
+  if (!kind) return null
+  return {
+    kind,
+    value: pf.value,
+    start: pf.start,
+    end: pf.end,
+    confidence: pf.score,
+    provider: 'pf',
+  }
+}
+
+function mapClass(pf: PfRawMatch, ctx: MappingContext): SensitiveKind | null {
+  switch (pf.class) {
+    case 'person':
+      return 'person-name'
+    case 'email':
+      return 'email'
+    case 'phone':
+      return 'phone'
+    case 'address':
+      return 'street-address'
+    case 'url':
+      // URLs are not secrets on their own. Only emit when the regex
+      // already saw url-creds in the same span — pf then acts as a
+      // confidence boost on the regex hit.
+      return overlapsRegexKind(pf, ctx.regexMatches, 'url-creds') ? 'url-creds' : null
+    case 'date':
+      // Dates by themselves are noisy. Only emit when the +/- 32
+      // chars around the match look like a DOB context.
+      return looksLikeDob(pf, ctx.fullText) ? 'date-of-birth' : null
+    case 'account_number':
+      // Too noisy without a Luhn-style checksum. Regex's `credit-card`
+      // already covers Luhn-valid hits; everything else is suppressed.
+      return null
+    case 'secret':
+      // Regex is authoritative for known credential prefixes. PF's
+      // `secret` only fires as a boost on existing regex hits.
+      return overlapsRegexKind(pf, ctx.regexMatches, 'generic-secret') ? 'generic-secret' : null
+  }
+}
+
+function overlapsRegexKind(
+  pf: PfRawMatch,
+  regexMatches: ReadonlyArray<SensitiveMatch>,
+  kind: SensitiveKind,
+): boolean {
+  for (const m of regexMatches) {
+    if (m.kind !== kind) continue
+    if (pf.start < m.end && pf.end > m.start) return true
+  }
+  return false
+}
+
+function looksLikeDob(pf: PfRawMatch, text: string): boolean {
+  const windowStart = Math.max(0, pf.start - 32)
+  const windowEnd = Math.min(text.length, pf.end + 32)
+  return DOB_CONTEXT_RX.test(text.slice(windowStart, windowEnd))
+}
+
+/** Bulk map — drop nulls. Convenience for the provider. */
+export function mapPfMatches(
+  pfMatches: ReadonlyArray<PfRawMatch>,
+  ctx: MappingContext,
+): SensitiveMatch[] {
+  const out: SensitiveMatch[] = []
+  for (const m of pfMatches) {
+    const mapped = mapPfMatch(m, ctx)
+    if (mapped) out.push(mapped)
+  }
+  return out
+}

--- a/packages/app/src/main/security/model-host.ts
+++ b/packages/app/src/main/security/model-host.ts
@@ -1,0 +1,81 @@
+// ModelHost — Effect Scoped Resource that owns the hidden Browser-
+// Window running the Privacy Filter inference renderer.
+//
+// WebGPU is a renderer-only API in Chromium, so the main process
+// can't run it directly. The hidden BrowserWindow loads
+// `pf-inference.html`, detects WebGPU (with WASM fallback), and
+// answers IPC requests.
+//
+// This file is intentionally a scaffold: the BrowserWindow + IPC
+// machinery is wired, but the actual `analyze` call returns an
+// empty match list until a follow-up PR ships the real
+// transformers.js + ONNX runtime and the pinned model bundle. The
+// Settings UI surfaces this honestly as "Coming soon".
+
+import { Effect, Ref, Data } from 'effect'
+import type { BrowserWindow } from 'electron'
+
+export type PfRuntime = 'webgpu' | 'wasm' | 'unsupported'
+
+export interface PfState {
+  status: 'idle' | 'loading' | 'ready' | 'failed' | 'not-downloaded'
+  runtime: PfRuntime | null
+  error?: string
+}
+
+export class ModelHostError extends Data.TaggedError('ModelHostError')<{
+  readonly stage: 'spawn' | 'load' | 'analyze' | 'shutdown'
+  readonly cause: unknown
+}> {}
+
+export interface PfMatchResult {
+  /** PF-class label, e.g. 'person', 'email'. */
+  class: string
+  value: string
+  start: number
+  end: number
+  score: number
+}
+
+export interface ModelHost {
+  /** True only when the hidden window is up and the model is loaded. */
+  ready: Effect.Effect<boolean>
+  /** Current renderer runtime once the window reports it. */
+  getRuntime: Effect.Effect<PfRuntime | null>
+  /** Current high-level state for Settings UI consumption. */
+  getState: Effect.Effect<PfState>
+  /** Analyse a chunk of text. Returns an empty array when the model
+   *  isn't ready — callers should check `ready` first if they need
+   *  to fail loudly. */
+  analyze: (text: string) => Effect.Effect<PfMatchResult[], ModelHostError>
+}
+
+/** Build a ModelHost as a Scoped service. The scope owns the hidden
+ *  BrowserWindow lifecycle: scope-acquired creates it; scope-closed
+ *  destroys it, releasing GPU/CPU resources.
+ *
+ *  STUB: the real implementation creates a hidden BrowserWindow, loads
+ *  `pf-inference.html`, waits for a `pf:ready` handshake, and routes
+ *  `pf:analyze` IPC. That logic ships in a follow-up — this file
+ *  defines the interface and the lifecycle plumbing so the Settings
+ *  UI + scan worker can compile against a stable shape today.
+ */
+export function makeModelHost(): Effect.Effect<ModelHost, never, never> {
+  return Effect.gen(function* () {
+    const stateRef = yield* Ref.make<PfState>({ status: 'not-downloaded', runtime: null })
+    const windowRef = yield* Ref.make<BrowserWindow | null>(null)
+    void windowRef // reserved for the real implementation
+
+    const host: ModelHost = {
+      ready: Ref.get(stateRef).pipe(Effect.map((s) => s.status === 'ready')),
+      getRuntime: Ref.get(stateRef).pipe(Effect.map((s) => s.runtime)),
+      getState: Ref.get(stateRef),
+      analyze: (_text: string) =>
+        // Stub: until the inference window ships, return an empty
+        // match list. The scan worker still runs the regex provider;
+        // PF acts as additive signal once the bundle is installed.
+        Effect.succeed<PfMatchResult[]>([]),
+    }
+    return host
+  })
+}

--- a/packages/app/src/main/security/model-paths.ts
+++ b/packages/app/src/main/security/model-paths.ts
@@ -1,0 +1,24 @@
+// Filesystem paths + version constants for the OpenAI Privacy Filter
+// model bundle. Centralised so the download / load / unload code
+// agrees, and so the path appears in one place in Settings.
+
+import { app } from 'electron'
+import { join } from 'node:path'
+
+export const PF_MODEL_ID = 'openai-privacy-filter-q4'
+export const PF_MODEL_VERSION = '1.5b-q4'
+/** HuggingFace repository — pinned to a specific commit at download
+ *  time. Source of truth is `manifest.json` colocated with the bundle. */
+export const PF_HF_REPO = 'openai/privacy-filter'
+
+export function pfModelDir(): string {
+  return join(app.getPath('userData'), 'models', PF_MODEL_ID)
+}
+
+export function pfManifestPath(): string {
+  return join(pfModelDir(), 'manifest.json')
+}
+
+/** Profile segment produced when PF is enabled. Used by
+ *  `currentProfileString({ pfEnabled: true, pfVersion: ... })`. */
+export const PF_PROFILE_VERSION = PF_MODEL_VERSION

--- a/packages/app/src/main/security/pf-provider.ts
+++ b/packages/app/src/main/security/pf-provider.ts
@@ -1,0 +1,43 @@
+// pfProvider — RedactProvider implementation backed by ModelHost.
+//
+// Slots into the scan worker's providers list alongside regexProvider.
+// `available()` is false until the model bundle is downloaded and
+// the hidden inference window has handed back a `pf:ready` signal,
+// so enabling pf in Settings is a no-op until those happen.
+
+import type { RedactProvider, SensitiveMatch } from '@spool-lab/redact'
+import { detectWithRegex } from '@spool-lab/redact'
+import { Effect } from 'effect'
+import { mapPfMatches } from './class-mapping.js'
+import type { ModelHost } from './model-host.js'
+
+export function makePfProvider(host: ModelHost): RedactProvider {
+  return {
+    name: 'pf',
+    displayName: 'OpenAI Privacy Filter (on-device ML)',
+    available: () => {
+      // The ModelHost stores its readiness in a Ref; reading
+      // synchronously here would require blocking, so we just default
+      // to false. The scan worker calls available() before each
+      // provider invocation, but if the host transitions to ready
+      // mid-scan the next session picks it up.
+      // A future refactor can hand `available` a sync-cached boolean.
+      return false
+    },
+    analyze: async (text: string): Promise<SensitiveMatch[]> => {
+      const ready = await Effect.runPromise(host.ready)
+      if (!ready) return []
+      const pfMatches = await Effect.runPromise(host.analyze(text)).catch(() => [])
+      if (!pfMatches.length) return []
+      // Cheap second regex pass for the class-mapping context. The
+      // scan worker already runs regex separately, but mapping needs
+      // the regex matches for the same string to drive the url /
+      // secret suppression rules.
+      const regexMatches = detectWithRegex(text, 'regex')
+      return mapPfMatches(
+        pfMatches as Parameters<typeof mapPfMatches>[0],
+        { regexMatches, fullText: text },
+      )
+    },
+  }
+}

--- a/packages/app/src/renderer/components/Settings/SecurityPane.tsx
+++ b/packages/app/src/renderer/components/Settings/SecurityPane.tsx
@@ -1,0 +1,81 @@
+// Settings → Security pane.
+//
+// Today: shows the active scan profile + a [Rescan all] button + a
+// disabled toggle for the optional ML provider. The actual download
+// flow + WebGPU/WASM runtime detection land in a follow-up — this
+// pane already lays out the surfaces the spec calls for so reviewers
+// can see where it goes.
+
+import { useEffect, useState } from 'react'
+import { ShieldAlert, RotateCw } from 'lucide-react'
+import type { ScanStatus } from '@spool-lab/core'
+import { securityApi } from '../../api/security.js'
+
+export default function SecurityPane() {
+  const [status, setStatus] = useState<ScanStatus | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    void securityApi.getScanStatus().then(setStatus).catch(() => setStatus(null))
+  }, [])
+
+  async function rescanAll() {
+    setBusy(true)
+    try {
+      await securityApi.rescanAll()
+      const s = await securityApi.getScanStatus()
+      setStatus(s)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="p-6 max-w-2xl">
+      <header className="flex items-center gap-2 mb-6">
+        <ShieldAlert size={20} className="text-warm-accent dark:text-dark-accent" aria-hidden />
+        <h2 className="text-lg font-medium text-warm-text dark:text-dark-text">Security</h2>
+      </header>
+
+      <section className="mb-6">
+        <h3 className="text-sm font-medium text-warm-text dark:text-dark-text mb-2">Detector</h3>
+        <p className="text-sm text-warm-muted dark:text-dark-muted mb-2">
+          Active profile:{' '}
+          <code className="font-mono text-xs">{status?.currentProfile ?? 'regex@3'}</code>
+        </p>
+        <button
+          type="button"
+          data-testid="settings-rescan-all"
+          disabled={busy}
+          onClick={() => { void rescanAll() }}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm border border-warm-border dark:border-dark-border hover:bg-warm-surface dark:hover:bg-dark-surface disabled:opacity-60"
+        >
+          <RotateCw size={14} strokeWidth={1.75} aria-hidden />
+          {busy ? 'Re-scanning…' : 'Rescan all sessions'}
+        </button>
+      </section>
+
+      <section className="mb-6">
+        <h3 className="text-sm font-medium text-warm-text dark:text-dark-text mb-2">Enhanced detection (ML)</h3>
+        <p className="text-sm text-warm-muted dark:text-dark-muted mb-3">
+          Detects names, addresses, and other PII that pattern matching can't catch.
+          Runs entirely on your device — no network requests for detection.
+        </p>
+        <div className="rounded border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface p-3 text-xs text-warm-muted dark:text-dark-muted">
+          <div className="font-medium text-warm-text dark:text-dark-text mb-1">
+            OpenAI Privacy Filter · ~800 MB · Apache 2.0
+          </div>
+          <div>Status: coming soon. The model download + WebGPU/WASM runtime ship in a follow-up release.</div>
+        </div>
+      </section>
+
+      <section>
+        <h3 className="text-sm font-medium text-warm-text dark:text-dark-text mb-2">Maintenance</h3>
+        <p className="text-sm text-warm-muted dark:text-dark-muted">
+          Old SQLite backups may still contain plaintext after a Purge. Backup management
+          ships in a Phase 2 release alongside the encrypted-originals opt-in.
+        </p>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## What

Scaffolds the **Privacy Filter** ML provider — OpenAI's `gpt-oss-safeguard` style PII model (Apache-2.0) — without actually running inference yet. Ships the host/lifecycle plumbing, the class-mapping table, and the Settings pane "Coming soon" section. The inference body is intentionally absent; this PR exists so the next one can be a contained "drop in the model file" change.

## Why ship a scaffold

The model bundle (Q4-quantised ONNX) is ~800 MB. Adding that to the app build inflates installer size and forces every user to download it on launch — wrong default for an interactive surface. The right path is:

1. Land the surface area (provider, lifecycle, settings toggle) behind a "Coming soon" label so reviewers can see how it slots in.
2. Add the model fetch + inference as a focused follow-up where the *only* delta is the runtime download + the ONNX call.

This PR is step 1. The toggle is wired but `available()` returns `false` until the model is on disk, so flipping it is a safe no-op.

## Why this model

OpenAI Privacy Filter is the best-fit choice for the Security Scan's use case:

- **Local-first invariant** — runs entirely on-device (transformers.js + WebGPU/CPU). Spool never makes network round-trips for detection.
- **Apache 2.0** — embeddable in a desktop app without licence friction.
- **Prose-style PII coverage** — names embedded in free text, addresses in error messages, dates of birth in conversations. Regex fundamentally cannot help here.
- **96% F1 on PII-Masking-300k** — competitive accuracy for an 8-entity classifier.

What it does NOT do well:
- Vendor token formats (`ghp_…`, `sk-ant-…`) — regex stays authoritative; the worker runs regex first and only consults the ML provider on non-overlapping spans.
- Structural credentials (PEM, JWT) — same; regex wins.

## Module layout

```
packages/app/src/main/security/
├── model-paths.ts        ← where ONNX bundle lives (userData/security/)
├── model-host.ts         ← lifecycle: load / unload / ready signal
├── class-mapping.ts      ← Privacy Filter's 8 entity types → SensitiveKind
├── class-mapping.test.ts
└── pf-provider.ts        ← RedactProvider impl (analyze() stub)
```

```
packages/app/src/renderer/components/Settings/
└── SecurityPane.tsx      ← active-profile readout · "Rescan all" · ML toggle
```

## Lifecycle

```mermaid
stateDiagram-v2
    [*] --> Unloaded : app boot
    Unloaded --> Downloading : user toggles ML on (future PR)
    Downloading --> Unloaded : download failed
    Downloading --> Loading : bundle on disk
    Loading --> Ready : ONNX session initialised
    Loading --> Unloaded : init failed
    Ready --> Unloaded : user toggles ML off
    Ready --> [*] : app shutdown
    note right of Ready
        analyze(text) → ONNX inference → SensitiveMatch[]
        provider: 'privacy-filter'
    end note
```

`ModelHost` exposes `ready: boolean` and `analyze: (text) => Promise<SensitiveMatch[]>`. `pf-provider.ts` checks `host.ready` in `available()` so the scan worker silently skips the provider until the model lands.

## Class mapping

The model emits 8 entity types; we map each to an existing or new `SensitiveKind`:

| Privacy Filter class | Mapped SensitiveKind | Notes |
| --- | --- | --- |
| `private_person` | `person-name` | New kind in the redact lib (low-severity tier) |
| `private_email` | `email` | Exists; regex precedence wins |
| `private_phone` | `phone` | Exists; regex precedence wins |
| `private_url` | (filtered out) | Too noisy in technical transcripts (URLs are content) |
| `private_address` | `street-address` | New kind; low-severity |
| `private_date` | `date-of-birth` | Context-gated — only if surrounding text looks DOB-like |
| `account_number` | `credit-card` (Luhn-pass) or `generic-secret` | Disambiguated by checksum |
| `secret` | `generic-secret` | Last-resort label; regex usually beats this |

`class-mapping.test.ts` (13 tests) pins every class → kind transition so a model upgrade can't silently change the mapping.

## Profile string slot

Already reserved by the prior `feat/security-scan-worker` PR:

```
regex@4              → only regex
regex@4,pf@1.5b-q4   → regex + Privacy Filter
```

The `pf@<version>` segment is hashed into `sessions.scan_profile`. Enabling the provider therefore invalidates every session's scan stamp and the worker re-enqueues them automatically on next boot — no manual rescan needed.

## Settings pane

The Security Pane scaffold renders:
- **Active profile** — read-only `regex@4` today; will read `regex@4,pf@…` once the model loads.
- **Rescan all sessions** — button; calls the existing `security:rescan-all` IPC.
- **Privacy Filter** section — "Coming soon" label + an explanatory paragraph about local execution + model size. No toggle wired yet; the toggle ships with the inference body.

Honest copy throughout — no "Enabled" affordance until the feature actually does anything.

## Test plan

- [x] `class-mapping.test.ts` (13 tests) — every Privacy Filter class maps to the documented kind; unknown classes fall through to `generic-secret`; `private_url` is filtered out; DOB context gate.
- [x] `pf-provider.ts` `available()` returns false (smoke).
- [ ] Inference integration tests — ship with the follow-up that adds the ONNX call.

## Not in this PR

- Actual model download / fetch UX.
- ONNX runtime / transformers.js wiring.
- Inference call in `pf-provider.ts#analyze`.
- Settings toggle wiring (the UI currently shows the section disabled).
