### PR TITLE
feat(observability): Effect.withSpan + OTel pretty/jsonl exporters for security pipeline

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -34,6 +34,8 @@ import {
   listProjectGroups, listSessionsByIdentity, listPinnedSessionsByIdentity, listProjectDirectoryCounts,
   listShareDrafts, getShareDraft, upsertShareDraft, deleteShareDraft, countDraftsBySession,
   invalidateSessionScanProfile,
+  makeObservabilityRuntime,
+  SPOOL_DIR,
 } from '@spool-lab/core'
 import { spawnScanWorker, type ScanWorkerProxy } from './scan-worker-proxy.js'
 import { Effect } from 'effect'
@@ -69,6 +71,12 @@ const customUserDataDir = process.env['SPOOL_ELECTRON_USER_DATA_DIR']?.trim()
 if (customUserDataDir) {
   app.setPath('userData', customUserDataDir)
 }
+
+const { run: runWithObservability } = makeObservabilityRuntime(
+  isDevMode
+    ? { serviceName: 'spool-app-main', serviceVersion: app.getVersion(), env: 'dev' }
+    : { serviceName: 'spool-app-main', serviceVersion: app.getVersion(), env: 'prod', logsDir: join(SPOOL_DIR, 'logs') },
+)
 // macOS menu bar shows the first menu's label as the app name
 app.setName(isDevMode ? 'Spool DEV' : 'Spool')
 
