### PR TITLE
fix(security): hide sessions with zero messages from Security page list

### DIFF
--- a/packages/app/src/main/ipc/security.test.ts
+++ b/packages/app/src/main/ipc/security.test.ts
@@ -84,8 +84,8 @@ function setupDb(): Database.Database {
      VALUES (1, 1, 'p', '/p', 'p')`,
   ).run()
   db.prepare(
-    `INSERT INTO sessions (id, project_id, source_id, session_uuid, file_path, title, started_at, ended_at)
-     VALUES (1, 1, 1, 's-1', '/p/s-1', 'Session 1', '2026-01-01', '2026-01-01')`,
+    `INSERT INTO sessions (id, project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count)
+     VALUES (1, 1, 1, 's-1', '/p/s-1', 'Session 1', '2026-01-01', '2026-01-01', 1)`,
   ).run()
   db.prepare(
     `INSERT INTO messages (id, session_id, source_id, role, content_text, timestamp, seq)

--- a/packages/core/src/security/repo.test.ts
+++ b/packages/core/src/security/repo.test.ts
@@ -32,9 +32,9 @@ function setupDb(): Database.Database {
      VALUES (1, 1, 'p', '/p', 'p')`,
   ).run()
   db.prepare(
-    `INSERT INTO sessions (id, project_id, source_id, session_uuid, file_path, title, started_at, ended_at)
-     VALUES (1, 1, 1, 's-1', '/p/s-1', 'Session 1', '2026-01-01', '2026-01-01'),
-            (2, 1, 1, 's-2', '/p/s-2', 'Other Session', '2026-01-02', '2026-01-02')`,
+    `INSERT INTO sessions (id, project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count)
+     VALUES (1, 1, 1, 's-1', '/p/s-1', 'Session 1', '2026-01-01', '2026-01-01', 1),
+            (2, 1, 1, 's-2', '/p/s-2', 'Other Session', '2026-01-02', '2026-01-02', 1)`,
   ).run()
   db.prepare(
     `INSERT INTO messages (id, session_id, source_id, role, content_text, timestamp, seq)
@@ -140,6 +140,16 @@ describe('repo: list + filter', () => {
 
   it('listSessionsWithFindings filters by kind', () => {
     const rows = listSessionsWithFindings(db, { kind: 'email' })
+    expect(rows.map(r => r.sessionUuid)).toEqual(['s-1'])
+  })
+
+  it('listSessionsWithFindings excludes sessions whose message_count dropped to 0 — stale finding rows from emptied/pruned sessions must not surface', () => {
+    // s-2 keeps its message row but its denormalised counter falls to
+    // 0 (mirrors the prod case where sessions were captured with zero
+    // body text — likely a source-file edge case — yet finding rows
+    // already exist).
+    db.prepare(`UPDATE sessions SET message_count = 0 WHERE id = 2`).run()
+    const rows = listSessionsWithFindings(db, {})
     expect(rows.map(r => r.sessionUuid)).toEqual(['s-1'])
   })
 

--- a/packages/core/src/security/repo.ts
+++ b/packages/core/src/security/repo.ts
@@ -361,6 +361,7 @@ export function listSessionsWithFindings(
     JOIN sources src ON src.id = s.source_id
     JOIN projects p ON p.id = s.project_id
     WHERE ${stateCondition} ${kindCondition} ${severityCondition} ${infoExclusion} ${textCondition}
+      AND COALESCE(s.message_count, 0) > 0
     GROUP BY s.id
     ORDER BY high_count DESC, finding_count DESC, s.started_at DESC
   `


### PR DESCRIPTION
## What

`listSessionsWithFindings` (the query that powers the Security page's "Sessions with active findings" list) now skips any session whose `message_count` is `0` (or `NULL`).

## Why

On a real archive the list was showing rows like:

> Session title — *2 weeks ago · 0 条 · sonnet 4.5*

with one or two finding entries attached. The session had no visible message body — yet finding rows still existed, likely captured before the source file got pruned / shortened on the upstream side. From the user's perspective there's nothing to act on:

- Opening the session shows an empty transcript.
- "Purge" rewrites nothing the user can see.
- The `0 条` meta line reads as a stale-data bug rather than a real signal.

Hiding these at the source keeps the list focused on actionable findings.

## How

One predicate added to the existing `WHERE` clause in `packages/core/src/security/repo.ts`:

```sql
WHERE ${stateCondition} ${kindCondition} ${severityCondition} ${infoExclusion} ${textCondition}
  AND COALESCE(s.message_count, 0) > 0
GROUP BY s.id
```

Server-side filter rather than a renderer `.filter()` so:
- The "X sessions" header count and the rendered list stay in sync.
- Pagination (when it lands) doesn't have to over-fetch to compensate for client-side drops.
- The exclusion applies anywhere this query is reused (settings rescan summary, future API surface).

## Test plan

- Added `listSessionsWithFindings excludes sessions whose message_count dropped to 0` — drops `s-2`'s counter to 0 and asserts it disappears from results.
- Updated the test fixture to seed `message_count = 1` on the existing two sessions (previously relied on `DEFAULT 0`, which the new filter would have hidden — masking the change).
- `pnpm test` in `packages/core`: **287/287 green**.
- `tsc --noEmit` on core: clean.