### PR TITLE
fix(security): make finding values selectable so users can copy them

### DIFF
--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -1094,10 +1094,14 @@ function FindingItem({
       ? 'bg-accent dark:bg-accent-dark'
       : 'bg-warm-muted dark:bg-dark-muted'
 
+  // Body sets `user-select: none` app-wide; revealed values need to
+  // opt back in so the user can copy a leaked key / phone / email out.
+  // Blurred mode keeps `select-none` so a stray drag doesn't reveal
+  // the value via selection.
   const valueClass = isPurged
-    ? 'line-through text-warm-faint dark:text-dark-faint'
+    ? 'line-through text-warm-faint dark:text-dark-faint select-text cursor-text'
     : revealed
-      ? 'text-warm-text dark:text-dark-text'
+      ? 'text-warm-text dark:text-dark-text select-text cursor-text'
       : 'text-warm-text dark:text-dark-text blur-[3.5px] cursor-pointer select-none'
 
   const displayValue = isPurged

--- a/packages/app/src/renderer/components/security/FindingsStrip.tsx
+++ b/packages/app/src/renderer/components/security/FindingsStrip.tsx
@@ -220,7 +220,7 @@ function StripFindingRow({ finding, value }: { finding: FindingRow; value: strin
       <span className="font-mono text-warm-muted dark:text-dark-muted w-24 shrink-0 truncate">
         {finding.kind}
       </span>
-      <span className="font-mono flex-1 truncate text-warm-text dark:text-dark-text">
+      <span className="font-mono flex-1 truncate text-warm-text dark:text-dark-text select-text cursor-text">
         {value ?? <em className="text-warm-faint dark:text-dark-faint">{t('security.value_unavailable', { defaultValue: '(value unavailable)' })}</em>}
       </span>
     </li>


### PR DESCRIPTION
## What

Allows the user to select and copy finding values (API keys, phone numbers, emails, etc.) from both the Security page and the session-detail findings strip.

## Why

The app's global stylesheet sets `body { user-select: none }` — a deliberate convention so the chrome doesn't feel webpage-y. Specific surfaces (markdown body, fragment results) opt back in with Tailwind's `select-text`. The Security feature's value spans never did.

The result was a security-feature paper cut: the user could see a value Spool had flagged (`AKIA…`, `+0000 2024`, `user@example.com`), but couldn't get it out of the app — no triple-click select, no drag-select, no Cmd+C. Defeated the point of having the value displayed at all.

## How

Two one-line additions of `select-text cursor-text` on the value spans:

- `SecurityPage.tsx` — `FindingItem`'s `valueClass`: opt in when `revealed` OR `isPurged`. Blurred (values-hidden) mode keeps `select-none` so a stray drag highlight doesn't reveal the underlying value.
- `security/FindingsStrip.tsx` — strip row's value span: always opt in (the strip is default-revealed by convention).

`cursor-text` paired with `select-text` matches the existing `MarkdownContent` / `FragmentResults` pattern so the I-beam appears on hover, telegraphing "this is selectable."

## Test plan

- `pnpm test` (app) — 216/216 green.
- `tsc --noEmit` clean.
- Verified in dev: triple-click on a value selects it; Cmd+C copies; values stay non-selectable while blurred.