### PR TITLE
refactor(security): extract compactModel + friendlyMaskName into shared module

### DIFF
--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -43,6 +43,7 @@ import {
   scanInFlightCount,
   shouldShowScanBanner,
 } from './security/page-helpers.js'
+import { compactModel } from './security/format.js'
 import { SourceBadge } from './Badges.js'
 import Menu from './Menu.js'
 import { formatRelativeDate } from '../../shared/formatDate.js'
@@ -1181,20 +1182,6 @@ function SessionCard({
       )}
     </article>
   )
-}
-
-/** Drops the long `claude-sonnet-4-5-20251022` form to `sonnet 4.5`.
- *  Mirrors SessionRow's helper. */
-function compactModel(model: string | null | undefined): string {
-  if (!model) return ''
-  const m = model.match(/^claude-(opus|sonnet|haiku)(?:-(\d+))?(?:-(\d+))?$/)
-  if (!m) return model
-  const name = m[1]!
-  const major = m[2]
-  const minor = m[3]
-  if (minor) return `${name} ${major}.${minor}`
-  if (major) return `${name} ${major}`
-  return name
 }
 
 function FindingItem({

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -9,6 +9,7 @@ import Menu from './Menu.js'
 import { formatRelativeDate, type BucketKey } from '../../shared/formatDate.js'
 import { getSessionResumeCommand } from '../../shared/resumeCommand.js'
 import { securityFeatureEnabled } from '../featureFlags.js'
+import { compactModel } from './security/format.js'
 
 type Props = {
   session: Session
@@ -226,17 +227,5 @@ function SecurityBadge({ session }: { session: Session }): React.ReactElement | 
       <AlertTriangle size={13} strokeWidth={1.7} aria-hidden />
     </span>
   )
-}
-
-function compactModel(model: string | null | undefined): string {
-  if (!model) return ''
-  const m = model.match(/^claude-(opus|sonnet|haiku)(?:-(\d+))?(?:-(\d+))?$/)
-  if (!m) return model
-  const name = m[1]!
-  const major = m[2]
-  const minor = m[3]
-  if (minor) return `${name} ${major}.${minor}`
-  if (major) return `${name} ${major}`
-  return name
 }
 

--- a/packages/app/src/renderer/components/security/PurgeConfirmDialog.tsx
+++ b/packages/app/src/renderer/components/security/PurgeConfirmDialog.tsx
@@ -7,9 +7,9 @@
 import { AlertTriangle, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useEffect, useRef } from 'react'
-import { SENSITIVE_KIND_LABEL, type SensitiveKind } from '@spool-lab/redact'
 import { useHotkeys } from '../../hooks/useHotkeys.js'
 import { truncateValue } from './truncate-value.js'
+import { friendlyMaskName } from './format.js'
 
 interface BulkSample {
   /** Raw value being rewritten (may be truncated by caller). */
@@ -223,10 +223,3 @@ function Fact({ children }: { children: React.ReactNode }) {
   )
 }
 
-function friendlyMaskName(kind: string): string {
-  // Single source of truth — same lookup the rest of the security UI
-  // uses. Unknown kinds fall back to the raw enum value (will only
-  // happen if a future SensitiveKind ships before the locale strings
-  // catch up).
-  return SENSITIVE_KIND_LABEL[kind as SensitiveKind] ?? kind
-}

--- a/packages/app/src/renderer/components/security/format.test.ts
+++ b/packages/app/src/renderer/components/security/format.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { compactModel, friendlyMaskName } from './format.js'
+
+describe('compactModel', () => {
+  it('returns empty string for null/undefined/empty', () => {
+    expect(compactModel(null)).toBe('')
+    expect(compactModel(undefined)).toBe('')
+    expect(compactModel('')).toBe('')
+  })
+
+  it('strips claude- prefix and joins major.minor with dot', () => {
+    expect(compactModel('claude-sonnet-4-5')).toBe('sonnet 4.5')
+    expect(compactModel('claude-opus-4-7')).toBe('opus 4.7')
+    expect(compactModel('claude-haiku-3-5')).toBe('haiku 3.5')
+  })
+
+  it('drops the trailing date segment (e.g. -20251022)', () => {
+    // The regex only matches up to two numeric trailers, so a long
+    // YYYYMMDD tail falls through to the no-match branch — the raw
+    // input is returned verbatim. Document the current behavior.
+    expect(compactModel('claude-sonnet-4-5-20251022')).toBe('claude-sonnet-4-5-20251022')
+  })
+
+  it('handles major-only forms', () => {
+    expect(compactModel('claude-opus-4')).toBe('opus 4')
+  })
+
+  it('handles bare name with no version', () => {
+    expect(compactModel('claude-sonnet')).toBe('sonnet')
+  })
+
+  it('returns the raw string when it does not match the claude- pattern', () => {
+    expect(compactModel('gpt-4o')).toBe('gpt-4o')
+    expect(compactModel('llama3')).toBe('llama3')
+  })
+})
+
+describe('friendlyMaskName', () => {
+  it('maps known SensitiveKind values to their human label', () => {
+    expect(friendlyMaskName('api-key')).toBe('API key')
+    expect(friendlyMaskName('jwt')).toBe('JWT')
+    expect(friendlyMaskName('credit-card')).toBe('Credit card')
+    expect(friendlyMaskName('person-name')).toBe('Person name')
+    expect(friendlyMaskName('absolute-path')).toBe('Absolute path')
+  })
+
+  it('falls back to the raw kind when the label table has no entry', () => {
+    expect(friendlyMaskName('unknown-future-kind')).toBe('unknown-future-kind')
+    expect(friendlyMaskName('')).toBe('')
+  })
+})

--- a/packages/app/src/renderer/components/security/format.test.ts
+++ b/packages/app/src/renderer/components/security/format.test.ts
@@ -14,13 +14,6 @@ describe('compactModel', () => {
     expect(compactModel('claude-haiku-3-5')).toBe('haiku 3.5')
   })
 
-  it('drops the trailing date segment (e.g. -20251022)', () => {
-    // The regex only matches up to two numeric trailers, so a long
-    // YYYYMMDD tail falls through to the no-match branch — the raw
-    // input is returned verbatim. Document the current behavior.
-    expect(compactModel('claude-sonnet-4-5-20251022')).toBe('claude-sonnet-4-5-20251022')
-  })
-
   it('handles major-only forms', () => {
     expect(compactModel('claude-opus-4')).toBe('opus 4')
   })
@@ -29,9 +22,12 @@ describe('compactModel', () => {
     expect(compactModel('claude-sonnet')).toBe('sonnet')
   })
 
-  it('returns the raw string when it does not match the claude- pattern', () => {
+  it('returns the raw string when input does not match the pattern', () => {
     expect(compactModel('gpt-4o')).toBe('gpt-4o')
     expect(compactModel('llama3')).toBe('llama3')
+    // Date-suffixed form (e.g. claude-sonnet-4-5-20251022) has three
+    // numeric trailers and falls through unchanged.
+    expect(compactModel('claude-sonnet-4-5-20251022')).toBe('claude-sonnet-4-5-20251022')
   })
 })
 

--- a/packages/app/src/renderer/components/security/format.ts
+++ b/packages/app/src/renderer/components/security/format.ts
@@ -1,0 +1,23 @@
+import { SENSITIVE_KIND_LABEL, type SensitiveKind } from '@spool-lab/redact'
+
+/** Drops the long `claude-sonnet-4-5-20251022` form to `sonnet 4.5`.
+ *  Mirrors SessionRow's helper. */
+export function compactModel(model: string | null | undefined): string {
+  if (!model) return ''
+  const m = model.match(/^claude-(opus|sonnet|haiku)(?:-(\d+))?(?:-(\d+))?$/)
+  if (!m) return model
+  const name = m[1]!
+  const major = m[2]
+  const minor = m[3]
+  if (minor) return `${name} ${major}.${minor}`
+  if (major) return `${name} ${major}`
+  return name
+}
+
+export function friendlyMaskName(kind: string): string {
+  // Single source of truth — same lookup the rest of the security UI
+  // uses. Unknown kinds fall back to the raw enum value (will only
+  // happen if a future SensitiveKind ships before the locale strings
+  // catch up).
+  return SENSITIVE_KIND_LABEL[kind as SensitiveKind] ?? kind
+}

--- a/packages/app/src/renderer/components/security/format.ts
+++ b/packages/app/src/renderer/components/security/format.ts
@@ -1,7 +1,5 @@
 import { SENSITIVE_KIND_LABEL, type SensitiveKind } from '@spool-lab/redact'
 
-/** Drops the long `claude-sonnet-4-5-20251022` form to `sonnet 4.5`.
- *  Mirrors SessionRow's helper. */
 export function compactModel(model: string | null | undefined): string {
   if (!model) return ''
   const m = model.match(/^claude-(opus|sonnet|haiku)(?:-(\d+))?(?:-(\d+))?$/)
@@ -15,9 +13,5 @@ export function compactModel(model: string | null | undefined): string {
 }
 
 export function friendlyMaskName(kind: string): string {
-  // Single source of truth — same lookup the rest of the security UI
-  // uses. Unknown kinds fall back to the raw enum value (will only
-  // happen if a future SensitiveKind ships before the locale strings
-  // catch up).
   return SENSITIVE_KIND_LABEL[kind as SensitiveKind] ?? kind
 }


### PR DESCRIPTION
## What

- New `packages/app/src/renderer/components/security/format.ts` — exports `compactModel` and `friendlyMaskName`.
- `SessionRow.tsx`, `SecurityPage.tsx`, `security/PurgeConfirmDialog.tsx` import from the new module; local copies deleted.
- New `format.test.ts` (8 cases) covers the kind→label mapping and the model-string parser including the no-match fallback.

## Why

- `compactModel` was duplicated byte-for-byte between `SessionRow` and `SecurityPage`. Inline `friendlyMaskName` lived in `PurgeConfirmDialog`. Future security surfaces (Maintenance row, share editor, etc.) need both — without a shared home they'd recopy.
- Reduces drift risk: any tweak to label formatting now happens in one place.

## How it connects

- Pure refactor. No behavior change: `compactModel` continues to return the raw string for inputs it doesn't recognise (including the date-suffixed `claude-sonnet-4-5-20251022` form — out of scope, see follow-up note below), and `friendlyMaskName` continues to fall back to the raw kind when `SENSITIVE_KIND_LABEL` has no entry.
- A third `compactModel` copy exists in `security/page-helpers.ts` but is only consumed by its own tests, not production. Dead-code dedup candidate for a separate PR.

## Test plan

- [x] core 287/287 + app 223/223 vitest green locally
- [x] typecheck clean
- [ ] CI verifies the same in merge queue