### PR TITLE
fix(core): exclude subagent jsonl files from claude indexer

### DIFF
--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -14,7 +14,7 @@ export const DB_PATH = join(SPOOL_DIR, 'spool.db')
  * Latest schema version the running build knows how to migrate to.
  * Bump in lockstep with the last `db.pragma('user_version = N')` in runMigrations.
  */
-export const LATEST_SCHEMA_VERSION = 12
+export const LATEST_SCHEMA_VERSION = 13
 
 let _db: Database.Database | null = null
 let _wasNewDb = false
@@ -548,6 +548,36 @@ export function runMigrations(db: Database.Database): void {
         );
       `)
       db.pragma('user_version = 12')
+    })()
+  }
+
+  if (version < 13) {
+    // v13: purge subagent jsonl rows that hijacked their parent's session_uuid.
+    // Claude code writes subagent transcripts to <slug>/<uuid>/subagents/agent-*.jsonl;
+    // every record inside carries sessionId = parent uuid, so the indexer used to
+    // upsert these on top of the parent row via UNIQUE(session_uuid) — clobbering
+    // file_path and zeroing message_count (all messages are isSidechain). The
+    // matching read-side fix in source-paths.ts excludes the files going forward;
+    // here we delete the orphan rows so the next sync re-indexes the real parent.
+    // Cascades cover messages / session_search / findings / allowlist_session;
+    // pins survives (keyed by session_uuid TEXT, no FK) and re-attaches on re-sync.
+    db.transaction(() => {
+      const claudeSourceId = (db.prepare(
+        "SELECT id FROM sources WHERE name = 'claude'"
+      ).get() as { id: number } | undefined)?.id
+      if (claudeSourceId !== undefined) {
+        db.prepare(
+          `DELETE FROM sessions
+             WHERE source_id = ?
+               AND file_path LIKE '%/subagents/agent-%'`
+        ).run(claudeSourceId)
+        db.prepare(
+          `DELETE FROM sync_log
+             WHERE source_id = ?
+               AND file_path LIKE '%/subagents/agent-%'`
+        ).run(claudeSourceId)
+      }
+      db.pragma('user_version = 13')
     })()
   }
 

--- a/packages/core/src/db/queries.ts
+++ b/packages/core/src/db/queries.ts
@@ -124,10 +124,24 @@ export function upsertSession(
   },
 ): number {
   const existing = db
-    .prepare('SELECT id FROM sessions WHERE session_uuid = ?')
-    .get(opts.sessionUuid) as { id: number } | undefined
+    .prepare('SELECT id, file_path FROM sessions WHERE session_uuid = ?')
+    .get(opts.sessionUuid) as { id: number; file_path: string } | undefined
 
   if (existing) {
+    // Warn loudly if two files claim the same session_uuid. The 'spool:pending:'
+    // sentinel rebinding is legitimate (Spool-authored sessions); anything else
+    // means we're about to silently overwrite a session row — historically this
+    // happened when subagent jsonls under <slug>/<uuid>/subagents/ got indexed
+    // and clobbered the parent row.
+    if (
+      existing.file_path !== opts.filePath
+      && !existing.file_path.startsWith('spool:pending:')
+    ) {
+      console.warn(
+        `[upsertSession] session_uuid ${opts.sessionUuid} switching file_path: `
+        + `${existing.file_path} → ${opts.filePath}`,
+      )
+    }
     db.prepare('DELETE FROM messages WHERE session_id = ?').run(existing.id)
     // file_path is updated too: Spool-authored sessions start with a sentinel
     // ('spool:pending:<uuid>') and get rebound to the real JSONL path here on

--- a/packages/core/src/sync/source-paths.test.ts
+++ b/packages/core/src/sync/source-paths.test.ts
@@ -82,4 +82,81 @@ describe('detectSessionSource', () => {
     expect(detectSessionSource(join(geminiRoot, 'workspace', 'chats', 'session-2026-04-08T00-00-deadbeef.json'), sourceRoots)).toBe('gemini')
     expect(detectSessionSource(join(baseDir, 'other', 'session.jsonl'), sourceRoots)).toBeUndefined()
   })
+
+  test('rejects nested Claude files (subagent scratchpads) below the slug directory', () => {
+    const baseDir = mkdtempSync(join(tmpdir(), 'spool-claude-nested-'))
+    tempDirs.push(baseDir)
+
+    const claudeRoot = join(baseDir, '.claude', 'projects')
+    mkdirSync(join(claudeRoot, '-Users-me-spool', 'c3859389-e126-4b46-b207-63f322f41893', 'subagents'), {
+      recursive: true,
+    })
+
+    const sourceRoots = {
+      claude: [claudeRoot],
+      codex: [join(baseDir, 'codex-empty')],
+      gemini: [join(baseDir, 'gemini-empty')],
+    } as const
+
+    // Top-level session: indexed as claude.
+    expect(
+      detectSessionSource(
+        join(claudeRoot, '-Users-me-spool', 'c3859389-e126-4b46-b207-63f322f41893.jsonl'),
+        sourceRoots,
+      ),
+    ).toBe('claude')
+
+    // Subagent jsonl shares the parent's sessionId — must be ignored.
+    expect(
+      detectSessionSource(
+        join(
+          claudeRoot,
+          '-Users-me-spool',
+          'c3859389-e126-4b46-b207-63f322f41893',
+          'subagents',
+          'agent-aac075d8798c35986.jsonl',
+        ),
+        sourceRoots,
+      ),
+    ).toBeUndefined()
+
+    // Hypothetical future nested dirs (checkpoints, snapshots, etc.) are also ignored,
+    // not just files literally under /subagents/.
+    expect(
+      detectSessionSource(
+        join(claudeRoot, '-Users-me-spool', 'c3859389', 'checkpoints', 'snap.jsonl'),
+        sourceRoots,
+      ),
+    ).toBeUndefined()
+  })
+
+  test('keeps Codex deep paths and Claude slugs containing "subagents" working', () => {
+    const baseDir = mkdtempSync(join(tmpdir(), 'spool-claude-slug-edge-'))
+    tempDirs.push(baseDir)
+
+    const claudeRoot = join(baseDir, '.claude', 'projects')
+    const codexRoot = join(baseDir, '.codex', 'sessions')
+    // Edge case: a real project whose cwd path contains "subagents" → slug includes it.
+    mkdirSync(join(claudeRoot, '-Users-me-work-subagents-app'), { recursive: true })
+    mkdirSync(join(codexRoot, '2026', '05', '21'), { recursive: true })
+
+    const sourceRoots = {
+      claude: [claudeRoot],
+      codex: [codexRoot],
+      gemini: [join(baseDir, 'gemini-empty')],
+    } as const
+
+    // Slug with "subagents" substring must still classify as claude.
+    expect(
+      detectSessionSource(
+        join(claudeRoot, '-Users-me-work-subagents-app', 'fffe1234-5678-90ab-cdef-000000000000.jsonl'),
+        sourceRoots,
+      ),
+    ).toBe('claude')
+
+    // Codex deep path (YYYY/MM/DD/rollout-*.jsonl) is unaffected by the claude rule.
+    expect(
+      detectSessionSource(join(codexRoot, '2026', '05', '21', 'rollout-abc.jsonl'), sourceRoots),
+    ).toBe('codex')
+  })
 })

--- a/packages/core/src/sync/source-paths.ts
+++ b/packages/core/src/sync/source-paths.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { basename, delimiter, isAbsolute, join, relative, resolve } from 'node:path'
+import { basename, delimiter, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import type { SessionSource } from '../types.js'
 
 const SOURCE_DIR_NAMES: Record<Exclude<SessionSource, 'gemini'>, string> = {
@@ -122,14 +122,23 @@ function getGeminiBaseDir(): string {
     : join(homedir(), '.gemini')
 }
 
-function isSessionFileForSource(source: SessionSource, filePath: string, root: string): boolean {
+export function isSessionFileForSource(source: SessionSource, filePath: string, root: string): boolean {
   if (!isWithinRoot(filePath, root)) return false
   if (source === 'gemini') {
     return filePath.endsWith('.json')
       && basename(filePath).startsWith('session-')
       && /(?:^|\/)chats\//.test(filePath)
   }
-  return filePath.endsWith('.jsonl')
+  if (!filePath.endsWith('.jsonl')) return false
+  if (source === 'claude') {
+    // Claude sessions live at <root>/<slug>/<uuid>.jsonl — exactly two segments
+    // relative to root. Nested files (e.g. <slug>/<uuid>/subagents/agent-*.jsonl)
+    // are subagent scratchpads that share the parent's sessionId; indexing them
+    // clobbers the parent row via UNIQUE(session_uuid) and zeros message_count.
+    const rel = relative(root, filePath)
+    return rel.length > 0 && rel.split(sep).length === 2
+  }
+  return true
 }
 
 function isWithinRoot(filePath: string, root: string): boolean {

--- a/packages/core/src/sync/syncer.ts
+++ b/packages/core/src/sync/syncer.ts
@@ -6,7 +6,7 @@ import { loadClaudeSession, decodeProjectSlug } from '../parsers/claude.js'
 import { loadCodexSession, CODEX_INDEX_VERSION } from '../parsers/codex.js'
 import { loadGeminiSession } from '../parsers/gemini.js'
 import type { SessionSource } from '../types.js'
-import { getSessionRoots } from './source-paths.js'
+import { getSessionRoots, isSessionFileForSource } from './source-paths.js'
 import {
   deleteSessionByFilePath,
   getSourceId,
@@ -292,12 +292,13 @@ function collectSessionFiles(
   source: SessionSource,
 ): Array<{ path: string; source: SessionSource }> {
   const results: Array<{ path: string; source: SessionSource }> = []
-  walkDir(dir, results, source)
+  walkDir(dir, dir, results, source)
   return results
 }
 
 function walkDir(
   dir: string,
+  root: string,
   results: Array<{ path: string; source: SessionSource }>,
   source: SessionSource,
 ): void {
@@ -311,8 +312,12 @@ function walkDir(
     const fullPath = join(dir, entry.name)
     if (entry.isDirectory()) {
       if (source === 'gemini' && !shouldTraverseGeminiDir(dir, fullPath, entry.name)) continue
-      walkDir(fullPath, results, source)
-    } else if (entry.isFile() && isSessionFilePath(fullPath, source)) {
+      // For claude, session files only live at <root>/<slug>/<uuid>.jsonl. Anything
+      // deeper is subagent / future-nested scratch data that hijacks the parent
+      // sessionId — see isSessionFileForSource for the matching read-side check.
+      if (source === 'claude' && dirname(fullPath) !== root) continue
+      walkDir(fullPath, root, results, source)
+    } else if (entry.isFile() && isSessionFileForSource(source, fullPath, root)) {
       results.push({ path: fullPath, source })
     }
   }
@@ -323,15 +328,6 @@ function shouldTraverseGeminiDir(parentDir: string, fullPath: string, entryName:
   if (basename(parentDir) === 'tmp') return true
   if (/(?:^|\/)chats(?:\/|$)/.test(parentDir)) return true
   return existsSync(join(fullPath, 'chats'))
-}
-
-function isSessionFilePath(filePath: string, source: SessionSource): boolean {
-  if (source === 'gemini') {
-    return filePath.endsWith('.json')
-      && basename(filePath).startsWith('session-')
-      && /(?:^|\/)chats\//.test(filePath)
-  }
-  return filePath.endsWith('.jsonl')
 }
 
 function loadCodexSessionIndex(): Map<string, string> {


### PR DESCRIPTION
## What

Claude Code writes subagent transcripts to `<projects>/<slug>/<uuid>/subagents/agent-*.jsonl`. The recursive `**/*.jsonl` glob was picking these up; each record carries `sessionId = parent uuid`, so the `session_uuid`-keyed upsert clobbered the parent session row — rewriting `file_path` to the subagent path and zeroing `message_count` (every message is `isSidechain`, filtered out by the syncer's count). With `message_count = 0`, the parent session disappeared from every list query (all gated on `message_count > 0`).

User symptom: pin appears to fail → restart → session shows as pinned → unpin → session vanishes from the sessions view. The pin DB write always succeeded, but the row underneath was getting clobbered back to msg=0 by a subsequent subagent re-sync, so `listPinnedSessions` (which filters on `message_count > 0`) hid it.

## Why structural depth, not substring

`!filePath.includes('/subagents/')` would have worked today but is fragile. Real Claude session paths are always exactly two segments below the source root (`<slug>/<uuid>.jsonl`). Enforcing that structurally:

- excludes any future nested dirs Claude Code might add (`checkpoints/`, `snapshots/`, …) without code changes;
- doesn't false-positive on projects whose cwd path contains the word `subagents` (slug encodes `/` as `-`, so the substring is part of the slug name and lives at depth 1);
- expresses the actual contract ("only index top-level session files") instead of "I dislike one specific dirname".

Codex's deeper `YYYY/MM/DD/rollout-*.jsonl` layout is unaffected — the depth rule is claude-only.

## How it connects

- `source-paths.ts` — `isSessionFileForSource` now requires `relative(root, filePath).split(sep).length === 2` for claude. The function is exported and reused by the syncer's walker.
- `syncer.ts` — `walkDir` carries the root through, stops recursing into directories below the slug for claude, and uses the shared predicate. Local `isSessionFilePath` helper deleted.
- `db.ts` — v13 migration deletes orphan rows whose `file_path` matches `%/subagents/agent-%` (claude source only) and sweeps matching `sync_log` entries. Cascade handles `messages` / `session_search` / `findings` / `allowlist_session`; FTS `AFTER DELETE` triggers clean their own indexes; `pins` survive (TEXT `session_uuid`, no FK) and re-attach to the parent on the next syncAll. Wrapped in `db.transaction()` so a mid-migration failure stays atomic.
- `queries.ts` — `upsertSession` warns when an existing row's `file_path` is silently rewritten by a different incoming file claiming the same `session_uuid`. The `spool:pending:` sentinel rebind is excluded so first-sync of Spool-authored sessions stays quiet. Surfaces any future "two files claim one uuid" bug loudly instead of silently overwriting.

## Test plan

Unit:
- [x] `pnpm --filter @spool-lab/core typecheck` clean
- [x] `pnpm --filter @spool/app typecheck` clean
- [x] `pnpm --filter @spool-lab/core test` — 288/288 passing
- [x] New `source-paths.test.ts` cases: subagent path rejected; hypothetical nested dirs (`checkpoints/`) rejected; slug containing "subagents" still classifies as claude; codex deep paths still work

End-to-end on a real prod-sized DB (336 claude sessions, 166 subagent orphans, 4 pins including one on a buried session, schema at v11):
- [x] v11 → v12 → v13 migration chain runs cleanly, leaves `user_version = 13`
- [x] 166 subagent rows deleted; subsequent syncAll adds zero subagent rows back (indexer fix working)
- [x] syncAll re-indexes 25 parent sessions that had been buried under subagent file_paths
- [x] All 4 pins re-attach to their parent rows with real `message_count` (no orphan pins)
- [x] Target session that triggered the report (`c3859389-…`) now indexed at the parent jsonl path with `message_count = 116`
- [x] FTS integrity-check passes; zero orphan rows in `messages` / `session_search` / `findings` / `pins`
- [x] Dev DB (60 subagent orphans) also re-verified from scratch at v13 after full reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)