### PR TITLE
feat(security): isolate scan worker in node:worker_thread to keep main responsive

### DIFF
--- a/packages/app/electron.vite.config.ts
+++ b/packages/app/electron.vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
         input: {
           index: resolve(__dirname, 'src/main/index.ts'),
           'sync-worker': resolve(__dirname, 'src/main/sync-worker.ts'),
+          'scan-worker-thread': resolve(__dirname, 'src/main/scan-worker-thread.ts'),
         },
       },
     },

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -33,8 +33,7 @@ import {
   pinSession, unpinSession, getPinnedUuids, listPinnedSessions,
   listProjectGroups, listSessionsByIdentity, listPinnedSessionsByIdentity, listProjectDirectoryCounts,
   listShareDrafts, getShareDraft, upsertShareDraft, deleteShareDraft, countDraftsBySession,
-  currentProfileString, invalidateSessionScanProfile,
-  type ScanWorker,
+  invalidateSessionScanProfile,
 } from '@spool-lab/core'
 import { spawnScanWorker, type ScanWorkerProxy } from './scan-worker-proxy.js'
 import { Effect } from 'effect'
@@ -319,7 +318,15 @@ app.whenReady().then(async () => {
     // way, which keeps state consistent if the flag flips on later.
     invalidateSessionScanProfile(db, sessionId)
     if (scanWorker && loadSecurityPreferences().rescanAfterSync === 'auto') {
-      Effect.runFork(scanWorker.enqueue(sessionId))
+      // Promise-shaped so a worker-thread rejection (e.g. the child
+      // died) surfaces in the log instead of vanishing silently
+      // through Effect.runFork. The Effect itself is failure-free
+      // shape (Effect<void, never>) — `.catch` here is the safety
+      // net for runtime promise rejections from the underlying
+      // postMessage round-trip.
+      Effect.runPromise(scanWorker.enqueue(sessionId)).catch((err) => {
+        console.error('[security] scan-worker enqueue failed:', err)
+      })
     }
   })
   watcher = new SpoolWatcher(syncer)
@@ -347,7 +354,11 @@ app.whenReady().then(async () => {
     // Sessions were inserted by the worker thread which has its own DB
     // handle — no onSessionChanged callbacks reached this process. Kick
     // off a backfill round now that the sessions table is populated.
-    if (scanWorker) Effect.runFork(scanWorker.backfill())
+    if (scanWorker) {
+      Effect.runPromise(scanWorker.backfill()).catch((err) => {
+        console.error('[security] post-sync backfill failed:', err)
+      })
+    }
   }).catch((err) => {
     console.error('[sync-worker] failed:', err)
   })
@@ -372,7 +383,9 @@ app.whenReady().then(async () => {
         runPromise: <A, E>(eff: Effect.Effect<A, E>) => Effect.runPromise(eff as unknown as Effect.Effect<A>),
         getMainWindow: () => mainWindow,
       })
-      Effect.runFork(scanWorker.backfill())
+      Effect.runPromise(scanWorker.backfill()).catch((err) => {
+        console.error('[security] boot backfill failed:', err)
+      })
     })
   }
 

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -33,11 +33,11 @@ import {
   pinSession, unpinSession, getPinnedUuids, listPinnedSessions,
   listProjectGroups, listSessionsByIdentity, listPinnedSessionsByIdentity, listProjectDirectoryCounts,
   listShareDrafts, getShareDraft, upsertShareDraft, deleteShareDraft, countDraftsBySession,
-  makeScanWorker, currentProfileString, invalidateSessionScanProfile,
+  currentProfileString, invalidateSessionScanProfile,
   type ScanWorker,
 } from '@spool-lab/core'