@@ -324,7 +332,7 @@ app.whenReady().then(async () => {
       // shape (Effect<void, never>) — `.catch` here is the safety
       // net for runtime promise rejections from the underlying
       // postMessage round-trip.
-      Effect.runPromise(scanWorker.enqueue(sessionId)).catch((err) => {
+      runWithObservability(scanWorker.enqueue(sessionId)).catch((err) => {
         console.error('[security] scan-worker enqueue failed:', err)
       })
     }
@@ -355,7 +363,7 @@ app.whenReady().then(async () => {
     // handle — no onSessionChanged callbacks reached this process. Kick
     // off a backfill round now that the sessions table is populated.
     if (scanWorker) {
-      Effect.runPromise(scanWorker.backfill()).catch((err) => {
+      runWithObservability(scanWorker.backfill()).catch((err) => {
         console.error('[security] post-sync backfill failed:', err)
       })
     }
@@ -380,10 +388,10 @@ app.whenReady().then(async () => {
       disposeSecurityIpc = registerSecurityIpc({
         db,
         worker: scanWorker,
-        runPromise: <A, E>(eff: Effect.Effect<A, E>) => Effect.runPromise(eff as unknown as Effect.Effect<A>),
+        runPromise: runWithObservability,
         getMainWindow: () => mainWindow,
       })
-      Effect.runPromise(scanWorker.backfill()).catch((err) => {
+      runWithObservability(scanWorker.backfill()).catch((err) => {
         console.error('[security] boot backfill failed:', err)
       })
     })

--- a/packages/app/src/main/scan-worker-thread.ts
+++ b/packages/app/src/main/scan-worker-thread.ts
@@ -24,11 +24,14 @@
 // Protocol — see `ToWorker` / `FromWorker` unions below.
 
 import { parentPort, threadId } from 'node:worker_threads'
+import { join } from 'node:path'
 import { Effect, Exit, Fiber, Scope, Stream } from 'effect'
 import {
   currentProfileString,
   getDB,
+  makeObservabilityRuntime,
   makeScanWorker,
+  SPOOL_DIR,
   type FindingsChange,
   type ScanStatus,
 } from '@spool-lab/core'
@@ -74,6 +77,16 @@ process.on('uncaughtException', reportFatal)
 
 void (async () => {
   console.log('[security] scan worker thread booted; threadId =', threadId)
+
+  // Worker has its own Effect runtime; without provisioning the layer
+  // here, spans inside scanSession/backfill never reach an exporter.
+  const isDevMode = Boolean(process.env['ELECTRON_RENDERER_URL'])
+  const { run: runEff } = makeObservabilityRuntime(
+    isDevMode
+      ? { serviceName: 'spool-app-scan-worker', env: 'dev' }
+      : { serviceName: 'spool-app-scan-worker', env: 'prod', logsDir: join(SPOOL_DIR, 'logs') },
+  )
+
   // Main process already migrated the file before spawning this
   // thread; skipping here avoids a race with sync-worker (whose
   // getDB() also opens with migrations skipped now) over the
@@ -81,7 +94,7 @@ void (async () => {
   const db = getDB({ runMigrations: false })
   const scope = await Effect.runPromise(Scope.make())
 
-  const worker = await Effect.runPromise(
+  const worker = await runEff(
     Effect.provideService(
       makeScanWorker({
         db,
@@ -112,14 +125,14 @@ void (async () => {
     })
   }
 
-  const changesFiber = await Effect.runPromise(
+  const changesFiber = await runEff(
     Effect.forkDaemon(
       Stream.runForEach(worker.changes, (change) =>
         safePost({ type: 'event-change', change }),
       ),
     ),
   )
-  const statusFiber = await Effect.runPromise(
+  const statusFiber = await runEff(
     Effect.forkDaemon(
       Stream.runForEach(worker.statusChanges, (status) =>
         safePost({ type: 'event-status', status }),
@@ -134,9 +147,9 @@ void (async () => {
           // Interrupt forwarders first so no events leak in after the
           // parent has stopped listening, then close the scope which
           // tears down the worker's drain fiber + PubSubs.
-          await Effect.runPromise(Fiber.interrupt(changesFiber))
-          await Effect.runPromise(Fiber.interrupt(statusFiber))
-          await Effect.runPromise(Scope.close(scope, Exit.void))
+          await runEff(Fiber.interrupt(changesFiber))
+          await runEff(Fiber.interrupt(statusFiber))
+          await runEff(Scope.close(scope, Exit.void))
         } finally {
           process.exit(0)
         }
@@ -150,16 +163,16 @@ void (async () => {
         let result: unknown = null
         switch (payload.cmd) {
           case 'enqueue':
-            await Effect.runPromise(worker.enqueue(payload.sessionId))
+            await runEff(worker.enqueue(payload.sessionId))
             break
           case 'rescanAll':
-            result = await Effect.runPromise(worker.rescanAll())
+            result = await runEff(worker.rescanAll())
             break
           case 'backfill':
-            result = await Effect.runPromise(worker.backfill())
+            result = await runEff(worker.backfill())
             break
           case 'getStatus':
-            result = await Effect.runPromise(worker.getStatus)
+            result = await runEff(worker.getStatus)
             break
         }
         port.postMessage({ type: 'cmd-result', reqId, result } satisfies FromWorker)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,12 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
+    "@effect/opentelemetry": "^0.63.0",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/resources": "^2.7.1",
+    "@opentelemetry/sdk-trace-base": "^2.7.1",
+    "@opentelemetry/sdk-trace-node": "^2.7.1",
+    "@opentelemetry/semantic-conventions": "^1.41.1",
     "@spool-lab/redact": "workspace:*",
     "better-sqlite3": "^11.10.0",
     "effect": "^3.21.2"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,3 +21,4 @@ export {
 } from './util/resolve-bin.js'
 export * from './doctor/index.js'
 export * from './security/index.js'
+export * from './observability/index.js'

--- a/packages/core/src/observability/exporter-file.test.ts
+++ b/packages/core/src/observability/exporter-file.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { Effect } from 'effect'
+import { RotatingFileSpanExporter, listLogFiles } from './exporter-file.js'
+import { observabilityLayer } from './layer.js'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const d = tempDirs.pop()
+    if (d) rmSync(d, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'spool-otel-'))
+  tempDirs.push(d)
+  return d
+}
+
+async function emitSpan(name: string, attrs: Record<string, unknown>, exporter: RotatingFileSpanExporter): Promise<void> {
+  await Effect.runPromise(
+    Effect.succeed(undefined).pipe(
+      Effect.withSpan(name, { attributes: attrs }),
+      Effect.provide(observabilityLayer({
+        serviceName: 'test',
+        env: 'test',
+        testExporter: exporter,
+      })),
+    ),
+  )
+}
+
+describe('RotatingFileSpanExporter', () => {
+  it('writes one JSON line per span to spool-YYYY-MM-DD.jsonl', async () => {
+    const dir = makeTempDir()
+    const exporter = new RotatingFileSpanExporter({
+      dir,
+      now: () => new Date('2026-05-21T12:00:00Z'),
+    })
+    await emitSpan('test.work', { sessionId: 7 }, exporter)
+    const files = listLogFiles(dir)
+    expect(files).toEqual(['spool-2026-05-21.jsonl'])
+    const content = readFileSync(join(dir, files[0]!), 'utf8')
+    const lines = content.trim().split('\n')
+    expect(lines).toHaveLength(1)
+    const rec = JSON.parse(lines[0]!)
+    expect(rec.name).toBe('test.work')
+    expect(rec.attributes).toMatchObject({ sessionId: 7 })
+    expect(rec.traceId).toMatch(/^[0-9a-f]{32}$/)
+    expect(rec.spanId).toMatch(/^[0-9a-f]{16}$/)
+  })
+
+  it('appends additional spans to the same daily file', async () => {
+    const dir = makeTempDir()
+    const exporter = new RotatingFileSpanExporter({
+      dir,
+      now: () => new Date('2026-05-21T12:00:00Z'),
+    })
+    await emitSpan('a', {}, exporter)
+    await emitSpan('b', {}, exporter)
+    await emitSpan('c', {}, exporter)
+    const content = readFileSync(join(dir, 'spool-2026-05-21.jsonl'), 'utf8')
+    const lines = content.trim().split('\n')
+    expect(lines).toHaveLength(3)
+    expect(lines.map(l => JSON.parse(l).name)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('drops oldest files when total size exceeds the cap', async () => {
+    const dir = makeTempDir()
+    // Seed three pre-existing files (different days, varying ages).
+    const old1 = join(dir, 'spool-2026-05-01.jsonl')
+    const old2 = join(dir, 'spool-2026-05-02.jsonl')
+    const recent = join(dir, 'spool-2026-05-20.jsonl')
+    writeFileSync(old1, 'a'.repeat(800))
+    writeFileSync(old2, 'b'.repeat(800))
+    writeFileSync(recent, 'c'.repeat(800))
+    const t = Date.now() / 1000
+    utimesSync(old1, t - 20 * 86400, t - 20 * 86400)
+    utimesSync(old2, t - 19 * 86400, t - 19 * 86400)
+    utimesSync(recent, t - 1 * 86400, t - 1 * 86400)
+    const exporter = new RotatingFileSpanExporter({
+      dir,
+      maxTotalBytes: 2000,
+      now: () => new Date('2026-05-21T12:00:00Z'),
+    })
+    await emitSpan('new', {}, exporter)
+    const remaining = readdirSync(dir).sort()
+    // Total before: 2400 + today's tiny addition. Cap 2000 → must drop the oldest one or two.
+    expect(remaining).toContain('spool-2026-05-21.jsonl')
+    expect(remaining).toContain('spool-2026-05-20.jsonl')
+    expect(remaining).not.toContain('spool-2026-05-01.jsonl')
+  })
+
+  it('ignores non-Spool files in the directory', async () => {
+    const dir = makeTempDir()
+    writeFileSync(join(dir, 'unrelated.txt'), 'keep')
+    writeFileSync(join(dir, 'README.md'), 'keep')
+    const exporter = new RotatingFileSpanExporter({
+      dir,
+      now: () => new Date('2026-05-21T12:00:00Z'),
+    })
+    await emitSpan('x', {}, exporter)
+    const files = readdirSync(dir).sort()
+    expect(files).toContain('unrelated.txt')
+    expect(files).toContain('README.md')
+    expect(files).toContain('spool-2026-05-21.jsonl')
+  })
+})

--- a/packages/core/src/observability/exporter-file.ts
+++ b/packages/core/src/observability/exporter-file.ts
@@ -1,0 +1,156 @@
+import {
+  appendFileSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from 'node:fs'
+import { join } from 'node:path'
+import { SpanStatusCode } from '@opentelemetry/api'
+import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base'
+
+// Minimal shape of @opentelemetry/core's ExportResult — avoids pulling
+// in the package just for two fields.
+interface ExportResult {
+  code: number
+  error?: Error
+}
+
+export interface RotatingFileSpanExporterOptions {
+  /** Directory where `spool-YYYY-MM-DD.jsonl` files live. */
+  readonly dir: string
+  /** Cap total bytes across all log files; oldest dropped first. */
+  readonly maxTotalBytes?: number
+  /** Override "today" for tests. */
+  readonly now?: () => Date
+}
+
+const FILE_PREFIX = 'spool-'
+const FILE_SUFFIX = '.jsonl'
+const DEFAULT_MAX_TOTAL_BYTES = 50 * 1024 * 1024
+
+export class RotatingFileSpanExporter implements SpanExporter {
+  private readonly dir: string
+  private readonly maxTotalBytes: number
+  private readonly now: () => Date
+  // Running estimate of bytes on disk across all log files. Maintained
+  // incrementally on each append so the happy path doesn't pay for a
+  // full readdir+stat sweep per span (SimpleSpanProcessor calls
+  // export() once per finished span — so this runs in the scan hot
+  // path). Seeded from disk on first export.
+  private totalBytes: number | null = null
+
+  constructor(opts: RotatingFileSpanExporterOptions) {
+    this.dir = opts.dir
+    this.maxTotalBytes = opts.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES
+    this.now = opts.now ?? (() => new Date())
+    mkdirSync(this.dir, { recursive: true })
+  }
+
+  export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    try {
+      const path = this.todayPath()
+      const payload = spans.map(spanToJsonLine).join('')
+      if (payload.length > 0) appendFileSync(path, payload)
+      if (this.totalBytes === null) this.totalBytes = readDirTotal(this.dir)
+      else this.totalBytes += payload.length
+      if (this.totalBytes > this.maxTotalBytes) this.enforceSizeCap()
+      resultCallback({ code: 0 })
+    } catch (err) {
+      resultCallback({ code: 1, error: err instanceof Error ? err : new Error(String(err)) })
+    }
+  }
+
+  shutdown(): Promise<void> { return Promise.resolve() }
+  forceFlush(): Promise<void> { return Promise.resolve() }
+
+  private todayPath(): string {
+    const d = this.now()
+    const yyyy = d.getFullYear()
+    const mm = String(d.getMonth() + 1).padStart(2, '0')
+    const dd = String(d.getDate()).padStart(2, '0')
+    return join(this.dir, `${FILE_PREFIX}${yyyy}-${mm}-${dd}${FILE_SUFFIX}`)
+  }
+
+  private enforceSizeCap(): void {
+    const entries = listEntries(this.dir)
+    let total = entries.reduce((a, e) => a + e.size, 0)
+    if (total <= this.maxTotalBytes) {
+      this.totalBytes = total
+      return
+    }
+    entries.sort((a, b) => a.mtimeMs - b.mtimeMs)
+    for (const e of entries) {
+      if (total <= this.maxTotalBytes) break
+      try { rmSync(e.path, { force: true }) } catch { continue }
+      total -= e.size
+    }
+    this.totalBytes = total
+  }
+}
+
+interface SpanRecord {
+  readonly ts: string
+  readonly name: string
+  readonly durationMs: number
+  readonly traceId: string
+  readonly spanId: string
+  readonly parentSpanId: string | null
+  readonly status: 'ok' | 'error' | 'unset'
+  readonly statusMessage?: string
+  readonly attributes: Record<string, unknown>
+}
+
+function spanToJsonLine(span: ReadableSpan): string {
+  const rec: SpanRecord = {
+    ts: hrTimeToIso(span.endTime),
+    name: span.name,
+    durationMs: hrTimeToMs(span.duration),
+    traceId: span.spanContext().traceId,
+    spanId: span.spanContext().spanId,
+    parentSpanId: span.parentSpanContext?.spanId ?? null,
+    status:
+      span.status.code === SpanStatusCode.OK ? 'ok'
+      : span.status.code === SpanStatusCode.ERROR ? 'error'
+      : 'unset',
+    ...(span.status.message ? { statusMessage: span.status.message } : {}),
+    attributes: { ...span.attributes },
+  }
+  return JSON.stringify(rec) + '\n'
+}
+
+function hrTimeToIso(hr: [number, number]): string {
+  const ms = hr[0] * 1000 + Math.floor(hr[1] / 1_000_000)
+  return new Date(ms).toISOString()
+}
+
+function hrTimeToMs(hr: [number, number]): number {
+  return hr[0] * 1000 + hr[1] / 1_000_000
+}
+
+interface FileEntry { path: string; size: number; mtimeMs: number }
+
+function listEntries(dir: string): FileEntry[] {
+  let names: string[]
+  try { names = readdirSync(dir) } catch { return [] }
+  return names
+    .filter((name) => name.startsWith(FILE_PREFIX) && name.endsWith(FILE_SUFFIX))
+    .map((name): FileEntry | null => {
+      const path = join(dir, name)
+      try {
+        const st = statSync(path)
+        return { path, size: st.size, mtimeMs: st.mtimeMs }
+      } catch { return null }
+    })
+    .filter((e): e is FileEntry => e !== null)
+}
+
+function readDirTotal(dir: string): number {
+  return listEntries(dir).reduce((a, e) => a + e.size, 0)
+}
+
+/** Test-only utility — exported for fixtures that need to enumerate
+ *  rotated files. Not part of the public surface. */
+export function listLogFiles(dir: string): string[] {
+  return listEntries(dir).map((e) => e.path.split('/').pop() ?? '').sort()
+}

--- a/packages/core/src/observability/exporter-pretty.test.ts
+++ b/packages/core/src/observability/exporter-pretty.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { Effect } from 'effect'
+import { PrettyConsoleSpanExporter } from './exporter-pretty.js'
+import { observabilityLayer } from './layer.js'
+
+function lines(): { sink: (l: string) => void; out: string[] } {
+  const out: string[] = []
+  return { sink: (l) => out.push(l), out }
+}
+
+describe('PrettyConsoleSpanExporter', () => {
+  it('writes one line per finished span with name, duration, attributes', async () => {
+    const { sink, out } = lines()
+    const exporter = new PrettyConsoleSpanExporter({ sink, noColor: true })
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* Effect.succeed(undefined).pipe(
+          Effect.withSpan('test.work', { attributes: { sessionId: 42, kind: 'api-key' } }),
+        )
+      }).pipe(Effect.provide(observabilityLayer({
+        serviceName: 'test',
+        env: 'test',
+        testExporter: exporter,
+      }))),
+    )
+    expect(out).toHaveLength(1)
+    expect(out[0]).toContain('[test.work]')
+    expect(out[0]).toContain('sessionId=42')
+    expect(out[0]).toContain('kind=api-key')
+    expect(out[0]).toMatch(/\(\d+(\.\d+)?(ms|s)\)/)
+  })
+
+  it('truncates long string attributes to keep one-line output readable', async () => {
+    const { sink, out } = lines()
+    const exporter = new PrettyConsoleSpanExporter({ sink, noColor: true })
+    const longValue = 'x'.repeat(200)
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* Effect.succeed(undefined).pipe(
+          Effect.withSpan('test.work', { attributes: { blob: longValue } }),
+        )
+      }).pipe(Effect.provide(observabilityLayer({
+        serviceName: 'test',
+        env: 'test',
+        testExporter: exporter,
+      }))),
+    )
+    expect(out[0]).toContain('…')
+    expect(out[0]?.length).toBeLessThan(longValue.length + 80)
+  })
+
+  it.skipIf(!process.stdout.isTTY)('emits ANSI color codes when stdout is a TTY', async () => {
+    const { sink, out } = lines()
+    const exporter = new PrettyConsoleSpanExporter({ sink, noColor: false })
+    await Effect.runPromise(
+      Effect.succeed(undefined).pipe(
+        Effect.withSpan('test.work', { attributes: { k: 1 } }),
+        Effect.provide(observabilityLayer({
+          serviceName: 'test',
+          env: 'test',
+          testExporter: exporter,
+        })),
+      ),
+    )
+    // eslint-disable-next-line no-control-regex
+    expect(out[0]).toMatch(/\x1b\[\d+m/)
+  })
+})

--- a/packages/core/src/observability/exporter-pretty.ts
+++ b/packages/core/src/observability/exporter-pretty.ts
@@ -1,0 +1,104 @@
+import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base'
+import { SpanStatusCode } from '@opentelemetry/api'
+
+// Minimal shape of @opentelemetry/core's ExportResult — avoids pulling
+// in the package just for two fields. The OTel SDK only ever calls back
+// with this structure, never type-checks the argument.
+interface ExportResult {
+  code: number
+  error?: Error
+}
+
+const ANSI = {
+  reset: '\x1b[0m',
+  dim: '\x1b[2m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  cyan: '\x1b[36m',
+  gray: '\x1b[90m',
+} as const
+
+export interface PrettyConsoleSpanExporterOptions {
+  /** Where to write each line. Defaults to process.stdout. */
+  readonly sink?: (line: string) => void
+  /** Force colors off (e.g. when stdout isn't a TTY). */
+  readonly noColor?: boolean
+}
+
+/** Span exporter that prints one line per finished span to the console.
+ *  Format: `HH:MM:SS.mmm  [span.name]  (Nms)  k1=v1 k2=v2`.
+ *  Designed for the dev loop — file-backed structured output lives in
+ *  the file exporter. */
+export class PrettyConsoleSpanExporter implements SpanExporter {
+  private readonly sink: (line: string) => void
+  private readonly color: boolean
+
+  constructor(opts: PrettyConsoleSpanExporterOptions = {}) {
+    this.sink = opts.sink ?? ((line) => process.stdout.write(line + '\n'))
+    this.color = opts.noColor ? false : process.stdout.isTTY === true
+  }
+
+  export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    for (const span of spans) this.sink(this.format(span))
+    resultCallback({ code: 0 })
+  }
+
+  shutdown(): Promise<void> { return Promise.resolve() }
+  forceFlush(): Promise<void> { return Promise.resolve() }
+
+  private format(span: ReadableSpan): string {
+    const ts = formatTimestamp(span.endTime)
+    const durMs = hrTimeToMs(span.duration)
+    const isError = span.status.code === SpanStatusCode.ERROR
+    const name = isError ? this.tint(span.name, ANSI.red) : this.tint(span.name, ANSI.cyan)
+    const dur = this.tint(`(${formatDuration(durMs)})`, ANSI.gray)
+    const attrs = formatAttributes(span.attributes)
+    const attrsTinted = attrs ? '  ' + this.tint(attrs, ANSI.yellow) : ''
+    const statusSuffix = isError && span.status.message
+      ? '  ' + this.tint(`error: ${span.status.message}`, ANSI.red)
+      : ''
+    return `${this.tint(ts, ANSI.dim)}  [${name}]  ${dur}${attrsTinted}${statusSuffix}`
+  }
+
+  private tint(s: string, code: string): string {
+    return this.color ? `${code}${s}${ANSI.reset}` : s
+  }
+}
+
+function pad2(n: number): string { return n < 10 ? `0${n}` : `${n}` }
+function pad3(n: number): string { return n < 10 ? `00${n}` : n < 100 ? `0${n}` : `${n}` }
+
+function formatTimestamp(hr: [number, number]): string {
+  const ms = hr[0] * 1000 + Math.floor(hr[1] / 1_000_000)
+  const d = new Date(ms)
+  return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}.${pad3(d.getMilliseconds())}`
+}
+
+function hrTimeToMs(hr: [number, number]): number {
+  return hr[0] * 1000 + hr[1] / 1_000_000
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1) return `${ms.toFixed(2)}ms`
+  if (ms < 1000) return `${ms.toFixed(1)}ms`
+  return `${(ms / 1000).toFixed(2)}s`
+}
+
+function formatAttributes(attrs: Record<string, unknown>): string {
+  const entries = Object.entries(attrs)
+  if (entries.length === 0) return ''
+  return entries
+    .map(([k, v]) => `${k}=${formatValue(v)}`)
+    .join(' ')
+}
+
+function formatValue(v: unknown): string {
+  if (v == null) return String(v)
+  if (typeof v === 'string') return v.length > 60 ? `${v.slice(0, 57)}…` : v
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+  if (Array.isArray(v)) return `[${v.length}]`
+  return JSON.stringify(v).slice(0, 60)
+}

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -1,0 +1,6 @@
+export {
+  observabilityLayer,
+  makeObservabilityRuntime,
+  type ObservabilityConfig,
+  type ObservabilityEnv,
+} from './layer.js'

--- a/packages/core/src/observability/layer.ts
+++ b/packages/core/src/observability/layer.ts
@@ -1,0 +1,68 @@
+import { NodeSdk } from '@effect/opentelemetry'
+import {
+  SimpleSpanProcessor,
+  type SpanExporter,
+  type SpanProcessor,
+} from '@opentelemetry/sdk-trace-base'
+import { Effect, Layer, ManagedRuntime } from 'effect'
+import { PrettyConsoleSpanExporter } from './exporter-pretty.js'
+import { RotatingFileSpanExporter } from './exporter-file.js'
+
+export type ObservabilityEnv = 'dev' | 'prod' | 'test'
+
+interface CommonConfig {
+  readonly serviceName: string
+  readonly serviceVersion?: string
+}
+
+export type ObservabilityConfig =
+  | (CommonConfig & { readonly env: 'dev' })
+  | (CommonConfig & { readonly env: 'prod'; readonly logsDir: string })
+  | (CommonConfig & { readonly env: 'test'; readonly testExporter?: SpanExporter })
+
+/** Effect Layer that wires `Effect.withSpan` to either a pretty console
+ *  exporter (dev), a rotating jsonl file exporter (prod), or the
+ *  supplied test exporter / noop (test). */
+export function observabilityLayer(config: ObservabilityConfig): Layer.Layer<never> {
+  return NodeSdk.layer(() => ({
+    resource: {
+      serviceName: config.serviceName,
+      ...(config.serviceVersion ? { serviceVersion: config.serviceVersion } : {}),
+    },
+    spanProcessor: makeProcessor(config),
+  }))
+}
+
+function makeProcessor(config: ObservabilityConfig): SpanProcessor {
+  switch (config.env) {
+    case 'test':
+      return new SimpleSpanProcessor(config.testExporter ?? noopExporter)
+    case 'dev':
+      return new SimpleSpanProcessor(new PrettyConsoleSpanExporter())
+    case 'prod':
+      // SimpleSpanProcessor on purpose: BatchSpanProcessor batches for
+      // network export, but our prod sink is a local file. Per-span
+      // writes keep logs current for live `tail -f` debugging.
+      return new SimpleSpanProcessor(new RotatingFileSpanExporter({ dir: config.logsDir }))
+  }
+}
+
+const noopExporter: SpanExporter = {
+  export: (_spans, cb) => cb({ code: 0 }),
+  shutdown: () => Promise.resolve(),
+}
+
+/** Build a ManagedRuntime carrying the observability layer + a typed
+ *  promise runner. Lets main / scan-worker / sync-worker share the
+ *  same env-detection + cast pattern instead of each rolling its own. */
+export function makeObservabilityRuntime(config: ObservabilityConfig): {
+  readonly runtime: ManagedRuntime.ManagedRuntime<never, never>
+  readonly run: <A, E>(eff: Effect.Effect<A, E>) => Promise<A>
+} {
+  const runtime = ManagedRuntime.make(observabilityLayer(config))
+  return {
+    runtime,
+    run: <A, E>(eff: Effect.Effect<A, E>) =>
+      runtime.runPromise(eff as Effect.Effect<A, never>),
+  }
+}

--- a/packages/core/src/security/purge.ts
+++ b/packages/core/src/security/purge.ts
@@ -92,7 +92,9 @@ export function purgeFinding(
     })
 
     return result
-  })
+  }).pipe(
+    Effect.withSpan('security.purge.single', { attributes: { findingId } }),
+  )
 }
 
 /** Bulk purge across many findings. Caller passes an arbitrary
@@ -131,8 +133,11 @@ export function purgeFindings(
       )
       if (result) out.push(result)
     }
+    yield* Effect.annotateCurrentSpan('purged', out.length)
     return out
-  })
+  }).pipe(
+    Effect.withSpan('security.purge.bulk', { attributes: { requested: findingIds.length } }),
+  )
 }
 
 /** Produce a purge order that's safe against offset drift. Findings

--- a/packages/core/src/security/scan.ts
+++ b/packages/core/src/security/scan.ts
@@ -90,6 +90,8 @@ export function scanSession(
       catch: (cause) => new ScanError({ sessionId, cause, reason: 'db-failed' }),
     })
 
+    yield* Effect.annotateCurrentSpan('messageCount', messages.length)
+
     if (messages.length === 0) {
       // Session has no messages yet. Still mark it scanned with the
       // current profile so we don't loop on it; future sync will
@@ -154,9 +156,12 @@ export function scanSession(
     })
 
     yield* deps.publish({ type: 'session-rescanned', sessionId })
+    yield* Effect.annotateCurrentSpan('inserted', inputs.length)
 
     return { sessionId, inserted: inputs.length, profile: deps.currentProfile }
-  })
+  }).pipe(
+    Effect.withSpan('security.scan.session', { attributes: { sessionId } }),
+  )
 }
 
 function applyEmpty(sessionId: number, deps: ScanSessionDeps): Effect.Effect<void, ScanError> {

--- a/packages/core/src/security/worker.ts
+++ b/packages/core/src/security/worker.ts
@@ -219,8 +219,9 @@ export function makeScanWorker(
         for (const r of all) {
           yield* enqueue(r.id)
         }
+        yield* Effect.annotateCurrentSpan('enqueued', all.length)
         return all.length
-      })
+      }).pipe(Effect.withSpan('security.worker.rescan_all'))
 
     const backfill = () =>
       Effect.gen(function* () {
@@ -236,8 +237,9 @@ export function makeScanWorker(
         for (const id of stale) {
           yield* enqueue(id)
         }
+        yield* Effect.annotateCurrentSpan('enqueued', stale.length)
         return stale.length
-      })
+      }).pipe(Effect.withSpan('security.worker.backfill'))
 
     return {
       enqueue,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,24 @@ importers:
 
   packages/core:
     dependencies:
+      '@effect/opentelemetry':
+        specifier: ^0.63.0
+        version: 0.63.0(@effect/platform@0.96.1(effect@3.21.2))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@3.21.2)
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
+      '@opentelemetry/resources':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.41.1
+        version: 1.41.1
       '@spool-lab/redact':
         specifier: workspace:*
         version: link:../redact
@@ -609,6 +627,25 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@effect/opentelemetry@0.63.0':
+    resolution: {integrity: sha512-2yUG2QWNATi1uKP0kwhaP5eLp+c5NDzAL3EOpIcGLBAC0cbXZrx4n9Qw/QwUKxpuV+pbhrBUPCiByyWAFKfuCw==}
+    peerDependencies:
+      '@effect/platform': ^0.96.0
+      '@opentelemetry/api': ^1.9
+      '@opentelemetry/resources': ^2.0.0
+      '@opentelemetry/sdk-logs': '>=0.203.0 <0.300.0'
+      '@opentelemetry/sdk-metrics': ^2.0.0
+      '@opentelemetry/sdk-trace-base': ^2.0.0
+      '@opentelemetry/sdk-trace-node': ^2.0.0
+      '@opentelemetry/sdk-trace-web': ^2.0.0
+      '@opentelemetry/semantic-conventions': ^1.33.0
+      effect: ^3.21.0
+
+  '@effect/platform@0.96.1':
+    resolution: {integrity: sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A==}
+    peerDependencies:
+      effect: ^3.21.2
 
   '@effect/vitest@0.29.0':
     resolution: {integrity: sha512-DvWr1aeEcaZ8mtu8hNVb4e3rEYvGEwQSr7wsNrW53t6nKYjkmjRICcvVEsXUhjoCblRHSxRsRV0TOt0+UmcvaQ==}
@@ -1381,6 +1418,36 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@napi-rs/keyring-darwin-arm64@1.3.0':
     resolution: {integrity: sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==}
     engines: {node: '>= 10'}
@@ -1482,12 +1549,68 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This functionality has been moved to @npmcli/fs
 
+  '@opentelemetry/api-logs@0.218.0':
+    resolution: {integrity: sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/context-async-hooks@2.7.1':
+    resolution: {integrity: sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.218.0':
+    resolution: {integrity: sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.7.1':
+    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.7.1':
+    resolution: {integrity: sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-web@2.7.1':
+    resolution: {integrity: sha512-K806OouCSOjMd8Nr7+ZCq3QT22tdAzzS/7h8vprfiKjkgFQ99/dvwU8d12WJANA6D5Qtme65hyBAqAu9CkQuxQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/semantic-conventions@1.40.0':
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
 
   '@oxc-project/runtime@0.127.0':
@@ -3525,6 +3648,9 @@ packages:
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
+  find-my-way-ts@0.1.6:
+    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -4389,8 +4515,18 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.12:
+    resolution: {integrity: sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==}
+
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
+  multipasta@0.2.7:
+    resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -4428,6 +4564,10 @@ packages:
 
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-gyp@11.5.0:
     resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
@@ -5879,6 +6019,26 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@effect/opentelemetry@0.63.0(@effect/platform@0.96.1(effect@3.21.2))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@3.21.2)':
+    dependencies:
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-web': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      effect: 3.21.2
+
+  '@effect/platform@0.96.1(effect@3.21.2)':
+    dependencies:
+      effect: 3.21.2
+      find-my-way-ts: 0.1.6
+      msgpackr: 1.11.12
+      multipasta: 0.2.7
+
   '@effect/vitest@0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
       effect: 3.21.2
@@ -6500,6 +6660,24 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
+
   '@napi-rs/keyring-darwin-arm64@1.3.0':
     optional: true
 
@@ -6579,10 +6757,64 @@ snapshots:
       mkdirp: 1.0.4
       rimraf: 3.0.2
 
-  '@opentelemetry/api@1.9.1':
-    optional: true
+  '@opentelemetry/api-logs@0.218.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-logs@0.218.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.218.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-web@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
 
   '@oxc-project/runtime@0.127.0': {}
 
@@ -8492,6 +8724,8 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
+  find-my-way-ts@0.1.6: {}
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -9606,7 +9840,25 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.12:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
   muggle-string@0.4.1: {}
+
+  multipasta@0.2.7: {}
 
   nanoid@3.3.11: {}
 
@@ -9634,6 +9886,11 @@ snapshots:
   node-api-version@0.2.1:
     dependencies:
       semver: 7.7.4
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-gyp@11.5.0:
     dependencies:


### PR DESCRIPTION
## What

Wires Effect's built-in tracing to OpenTelemetry via `@effect/opentelemetry` and instruments `core/security` with spans + per-stage annotations. Closes the Security GA backlog item that would have caught the forwarder-fiber bug (#271 root cause) in seconds: every scan / purge / worker burst now produces a span with timing + attributes.

- **Dev**: colored stdout, one line per span — `HH:MM:SS.mmm  [span.name]  (Nms)  k=v`
- **Prod**: one JSON line per span under `~/.spool/logs/spool-YYYY-MM-DD.jsonl`, rotated daily, 50 MB cap

## New module — `packages/core/src/observability`

- `observabilityLayer(config)` — Effect Layer wiring the OTel `NodeSdk` tracer. Config is a **discriminated union** so `env='prod'` requires `logsDir` at compile time (no runtime throw), and the test escape hatch is only typeable under `env='test'`.
- `makeObservabilityRuntime(config)` — convenience builder returning `{ runtime, run }` so main + worker_thread bootstraps share one pattern. The `as Effect.Effect<A, never>` cast lives here, **in one place, explicitly named**.
- `PrettyConsoleSpanExporter` — ANSI colors only when stdout is a TTY; truncates wide attributes.
- `RotatingFileSpanExporter` — appends one JSON record per span to the daily file. Uses a **running-byte counter** so the steady-state hot path doesn't pay for a `readdir+stat` sweep per export call — sweep only runs when the counter actually crosses the cap. (Per-span sync writes are fine for local sinks and give live `tail -f` debugging.)

## Instrumentation — `core/security`

| Span | Attributes |
|---|---|
| `security.scan.session` | `sessionId`, `messageCount`, `inserted` |
| `security.purge.single` | `findingId` |
| `security.purge.bulk` | `requested`, `purged` |
| `security.worker.backfill` | `enqueued` |
| `security.worker.rescan_all` | `enqueued` |

## Wiring — `app/main`

- `packages/app/src/main/index.ts` builds one runtime via `makeObservabilityRuntime`, threads `runWithObservability` into both scan-worker callbacks and `registerSecurityIpc`'s `runPromise:` arg.
- `packages/app/src/main/scan-worker-thread.ts` mirrors the bootstrap inside the worker because the worker_thread has its own Effect runtime — without provisioning the layer there, spans inside `scanSession`/`backfill` never reach an exporter.

## Test plan

- [x] core 321 / 1 skipped (TTY-only ANSI assertion), app 229/229 — full vitest
- [x] typecheck clean (core + app)
- [x] Manually verified in dev with the refactored bootstrap: backfill + `scan.session` spans render with attributes; both the main-process backfill span and the worker-thread scan span emit correctly
- [ ] CI re-verifies

## What's intentionally NOT in this PR

- **Drain-fiber / forwarder spans** — flagged in review as the "would have caught forwarder bug" gap. Adding them requires span context propagation across postMessage; deferred to a follow-up so this PR stays narrow.
- **Span-name constants** — deferred until first rename pain.
- **formatBytes / ANSI palette consolidation** across other packages — pre-existing tech debt, separate cleanup.
- **Vacuum DB** (still owed from the Maintenance PR) — separate PR.

## Review notes

Three-agent code review (reuse / quality / efficiency) ran at high effort before this submission. All must-fix findings were addressed in a second pass — see commit body for the full list. Skipped items above are the explicit non-goals.