### PR TITLE
Fix non-macOS sidebar toggle layout

### DIFF
--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -39,6 +39,7 @@ export interface BuiltinAgent {
 }
 
 export type LanguagePreference = 'system' | 'en' | 'zh-CN' | 'zh-TW' | 'ja' | 'ko' | 'de' | 'fr'
+export type RuntimePlatform = NodeJS.Platform
 
 export interface AgentsConfig {
   defaultAgent?: string
@@ -64,6 +65,8 @@ export interface AgentsConfig {
 export type SpoolAPI = typeof api
 
 const api = {
+  platform: process.platform as RuntimePlatform,
+
   search: (query: string, limit?: number, source?: string, onlyPinned?: boolean, identityKey?: string): Promise<SearchResult[]> =>
     ipcRenderer.invoke('spool:search', { query, limit, source, onlyPinned, identityKey }),
 

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -113,6 +113,7 @@ export default function App() {
   const [searchScopeProject, setSearchScopeProject] = useState<ScopeValue | null>(null)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [sharePanelOpen, setSharePanelOpen] = useState(true)
+  const trafficLightInset = typeof window !== 'undefined' && window.spool?.platform === 'darwin'
   /** Active share-editor session: conversation, the user's last
    *  accepted opts, and the draft-row metadata the editor needs to
    *  upsert autosaves back into share_drafts. Cleared on Back. */
@@ -835,6 +836,13 @@ export default function App() {
       onPinnedSortOrderChange={handlePinnedSortChange}
       onCopySessionId={handleCopySessionId}
       {...(shareEnabled ? { onShareSession: handleStartShareFromUuid } : {})}
+      {...(!trafficLightInset ? {
+        sidebarToggle: {
+          collapsed: sidebarCollapsed,
+          onToggle: toggleSidebar,
+        },
+      } : {})}
+      chromeOnly={!trafficLightInset && sidebarCollapsed}
       onSettingsClick={() => { setSettingsTab('general'); setShowSettings(true) }}
     />
   )
@@ -856,6 +864,7 @@ export default function App() {
           sidebar={sidebarElement}
           sidebarCollapsed={sidebarCollapsed}
           onToggleSidebar={toggleSidebar}
+          trafficLightInset={trafficLightInset}
         />
         <AppToaster />
         {/* App-level overlays (settings, search) still mount above the
@@ -905,67 +914,17 @@ export default function App() {
       <AppTopBar
         sidebarCollapsed={sidebarCollapsed}
         onToggleSidebar={toggleSidebar}
+        trafficLightInset={trafficLightInset}
       />
       <div className="flex flex-1 min-h-0">
-      <SidebarRail collapsed={sidebarCollapsed}>
-      <Sidebar
-        activeIdentityKey={activeProjectKey}
-        activeSessionUuid={view === 'session' ? selectedSession : null}
-        isLibraryActive={isHomeMode}
-        onSelectProject={(key) => {
-          setActiveProjectKey(key)
-          setHomeMode(false)
-          setSelectedSession(null)
-          setTargetMessageId(null)
-          setView('search')
-          setQuery('')
-        }}
-        onSelectSession={handleOpenSession}
-        onSelectHome={() => {
-          setActiveProjectKey(null)
-          setHomeMode(true)
-          setSelectedSession(null)
-          setTargetMessageId(null)
-          setView('search')
-          setQuery('')
-        }}
-        {...(shareEnabled ? {
-          onSelectShares: () => {
-            setActiveProjectKey(null)
-            setHomeMode(false)
-            setSelectedSession(null)
-            setTargetMessageId(null)
-            setView('shares')
-            setQuery('')
-          },
-        } : {})}
-        isSharesActive={isSharesView}
-        onSelectSecurity={() => {
-          setSelectedSession(null)
-          setTargetMessageId(null)
-          setActiveProjectKey(null)
-          setActiveProjectName(null)
-          setHomeMode(false)
-          setView('security')
-          setQuery('')
-        }}
-        isSecurityActive={isSecurityView}
-        onOpenSearch={handleSearchOpen}
-        syncStatus={syncStatus}
-        status={status}
-        showSourceDots={sidebarShowSourceDots}
-        showSessionCount={sidebarShowSessionCount}
-        sortOrder={sidebarSortOrder}
-        onSortOrderChange={handleSidebarSortChange}
-        pinnedSortOrder={pinnedSortOrder}
-        onPinnedSortOrderChange={handlePinnedSortChange}
-        onCopySessionId={handleCopySessionId}
-        {...(shareEnabled ? { onShareSession: handleStartShareFromUuid } : {})}
-        onSettingsClick={() => { setSettingsTab('general'); setShowSettings(true) }}
-      />
-      </SidebarRail>
-      <div className="relative flex flex-col flex-1 min-w-0">
-      <div className="flex flex-col flex-1 min-h-0 relative">
+        <SidebarRail
+          collapsed={sidebarCollapsed}
+          collapsedWidth={!trafficLightInset ? 'chrome' : 'none'}
+        >
+          {sidebarElement}
+        </SidebarRail>
+        <div className="relative flex flex-col flex-1 min-w-0">
+          <div className="flex flex-col flex-1 min-h-0 relative">
         {isSharesView ? (
           <SharesPage
             onOpenDraft={handleOpenDraft}
@@ -1097,9 +1056,8 @@ export default function App() {
             </div>
           </>
         )}
-      </div>
-
-      </div>
+          </div>
+        </div>
       </div>
 
       <AppToaster />
@@ -1192,4 +1150,3 @@ const AgentSelector = memo(function AgentSelector({ agents, activeAgent, onSelec
     </div>
   )
 })
-

--- a/packages/app/src/renderer/components/AppTopBar.tsx
+++ b/packages/app/src/renderer/components/AppTopBar.tsx
@@ -67,7 +67,7 @@ export default function AppTopBar({ sidebarCollapsed, onToggleSidebar, trafficLi
             <div
               className={[
                 'flex-none transition-[width] duration-[280ms] ease-out',
-                sidebarCollapsed ? 'w-0' : 'w-[138px]',
+                sidebarCollapsed ? 'w-0' : 'w-[134px]',
               ].join(' ')}
               aria-hidden="true"
             />
@@ -117,10 +117,10 @@ function SidebarToggleButton({
       title={title}
       aria-label={ariaLabel}
       aria-pressed={pressed}
-      className="flex-none inline-flex items-center justify-center w-6 h-6 rounded-md text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75"
+      className="flex-none inline-flex items-center justify-center w-5 h-5 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75"
       style={noDragStyle}
     >
-      <PanelLeft size={14} strokeWidth={1.5} />
+      <PanelLeft size={13} strokeWidth={1.75} />
     </button>
   )
 }

--- a/packages/app/src/renderer/components/AppTopBar.tsx
+++ b/packages/app/src/renderer/components/AppTopBar.tsx
@@ -1,10 +1,11 @@
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { PanelLeft } from 'lucide-react'
 
 type Props = {
   sidebarCollapsed: boolean
   onToggleSidebar: () => void
+  trafficLightInset?: boolean
   /** Page-level chrome (page title, primary action). Rendered into a
    *  flex slot to the right of the sidebar fold toggle. */
   children?: ReactNode
@@ -17,61 +18,69 @@ type Props = {
  * boundary below it, so the eye reads "left column + right column"
  * running top-to-bottom.
  */
-export default function AppTopBar({ sidebarCollapsed, onToggleSidebar, children }: Props) {
+export default function AppTopBar({ sidebarCollapsed, onToggleSidebar, trafficLightInset = true, children }: Props) {
   const { t } = useTranslation()
-  const dragStyle = { WebkitAppRegion: 'drag' } as React.CSSProperties
-  const noDragStyle = { WebkitAppRegion: 'no-drag' } as React.CSSProperties
+  const dragStyle = { WebkitAppRegion: 'drag' } as CSSProperties
+  const noDragStyle = { WebkitAppRegion: 'no-drag' } as CSSProperties
   const sidebarTitle = sidebarCollapsed
     ? `${t('sidebar.expand')} (⌘B)`
     : `${t('sidebar.collapse')} (⌘B)`
 
+  if (!trafficLightInset && !children) {
+    return null
+  }
+
   return (
     <div data-testid="app-top-bar" className="relative flex-none min-h-9 select-none" style={dragStyle}>
       {/* Background: animated sidebar split + content bg flooding the
-          rest of the bar (including over the right rail). The rail
-          itself gets its surface tint only BELOW the bar. */}
+          rest of the bar. macOS collapses the sidebar segment to zero
+          because its traffic-light gutter stays in the top bar; Linux
+          keeps a narrow sidebar chrome segment so page chrome aligns
+          with the content pane below. */}
       <div className="absolute inset-0 flex pointer-events-none" aria-hidden="true">
         <div
           className={[
             'flex-none transition-[width] duration-[280ms] ease-out bg-warm-surface dark:bg-dark-surface',
-            sidebarCollapsed ? 'w-0' : 'w-60',
+            sidebarCollapsed ? (trafficLightInset ? 'w-0' : 'w-12') : 'w-60',
           ].join(' ')}
         />
         <div className="flex-1 bg-warm-bg dark:bg-dark-bg" />
       </div>
 
-      {/* Foreground: traffic-light gutter + fold button + sidebar-width
-          spacer + page slot. */}
+      {/* Foreground: macOS keeps the fold button in the hiddenInset title
+          bar next to the traffic lights. Other platforms render the
+          fold row inside the sidebar itself, so this bar only reserves
+          the sidebar width before page chrome. */}
       <div className="relative min-h-9 flex items-stretch">
-        <div className="flex-none w-[78px]" aria-hidden="true" />
-        <div className="flex-none flex items-center">
-          <button
-            type="button"
-            data-testid="sidebar-toggle"
-            onClick={onToggleSidebar}
-            title={sidebarTitle}
-            aria-label={sidebarCollapsed ? t('sidebar.expand') : t('sidebar.collapse')}
-            aria-pressed={sidebarCollapsed}
-            className="flex-none inline-flex items-center justify-center w-5 h-5 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75"
-            style={noDragStyle}
-          >
-            <PanelLeft size={13} strokeWidth={1.75} />
-          </button>
-        </div>
-        {/* Animates over the same 280ms and the same Tailwind ease-out
-         *  curve as the bg sidebar layer above and the sidebar wrapper
-         *  below, so the page slot's left edge stays in lock-step with
-         *  the sidebar fold. Per-pixel velocity is lower than the
-         *  sidebar's (this spacer is 134px, sidebar is 240px), but the
-         *  motions share start/end frames so the eye reads them as one
-         *  unified fold rather than two separate animations. */}
-        <div
-          className={[
-            'flex-none transition-[width] duration-[280ms] ease-out',
-            sidebarCollapsed ? 'w-0' : 'w-[134px]',
-          ].join(' ')}
-          aria-hidden="true"
-        />
+        {trafficLightInset ? (
+          <>
+            <div className="flex-none w-[78px]" aria-hidden="true" />
+            <div className="flex-none flex items-center">
+              <SidebarToggleButton
+                title={sidebarTitle}
+                ariaLabel={sidebarCollapsed ? t('sidebar.expand') : t('sidebar.collapse')}
+                pressed={sidebarCollapsed}
+                onToggle={onToggleSidebar}
+                noDragStyle={noDragStyle}
+              />
+            </div>
+            <div
+              className={[
+                'flex-none transition-[width] duration-[280ms] ease-out',
+                sidebarCollapsed ? 'w-0' : 'w-[138px]',
+              ].join(' ')}
+              aria-hidden="true"
+            />
+          </>
+        ) : (
+          <div
+            className={[
+              'flex-none transition-[width] duration-[280ms] ease-out',
+              sidebarCollapsed ? 'w-12' : 'w-60',
+            ].join(' ')}
+            aria-hidden="true"
+          />
+        )}
         {/* Slot inherits `drag` from the bar so whitespace around page
             chrome remains a drag handle. Interactive elements injected
             into this slot must opt out individually with
@@ -84,5 +93,34 @@ export default function AppTopBar({ sidebarCollapsed, onToggleSidebar, children 
         </div>
       </div>
     </div>
+  )
+}
+
+function SidebarToggleButton({
+  title,
+  ariaLabel,
+  pressed,
+  onToggle,
+  noDragStyle,
+}: {
+  title: string
+  ariaLabel: string
+  pressed: boolean
+  onToggle: () => void
+  noDragStyle: CSSProperties
+}) {
+  return (
+    <button
+      type="button"
+      data-testid="sidebar-toggle"
+      onClick={onToggle}
+      title={title}
+      aria-label={ariaLabel}
+      aria-pressed={pressed}
+      className="flex-none inline-flex items-center justify-center w-6 h-6 rounded-md text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75"
+      style={noDragStyle}
+    >
+      <PanelLeft size={14} strokeWidth={1.5} />
+    </button>
   )
 }

--- a/packages/app/src/renderer/components/PageLayout.tsx
+++ b/packages/app/src/renderer/components/PageLayout.tsx
@@ -11,6 +11,7 @@ type Props = {
   sidebar: ReactNode
   sidebarCollapsed: boolean
   onToggleSidebar: () => void
+  trafficLightInset?: boolean
   /** Page chrome that gets portaled into the top bar's flex slot
    *  (back arrow, title, primary action buttons). Pass null on pages
    *  that don't need any. */
@@ -39,6 +40,7 @@ export default function PageLayout({
   sidebar,
   sidebarCollapsed,
   onToggleSidebar,
+  trafficLightInset = true,
   topBar,
   rightPanel,
   rightPanelOpen = false,
@@ -49,11 +51,17 @@ export default function PageLayout({
       <AppTopBar
         sidebarCollapsed={sidebarCollapsed}
         onToggleSidebar={onToggleSidebar}
+        trafficLightInset={trafficLightInset}
       >
         {topBar}
       </AppTopBar>
       <div className="flex flex-1 min-h-0">
-        <SidebarRail collapsed={sidebarCollapsed}>{sidebar}</SidebarRail>
+        <SidebarRail
+          collapsed={sidebarCollapsed}
+          collapsedWidth={!trafficLightInset ? 'chrome' : 'none'}
+        >
+          {sidebar}
+        </SidebarRail>
         <div className="relative flex flex-col flex-1 min-w-0">
           {children}
         </div>

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -91,7 +91,7 @@ export default function SessionRow({ session, pinned = false, showProject = fals
       </div>
 
       <div className="flex-none flex items-center gap-1 -mt-0.5" onClick={(e) => e.stopPropagation()}>
-        <SecurityBadgeSlot session={session} />
+        <SecurityBadge session={session} />
         <span
           className={
             pinned
@@ -153,27 +153,6 @@ export default function SessionRow({ session, pinned = false, showProject = fals
   )
 }
 
-/** Fixed-width state slot containing the SecurityBadge.
- *
- *  Naive placement (`{badge && <SecurityBadge />}` inline) shifts the pin
- *  icon column left on rows without a badge. By reserving a 32px slot
- *  for every row — even when empty — the pin/menu icons lock to the
- *  same X across the entire library.
- *
- *  Vertical alignment: the slot is `h-5` to match `PinButton`'s `w-5
- *  h-5` button, and lives inside the action group so it inherits the
- *  group's `-mt-0.5` offset against the title row. Icon size = 13 so
- *  the AlertTriangle reads as the same visual weight as PinIcon (also
- *  size 13). */
-function SecurityBadgeSlot({ session }: { session: Session }): React.ReactElement {
-  return (
-    <span className="flex-none inline-flex items-center justify-center w-5 h-5">
-      <SecurityBadge session={session} />
-    </span>
-  )
-}
-
-
 function SecurityBadge({ session }: { session: Session }): React.ReactElement | null {
   const { t } = useTranslation()
   if (!securityFeatureEnabled()) return null
@@ -228,4 +207,3 @@ function SecurityBadge({ session }: { session: Session }): React.ReactElement | 
     </span>
   )
 }
-

--- a/packages/app/src/renderer/components/SessionRow.tsx
+++ b/packages/app/src/renderer/components/SessionRow.tsx
@@ -91,7 +91,7 @@ export default function SessionRow({ session, pinned = false, showProject = fals
       </div>
 
       <div className="flex-none flex items-center gap-1 -mt-0.5" onClick={(e) => e.stopPropagation()}>
-        <SecurityBadge session={session} />
+        <SecurityBadgeSlot session={session} />
         <span
           className={
             pinned
@@ -152,6 +152,27 @@ export default function SessionRow({ session, pinned = false, showProject = fals
     </div>
   )
 }
+
+/** Fixed-width state slot containing the SecurityBadge.
+ *
+ *  Naive placement (`{badge && <SecurityBadge />}` inline) shifts the pin
+ *  icon column left on rows without a badge. By reserving a 32px slot
+ *  for every row — even when empty — the pin/menu icons lock to the
+ *  same X across the entire library.
+ *
+ *  Vertical alignment: the slot is `h-5` to match `PinButton`'s `w-5
+ *  h-5` button, and lives inside the action group so it inherits the
+ *  group's `-mt-0.5` offset against the title row. Icon size = 13 so
+ *  the AlertTriangle reads as the same visual weight as PinIcon (also
+ *  size 13). */
+function SecurityBadgeSlot({ session }: { session: Session }): React.ReactElement {
+  return (
+    <span className="flex-none inline-flex items-center justify-center w-5 h-5">
+      <SecurityBadge session={session} />
+    </span>
+  )
+}
+
 
 function SecurityBadge({ session }: { session: Session }): React.ReactElement | null {
   const { t } = useTranslation()

--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -44,6 +44,7 @@ type Props = {
   sidebar: ReactNode
   sidebarCollapsed: boolean
   onToggleSidebar: () => void
+  trafficLightInset?: boolean
 }
 
 type SaveState = 'idle' | 'saving' | 'error'
@@ -67,6 +68,7 @@ export default function ShareEditorPage({
   sidebar,
   sidebarCollapsed,
   onToggleSidebar,
+  trafficLightInset = true,
 }: Props) {
   const { t } = useTranslation()
   // opts + title share one undo stack — Cmd+Z reverts whichever was
@@ -485,6 +487,7 @@ export default function ShareEditorPage({
       sidebar={sidebar}
       sidebarCollapsed={sidebarCollapsed}
       onToggleSidebar={onToggleSidebar}
+      trafficLightInset={trafficLightInset}
       topBar={topBarContent}
       rightPanel={<ControlPanel convo={liveConversation} opts={opts} setOpts={setOpts} />}
       rightPanelOpen={panelOpen}

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
 import type { ProjectGroup, Session, SessionSource, StatusInfo } from '@spool-lab/core'
-import { Layers3 as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, ShieldAlert as SecurityIcon, AlertTriangle, SquareTerminal, MoreHorizontal, Copy, Loader2, SquarePen } from 'lucide-react'
+import { Layers3 as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, ShieldAlert as SecurityIcon, AlertTriangle, SquareTerminal, MoreHorizontal, Copy, Loader2, SquarePen, PanelLeft } from 'lucide-react'
 import { securityFeatureEnabled } from '../featureFlags.js'
 import { useTranslation } from 'react-i18next'
 import PinIcon from './PinIcon.js'
@@ -45,9 +45,14 @@ type Props = {
   onPinnedSortOrderChange?: (next: PinnedSortOrder) => void
   onCopySessionId?: (source: SessionSource) => void
   onShareSession?: (uuid: string) => void
+  sidebarToggle?: {
+    collapsed: boolean
+    onToggle: () => void
+  }
+  chromeOnly?: boolean
 }
 
-export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, onSelectProject, onSelectSession, onSelectHome, isLibraryActive = false, onSelectShares, isSharesActive = false, onSelectSecurity, isSecurityActive = false, securityHighCount = 0, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true, sortOrder = DEFAULT_SIDEBAR_SORT_ORDER, onSortOrderChange, pinnedSortOrder = DEFAULT_PINNED_SORT_ORDER, onPinnedSortOrderChange, onCopySessionId, onShareSession }: Props) {
+export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, onSelectProject, onSelectSession, onSelectHome, isLibraryActive = false, onSelectShares, isSharesActive = false, onSelectSecurity, isSecurityActive = false, securityHighCount = 0, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true, sortOrder = DEFAULT_SIDEBAR_SORT_ORDER, onSortOrderChange, pinnedSortOrder = DEFAULT_PINNED_SORT_ORDER, onPinnedSortOrderChange, onCopySessionId, onShareSession, sidebarToggle, chromeOnly = false }: Props) {
   const { t } = useTranslation()
   const sidebarSortLabel = (value: SidebarSortOrder): string => {
     switch (value) {
@@ -105,9 +110,37 @@ export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, o
   return (
     <aside
       data-testid="sidebar"
-      className="w-60 flex-none bg-warm-surface dark:bg-dark-surface flex flex-col h-full overflow-hidden"
+      className={[
+        'w-60 flex-none flex flex-col h-full overflow-hidden transition-colors duration-[280ms] ease-out',
+        chromeOnly
+          ? 'bg-warm-bg dark:bg-dark-bg'
+          : 'bg-warm-surface dark:bg-dark-surface',
+      ].join(' ')}
     >
-      <nav className="px-2 pt-1 pb-2 flex-none flex flex-col gap-0.5" aria-label={t('sidebar.library')}>
+      {sidebarToggle && (
+        <div className="px-2 pt-1 flex-none flex flex-col gap-0.5">
+          {chromeOnly ? (
+            <SidebarCollapsedToggle
+              collapsed={sidebarToggle.collapsed}
+              onToggle={sidebarToggle.onToggle}
+              title={sidebarToggle.collapsed ? t('sidebar.expand') : t('sidebar.collapse')}
+            />
+          ) : (
+            <NavRow
+              testId="sidebar-toggle"
+              icon={<PanelLeft size={14} strokeWidth={1.5} />}
+              label={t('sidebar.sidebar')}
+              trailing={<KbdHint>{formatModShortcut('B')}</KbdHint>}
+              onClick={sidebarToggle.onToggle}
+              title={sidebarToggle.collapsed ? t('sidebar.expand') : t('sidebar.collapse')}
+              ariaPressed={sidebarToggle.collapsed}
+            />
+          )}
+        </div>
+      )}
+      {!chromeOnly && (
+        <>
+      <nav className={`px-2 ${sidebarToggle ? 'pt-0 mt-0.5' : 'pt-1'} pb-2 flex-none flex flex-col gap-0.5`} aria-label={t('sidebar.library')}>
         {onSelectHome && (
           <NavRow
             testId="sidebar-library"
@@ -154,7 +187,7 @@ export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, o
             testId="sidebar-search"
             icon={<SearchIcon size={14} strokeWidth={1.75} />}
             label={t('sidebar.search')}
-            trailing={<KbdHint>⌘K</KbdHint>}
+            trailing={<KbdHint>{formatModShortcut('K')}</KbdHint>}
             onClick={onOpenSearch}
           />
         )}
@@ -296,6 +329,8 @@ export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, o
         status={status ?? null}
         {...(onSettingsClick ? { onSettingsClick } : {})}
       />
+        </>
+      )}
     </aside>
   )
 }
@@ -306,6 +341,8 @@ function NavRow({
   label,
   active = false,
   trailing,
+  title,
+  ariaPressed,
   onClick,
 }: {
   testId?: string
@@ -313,6 +350,8 @@ function NavRow({
   label: string
   active?: boolean
   trailing?: ReactNode
+  title?: string
+  ariaPressed?: boolean
   onClick: () => void
 }) {
   const dataAttrs = testId ? { 'data-testid': testId } : {}
@@ -321,9 +360,11 @@ function NavRow({
       type="button"
       {...dataAttrs}
       onClick={onClick}
+      title={title}
       aria-current={active ? 'page' : undefined}
+      aria-pressed={ariaPressed}
       className={[
-        'w-full flex items-center gap-2 px-2 py-1 rounded-md transition-colors duration-75 text-[13px]',
+        'w-full flex items-center gap-2 px-2 py-1 rounded-md transition-colors duration-75 text-[13px] leading-4',
         active
           ? 'bg-warm-surface2 dark:bg-dark-surface2 text-warm-text dark:text-dark-text'
           : 'text-warm-text/85 dark:text-dark-text/85 hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text',
@@ -334,6 +375,29 @@ function NavRow({
       {trailing}
     </button>
   )
+}
+
+function SidebarCollapsedToggle({ collapsed, onToggle, title }: { collapsed: boolean; onToggle: () => void; title: string }) {
+  const { t } = useTranslation()
+  return (
+    <button
+      type="button"
+      data-testid="sidebar-toggle"
+      onClick={onToggle}
+      title={title}
+      aria-label={collapsed ? t('sidebar.expand') : t('sidebar.collapse')}
+      aria-pressed={collapsed}
+      className="ml-1 flex-none inline-flex items-center justify-center w-6 h-6 rounded-md text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75"
+      style={{ WebkitAppRegion: 'no-drag' } as CSSProperties}
+    >
+      <PanelLeft size={14} strokeWidth={1.5} />
+    </button>
+  )
+}
+
+function formatModShortcut(key: string) {
+  const isMac = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform)
+  return isMac ? `⌘${key}` : `Ctrl+${key}`
 }
 
 function KbdHint({ children }: { children: ReactNode }) {

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -128,7 +128,7 @@ export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, o
           ) : (
             <NavRow
               testId="sidebar-toggle"
-              icon={<PanelLeft size={14} strokeWidth={1.5} />}
+              icon={<PanelLeft size={14} strokeWidth={1.75} />}
               label={t('sidebar.sidebar')}
               trailing={<KbdHint>{formatModShortcut('B')}</KbdHint>}
               onClick={sidebarToggle.onToggle}
@@ -364,7 +364,7 @@ function NavRow({
       aria-current={active ? 'page' : undefined}
       aria-pressed={ariaPressed}
       className={[
-        'w-full flex items-center gap-2 px-2 py-1 rounded-md transition-colors duration-75 text-[13px] leading-4',
+        'w-full flex items-center gap-2 px-2 py-1 rounded-md transition-colors duration-75 text-[13px]',
         active
           ? 'bg-warm-surface2 dark:bg-dark-surface2 text-warm-text dark:text-dark-text'
           : 'text-warm-text/85 dark:text-dark-text/85 hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text',
@@ -390,13 +390,13 @@ function SidebarCollapsedToggle({ collapsed, onToggle, title }: { collapsed: boo
       className="ml-1 flex-none inline-flex items-center justify-center w-6 h-6 rounded-md text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75"
       style={{ WebkitAppRegion: 'no-drag' } as CSSProperties}
     >
-      <PanelLeft size={14} strokeWidth={1.5} />
+      <PanelLeft size={14} strokeWidth={1.75} />
     </button>
   )
 }
 
 function formatModShortcut(key: string) {
-  const isMac = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform)
+  const isMac = typeof window !== 'undefined' && window.spool?.platform === 'darwin'
   return isMac ? `⌘${key}` : `Ctrl+${key}`
 }
 

--- a/packages/app/src/renderer/components/SidebarRail.tsx
+++ b/packages/app/src/renderer/components/SidebarRail.tsx
@@ -14,6 +14,7 @@ export const FOLD_DURATION_MS = 280
 type Props = {
   collapsed: boolean
   children: ReactNode
+  collapsedWidth?: 'none' | 'chrome'
 }
 
 /**
@@ -27,14 +28,15 @@ type Props = {
  * AppTopBar's bg sidebar segment, which paints the same surface
  * colour over the top of the chrome.
  */
-export default function SidebarRail({ collapsed, children }: Props) {
+export default function SidebarRail({ collapsed, collapsedWidth = 'none', children }: Props) {
+  const collapsedClass = collapsedWidth === 'chrome' ? 'w-12' : 'w-0'
   return (
     <div
       className={[
         'flex-none overflow-hidden transition-[width] duration-[280ms] ease-out',
-        collapsed ? 'w-0' : 'w-60',
+        collapsed ? collapsedClass : 'w-60',
       ].join(' ')}
-      aria-hidden={collapsed}
+      aria-hidden={collapsed && collapsedWidth === 'none'}
     >
       {children}
     </div>

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -38,6 +38,7 @@
     "errorDialog_keepRunning": "Spool läuft weiter. Wenn diese Meldung wiederholt erscheint, starten Sie die App bitte neu."
   },
   "sidebar": {
+    "sidebar": "Seitenleiste",
     "library": "Sitzungen",
     "search": "Suche",
     "shares": "Teilen",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -38,6 +38,7 @@
     "errorDialog_keepRunning": "Spool will keep running, but if you see this repeatedly please restart the app."
   },
   "sidebar": {
+    "sidebar": "Sidebar",
     "library": "Sessions",
     "search": "Search",
     "shares": "Shares",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -38,6 +38,7 @@
     "errorDialog_keepRunning": "Spool continue de fonctionner. Si ce message revient, redémarrez l'application."
   },
   "sidebar": {
+    "sidebar": "Barre latérale",
     "library": "Sessions",
     "search": "Recherche",
     "shares": "Partages",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -38,6 +38,7 @@
     "errorDialog_keepRunning": "Spool は実行を継続します。このメッセージが繰り返し表示される場合はアプリを再起動してください。"
   },
   "sidebar": {
+    "sidebar": "サイドバー",
     "library": "セッション",
     "search": "検索",
     "shares": "共有",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -38,6 +38,7 @@
     "errorDialog_keepRunning": "Spool은 계속 실행됩니다. 이 메시지가 반복해서 나타나면 앱을 다시 시작하세요."
   },
   "sidebar": {
+    "sidebar": "사이드바",
     "library": "세션",
     "search": "검색",
     "shares": "공유",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -39,7 +39,7 @@
   },
   "sidebar": {
     "sidebar": "侧栏",
-    "library": "全部会话",
+    "library": "会话",
     "search": "搜索",
     "shares": "分享",
     "security": "安全",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -38,7 +38,8 @@
     "errorDialog_keepRunning": "Spool 会继续运行；如反复出现该提示，请重启应用。"
   },
   "sidebar": {
-    "library": "会话",
+    "sidebar": "侧栏",
+    "library": "全部会话",
     "search": "搜索",
     "shares": "分享",
     "security": "安全",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -38,6 +38,7 @@
     "errorDialog_keepRunning": "Spool 會繼續運行；若反覆出現此訊息，請重新啟動應用程式。"
   },
   "sidebar": {
+    "sidebar": "側欄",
     "library": "會話",
     "search": "搜尋",
     "shares": "分享",


### PR DESCRIPTION
  The sidebar toggle was positioned for macOS `hiddenInset` windows, where the empty space on the left aligns with the traffic-light controls. On Linux and Windows there are no traffic-light controls, so the same reserved space made the toggle feel offset and left an awkward standalone top-bar row when the sidebar was collapsed.

  This PR keeps the macOS titlebar behavior intact, but moves the non-macOS toggle into the sidebar itself. When expanded, the toggle is rendered as a normal sidebar row above the library/search rows, with a label and shortcut hint. When collapsed, the sidebar keeps only a narrow chrome area with a stable square toggle button, matching the main background so the collapsed rail does not visually compete with the content.

Before this PR:
<img width="360" height="360" alt="before" src="https://github.com/user-attachments/assets/fdaad639-a1cc-4d72-8241-91a628aa3fc9" />
After this PR:
<img width="526" height="360" alt="after" src="https://github.com/user-attachments/assets/4bb431c9-36af-428f-8e49-467392fb7051" />