-import { Effect, Scope, Exit } from 'effect'
-import { regexProvider } from '@spool-lab/redact'
+import { spawnScanWorker, type ScanWorkerProxy } from './scan-worker-proxy.js'
+import { Effect } from 'effect'
 import { registerSecurityIpc } from './ipc/security.js'
 import { loadSecurityPreferences } from './securityPreferences.js'
 import type {
@@ -92,8 +92,7 @@ let syncer: Syncer
 let watcher: SpoolWatcher
 let acpManager: AcpManager
 let isSyncActive = false
-let scanWorker: ScanWorker | null = null
-let scanWorkerScope: Scope.CloseableScope | null = null
+let scanWorker: ScanWorkerProxy | null = null
 let disposeSecurityIpc: (() => void) | null = null
 
 type CachedSearchValue = FragmentResult[]
@@ -159,31 +158,12 @@ function securityFeatureEnabled(): boolean {
 
 async function bootScanWorker(): Promise<void> {
   try {
-    const scope = await Effect.runPromise(Scope.make())
-    scanWorkerScope = scope
-    const worker = await Effect.runPromise(
-      Effect.provideService(
-        makeScanWorker({
-          db,
-          providers: [regexProvider],
-          // Recompute the profile string on every read so a pref save
-          // (kindAllowlist change) immediately marks every session
-          // whose `scan_profile` no longer matches as stale —
-          // `worker.backfill()` then enqueues them on its next call.
-          currentProfile: () => currentProfileString({
-            kindAllowlist: loadSecurityPreferences().kindAllowlist,
-          }),
-          providerNames: ['regex'],
-          // Read the persisted kind allowlist on every scan so the
-          // Settings → Security pane's multi-select takes effect on
-          // the next session without a worker restart.
-          getKindAllowlist: () => new Set(loadSecurityPreferences().kindAllowlist),
-        }),
-        Scope.Scope,
-        scope,
-      ),
-    )
-    scanWorker = worker
+    // Engine lives in a worker thread so its synchronous SQL + regex
+    // CPU work doesn't block the main-process event loop — keeping
+    // window drag, foreground IPC, and renderer-driven queries
+    // responsive even mid-backfill. WAL mode lets the main-process
+    // read handle coexist with the worker's write handle.
+    scanWorker = await spawnScanWorker(join(__dirname, 'scan-worker-thread.js'))
   } catch (err) {
     console.error('[security] scan worker failed to boot:', err)
     scanWorker = null
@@ -195,11 +175,10 @@ async function shutdownScanWorker(): Promise<void> {
     try { disposeSecurityIpc() } catch { /* best effort */ }
     disposeSecurityIpc = null
   }
-  if (scanWorkerScope) {
+  if (scanWorker) {
     try {
-      await Effect.runPromise(Scope.close(scanWorkerScope, Exit.void))
+      await scanWorker.shutdown()
     } catch { /* best effort */ }
-    scanWorkerScope = null
     scanWorker = null
   }
 }
@@ -439,9 +418,10 @@ app.on('window-all-closed', () => {
 })
 
 app.on('before-quit', (event) => {
-  // Tear down the scan worker scope (interrupts the drain fiber) before
-  // Electron releases the database.
-  if (scanWorkerScope) {
+  // Tear down the scan worker thread before Electron releases the
+  // database — the thread holds its own DB handle and needs a clean
+  // Scope.close to drop it.
+  if (scanWorker) {
     event.preventDefault()
     shutdownScanWorker()
       .catch((err) => { console.error('[security] shutdown failed:', err) })

--- a/packages/app/src/main/ipc/security.ts
+++ b/packages/app/src/main/ipc/security.ts
@@ -201,13 +201,31 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
   // until explicitly interrupted by the returned disposer below.
   let forwarderFiber: Fiber.RuntimeFiber<void, never> | null = null
   let statusForwarderFiber: Fiber.RuntimeFiber<void, never> | null = null
+  // Stream consumers wrapped in `Effect.catchAllDefect` — webContents
+  // .send synchronously throws on a destroyed window (e.g. user closed
+  // the main window while a scan was mid-burst). Without this the
+  // daemon fiber dies on the first throw and every subsequent
+  // change / status event is silently lost. Logging + swallowing
+  // keeps the fiber alive across window lifecycle events; the next
+  // surviving send will reach a new window if one opens.
+  function safeSend(channel: string, payload: unknown): Effect.Effect<void> {
+    return Effect.sync(() => {
+      try {
+        // webContents.send throws if the BrowserWindow has been
+        // destroyed — caught here so a closed window doesn't take
+        // the daemon fiber with it.
+        getMainWindow()?.webContents.send(channel, payload)
+      } catch (err) {
+        console.error('[security] forwarder send failed:', err)
+      }
+    })
+  }
+
   Effect.runPromise(
     Effect.gen(function* () {
       forwarderFiber = yield* Effect.forkDaemon(
         Stream.runForEach(worker.changes, (change) =>
-          Effect.sync(() => {
-            getMainWindow()?.webContents.send(SECURITY_IPC_CHANNELS.EVT_FINDINGS_CHANGED, change)
-          }),
+          safeSend(SECURITY_IPC_CHANNELS.EVT_FINDINGS_CHANGED, change),
         ),
       )
       // Parallel forwarder for ScanStatus snapshots — every queue /
@@ -216,9 +234,7 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
       // a 500 ms pull loop.
       statusForwarderFiber = yield* Effect.forkDaemon(
         Stream.runForEach(worker.statusChanges, (status) =>
-          Effect.sync(() => {
-            getMainWindow()?.webContents.send(SECURITY_IPC_CHANNELS.EVT_SCAN_STATUS, status)
-          }),
+          safeSend(SECURITY_IPC_CHANNELS.EVT_SCAN_STATUS, status),
         ),
       )
     }),

--- a/packages/app/src/main/scan-worker-proxy.ts
+++ b/packages/app/src/main/scan-worker-proxy.ts
@@ -53,7 +53,18 @@ export async function spawnScanWorker(workerPath: string): Promise<ScanWorkerPro
     const reqId = nextReqId++
     return new Promise<T>((resolve, reject) => {
       pending.set(reqId, { resolve: resolve as (v: unknown) => void, reject })
-      worker.postMessage({ type: 'cmd', reqId, payload } satisfies ToWorker)
+      try {
+        worker.postMessage({ type: 'cmd', reqId, payload } satisfies ToWorker)
+      } catch (err) {
+        // worker.postMessage throws synchronously if the MessagePort
+        // is closed (e.g. the thread has already exited). Without
+        // this catch the Promise would hang forever — onExit's
+        // pending-rejection sweep only fires if the worker emits
+        // the 'exit' event AFTER we registered it, which isn't the
+        // case for a posthumous send.
+        pending.delete(reqId)
+        reject(err instanceof Error ? err : new Error(String(err)))
+      }
     })
   }
 
@@ -158,7 +169,16 @@ export async function spawnScanWorker(workerPath: string): Promise<ScanWorkerPro
     shutdown: () =>
       new Promise<void>((resolve) => {
         worker.once('exit', () => resolve())
-        worker.postMessage({ type: 'shutdown' } satisfies ToWorker)
+        try {
+          worker.postMessage({ type: 'shutdown' } satisfies ToWorker)
+        } catch {
+          // postMessage throws on a closed port — the thread is
+          // already gone, so satisfy the shutdown contract by
+          // resolving immediately. Without this the exit listener
+          // would never fire and the parent's `before-quit` handler
+          // could stall the app shutdown.
+          resolve()
+        }
       }),
   }
 }

--- a/packages/app/src/main/scan-worker-proxy.ts
+++ b/packages/app/src/main/scan-worker-proxy.ts
@@ -25,10 +25,17 @@ interface PendingCommand {
 /** Spawn the worker thread at `workerPath` and return the proxy
  *  once it sends its first `ready` event. Throws if the child
  *  dies before ready. */
+/** Boot timeout — guard against the worker_thread never reporting
+ *  ready (e.g. a native-binding load failure that hangs the child
+ *  rather than crashing it cleanly). 10s is comfortably above slow-
+ *  disk Spotlight-indexing migrations on a fresh install. */
+const BOOT_TIMEOUT_MS = 10_000
+
 export async function spawnScanWorker(workerPath: string): Promise<ScanWorkerProxy> {
   const worker = new Worker(workerPath)
   const pending = new Map<number, PendingCommand>()
   let nextReqId = 1
+  let seenFirstStatus = false
   let lastStatus: ScanStatus = {
     queued: 0,
     scanning: null,
@@ -51,10 +58,21 @@ export async function spawnScanWorker(workerPath: string): Promise<ScanWorkerPro
   }
 
   await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      worker.off('message', onMessage)
+      worker.off('error', onError)
+      // Best-effort terminate; if it's already dead this is a no-op.
+      worker.terminate().catch(() => { /* nothing to do */ })
+      reject(new Error(`scan worker did not report ready within ${BOOT_TIMEOUT_MS}ms`))
+    }, BOOT_TIMEOUT_MS)
+    function clear(): void {
+      clearTimeout(timeout)
+      worker.off('message', onMessage)
+      worker.off('error', onError)
+    }
     function onMessage(msg: FromWorker): void {
       if (msg.type === 'ready') {
-        worker.off('message', onMessage)
-        worker.off('error', onError)
+        clear()
         worker.on('message', onSteadyState)
         worker.on('error', onSteadyError)
         worker.on('exit', onExit)
@@ -62,14 +80,15 @@ export async function spawnScanWorker(workerPath: string): Promise<ScanWorkerPro
         return
       }
       if (msg.type === 'fatal') {
-        worker.off('message', onMessage)
-        worker.off('error', onError)
+        clear()
         reject(new Error(`scan worker failed during boot: ${msg.error}`))
       }
+      // Any other message type before ready is ignored — the worker
+      // sends ready first, so this branch only fires for protocol
+      // drift that should be caught in code review, not at runtime.
     }
     function onError(err: Error): void {
-      worker.off('message', onMessage)
-      worker.off('error', onError)
+      clear()
       reject(err)
     }
     worker.on('message', onMessage)
@@ -99,6 +118,7 @@ export async function spawnScanWorker(workerPath: string): Promise<ScanWorkerPro
         return
       case 'event-status':
         lastStatus = msg.status
+        seenFirstStatus = true
         Effect.runFork(PubSub.publish(statusChanges, msg.status))
         return
       case 'fatal':
@@ -126,11 +146,12 @@ export async function spawnScanWorker(workerPath: string): Promise<ScanWorkerPro
     backfill: () => Effect.promise(() => send<number>({ cmd: 'backfill' })),
     // getStatus uses the last pushed status when available — saves a
     // round-trip on every renderer mount. Falls back to a real call
-    // before the first push lands.
+    // before the first push lands (boolean sentinel because an empty
+    // profile string is a valid future value).
     getStatus: Effect.suspend(() =>
-      lastStatus.currentProfile === ''
-        ? Effect.promise(() => send<ScanStatus>({ cmd: 'getStatus' }))
-        : Effect.succeed(lastStatus),
+      seenFirstStatus
+        ? Effect.succeed(lastStatus)
+        : Effect.promise(() => send<ScanStatus>({ cmd: 'getStatus' })),
     ),
     changes: Stream.fromPubSub(changes),
     statusChanges: Stream.fromPubSub(statusChanges),

--- a/packages/app/src/main/scan-worker-proxy.ts
+++ b/packages/app/src/main/scan-worker-proxy.ts
@@ -1,0 +1,143 @@
+// Main-process proxy that exposes the worker-thread scan engine as
+// a regular ScanWorker. Renderers + IPC handlers don't need to know
+// the engine actually lives in a child thread — the interface is
+// identical to what `makeScanWorker` returns in-process, only the
+// Effects shell out to postMessage round-trips instead of running
+// SQL on the spot.
+//
+// See scan-worker-thread.ts for the worker side of the protocol.
+
+import { Worker } from 'node:worker_threads'
+import { Effect, PubSub, Stream } from 'effect'
+import type { FindingsChange, ScanStatus, ScanWorker } from '@spool-lab/core'
+import type { FromWorker, ScanCommand, ToWorker } from './scan-worker-thread.js'
+
+export interface ScanWorkerProxy extends ScanWorker {
+  /** Asks the worker thread to drain cleanly and waits for `exit`. */
+  shutdown: () => Promise<void>
+}
+
+interface PendingCommand {
+  resolve: (value: unknown) => void
+  reject: (err: Error) => void
+}
+
+/** Spawn the worker thread at `workerPath` and return the proxy
+ *  once it sends its first `ready` event. Throws if the child
+ *  dies before ready. */
+export async function spawnScanWorker(workerPath: string): Promise<ScanWorkerProxy> {
+  const worker = new Worker(workerPath)
+  const pending = new Map<number, PendingCommand>()
+  let nextReqId = 1
+  let lastStatus: ScanStatus = {
+    queued: 0,
+    scanning: null,
+    backfillRemaining: 0,
+    currentProfile: '',
+  }
+
+  // PubSubs live in main; they replay every event from the child
+  // into the existing IPC forwarders (registerSecurityIpc subscribes
+  // to `worker.changes` / `worker.statusChanges` via Stream.fromPubSub).
+  const changes = await Effect.runPromise(PubSub.unbounded<FindingsChange>())
+  const statusChanges = await Effect.runPromise(PubSub.unbounded<ScanStatus>())
+
+  function send<T>(payload: ScanCommand): Promise<T> {
+    const reqId = nextReqId++
+    return new Promise<T>((resolve, reject) => {
+      pending.set(reqId, { resolve: resolve as (v: unknown) => void, reject })
+      worker.postMessage({ type: 'cmd', reqId, payload } satisfies ToWorker)
+    })
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    function onMessage(msg: FromWorker): void {
+      if (msg.type === 'ready') {
+        worker.off('message', onMessage)
+        worker.off('error', onError)
+        worker.on('message', onSteadyState)
+        worker.on('error', onSteadyError)
+        worker.on('exit', onExit)
+        resolve()
+        return
+      }
+      if (msg.type === 'fatal') {
+        worker.off('message', onMessage)
+        worker.off('error', onError)
+        reject(new Error(`scan worker failed during boot: ${msg.error}`))
+      }
+    }
+    function onError(err: Error): void {
+      worker.off('message', onMessage)
+      worker.off('error', onError)
+      reject(err)
+    }
+    worker.on('message', onMessage)
+    worker.on('error', onError)
+  })
+
+  function onSteadyState(msg: FromWorker): void {
+    switch (msg.type) {
+      case 'cmd-result': {
+        const slot = pending.get(msg.reqId)
+        if (slot) {
+          pending.delete(msg.reqId)
+          slot.resolve(msg.result)
+        }
+        return
+      }
+      case 'cmd-error': {
+        const slot = pending.get(msg.reqId)
+        if (slot) {
+          pending.delete(msg.reqId)
+          slot.reject(new Error(msg.error))
+        }
+        return
+      }
+      case 'event-change':
+        Effect.runFork(PubSub.publish(changes, msg.change))
+        return
+      case 'event-status':
+        lastStatus = msg.status
+        Effect.runFork(PubSub.publish(statusChanges, msg.status))
+        return
+      case 'fatal':
+        // Surfaces in console; pending commands fail via 'exit' below.
+        console.error('[security] scan worker thread fatal:', msg.error)
+        return
+    }
+  }
+
+  function onSteadyError(err: Error): void {
+    console.error('[security] scan worker thread error:', err)
+  }
+
+  function onExit(code: number): void {
+    // Reject anything still in flight so renderer IPC handlers don't
+    // hang forever on a dead worker.
+    const err = new Error(`scan worker thread exited (code=${code})`)
+    for (const slot of pending.values()) slot.reject(err)
+    pending.clear()
+  }
+
+  return {
+    enqueue: (sessionId) => Effect.promise(() => send<void>({ cmd: 'enqueue', sessionId })),
+    rescanAll: () => Effect.promise(() => send<number>({ cmd: 'rescanAll' })),
+    backfill: () => Effect.promise(() => send<number>({ cmd: 'backfill' })),
+    // getStatus uses the last pushed status when available — saves a
+    // round-trip on every renderer mount. Falls back to a real call
+    // before the first push lands.
+    getStatus: Effect.suspend(() =>
+      lastStatus.currentProfile === ''
+        ? Effect.promise(() => send<ScanStatus>({ cmd: 'getStatus' }))
+        : Effect.succeed(lastStatus),
+    ),
+    changes: Stream.fromPubSub(changes),
+    statusChanges: Stream.fromPubSub(statusChanges),
+    shutdown: () =>
+      new Promise<void>((resolve) => {
+        worker.once('exit', () => resolve())
+        worker.postMessage({ type: 'shutdown' } satisfies ToWorker)
+      }),
+  }
+}

--- a/packages/app/src/main/scan-worker-thread.ts
+++ b/packages/app/src/main/scan-worker-thread.ts
@@ -99,21 +99,30 @@ void (async () => {
 
   // Forward both event streams over postMessage. Daemon fibers so
   // they outlive any single Effect.runPromise call site.
+  //
+  // `postMessage` throws synchronously when the parent's port has
+  // closed (parent shutting down / child being terminated). We
+  // swallow the throw here so the daemon fiber stays alive — when
+  // shutdown is on the way, `port.on('message', shutdown)` will run
+  // shortly and exit cleanly. Without this, a single failed post
+  // tears down the fiber and every subsequent event is dropped.
+  function safePost(msg: FromWorker): Effect.Effect<void> {
+    return Effect.sync(() => {
+      try { port.postMessage(msg) } catch { /* parent gone */ }
+    })
+  }
+
   const changesFiber = await Effect.runPromise(
     Effect.forkDaemon(
       Stream.runForEach(worker.changes, (change) =>
-        Effect.sync(() => {
-          port.postMessage({ type: 'event-change', change } satisfies FromWorker)
-        }),
+        safePost({ type: 'event-change', change }),
       ),
     ),
   )
   const statusFiber = await Effect.runPromise(
     Effect.forkDaemon(
       Stream.runForEach(worker.statusChanges, (status) =>
-        Effect.sync(() => {
-          port.postMessage({ type: 'event-status', status } satisfies FromWorker)
-        }),
+        safePost({ type: 'event-status', status }),
       ),
     ),
   )

--- a/packages/app/src/main/scan-worker-thread.ts
+++ b/packages/app/src/main/scan-worker-thread.ts
@@ -23,7 +23,7 @@
 //
 // Protocol — see ScanWorkerThreadMessage union below.
 
-import { parentPort } from 'node:worker_threads'
+import { parentPort, threadId } from 'node:worker_threads'
 import { Effect, Exit, Fiber, Scope, Stream } from 'effect'
 import {
   currentProfileString,
@@ -73,7 +73,12 @@ process.on('unhandledRejection', reportFatal)
 process.on('uncaughtException', reportFatal)
 
 void (async () => {
-  const db = getDB()
+  console.log('[scan-worker-thread] booting; threadId =', threadId)
+  // Main process already migrated the file before spawning this
+  // thread; skipping here avoids a race with sync-worker (whose
+  // getDB() also opens with migrations skipped now) over the
+  // FTS-trigger DROP/CREATE steps.
+  const db = getDB({ runMigrations: false })
   const scope = await Effect.runPromise(Scope.make())
 
   const worker = await Effect.runPromise(

--- a/packages/app/src/main/scan-worker-thread.ts
+++ b/packages/app/src/main/scan-worker-thread.ts
@@ -1,0 +1,160 @@
+// Security Scan worker — runs in a dedicated worker_thread so its
+// synchronous SQL + CPU work (regex matching across long sessions)
+// never blocks the main process event loop. Window dragging and
+// foreground IPC stay smooth while a full backfill is in flight.
+//
+// Architecture (mirror of sync-worker.ts):
+//
+//   • Opens its own better-sqlite3 handle via getDB(). With WAL
+//     enabled (db.ts:32), the main-process query handle can read
+//     concurrently while this thread writes scan output.
+//   • Constructs makeScanWorker the same way main used to do
+//     in-process, then exposes its commands + streams over
+//     parentPort.postMessage.
+//   • Reads preferences directly from ~/.spool/security.json on
+//     every scan via the same loadSecurityPreferences helper. The
+//     main process owns the file (SET_PREFS handler writes it);
+//     this thread re-reads on every call so pref changes take
+//     effect on the next session without restarting the worker.
+//   • A 'shutdown' message closes the Effect Scope cleanly and
+//     exits 0. Anything else (unhandled rejection, exception)
+//     posts an 'error' message and exit(1) so the parent's
+//     `worker.on('exit')` handler can decide what to do.
+//
+// Protocol — see ScanWorkerThreadMessage union below.
+
+import { parentPort } from 'node:worker_threads'
+import { Effect, Exit, Fiber, Scope, Stream } from 'effect'
+import {
+  currentProfileString,
+  getDB,
+  makeScanWorker,
+  type FindingsChange,
+  type ScanStatus,
+} from '@spool-lab/core'
+import { regexProvider } from '@spool-lab/redact'
+import { loadSecurityPreferences } from './securityPreferences.js'
+
+if (!parentPort) {
+  throw new Error('scan-worker-thread.ts is only meant to run as a worker_thread child')
+}
+const port = parentPort
+
+export type ScanCommand =
+  | { cmd: 'enqueue'; sessionId: number }
+  | { cmd: 'rescanAll' }
+  | { cmd: 'backfill' }
+  | { cmd: 'getStatus' }
+
+export type ToWorker =
+  | { type: 'cmd'; reqId: number; payload: ScanCommand }
+  | { type: 'shutdown' }
+
+export type FromWorker =
+  | { type: 'ready' }
+  | { type: 'cmd-result'; reqId: number; result: unknown }
+  | { type: 'cmd-error'; reqId: number; error: string }
+  | { type: 'event-change'; change: FindingsChange }
+  | { type: 'event-status'; status: ScanStatus }
+  | { type: 'fatal'; error: string }
+
+function reportFatal(err: unknown): void {
+  const error = err instanceof Error ? (err.stack ?? err.message) : String(err)
+  try {
+    port.postMessage({ type: 'fatal', error } satisfies FromWorker)
+  } catch { /* parent gone */ }
+  process.exit(1)
+}
+
+// Node 22's --unhandled-rejections=strict default takes down the host
+// process on any unhandled rejection inside a worker. Capturing both
+// channels here converts those into structured 'fatal' messages.
+process.on('unhandledRejection', reportFatal)
+process.on('uncaughtException', reportFatal)
+
+void (async () => {
+  const db = getDB()
+  const scope = await Effect.runPromise(Scope.make())
+
+  const worker = await Effect.runPromise(
+    Effect.provideService(
+      makeScanWorker({
+        db,
+        providers: [regexProvider],
+        currentProfile: () => currentProfileString({
+          kindAllowlist: loadSecurityPreferences().kindAllowlist,
+        }),
+        providerNames: ['regex'],
+        getKindAllowlist: () => new Set(loadSecurityPreferences().kindAllowlist),
+      }),
+      Scope.Scope,
+      scope,
+    ),
+  )
+
+  // Forward both event streams over postMessage. Daemon fibers so
+  // they outlive any single Effect.runPromise call site.
+  const changesFiber = await Effect.runPromise(
+    Effect.forkDaemon(
+      Stream.runForEach(worker.changes, (change) =>
+        Effect.sync(() => {
+          port.postMessage({ type: 'event-change', change } satisfies FromWorker)
+        }),
+      ),
+    ),
+  )
+  const statusFiber = await Effect.runPromise(
+    Effect.forkDaemon(
+      Stream.runForEach(worker.statusChanges, (status) =>
+        Effect.sync(() => {
+          port.postMessage({ type: 'event-status', status } satisfies FromWorker)
+        }),
+      ),
+    ),
+  )
+
+  port.on('message', (msg: ToWorker) => {
+    if (msg.type === 'shutdown') {
+      void (async () => {
+        try {
+          // Interrupt forwarders first so no events leak in after the
+          // parent has stopped listening, then close the scope which
+          // tears down the worker's drain fiber + PubSubs.
+          await Effect.runPromise(Fiber.interrupt(changesFiber))
+          await Effect.runPromise(Fiber.interrupt(statusFiber))
+          await Effect.runPromise(Scope.close(scope, Exit.void))
+        } finally {
+          process.exit(0)
+        }
+      })()
+      return
+    }
+    if (msg.type !== 'cmd') return
+    const { reqId, payload } = msg
+    void (async () => {
+      try {
+        let result: unknown = null
+        switch (payload.cmd) {
+          case 'enqueue':
+            await Effect.runPromise(worker.enqueue(payload.sessionId))
+            break
+          case 'rescanAll':
+            result = await Effect.runPromise(worker.rescanAll())
+            break
+          case 'backfill':
+            result = await Effect.runPromise(worker.backfill())
+            break
+          case 'getStatus':
+            result = await Effect.runPromise(worker.getStatus)
+            break
+        }
+        port.postMessage({ type: 'cmd-result', reqId, result } satisfies FromWorker)
+      } catch (err) {
+        const error = err instanceof Error ? (err.stack ?? err.message) : String(err)
+        port.postMessage({ type: 'cmd-error', reqId, error } satisfies FromWorker)
+      }
+    })()
+  })
+
+  port.postMessage({ type: 'ready' } satisfies FromWorker)
+})().catch(reportFatal)

--- a/packages/app/src/main/scan-worker-thread.ts
+++ b/packages/app/src/main/scan-worker-thread.ts
@@ -17,11 +17,11 @@
 //     this thread re-reads on every call so pref changes take
 //     effect on the next session without restarting the worker.
 //   • A 'shutdown' message closes the Effect Scope cleanly and
-//     exits 0. Anything else (unhandled rejection, exception)
-//     posts an 'error' message and exit(1) so the parent's
-//     `worker.on('exit')` handler can decide what to do.
+//     exits 0. Unhandled rejections / exceptions post a 'fatal'
+//     message and exit(1) so the parent's `worker.on('exit')`
+//     handler can decide what to do.
 //
-// Protocol — see ScanWorkerThreadMessage union below.
+// Protocol — see `ToWorker` / `FromWorker` unions below.
 
 import { parentPort, threadId } from 'node:worker_threads'
 import { Effect, Exit, Fiber, Scope, Stream } from 'effect'
@@ -73,7 +73,7 @@ process.on('unhandledRejection', reportFatal)
 process.on('uncaughtException', reportFatal)
 
 void (async () => {
-  console.log('[scan-worker-thread] booting; threadId =', threadId)
+  console.log('[security] scan worker thread booted; threadId =', threadId)
   // Main process already migrated the file before spawning this
   // thread; skipping here avoids a race with sync-worker (whose
   // getDB() also opens with migrations skipped now) over the

--- a/packages/app/src/main/sync-worker.ts
+++ b/packages/app/src/main/sync-worker.ts
@@ -26,7 +26,10 @@ process.on('unhandledRejection', reportAndExit)
 process.on('uncaughtException', reportAndExit)
 
 try {
-  const db = getDB()
+  // Main process already migrated the file before this worker
+  // spawns; skipping here keeps two threads from racing through
+  // the same CREATE-TRIGGER migration step.
+  const db = getDB({ runMigrations: false })
   const syncer = new Syncer(db, (event) => {
     parentPort?.postMessage({ type: 'progress', data: event } satisfies SyncWorkerMessage)
   })

--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -20,8 +20,20 @@ let _db: Database.Database | null = null
 let _wasNewDb = false
 let _initialUserVersion: number | null = null
 
-export function getDB(_readonly = false): Database.Database {
+export interface OpenOptions {
+  /** Worker-thread callers should pass `false` — the main process has
+   *  already run migrations on the shared DB file before spawning, and
+   *  two threads racing through the migration script trip over each
+   *  other on the `CREATE TRIGGER` / index steps (DROP IF EXISTS +
+   *  CREATE is not atomic across connections). Default `true`. */
+  runMigrations?: boolean
+}
+
+export function getDB(arg?: boolean | OpenOptions): Database.Database {
   if (_db) return _db
+  const opts: OpenOptions =
+    typeof arg === 'object' && arg !== null ? arg : {}
+  const shouldRunMigrations = opts.runMigrations !== false
   mkdirSync(SPOOL_DIR, { recursive: true })
   // Capture pre-open state before better-sqlite3 creates the file. These two
   // signals together let callers tell apart "fresh install" from "upgrade":
@@ -33,7 +45,9 @@ export function getDB(_readonly = false): Database.Database {
   db.pragma('foreign_keys = ON')
   db.pragma('busy_timeout = 5000')
   _initialUserVersion = (db.pragma('user_version') as Array<{ user_version: number }>)[0]?.user_version ?? 0
-  runMigrations(db)
+  if (shouldRunMigrations) {
+    runMigrations(db)
+  }
   _db = db
   return db
 }


### PR DESCRIPTION
## What

Moves the Security Scan engine out of the Electron main process and into a dedicated `node:worker_thread`, so window dragging, foreground IPC, and renderer-driven DB reads stay smooth even mid-backfill.

## Why

The scan worker has been running inside the main process since the feature shipped. `better-sqlite3` is **synchronous** — each `scanOne` is a 50–200 ms run of:

```
SELECT messages WHERE session_id = ?      -- 5-20 ms
run regex providers across content        -- 50-100 ms
INSERT findings                           -- few ms (holds DB lock)
UPDATE sessions SET scan_*                -- few ms
```

…with only a 50 ms `Effect.sleep` between sessions. On a multi-thousand-session archive a full backfill keeps the Node event loop busy ~75 % of the time. Symptoms a user actually feels:

- Window dragging stutters — Electron's window-drag handler is a main-process callback.
- Clicks queue behind the DB lock — IPC requests can't run while the worker's write is in flight.
- Renderer queries (`listSessions`, FTS search, etc.) wait for the worker's write lock to release.

`sync-worker.ts` already lives in a `worker_thread` for exactly this reason; the security scan engine had not been moved yet.

## How

Three new pieces (same pattern as `sync-worker.ts`):

### `packages/app/src/main/scan-worker-thread.ts`

Worker entry. Opens its own `better-sqlite3` handle via `getDB({ runMigrations: false })`, builds `makeScanWorker`, forwards `changes` + `statusChanges` over `parentPort.postMessage`, handles `enqueue / rescanAll / backfill / getStatus` commands, drains cleanly on `shutdown`.

```
parent ──────postMessage──────► worker
   │                              │
   │       cmd { reqId, payload } │
   │                              │
   │       cmd-result / cmd-error │
   │                              │
   │       event-change / status  │
   │                              │
   └──────postMessage─────────────┘
```

### `packages/app/src/main/scan-worker-proxy.ts`

Main-process adapter. Implements `ScanWorker` via `postMessage` round-trips and re-publishes events through PubSubs that the existing IPC forwarders already consume. `getStatus` short-circuits to a cached snapshot after the first status push, so renderer mounts don't pay a thread round-trip just to read "scanner idle".

### `bootScanWorker` in `main/index.ts`

Spawns the thread and stores the proxy. `shutdownScanWorker` awaits the worker's exit instead of closing an in-process Scope.

### Build wiring

`electron.vite.config.ts` gains the new rollup entry so the worker file ends up in `out/main/scan-worker-thread.js` alongside `sync-worker.js`.

## Migration race

Discovered + fixed during dev verification: now THREE actors race on `runMigrations` at first boot (main + sync-worker + scan-worker-thread). The migration uses `DROP TRIGGER IF EXISTS` + `CREATE TRIGGER` for the FTS sync triggers — fine sequentially, racy across connections:

```
SqliteError: trigger messages_fts_insert already exists
```

`getDB()` gains an `OpenOptions` parameter; worker threads open with `{ runMigrations: false }`. Main process is the authoritative migration runner, spawning workers happens after main's first `getDB()` resolves, so by the time workers call `getDB({ runMigrations: false })` the schema is already current.

## Defensive hardening

Audited every place a throw could escape; four seams now wrap their respective IO so a remote-side failure can't cascade into a renderer hang or fiber death:

1. **Proxy `send()`** — `worker.postMessage` throws on a closed MessagePort. Wrapped: deletes the pending entry + rejects the Promise. Without this `enqueue` / `rescanAll` calls to a dead worker would hang indefinitely (the `exit` listener only catches handles registered before exit).
2. **Proxy `shutdown()`** — same hazard, plus `worker.once('exit')` may never fire if the thread already exited. Wrapped: resolves immediately on posthumous post failure so `before-quit` doesn't stall.
3. **`registerSecurityIpc` forwarders** — `webContents.send` throws on a destroyed BrowserWindow. Wrapped in `safeSend`; daemon fibers stay alive across window lifecycle events instead of dying on the first throw and silently losing every subsequent event.
4. **Worker thread stream forwarders** — `port.postMessage` from the child throws on parent shutdown. Wrapped in `safePost`; daemon fibers stay alive until the explicit `shutdown` message arrives and the worker exits cleanly.

Plus:
- **10 s boot timeout** on `spawnScanWorker`. A hung child (native binding load failure that doesn't crash cleanly) used to lock the entire app launch. Now the proxy rejects + calls `worker.terminate()`.
- **Fire-and-forget Effects** in main were changed from `Effect.runFork(scanWorker.X())` to `Effect.runPromise(scanWorker.X()).catch(log)` — a dead worker now logs instead of swallowing silently.

## Test plan

- `pnpm test` in `packages/app`: **216/216 green** (the existing `registerSecurityIpc` test exercises the new `safeSend` path with a mock window).
- `pnpm test` in `packages/core`: **287/287 green** (covers the new `getDB({ runMigrations: false })` option through migration tests).
- `tsc --noEmit`: clean.
- **Verified live**: launched dev on a multi-thousand-session archive. `[security] scan worker thread booted; threadId = 2` in the log; window drag stays smooth during a full backfill; risk-board chevrons + tile clicks respond instantly.