### PR TITLE
feat(security): paginate findings + sessions reads with accurate total

### DIFF
--- a/packages/app/src/main/ipc/security.ts
+++ b/packages/app/src/main/ipc/security.ts
@@ -9,7 +9,9 @@ import { ipcMain, type BrowserWindow } from 'electron'
 import { Effect, Fiber, Stream } from 'effect'
 import {
   listFindings,
+  listFindingsPage,
   listSessionsWithFindings,
+  listSessionsWithFindingsPage,
   riskByCategory,
   getFindingValue,
   getFindingValues,
@@ -38,7 +40,9 @@ import {
 export const SECURITY_IPC_CHANNELS = {
   // queries
   LIST_FINDINGS:               'security:list-findings',
+  LIST_FINDINGS_PAGE:          'security:list-findings-page',
   LIST_SESSIONS_WITH_FINDINGS: 'security:list-sessions-with-findings',
+  LIST_SESSIONS_WITH_FINDINGS_PAGE: 'security:list-sessions-with-findings-page',
   RISK_BY_CATEGORY:            'security:risk-by-category',
   GET_FINDING_VALUE:           'security:get-finding-value',
   GET_FINDING_VALUES:          'security:get-finding-values',
@@ -85,8 +89,14 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
   ipcMain.handle(SECURITY_IPC_CHANNELS.LIST_FINDINGS, (_e, filter: FindingFilter) =>
     listFindings(db, filter),
   )
+  ipcMain.handle(SECURITY_IPC_CHANNELS.LIST_FINDINGS_PAGE, (_e, filter: FindingFilter) =>
+    listFindingsPage(db, filter),
+  )
   ipcMain.handle(SECURITY_IPC_CHANNELS.LIST_SESSIONS_WITH_FINDINGS, (_e, filter: SessionFindingFilter) =>
     listSessionsWithFindings(db, filter),
+  )
+  ipcMain.handle(SECURITY_IPC_CHANNELS.LIST_SESSIONS_WITH_FINDINGS_PAGE, (_e, filter: SessionFindingFilter) =>
+    listSessionsWithFindingsPage(db, filter),
   )
   ipcMain.handle(SECURITY_IPC_CHANNELS.RISK_BY_CATEGORY, () =>
     riskByCategory(db),

--- a/packages/app/src/main/ipc/security.ts
+++ b/packages/app/src/main/ipc/security.ts
@@ -12,6 +12,7 @@ import {
   listFindingsPage,
   listSessionsWithFindings,
   listSessionsWithFindingsPage,
+  countSessionsWithFindings,
   riskByCategory,
   getFindingValue,
   getFindingValues,
@@ -43,6 +44,7 @@ export const SECURITY_IPC_CHANNELS = {
   LIST_FINDINGS_PAGE:          'security:list-findings-page',
   LIST_SESSIONS_WITH_FINDINGS: 'security:list-sessions-with-findings',
   LIST_SESSIONS_WITH_FINDINGS_PAGE: 'security:list-sessions-with-findings-page',
+  COUNT_SESSIONS_WITH_FINDINGS: 'security:count-sessions-with-findings',
   RISK_BY_CATEGORY:            'security:risk-by-category',
   GET_FINDING_VALUE:           'security:get-finding-value',
   GET_FINDING_VALUES:          'security:get-finding-values',
@@ -97,6 +99,9 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
   )
   ipcMain.handle(SECURITY_IPC_CHANNELS.LIST_SESSIONS_WITH_FINDINGS_PAGE, (_e, filter: SessionFindingFilter) =>
     listSessionsWithFindingsPage(db, filter),
+  )
+  ipcMain.handle(SECURITY_IPC_CHANNELS.COUNT_SESSIONS_WITH_FINDINGS, (_e, filter: SessionFindingFilter) =>
+    countSessionsWithFindings(db, filter),
   )
   ipcMain.handle(SECURITY_IPC_CHANNELS.RISK_BY_CATEGORY, () =>
     riskByCategory(db),

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -230,6 +230,8 @@ const api = {
       ipcRenderer.invoke('security:list-sessions-with-findings', filter),
     listSessionsWithFindingsPage: (filter: SessionFindingFilter): Promise<Page<SessionWithFindingCounts>> =>
       ipcRenderer.invoke('security:list-sessions-with-findings-page', filter),
+    countSessionsWithFindings: (filter: SessionFindingFilter): Promise<number> =>
+      ipcRenderer.invoke('security:count-sessions-with-findings', filter),
     riskByCategory: (): Promise<RiskByCategoryRow[]> =>
       ipcRenderer.invoke('security:risk-by-category'),
     getFindingValue: (findingId: number): Promise<string | null> =>

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -7,6 +7,7 @@ import type {
   FindingRow, SessionWithFindingCounts, RiskByCategoryRow,
   FindingsChange, ScanStatus, FindingFilter, SessionFindingFilter,
   AllowlistEntryRow,
+  Page,
 } from '@spool-lab/core'
 import type { SensitiveKind } from '@spool-lab/redact'
 
@@ -223,8 +224,12 @@ const api = {
   security: {
     listFindings: (filter: FindingFilter): Promise<FindingRow[]> =>
       ipcRenderer.invoke('security:list-findings', filter),
+    listFindingsPage: (filter: FindingFilter): Promise<Page<FindingRow>> =>
+      ipcRenderer.invoke('security:list-findings-page', filter),
     listSessionsWithFindings: (filter: SessionFindingFilter): Promise<SessionWithFindingCounts[]> =>
       ipcRenderer.invoke('security:list-sessions-with-findings', filter),
+    listSessionsWithFindingsPage: (filter: SessionFindingFilter): Promise<Page<SessionWithFindingCounts>> =>
+      ipcRenderer.invoke('security:list-sessions-with-findings-page', filter),
     riskByCategory: (): Promise<RiskByCategoryRow[]> =>
       ipcRenderer.invoke('security:risk-by-category'),
     getFindingValue: (findingId: number): Promise<string | null> =>

--- a/packages/app/src/renderer/api/security.ts
+++ b/packages/app/src/renderer/api/security.ts
@@ -14,6 +14,7 @@ import type {
   FindingsChange,
   ScanStatus,
   AllowlistEntryRow,
+  Page,
 } from '@spool-lab/core'
 import type { SensitiveKind } from '@spool-lab/redact'
 import type { SecurityPreferences } from '../../preload/index.js'
@@ -26,8 +27,12 @@ export type { SecurityPreferences, AllowlistEntryRow }
 export const securityApi = {
   listFindings: (filter: FindingFilter = {}): Promise<FindingRow[]> =>
     window.spool.security.listFindings(filter),
+  listFindingsPage: (filter: FindingFilter = {}): Promise<Page<FindingRow>> =>
+    window.spool.security.listFindingsPage(filter),
   listSessionsWithFindings: (filter: SessionFindingFilter = {}): Promise<SessionWithFindingCounts[]> =>
     window.spool.security.listSessionsWithFindings(filter),
+  listSessionsWithFindingsPage: (filter: SessionFindingFilter = {}): Promise<Page<SessionWithFindingCounts>> =>
+    window.spool.security.listSessionsWithFindingsPage(filter),
   riskByCategory: (): Promise<RiskByCategoryRow[]> =>
     window.spool.security.riskByCategory(),
   getFindingValue: (findingId: number): Promise<string | null> =>

--- a/packages/app/src/renderer/api/security.ts
+++ b/packages/app/src/renderer/api/security.ts
@@ -33,6 +33,8 @@ export const securityApi = {
     window.spool.security.listSessionsWithFindings(filter),
   listSessionsWithFindingsPage: (filter: SessionFindingFilter = {}): Promise<Page<SessionWithFindingCounts>> =>
     window.spool.security.listSessionsWithFindingsPage(filter),
+  countSessionsWithFindings: (filter: SessionFindingFilter = {}): Promise<number> =>
+    window.spool.security.countSessionsWithFindings(filter),
   riskByCategory: (): Promise<RiskByCategoryRow[]> =>
     window.spool.security.riskByCategory(),
   getFindingValue: (findingId: number): Promise<string | null> =>

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -70,6 +70,9 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
   const { t } = useTranslation()
   const [risk, setRisk] = useState<RiskByCategoryRow[]>([])
   const [sessions, setSessions] = useState<Sess[]>([])
+  const [sessionsHasMore, setSessionsHasMore] = useState(false)
+  const [sessionsPageCount, setSessionsPageCount] = useState(1)
+  const SESSIONS_PAGE_SIZE = 50
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [query, setQuery] = useState('')
@@ -110,19 +113,30 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
 
   const filter: SessionFindingFilter = parsed.filter
 
+  // Reset to first page whenever the active filter changes so a chip
+  // toggle doesn't try to display offset-50 of a different result set.
+  const filterKey = JSON.stringify(filter)
+  useEffect(() => {
+    setSessionsPageCount(1)
+  }, [filterKey])
+
   const refresh = useCallback(async () => {
     try {
-      const [r, s, st] = await Promise.all([
+      const [r, sPage, st] = await Promise.all([
         securityApi.riskByCategory(),
-        securityApi.listSessionsWithFindings(filter),
+        securityApi.listSessionsWithFindingsPage({
+          ...filter,
+          limit: sessionsPageCount * SESSIONS_PAGE_SIZE,
+        }),
         securityApi.getScanStatus(),
       ])
       setRisk(r)
-      setSessions(s as Sess[])
+      setSessions(sPage.rows as Sess[])
+      setSessionsHasMore(sPage.hasMore)
       setScanStatus(st)
       // Pick the most recent scan_completed_at across the session set
       // we just fetched. Cheap because s is already in-memory.
-      const completedAts = (s as Sess[])
+      const completedAts = (sPage.rows as Sess[])
         .map(x => x.scanCompletedAt)
         .filter((x): x is string => Boolean(x))
       if (completedAts.length > 0) {
@@ -135,7 +149,7 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
       setError(err instanceof Error ? err.message : String(err))
       setLoading(false)
     }
-  }, [filter])
+  }, [filter, sessionsPageCount])
 
   useEffect(() => {
     void refresh()
@@ -648,6 +662,16 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
                         onRefresh={refresh}
                       />
                     ))}
+                    {sessionsHasMore && (
+                      <button
+                        type="button"
+                        data-testid="security-sessions-load-more"
+                        onClick={() => setSessionsPageCount((n) => n + 1)}
+                        className="self-start mt-2 h-7 px-2.5 rounded-md text-[12px] font-medium text-warm-muted dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors"
+                      >
+                        {t('security.load_more', { defaultValue: 'Load more' })}
+                      </button>
+                    )}
                   </div>
                 )}
               </section>
@@ -966,6 +990,9 @@ function SessionCard({
 }) {
   const { t } = useTranslation()
   const [findings, setFindings] = useState<FindingRow[] | null>(null)
+  const [findingsHasMore, setFindingsHasMore] = useState(false)
+  const [findingsPageCount, setFindingsPageCount] = useState(1)
+  const FINDINGS_PAGE_SIZE = 200
   const [showAll, setShowAll] = useState(false)
   // Click-to-collapse on the title row. Default expanded so the user
   // sees what's inside each card; can fold shut once they've reviewed.
@@ -975,18 +1002,23 @@ function SessionCard({
   const [values, setValues] = useState<Record<number, string | null>>({})
 
   const load = useCallback(async () => {
-    const f: FindingFilter = { sessionId: session.id, state: 'active' }
+    const f: FindingFilter = {
+      sessionId: session.id,
+      state: 'active',
+      limit: findingsPageCount * FINDINGS_PAGE_SIZE,
+    }
     if (activeKinds.length > 0) {
       f.kinds = activeKinds as NonNullable<FindingFilter['kinds']>
     }
     try {
-      const rows = await securityApi.listFindings(f)
-      setFindings(rows)
+      const page = await securityApi.listFindingsPage(f)
+      setFindings(page.rows)
+      setFindingsHasMore(page.hasMore)
       // Bulk-fetch raw values for the rows we're about to render in
       // one IPC trip instead of one-per-row. Caller passes the value
       // down as a prop; FindingItem no longer needs its own fetch.
-      if (rows.length > 0) {
-        const map = await securityApi.getFindingValues(rows.map(r => r.id))
+      if (page.rows.length > 0) {
+        const map = await securityApi.getFindingValues(page.rows.map(r => r.id))
         setValues(map)
       } else {
         setValues({})
@@ -996,9 +1028,16 @@ function SessionCard({
       setFindings([])
       setValues({})
     }
-  }, [session.id, activeKinds])
+  }, [session.id, activeKinds, findingsPageCount])
 
   useEffect(() => { void load() }, [load])
+
+  // Reset pagination to first page when the active kind filter
+  // changes — keeps Load-more counts aligned with the new result set.
+  const activeKindsKey = activeKinds.join('|')
+  useEffect(() => {
+    setFindingsPageCount(1)
+  }, [activeKindsKey])
 
   async function handleCopyId() {
     try { await navigator.clipboard.writeText(session.sessionUuid) } catch { /* clipboard blocked */ }
@@ -1176,6 +1215,16 @@ function SessionCard({
               className="self-start ml-6 mt-0.5 h-[22px] px-2 rounded bg-transparent font-mono text-[11px] text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors"
             >
               {t('security.show_more', { count: hidden, defaultValue: 'show {{count}} more' })}
+            </button>
+          )}
+          {showAll && findingsHasMore && (
+            <button
+              type="button"
+              data-testid="security-findings-load-more"
+              onClick={() => setFindingsPageCount((n) => n + 1)}
+              className="self-start ml-6 mt-0.5 h-[22px] px-2 rounded bg-transparent font-mono text-[11px] text-warm-muted dark:text-dark-muted hover:bg-warm-surface dark:hover:bg-dark-surface hover:text-warm-text dark:hover:text-dark-text transition-colors"
+            >
+              {t('security.load_more', { defaultValue: 'Load more' })}
             </button>
           )}
         </div>

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -71,6 +71,7 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
   const [risk, setRisk] = useState<RiskByCategoryRow[]>([])
   const [sessions, setSessions] = useState<Sess[]>([])
   const [sessionsHasMore, setSessionsHasMore] = useState(false)
+  const [sessionsTotal, setSessionsTotal] = useState<number | null>(null)
   const [sessionsPageCount, setSessionsPageCount] = useState(1)
   const SESSIONS_PAGE_SIZE = 50
   const [loading, setLoading] = useState(true)
@@ -122,17 +123,19 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
 
   const refresh = useCallback(async () => {
     try {
-      const [r, sPage, st] = await Promise.all([
+      const [r, sPage, sTotal, st] = await Promise.all([
         securityApi.riskByCategory(),
         securityApi.listSessionsWithFindingsPage({
           ...filter,
           limit: sessionsPageCount * SESSIONS_PAGE_SIZE,
         }),
+        securityApi.countSessionsWithFindings(filter),
         securityApi.getScanStatus(),
       ])
       setRisk(r)
       setSessions(sPage.rows as Sess[])
       setSessionsHasMore(sPage.hasMore)
+      setSessionsTotal(sTotal)
       setScanStatus(st)
       // Pick the most recent scan_completed_at across the session set
       // we just fetched. Cheap because s is already in-memory.
@@ -416,7 +419,7 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
        *  the distance from the sidebar reads identical across pages. */}
       <div className="flex-none flex items-center gap-3 px-6 pt-1.5 pb-3">
         <span className="font-mono text-[11px] text-warm-faint dark:text-dark-muted tabular-nums">
-          {t('security.summary', { findings: visibleActive, sessions: sessions.length, defaultValue: '{{findings}} risk · {{sessions}} sessions' })}
+          {t('security.summary', { findings: visibleActive, defaultValue: '{{findings}} risk' })}
           {infoCount > 0 && (
             <span className="opacity-70">
               {' · '}
@@ -616,7 +619,7 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
                     {t('security.sessions_with_findings', { defaultValue: 'Sessions with active findings' })}
                   </span>
                   <span className="font-mono text-[12px] text-warm-faint dark:text-dark-muted tabular-nums ml-1">
-                    {sessions.length}
+                    {sessionsTotal ?? sessions.length}
                   </span>
                   {/* Icon-only toggle, tooltip via title.
                    *  Eye = values currently visible, click to hide;

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -260,7 +260,7 @@
     }
   },
   "security": {
-    "summary": "{{findings}} aktiv · {{sessions}} Sitzungen",
+    "summary": "{{findings}} aktiv",
     "rescanAll": "Alle neu prüfen",
     "severity_high": "Hoch",
     "severity_low": "Niedrig",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -260,7 +260,7 @@
     }
   },
   "security": {
-    "summary": "{{findings}} risk · {{sessions}} sessions",
+    "summary": "{{findings}} risk",
     "summary_info": "{{count}} info",
     "rescanAll": "Rescan all",
     "severity_high": "High",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -260,7 +260,7 @@
     }
   },
   "security": {
-    "summary": "{{findings}} actifs · {{sessions}} sessions",
+    "summary": "{{findings}} actifs",
     "rescanAll": "Tout rescanner",
     "severity_high": "Élevé",
     "severity_low": "Faible",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -251,7 +251,7 @@
     }
   },
   "security": {
-    "summary": "{{findings}} 件 · {{sessions}} セッション",
+    "summary": "{{findings}} 件",
     "rescanAll": "すべて再スキャン",
     "severity_high": "高",
     "severity_low": "低",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -251,7 +251,7 @@
     }
   },
   "security": {
-    "summary": "{{findings}}개 · {{sessions}}개 세션",
+    "summary": "{{findings}}개",
     "rescanAll": "모두 다시 스캔",
     "severity_high": "높음",
     "severity_low": "낮음",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -251,7 +251,7 @@
     }
   },
   "security": {
-    "summary": "{{findings}} 项风险 · 涉及 {{sessions}} 个会话",
+    "summary": "{{findings}} 项风险",
     "summary_info": "{{count}} 项信息",
     "rescanAll": "全部重扫",
     "severity_high": "高风险",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -251,7 +251,7 @@
     }
   },
   "security": {
-    "summary": "{{findings}} 項 · 涉及 {{sessions}} 個會話",
+    "summary": "{{findings}} 項",
     "rescanAll": "全部重掃",
     "severity_high": "高風險",
     "severity_low": "低風險",

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -30,6 +30,7 @@ export {
   listFindingsPage,
   listSessionsWithFindings,
   listSessionsWithFindingsPage,
+  countSessionsWithFindings,
   riskByCategory,
   getFindingValue,
   getFindingValues,

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -27,7 +27,9 @@ export {
   invalidateSessionScanProfile,
   listSessionsNeedingScan,
   listFindings,
+  listFindingsPage,
   listSessionsWithFindings,
+  listSessionsWithFindingsPage,
   riskByCategory,
   getFindingValue,
   getFindingValues,
@@ -47,6 +49,7 @@ export type {
   FindingInput,
   AllowlistEntryRow,
   AllowlistSnapshot,
+  Page,
 } from './repo.js'
 
 export { scanSession, ScanError } from './scan.js'

--- a/packages/core/src/security/repo.test.ts
+++ b/packages/core/src/security/repo.test.ts
@@ -10,7 +10,9 @@ import {
   invalidateSessionScanProfile,
   listSessionsNeedingScan,
   listFindings,
+  listFindingsPage,
   listSessionsWithFindings,
+  listSessionsWithFindingsPage,
   riskByCategory,
   getFindingValue,
   getAllowlists,
@@ -166,6 +168,150 @@ describe('repo: list + filter', () => {
     const f = listFindings(db, { kind: 'api-key', sessionId: 1 })[0]!
     db.prepare("UPDATE findings SET state='purged' WHERE id = ?").run(f.id)
     expect(getFindingValue(db, f.id)).toBeNull()
+  })
+})
+
+describe('repo: pagination', () => {
+  let db: Database.Database
+  beforeEach(() => {
+    db = setupDb()
+    // 12 findings in session 1, all api-key (high) with distinct
+    // detected_at timestamps so order is deterministic.
+    const rows = Array.from({ length: 12 }, (_, i) => ({
+      sessionId: 1,
+      messageId: 10,
+      kind: 'api-key' as const,
+      valueHash: `h-${i}`,
+      confidence: 0.9,
+      provider: 'regex',
+      startOffset: i,
+      endOffset: i + 1,
+      state: 'active' as const,
+    }))
+    insertFindings(db, rows)
+    // Spread detected_at so ordering is unambiguous — default insert
+    // assigns the same timestamp to every row, which leaves only `id
+    // DESC` as the tiebreaker. We want to exercise BOTH clauses.
+    for (let i = 0; i < 12; i++) {
+      db.prepare(
+        `UPDATE findings SET detected_at = ? WHERE value_hash = ?`,
+      ).run(`2026-01-01T00:00:${(10 + i).toString().padStart(2, '0')}Z`, `h-${i}`)
+    }
+    updateSessionCounts(db, 1)
+  })
+
+  it('listFindings honours limit only', () => {
+    const rows = listFindings(db, { sessionId: 1, limit: 5 })
+    expect(rows).toHaveLength(5)
+  })
+
+  it('listFindings honours limit + offset', () => {
+    const all = listFindings(db, { sessionId: 1 })
+    expect(all).toHaveLength(12)
+    const first = listFindings(db, { sessionId: 1, limit: 5, offset: 0 })
+    const second = listFindings(db, { sessionId: 1, limit: 5, offset: 5 })
+    expect(first.map(r => r.valueHash)).toEqual(all.slice(0, 5).map(r => r.valueHash))
+    expect(second.map(r => r.valueHash)).toEqual(all.slice(5, 10).map(r => r.valueHash))
+  })
+
+  it('listFindings filter semantics unchanged when limit absent', () => {
+    // Add a non-active row that the default state filter should
+    // exclude. Pagination machinery must not affect WHERE semantics.
+    db.prepare(`INSERT INTO findings (session_id, message_id, kind, value_hash, confidence, provider, start_offset, end_offset, state)
+                VALUES (1, 10, 'email', 'h-dismissed', 0.5, 'regex', 0, 1, 'dismissed')`).run()
+    const def = listFindings(db, { sessionId: 1 })
+    expect(def).toHaveLength(12) // dismissed row excluded
+    expect(def.every(r => r.state === 'active')).toBe(true)
+  })
+
+  it('listFindings stable ordering across pages — no dup, no skip', () => {
+    // Sweep all 12 rows in 3 pages of 5/5/2 and assert the union has
+    // no duplicates and matches the full-fetch order.
+    const all = listFindings(db, { sessionId: 1 })
+    const p1 = listFindings(db, { sessionId: 1, limit: 5, offset: 0 })
+    const p2 = listFindings(db, { sessionId: 1, limit: 5, offset: 5 })
+    const p3 = listFindings(db, { sessionId: 1, limit: 5, offset: 10 })
+    const concat = [...p1, ...p2, ...p3]
+    expect(concat.map(r => r.id)).toEqual(all.map(r => r.id))
+    expect(new Set(concat.map(r => r.id)).size).toBe(12)
+  })
+
+  it('listFindingsPage sets hasMore=true when more rows exist', () => {
+    const page = listFindingsPage(db, { sessionId: 1, limit: 5 })
+    expect(page.rows).toHaveLength(5)
+    expect(page.hasMore).toBe(true)
+  })
+
+  it('listFindingsPage sets hasMore=false on the last page (exact match)', () => {
+    const page = listFindingsPage(db, { sessionId: 1, limit: 12 })
+    expect(page.rows).toHaveLength(12)
+    expect(page.hasMore).toBe(false)
+  })
+
+  it('listFindingsPage with no limit returns all rows + hasMore=false', () => {
+    const page = listFindingsPage(db, { sessionId: 1 })
+    expect(page.rows).toHaveLength(12)
+    expect(page.hasMore).toBe(false)
+  })
+
+  it('listSessionsWithFindings honours limit + offset and orders deterministically', () => {
+    // Seed extra sessions so the result set spans multiple pages.
+    for (let i = 3; i <= 8; i++) {
+      db.prepare(
+        `INSERT INTO sessions (id, project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count)
+         VALUES (?, 1, 1, ?, ?, ?, ?, ?, 1)`,
+      ).run(i, `s-${i}`, `/p/s-${i}`, `S${i}`, `2026-01-${(i + 1).toString().padStart(2, '0')}`, `2026-01-${(i + 1).toString().padStart(2, '0')}`)
+      db.prepare(
+        `INSERT INTO messages (id, session_id, source_id, role, content_text, timestamp, seq)
+         VALUES (?, ?, 1, 'user', 'x', '2026-01-01', 0)`,
+      ).run(100 + i, i)
+      insertFindings(db, [{
+        sessionId: i, messageId: 100 + i, kind: 'api-key', valueHash: `gh-${i}`,
+        confidence: 0.9, provider: 'regex', startOffset: 0, endOffset: 1, state: 'active',
+      }])
+      updateSessionCounts(db, i)
+    }
+    const all = listSessionsWithFindings(db, {})
+    expect(all.length).toBeGreaterThanOrEqual(7)
+    const p1 = listSessionsWithFindings(db, { limit: 3, offset: 0 })
+    const p2 = listSessionsWithFindings(db, { limit: 3, offset: 3 })
+    expect(p1.map(r => r.id)).toEqual(all.slice(0, 3).map(r => r.id))
+    expect(p2.map(r => r.id)).toEqual(all.slice(3, 6).map(r => r.id))
+    // No overlap between adjacent pages.
+    const p1Ids = new Set(p1.map(r => r.id))
+    expect(p2.some(r => p1Ids.has(r.id))).toBe(false)
+  })
+
+  it('listSessionsWithFindings semantics unchanged when limit absent', () => {
+    // Filter by kind should still work normally — pagination is opt-in.
+    const rows = listSessionsWithFindings(db, { kind: 'api-key' })
+    expect(rows.map(r => r.sessionUuid).sort()).toContain('s-1')
+  })
+
+  it('listSessionsWithFindingsPage sets hasMore correctly', () => {
+    // Seed 4 sessions with findings so we can probe both true and false.
+    for (let i = 3; i <= 5; i++) {
+      db.prepare(
+        `INSERT INTO sessions (id, project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count)
+         VALUES (?, 1, 1, ?, ?, ?, ?, ?, 1)`,
+      ).run(i, `s-${i}`, `/p/s-${i}`, `S${i}`, `2026-01-${(i + 1).toString().padStart(2, '0')}`, `2026-01-${(i + 1).toString().padStart(2, '0')}`)
+      db.prepare(
+        `INSERT INTO messages (id, session_id, source_id, role, content_text, timestamp, seq)
+         VALUES (?, ?, 1, 'user', 'x', '2026-01-01', 0)`,
+      ).run(100 + i, i)
+      insertFindings(db, [{
+        sessionId: i, messageId: 100 + i, kind: 'api-key', valueHash: `gh-${i}`,
+        confidence: 0.9, provider: 'regex', startOffset: 0, endOffset: 1, state: 'active',
+      }])
+      updateSessionCounts(db, i)
+    }
+    const total = listSessionsWithFindings(db, {}).length
+    const partial = listSessionsWithFindingsPage(db, { limit: total - 1 })
+    expect(partial.hasMore).toBe(true)
+    expect(partial.rows).toHaveLength(total - 1)
+    const full = listSessionsWithFindingsPage(db, { limit: total })
+    expect(full.hasMore).toBe(false)
+    expect(full.rows).toHaveLength(total)
   })
 })
 

--- a/packages/core/src/security/repo.test.ts
+++ b/packages/core/src/security/repo.test.ts
@@ -13,6 +13,7 @@ import {
   listFindingsPage,
   listSessionsWithFindings,
   listSessionsWithFindingsPage,
+  countSessionsWithFindings,
   riskByCategory,
   getFindingValue,
   getAllowlists,
@@ -312,6 +313,51 @@ describe('repo: pagination', () => {
     const full = listSessionsWithFindingsPage(db, { limit: total })
     expect(full.hasMore).toBe(false)
     expect(full.rows).toHaveLength(total)
+  })
+
+  it('countSessionsWithFindings returns the same total as the unpaginated list', () => {
+    const db = setupDb()
+    for (let i = 3; i <= 9; i++) {
+      db.prepare(
+        `INSERT INTO sessions (id, project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count)
+         VALUES (?, 1, 1, ?, ?, ?, '2026-01-01', '2026-01-01', 1)`,
+      ).run(i, `c-${i}`, `/p/c-${i}`, `C${i}`)
+      db.prepare(
+        `INSERT INTO messages (id, session_id, source_id, role, content_text, timestamp, seq)
+         VALUES (?, ?, 1, 'user', 'x', '2026-01-01', 0)`,
+      ).run(200 + i, i)
+      insertFindings(db, [{
+        sessionId: i, messageId: 200 + i, kind: i <= 5 ? 'api-key' : 'email', valueHash: `c-${i}`,
+        confidence: 0.9, provider: 'regex', startOffset: 0, endOffset: 1, state: 'active',
+      }])
+      updateSessionCounts(db, i)
+    }
+    expect(countSessionsWithFindings(db, {})).toBe(listSessionsWithFindings(db, {}).length)
+    expect(countSessionsWithFindings(db, { kind: 'api-key' }))
+      .toBe(listSessionsWithFindings(db, { kind: 'api-key' }).length)
+  })
+
+  it('countSessionsWithFindings is independent of limit/offset on the same filter', () => {
+    const db = setupDb()
+    for (let i = 3; i <= 7; i++) {
+      db.prepare(
+        `INSERT INTO sessions (id, project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count)
+         VALUES (?, 1, 1, ?, ?, ?, '2026-01-01', '2026-01-01', 1)`,
+      ).run(i, `d-${i}`, `/p/d-${i}`, `D${i}`)
+      db.prepare(
+        `INSERT INTO messages (id, session_id, source_id, role, content_text, timestamp, seq)
+         VALUES (?, ?, 1, 'user', 'x', '2026-01-01', 0)`,
+      ).run(300 + i, i)
+      insertFindings(db, [{
+        sessionId: i, messageId: 300 + i, kind: 'api-key', valueHash: `d-${i}`,
+        confidence: 0.9, provider: 'regex', startOffset: 0, endOffset: 1, state: 'active',
+      }])
+      updateSessionCounts(db, i)
+    }
+    const total = countSessionsWithFindings(db, {})
+    expect(total).toBe(5)
+    expect(countSessionsWithFindings(db, { limit: 2, offset: 0 })).toBe(total)
+    expect(countSessionsWithFindings(db, { limit: 2, offset: 2 })).toBe(total)
   })
 })
 

--- a/packages/core/src/security/repo.ts
+++ b/packages/core/src/security/repo.ts
@@ -65,8 +65,6 @@ export interface FindingFilter {
   kinds?: readonly SensitiveKind[]
   state?: FindingState | 'any'
   severity?: 'high' | 'low'
-  /** Pagination — when set, SQL appends `LIMIT ? OFFSET ?`. Undefined
-   *  preserves the historical unbounded read. */
   limit?: number
   offset?: number
 }
@@ -306,19 +304,22 @@ export function listFindings(db: Database.Database, filter: FindingFilter): Find
   return rows.map(rowToFinding)
 }
 
-/** Paginated variant — uses a `limit+1` peek to set `hasMore` without
- *  an extra COUNT(*) round-trip. Callers pass the displayed `limit`;
- *  the trimmed `rows` length stays ≤ limit. */
+/** limit+1 peek to set `hasMore` without an extra COUNT round-trip. */
+function paginate<F extends { limit?: number }, R>(
+  filter: F,
+  fetch: (f: F) => R[],
+): Page<R> {
+  if (filter.limit === undefined) return { rows: fetch(filter), hasMore: false }
+  const peeked = fetch({ ...filter, limit: filter.limit + 1 })
+  const hasMore = peeked.length > filter.limit
+  return { rows: hasMore ? peeked.slice(0, filter.limit) : peeked, hasMore }
+}
+
 export function listFindingsPage(
   db: Database.Database,
   filter: FindingFilter,
 ): Page<FindingRow> {
-  if (filter.limit === undefined) {
-    return { rows: listFindings(db, filter), hasMore: false }
-  }
-  const peeked = listFindings(db, { ...filter, limit: filter.limit + 1 })
-  const hasMore = peeked.length > filter.limit
-  return { rows: hasMore ? peeked.slice(0, filter.limit) : peeked, hasMore }
+  return paginate(filter, f => listFindings(db, f))
 }
 
 export function listSessionsWithFindings(
@@ -435,18 +436,11 @@ export function listSessionsWithFindings(
   }))
 }
 
-/** Paginated variant — limit+1 peek to set `hasMore` without a
- *  separate COUNT round-trip. */
 export function listSessionsWithFindingsPage(
   db: Database.Database,
   filter: SessionFindingFilter,
 ): Page<SessionWithFindingCounts> {
-  if (filter.limit === undefined) {
-    return { rows: listSessionsWithFindings(db, filter), hasMore: false }
-  }
-  const peeked = listSessionsWithFindings(db, { ...filter, limit: filter.limit + 1 })
-  const hasMore = peeked.length > filter.limit
-  return { rows: hasMore ? peeked.slice(0, filter.limit) : peeked, hasMore }
+  return paginate(filter, f => listSessionsWithFindings(db, f))
 }
 
 /** Risk by category — one row per kind that has ≥ 1 active finding.

--- a/packages/core/src/security/repo.ts
+++ b/packages/core/src/security/repo.ts
@@ -322,13 +322,13 @@ export function listFindingsPage(
   return paginate(filter, f => listFindings(db, f))
 }
 
-export function listSessionsWithFindings(
-  db: Database.Database,
-  filter: SessionFindingFilter,
-): SessionWithFindingCounts[] {
-  // For category/severity-aware filtering we need to compute counts
-  // from the findings table directly (denormalised counters can't
-  // express "only api-key findings"). We always recompute here.
+/** Shared WHERE-clause builder for the session-findings join. Used by
+ *  both `listSessionsWithFindings` (paginated rows) and
+ *  `countSessionsWithFindings` (total) so the two stay consistent. */
+function buildSessionFindingWhereSql(filter: SessionFindingFilter): {
+  whereClause: string
+  params: unknown[]
+} {
   const params: unknown[] = []
   const stateCondition = filter.state && filter.state !== 'any'
     ? 'f.state = ?'
@@ -373,6 +373,20 @@ export function listSessionsWithFindings(
     params.push(`%${filter.text.trim()}%`)
   }
 
+  const whereClause = `${stateCondition} ${kindCondition} ${severityCondition} ${infoExclusion} ${textCondition}
+      AND COALESCE(s.message_count, 0) > 0`
+  return { whereClause, params }
+}
+
+export function listSessionsWithFindings(
+  db: Database.Database,
+  filter: SessionFindingFilter,
+): SessionWithFindingCounts[] {
+  // For category/severity-aware filtering we need to compute counts
+  // from the findings table directly (denormalised counters can't
+  // express "only api-key findings"). We always recompute here.
+  const { whereClause, params } = buildSessionFindingWhereSql(filter)
+
   const sql = `
     SELECT
       s.id              AS id,
@@ -392,8 +406,7 @@ export function listSessionsWithFindings(
     JOIN findings f ON f.session_id = s.id
     JOIN sources src ON src.id = s.source_id
     JOIN projects p ON p.id = s.project_id
-    WHERE ${stateCondition} ${kindCondition} ${severityCondition} ${infoExclusion} ${textCondition}
-      AND COALESCE(s.message_count, 0) > 0
+    WHERE ${whereClause}
     GROUP BY s.id
     ORDER BY high_count DESC, finding_count DESC, s.started_at DESC, s.id DESC
     ${filter.limit !== undefined ? 'LIMIT ? OFFSET ?' : ''}
@@ -441,6 +454,27 @@ export function listSessionsWithFindingsPage(
   filter: SessionFindingFilter,
 ): Page<SessionWithFindingCounts> {
   return paginate(filter, f => listSessionsWithFindings(db, f))
+}
+
+/** Total distinct sessions matching the same filter as
+ *  `listSessionsWithFindings` — used by the renderer to show
+ *  "涉及 N 个会话" without loading every page. Cheaper than the list
+ *  query: no SELECT projection, no GROUP BY, no ORDER BY. */
+export function countSessionsWithFindings(
+  db: Database.Database,
+  filter: SessionFindingFilter,
+): number {
+  const { whereClause, params } = buildSessionFindingWhereSql(filter)
+  const sql = `
+    SELECT COUNT(DISTINCT s.id) AS total
+    FROM sessions s
+    JOIN findings f ON f.session_id = s.id
+    JOIN sources src ON src.id = s.source_id
+    JOIN projects p ON p.id = s.project_id
+    WHERE ${whereClause}
+  `
+  const row = db.prepare(sql).get(...params) as { total: number }
+  return row.total
 }
 
 /** Risk by category — one row per kind that has ≥ 1 active finding.

--- a/packages/core/src/security/repo.ts
+++ b/packages/core/src/security/repo.ts
@@ -65,6 +65,10 @@ export interface FindingFilter {
   kinds?: readonly SensitiveKind[]
   state?: FindingState | 'any'
   severity?: 'high' | 'low'
+  /** Pagination — when set, SQL appends `LIMIT ? OFFSET ?`. Undefined
+   *  preserves the historical unbounded read. */
+  limit?: number
+  offset?: number
 }
 
 export interface SessionFindingFilter {
@@ -74,6 +78,13 @@ export interface SessionFindingFilter {
   severity?: 'high' | 'low'
   /** Free-text on session title. */
   text?: string
+  limit?: number
+  offset?: number
+}
+
+export interface Page<T> {
+  rows: T[]
+  hasMore: boolean
 }
 
 // ─── Insert / delete (scan path) ──────────────────────────────────
@@ -283,11 +294,31 @@ export function listFindings(db: Database.Database, filter: FindingFilter): Find
     where.push(`kind NOT IN (${highKindsPlaceholders()})`)
     params.push(...HIGH_SEVERITY_KINDS_ARRAY)
   }
+  let pagination = ''
+  if (filter.limit !== undefined) {
+    pagination = ' LIMIT ? OFFSET ?'
+    params.push(filter.limit, filter.offset ?? 0)
+  }
   const sql = `SELECT * FROM findings
                ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
-               ORDER BY detected_at DESC, id DESC`
+               ORDER BY detected_at DESC, id DESC${pagination}`
   const rows = db.prepare(sql).all(...params) as FindingRowDb[]
   return rows.map(rowToFinding)
+}
+
+/** Paginated variant — uses a `limit+1` peek to set `hasMore` without
+ *  an extra COUNT(*) round-trip. Callers pass the displayed `limit`;
+ *  the trimmed `rows` length stays ≤ limit. */
+export function listFindingsPage(
+  db: Database.Database,
+  filter: FindingFilter,
+): Page<FindingRow> {
+  if (filter.limit === undefined) {
+    return { rows: listFindings(db, filter), hasMore: false }
+  }
+  const peeked = listFindings(db, { ...filter, limit: filter.limit + 1 })
+  const hasMore = peeked.length > filter.limit
+  return { rows: hasMore ? peeked.slice(0, filter.limit) : peeked, hasMore }
 }
 
 export function listSessionsWithFindings(
@@ -363,11 +394,15 @@ export function listSessionsWithFindings(
     WHERE ${stateCondition} ${kindCondition} ${severityCondition} ${infoExclusion} ${textCondition}
       AND COALESCE(s.message_count, 0) > 0
     GROUP BY s.id
-    ORDER BY high_count DESC, finding_count DESC, s.started_at DESC
+    ORDER BY high_count DESC, finding_count DESC, s.started_at DESC, s.id DESC
+    ${filter.limit !== undefined ? 'LIMIT ? OFFSET ?' : ''}
   `
   // Placeholder order matches SQL: SELECT's CASE WHEN IN (?) binds first,
   // then the WHERE clause's params.
   const allParams = [...HIGH_SEVERITY_KINDS_ARRAY, ...params]
+  if (filter.limit !== undefined) {
+    allParams.push(filter.limit, filter.offset ?? 0)
+  }
   const rows = db.prepare(sql).all(...allParams) as Array<{
     id: number
     session_uuid: string
@@ -398,6 +433,20 @@ export function listSessionsWithFindings(
     cwd: r.cwd,
     projectDisplayName: r.project_display_name,
   }))
+}
+
+/** Paginated variant — limit+1 peek to set `hasMore` without a
+ *  separate COUNT round-trip. */
+export function listSessionsWithFindingsPage(
+  db: Database.Database,
+  filter: SessionFindingFilter,
+): Page<SessionWithFindingCounts> {
+  if (filter.limit === undefined) {
+    return { rows: listSessionsWithFindings(db, filter), hasMore: false }
+  }
+  const peeked = listSessionsWithFindings(db, { ...filter, limit: filter.limit + 1 })
+  const hasMore = peeked.length > filter.limit
+  return { rows: hasMore ? peeked.slice(0, filter.limit) : peeked, hasMore }
 }
 
 /** Risk by category — one row per kind that has ≥ 1 active finding.


### PR DESCRIPTION
## What

- **Core**: `listFindings` and `listSessionsWithFindings` accept optional `limit?` / `offset?`. New `listFindingsPage` / `listSessionsWithFindingsPage` peers return `{rows, hasMore}` via a `limit+1` peek (one round-trip, no COUNT). The unpaginated helpers are preserved for callers that need every row.
- **Stable sort tiebreaker** added to `listSessionsWithFindings` (`s.id DESC` appended) — without it, two sessions sharing `started_at` could appear on two pages or be skipped between adjacent pages.
- **Cheap total**: new `countSessionsWithFindings(filter)` shares the WHERE-builder extracted from `listSessionsWithFindings`, doing `COUNT(DISTINCT s.id)` without GROUP BY. Feeds the renderer's "Sessions with active findings" header so the count is the real total, not the loaded page size.
- **IPC + preload + renderer API** for the three new entry points.
- **`SecurityPage`** consumes the paginated APIs with a "Load more" button (plain `<button>`, no IntersectionObserver) for both the sessions list (50/page) and the per-session findings strip (200/page). `pageCount` resets to 1 when the filter changes.
- **Meta-row cleanup**: dropped `涉及 N 个会话` from the meta row (across 7 locales). The row mixed global stats (`riskByCategory`) with a filter-aware sessions count — the pagination fix made the inconsistency visible. Sessions count now lives only in the section header below where it sits next to the list.

## Why

At 8000+ findings the React tree gets sluggish loading every row upfront. Pagination caps the initial render to a fixed budget and defers the rest to user intent. Default page sizes chosen to match the existing flat-scroll experience.

## How it connects

- `FindingsStrip`, bulk-purge code paths, `getFindingValues`, `riskByCategory`, allowlist queries stay on the unpaginated APIs. Bulk-purge especially must NOT paginate — calling the paginated path would silently truncate the destructive set.
- The new WHERE-builder helper is used by both `listSessionsWithFindings` (with GROUP BY / ORDER BY / LIMIT) and `countSessionsWithFindings` (plain DISTINCT count) so the two views can never disagree.

## Test plan

- [x] core 305/305 (37 files) — includes 10 pagination cases + 2 new count cases (parity with list, limit/offset-independence)
- [x] app 229/229 (21 files)
- [x] typecheck clean
- [x] Manually verified in dev with 227 sessions / 8000+ findings: Load more on sessions list works across pages with no dup/skip; per-session findings Load more works; filter switch (kind / severity) resets to page 1; bulk-purge confirm dialog reports the full impact, not 50; meta-row counts no longer rewind when paginating
- [ ] CI re-verifies the same in merge queue