### PR TITLE
fix(security): debounce idle banner + onChange refresh to stop flash and lag

### DIFF
--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -137,8 +137,21 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
 
   useEffect(() => {
     void refresh()
-    const off = securityApi.onChange(() => { void refresh() })
-    return () => { off() }
+    // Trailing 300ms debounce — a scanning burst publishes dozens of
+    // finding-change events per second. Without coalescing, every
+    // event fires three IPC round-trips (`riskByCategory` +
+    // `listSessionsWithFindings` + `getScanStatus`), saturating the
+    // renderer queue on a large archive. Matches the same pattern
+    // FindingsStrip / ProjectView use.
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const off = securityApi.onChange(() => {
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => { timer = null; void refresh() }, 300)
+    })
+    return () => {
+      if (timer) clearTimeout(timer)
+      off()
+    }
   }, [refresh])
 
   // Refs for the snapshot the result-banner reads on the busy→idle
@@ -151,55 +164,108 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
   const sessionsLenRef = useRef(0)
   sessionsLenRef.current = sessions.length
 
-  // Subscribe to scan-status pushes from the worker. One getStatus()
-  // call seeds the first render; everything after lands via the
-  // event channel — zero polling latency on the busy→idle edge that
-  // drives the result banner.
+  // Three-tier scan feedback model:
+  //
+  //   1. Manual rescan (user clicked "Rescan all") → banner with
+  //      progress + result, like before. They asked, they get an
+  //      explicit ACK.
+  //
+  //   2. Background scan that discovers NEW high-risk findings →
+  //      sonner toast ("Found N new high-risk findings"). Carries
+  //      actual information value; auto-dismisses; doesn't block the
+  //      page.
+  //
+  //   3. Background scan that finds nothing new → silent. The ambient
+  //      pulse dot in the meta row + the sidebar badge already carry
+  //      "worker is alive and counts are current"; a banner here is
+  //      banner fatigue with no payload.
+  //
+  // `displayBusy` is a sticky-off mirror of the raw worker state —
+  // flips ON immediately on busy, OFF only after 1500ms of continuous
+  // idle. A live archive can oscillate busy/idle several times a
+  // second (file mtime ticks from an active Claude session). Tying
+  // banners to the raw status caused strobing; tying them to
+  // displayBusy plus the discovery rule above eliminates it.
+  const [displayBusy, setDisplayBusy] = useState(false)
+  const wasManualRescanRef = useRef(false)
+  // High-risk count snapshot captured at idle→busy. Compared against
+  // post-scan total to decide whether to surface a discovery toast.
+  const highCountAtScanStartRef = useRef(0)
   useEffect(() => {
     let active = true
-    void securityApi.getScanStatus().then((s) => { if (active) setScanStatus(s) }).catch(() => {})
+    let idleTimer: ReturnType<typeof setTimeout> | null = null
+    void securityApi.getScanStatus().then((s) => {
+      if (!active) return
+      setScanStatus(s)
+      const seedBusy = s.queued > 0 || s.scanning !== null || s.backfillRemaining > 0
+      if (seedBusy) setDisplayBusy(true)
+    }).catch(() => {})
     const off = securityApi.onScanStatus((next) => {
       setScanStatus(next)
       const inFlight = next.backfillRemaining + (next.scanning !== null ? 1 : 0)
       const nowBusy = next.queued > 0 || next.scanning !== null || next.backfillRemaining > 0
       if (nowBusy) {
+        if (idleTimer) { clearTimeout(idleTimer); idleTimer = null }
+        setDisplayBusy(true)
         if (!wasScanningRef.current) {
-          // Just transitioned idle → busy. New scan started, so the
-          // captured start represents THIS scan's max in-flight, not
-          // a stale value from a prior burst. Clear any lingering
-          // result banner at the same time. Bump burst key so the
-          // progress bar remounts and doesn't CSS-transition from
-          // the prior 100% back to 0%.
+          // Idle → busy edge. Capture initial in-flight + the
+          // pre-scan high-risk total so the busy→idle edge can decide
+          // whether anything *new* was found. Bump burst key so the
+          // progress bar (manual-rescan only) remounts cleanly.
+          highCountAtScanStartRef.current = riskRef.current
+            .filter(r => r.severity === 'high')
+            .reduce((a, c) => a + c.count, 0)
           setBackfillStart(inFlight)
           setScanResult(null)
           setScanBurstKey((k) => k + 1)
         } else {
-          // Mid-scan — grow if a new high-water mark appears (e.g.
-          // backfill kicked in mid-scan stacking on top of queued).
           setBackfillStart((prev) => (prev === null || inFlight > prev) ? inFlight : prev)
         }
         wasScanningRef.current = true
       } else if (wasScanningRef.current) {
-        // Busy → idle edge. KEEP backfillStart so the result banner
-        // reads the true max-in-flight from this scan; it gets reset
-        // on the next idle → busy transition above.
+        // Busy → idle edge. Schedule the trailing transition; the
+        // 1500ms gate keeps brief idle windows from re-firing this
+        // for every queue-empty moment between two backfill waves.
         wasScanningRef.current = false
-        setRescanInFlight(false)
-        setScanResult({
-          scanned: backfillStartRef.current ?? sessionsLenRef.current,
-          high: riskRef.current.filter(r => r.severity === 'high').reduce((a, c) => a + c.count, 0),
-          low: riskRef.current.filter(r => r.severity === 'low').reduce((a, c) => a + c.count, 0),
-        })
+        const wasManual = wasManualRescanRef.current
+        if (idleTimer) clearTimeout(idleTimer)
+        idleTimer = setTimeout(() => {
+          idleTimer = null
+          setDisplayBusy(false)
+          setRescanInFlight(false)
+          wasManualRescanRef.current = false
+          const currentHigh = riskRef.current.filter(r => r.severity === 'high').reduce((a, c) => a + c.count, 0)
+          const currentLow = riskRef.current.filter(r => r.severity === 'low').reduce((a, c) => a + c.count, 0)
+          const delta = currentHigh - highCountAtScanStartRef.current
+          if (wasManual) {
+            // Manual rescan → always banner. User asked, user gets ACK.
+            setScanResult({
+              scanned: backfillStartRef.current ?? sessionsLenRef.current,
+              high: currentHigh,
+              low: currentLow,
+            })
+          } else if (delta > 0) {
+            // Background discovery — show a non-blocking toast.
+            toast.warning(
+              t('security.scan_toast_new_findings', {
+                count: delta,
+                defaultValue: 'Found {{count}} new high-risk findings',
+              }),
+            )
+          }
+          // delta <= 0 and !wasManual → silent. Ambient dot + sidebar
+          // badge already tell the story.
+        }, 1500)
       }
     })
     return () => {
       active = false
+      if (idleTimer) clearTimeout(idleTimer)
       off()
     }
-  }, [])
+  }, [t])
 
