### PR TITLE
fix(app): kill white flash on dark-mode window resize

### DIFF
--- a/packages/app/e2e/dark-mode-root-bg.spec.ts
+++ b/packages/app/e2e/dark-mode-root-bg.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, type AppContext } from './helpers/launch'
+
+// Regression test for a white flash visible at the window edge during
+// live drag-resize in dark mode. The renderer's React surface paints
+// `dark:bg-dark-bg` on its root <div>, but the html element below it
+// used to have a hardcoded `background: #FAFAF8`. On macOS the freshly
+// exposed strip during a live resize sits one frame behind the React
+// paint, so the html background showed through as a bright edge.
+//
+// Fix: `:root` now uses `var(--color-warm-bg)` and is overridden under
+// `prefers-color-scheme: dark` to `var(--color-dark-bg)`. This test
+// locks that in by asserting the computed html background follows the
+// emulated color scheme.
+
+let ctx: AppContext
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+test('html root background tracks color-scheme (no white flash on resize)', async () => {
+  await ctx.window.emulateMedia({ colorScheme: 'dark' })
+  const darkBg = await ctx.window.evaluate(
+    () => getComputedStyle(document.documentElement).backgroundColor,
+  )
+  // --color-dark-bg = #141410 = rgb(20, 20, 16)
+  expect(darkBg).toBe('rgb(20, 20, 16)')
+
+  await ctx.window.emulateMedia({ colorScheme: 'light' })
+  const lightBg = await ctx.window.evaluate(
+    () => getComputedStyle(document.documentElement).backgroundColor,
+  )
+  // --color-warm-bg = #FAFAF8 = rgb(250, 250, 248)
+  expect(lightBg).toBe('rgb(250, 250, 248)')
+})

--- a/packages/app/src/renderer/styles.css
+++ b/packages/app/src/renderer/styles.css
@@ -89,8 +89,16 @@
 :root {
   -webkit-font-smoothing: antialiased;
   font-family: var(--font-sans);
-  background: #FAFAF8;
-  color: #1C1C18;
+  color-scheme: light dark;
+  background: var(--color-warm-bg);
+  color: var(--color-warm-text);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    background: var(--color-dark-bg);
+    color: var(--color-dark-text);
+  }
 }
 
 * {


### PR DESCRIPTION
## What

Stop the html `:root` element from painting `#FAFAF8` in dark mode, which produced a bright edge on the side you were dragging during a live window resize.

## Why

The React tree paints `bg-warm-bg dark:bg-dark-bg` on its root `<div>`, but the html element under it had a hardcoded `background: #FAFAF8` with no dark-mode branch. On macOS the freshly exposed strip during live drag-resize sits one frame behind the renderer paint, so the html background bled through as a white edge that didn't track the window content — only visible in dark mode.

## How

In `packages/app/src/renderer/styles.css`:

- `:root` switched from literal `#FAFAF8` / `#1C1C18` to `var(--color-warm-bg)` / `var(--color-warm-text)` (already exposed by Tailwind `@theme`).
- Added a `prefers-color-scheme: dark` block that overrides to `var(--color-dark-bg)` / `var(--color-dark-text)`.
- Added `color-scheme: light dark` so Chromium's default form widgets, scrollbar paint, and fallback background also follow the active scheme — same class of latent issue, free to fix here.

The `BrowserWindow` `backgroundColor` in main is already theme-aware at creation time and unaffected.

## Test plan

- [x] New e2e regression `packages/app/e2e/dark-mode-root-bg.spec.ts` asserts the computed html background follows `emulateMedia({ colorScheme })` — `rgb(20, 20, 16)` under dark, `rgb(250, 250, 248)` under light. Would have returned the light value under dark before the fix.
- [x] Typecheck clean in `packages/app`.
- [x] Manual: launched `pnpm dev` in dark mode, drag-resized the window in/out — no more white edge.