### PR TITLE
chore(redact): publish @spool-lab/redact to npm

### DIFF
--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@spool-lab/redact",
   "version": "0.0.1",
-  "private": true,
   "description": "Local, pure-TS sensitive-data detection for Spool sessions. Pattern + checksum + entropy pipeline today; pluggable provider boundary for future on-device ML (e.g. OpenAI Privacy Filter via transformers.js).",
   "type": "module",
   "main": "./dist/index.js",
@@ -15,8 +14,12 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "pnpm run clean && tsc",
+    "prepack": "pnpm run build",
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## What

\`@spool-lab/core@0.4.20\` was published with a runtime dep on \`@spool-lab/redact@0.0.1\` (added alongside the Security Scan worker in #257), but redact itself was marked \`private: true\` and never published. As a result, \`npm install @spool-lab/cli\` or \`@spool-lab/core\` from the registry currently fails with a 404 on the missing dep.

## Change

- Drop \`private: true\` so it can publish
- Add \`publishConfig.access = public\` (required for first publish under the \`@spool-lab\` scope)
- Add \`prepack: pnpm run build\` for parity with \`core\` and \`cli\`

The package is pure-TS, dependency-free regex + checksum + entropy detection logic — no proprietary content, safe to expose. Its public surface is already shaped for consumption (\`main\`/\`types\`/\`exports\`/\`files\` were set up at creation).

## Test plan

- [x] \`pnpm pack --pack-destination /tmp\` from packages/redact produces a tarball whose manifest has no \`private\` flag and includes \`publishConfig.access = public\`
- [ ] After merge: \`pnpm publish\` from packages/redact at the merged commit
- [ ] Smoke: \`npm install @spool-lab/cli@0.4.20\` in an empty project resolves and the \`spool\` binary runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)