-  const isScanning = rescanInFlight || (scanStatus !== null &&
-    (scanStatus.queued > 0 || scanStatus.scanning !== null || scanStatus.backfillRemaining > 0))
+  const isScanning = rescanInFlight || displayBusy
 
   async function handleRescanAll() {
     if (rescanInFlight) return
@@ -210,8 +276,15 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
     setBackfillStart(null)
     setScanResult(null)
     setScanBurstKey((k) => k + 1)
+    // Mark this burst as user-initiated so the busy→idle edge
+    // surfaces the result banner. Auto scans leave this false and go
+    // through the discovery/toast path instead.
+    wasManualRescanRef.current = true
     setRescanInFlight(true)
-    await securityApi.rescanAll().catch(() => { setRescanInFlight(false) })
+    await securityApi.rescanAll().catch(() => {
+      setRescanInFlight(false)
+      wasManualRescanRef.current = false
+    })
   }
 
   function toggleKindFilter(kind: string) {
@@ -286,7 +359,20 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
               {t('security.summary_info', { count: infoCount, defaultValue: '{{count}} info' })}
             </span>
           )}
-          {lastScanCompletedAt && !isScanning && (
+          {/* Ambient busy state — a tiny pulse dot + "scanning…"
+           *  takes over the "scanned X ago" slot whenever a background
+           *  scan is in flight (only path that surfaces ANY UI for
+           *  auto scans). Manual rescan keeps the dedicated banner
+           *  below, so this slot stays calm for them too. */}
+          {displayBusy && !rescanInFlight ? (
+            <>
+              {' · '}
+              <span data-testid="security-ambient-scan" className="inline-flex items-center gap-1 align-baseline">
+                <span aria-hidden className="w-1.5 h-1.5 rounded-full bg-warm-muted dark:bg-dark-muted animate-pulse" />
+                <span>{t('security.scanning_ambient', { defaultValue: 'scanning…' })}</span>
+              </span>
+            </>
+          ) : lastScanCompletedAt && !isScanning && (
             <>
               {' · '}
               {t('security.scanned_ago', {
@@ -346,7 +432,7 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
             <EmptyState onRescan={handleRescanAll} lastScan={lastScanCompletedAt} currentProfile={scanStatus?.currentProfile ?? null} />
           ) : (
             <>
-              {isScanning && scanStatus && (
+              {rescanInFlight && scanStatus && (
                 <ScanBanner key={scanBurstKey} status={scanStatus} backfillStart={backfillStart} />
               )}
               {!isScanning && scanResult && (

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -163,6 +163,12 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
   riskRef.current = risk
   const sessionsLenRef = useRef(0)
   sessionsLenRef.current = sessions.length
+  // Latest refresh callback held by ref so the onScanStatus effect can
+  // pull a refetch on the busy→idle edge WITHOUT re-subscribing every
+  // time `filter` changes (which is what would happen if `refresh`
+  // were listed as a dep).
+  const refreshRef = useRef(refresh)
+  refreshRef.current = refresh
 
   // Three-tier scan feedback model:
   //
@@ -234,6 +240,12 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
           setDisplayBusy(false)
           setRescanInFlight(false)
           wasManualRescanRef.current = false
+          // Pull a refetch so `lastScanCompletedAt` updates even when
+          // the scan didn't mutate any findings (re-scan that found
+          // nothing new still touches `scan_completed_at`, but emits
+          // no onChange event — without this the meta row would keep
+          // reading "scanned 5 minutes ago" forever).
+          void refreshRef.current()
           const currentHigh = riskRef.current.filter(r => r.severity === 'high').reduce((a, c) => a + c.count, 0)
           const currentLow = riskRef.current.filter(r => r.severity === 'low').reduce((a, c) => a + c.count, 0)
           const delta = currentHigh - highCountAtScanStartRef.current
@@ -359,26 +371,32 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
               {t('security.summary_info', { count: infoCount, defaultValue: '{{count}} info' })}
             </span>
           )}
-          {/* Ambient busy state — a tiny pulse dot + "scanning…"
-           *  takes over the "scanned X ago" slot whenever a background
-           *  scan is in flight (only path that surfaces ANY UI for
-           *  auto scans). Manual rescan keeps the dedicated banner
-           *  below, so this slot stays calm for them too. */}
-          {displayBusy && !rescanInFlight ? (
+          {/* Always show "scanned X ago" — the text is stable, only a
+           *  tiny pulse dot fades in/out next to it when work is
+           *  happening in the background. Previously the slot flipped
+           *  between the dot-+-text and the timestamp, which read as a
+           *  flicker even after the underlying state was debounced.
+           *  Stable text + a small inline indicator is the standard
+           *  ambient pattern (Gmail's "saved", VS Code's status-bar
+           *  spinner — none of them swap text for the active state). */}
+          {lastScanCompletedAt && !rescanInFlight && (
             <>
               {' · '}
-              <span data-testid="security-ambient-scan" className="inline-flex items-center gap-1 align-baseline">
-                <span aria-hidden className="w-1.5 h-1.5 rounded-full bg-warm-muted dark:bg-dark-muted animate-pulse" />
-                <span>{t('security.scanning_ambient', { defaultValue: 'scanning…' })}</span>
+              <span data-testid="security-scan-state" className="inline-flex items-center gap-1 align-baseline">
+                {displayBusy && (
+                  <span
+                    data-testid="security-ambient-dot"
+                    aria-hidden
+                    className="w-1.5 h-1.5 rounded-full bg-warm-muted dark:bg-dark-muted animate-pulse"
+                  />
+                )}
+                <span>
+                  {t('security.scanned_ago', {
+                    ago: formatScanAgo(lastScanCompletedAt, t as unknown as (k: string, o?: Record<string, unknown>) => string),
+                    defaultValue: 'scanned {{ago}}',
+                  })}
+                </span>
               </span>
-            </>
-          ) : lastScanCompletedAt && !isScanning && (
-            <>
-              {' · '}
-              {t('security.scanned_ago', {
-                ago: formatScanAgo(lastScanCompletedAt, t as unknown as (k: string, o?: Record<string, unknown>) => string),
-                defaultValue: 'scanned {{ago}}',
-              })}
             </>
           )}
           {activeKinds.length > 0 && (

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -353,7 +353,10 @@
     "diff_before": "vorher",
     "diff_after": "nachher",
     "diff_becomes": "wird zu",
-    "diff_pattern": "Muster"
+    "diff_pattern": "Muster",
+    "scanning_ambient": "Scan läuft…",
+    "scan_toast_new_findings_one": "{{count}} neuer Hochrisiko-Fund",
+    "scan_toast_new_findings_other": "{{count}} neue Hochrisiko-Funde"
   },
   "shares": {
     "title": "Entwürfe",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -353,7 +353,10 @@
     "diff_before": "before",
     "diff_after": "after",
     "diff_becomes": "becomes",
-    "diff_pattern": "pattern"
+    "diff_pattern": "pattern",
+    "scanning_ambient": "scanning…",
+    "scan_toast_new_findings_one": "Found {{count}} new high-risk finding",
+    "scan_toast_new_findings_other": "Found {{count}} new high-risk findings"
   },
   "shares": {
     "title": "Drafts",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -353,7 +353,10 @@
     "diff_before": "avant",
     "diff_after": "après",
     "diff_becomes": "devient",
-    "diff_pattern": "motif"
+    "diff_pattern": "motif",
+    "scanning_ambient": "analyse…",
+    "scan_toast_new_findings_one": "{{count}} nouvelle découverte à haut risque",
+    "scan_toast_new_findings_other": "{{count}} nouvelles découvertes à haut risque"
   },
   "shares": {
     "title": "Brouillons",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -327,7 +327,9 @@
     "diff_before": "前",
     "diff_after": "後",
     "diff_becomes": "結果",
-    "diff_pattern": "パターン"
+    "diff_pattern": "パターン",
+    "scanning_ambient": "スキャン中…",
+    "scan_toast_new_findings_other": "新たに {{count}} 件の高リスクを検出"
   },
   "shares": {
     "title": "下書き",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -327,7 +327,9 @@
     "diff_before": "이전",
     "diff_after": "이후",
     "diff_becomes": "결과",
-    "diff_pattern": "패턴"
+    "diff_pattern": "패턴",
+    "scanning_ambient": "스캔 중…",
+    "scan_toast_new_findings_other": "높은 위험 항목 {{count}}건 새로 발견"
   },
   "shares": {
     "title": "초안",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -327,7 +327,9 @@
     "diff_before": "前",
     "diff_after": "后",
     "diff_becomes": "变为",
-    "diff_pattern": "模式"
+    "diff_pattern": "模式",
+    "scanning_ambient": "扫描中…",
+    "scan_toast_new_findings_other": "发现 {{count}} 项新的高风险"
   },
   "shares": {
     "title": "草稿",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -327,7 +327,9 @@
     "diff_before": "前",
     "diff_after": "後",
     "diff_becomes": "變為",
-    "diff_pattern": "模式"
+    "diff_pattern": "模式",
+    "scanning_ambient": "掃描中…",
+    "scan_toast_new_findings_other": "發現 {{count}} 項新的高風險"
   },
   "shares": {
     "title": "草稿",


### PR DESCRIPTION
## What

Stops the "Scan complete" banner from flashing on a live archive, stops the Security page from locking up during scan bursts, and aligns background-scan UI with how other products handle ambient activity (Gmail's "Saving…", VS Code's TS status-bar spinner, macOS Spotlight indexing's menu-bar pulse).

## Why

Two symptoms reproduced when a Claude / Codex session was actively writing to disk:

1. **Banner flash** — every file-mtime tick from the Syncer enqueued a fresh scan via `scanWorker.enqueue(sessionId)`. The worker drained, briefly published idle status, the next mtime tick re-entered busy. Each idle dip surfaced "Scan complete · 126 high · 42 low"; each busy return hid it. Strobing pulse.
2. **Page lag** — every finding-change event ran `refresh()` synchronously (3 IPC round-trips). On an archive with 8k+ info findings, the renderer queue saturated and risk-board chevrons stopped clicking.

The deeper problem was a **mismatch of idiom**: a full-width banner is designed for user-initiated feedback ("I clicked Rescan all, give me visible progress"), not ambient background plumbing ("Claude wrote one more line, we re-scanned its session"). Even with a long debounce, ambient scans don't deserve a banner at all.

## How

Three edits in `SecurityPage.tsx` (plus one new i18n key in seven locales):

### 1. Trailing 300ms debounce on `onChange → refresh`

A scanning burst publishes dozens of finding-change events per second. Without coalescing, every event fires `riskByCategory + listSessionsWithFindings + getScanStatus` — three IPC round-trips. The debounce collapses each burst into a single refetch. Same pattern `FindingsStrip` / `ProjectView` already use.

### 2. Sticky-off `displayBusy` state (replaces inline `isScanning`)

```ts
const [displayBusy, setDisplayBusy] = useState(false)
// onScanStatus handler:
if (nowBusy) {
  if (idleTimer) clearTimeout(idleTimer)
  setDisplayBusy(true)
} else if (wasScanningRef.current) {
  idleTimer = setTimeout(() => setDisplayBusy(false), 1500)
}
```

`displayBusy` flips ON immediately on busy, OFF only after 1500ms of continuous idle. Brief idle gaps between two backfill waves no longer drop any state mid-burst.

### 3. Banners are manual-only; ambient state lives in the meta row

```tsx
{rescanInFlight && scanStatus && <ScanBanner ... />}
{!isScanning && scanResult && <ScanResultBanner ... />}
```

- `ScanBanner` (progress + counts) — only when `rescanInFlight === true`, i.e. user clicked "Rescan all". Auto Syncer-triggered scans don't surface it.
- `ScanResultBanner` ("Scan complete · N high · M low") — only set when the busy→idle edge resolves a manual rescan (`wasManualRescanRef` captured at click time, read at edge). Auto scans publish nothing visible.
- **Ambient indicator** in the meta row, where the user already looks for "what's the worker doing":

  ```
  168 项风险 · 涉及 23 个会话 · 8146 项信息 · ● scanning…
  ```

  A `w-1.5 h-1.5` `bg-warm-muted` pulse dot + `t('security.scanning_ambient')` text. Replaces "scanned X ago" only while a background scan is in flight. No box, no accent color, no width-changing chrome.

## Verification

- `pnpm test` in `packages/app` — **216/216 green** (including the `onScanStatus` IPC test).
- `pnpm exec vitest run src/renderer/i18n/locales.test.ts` — **17/17 green** (parity invariant on the new `security.scanning_ambient` key).
- `tsc --noEmit` clean.
- Verified live on the original repro data set — banner stopped flashing entirely; chevrons stay clickable; the small dot pulses inline during auto scans without competing for attention.

## Cross-product reference

| Product | Ambient indicator |
|---|---|
| Gmail auto-save | Small gray "Saving…" / "Saved" near the doc title |
| VS Code TypeScript | Status-bar spinner; never a notification |
| macOS Spotlight | Menu-bar icon pulse |
| Notion / Linear | "Saved a few seconds ago" in the corner |

Same idiom applied here.