### PR TITLE
fix(e2e): deflake window-lifecycle close→activate test

### DIFF
--- a/packages/app/e2e/window-lifecycle.spec.ts
+++ b/packages/app/e2e/window-lifecycle.spec.ts
@@ -14,18 +14,26 @@ test.afterAll(async () => {
 test('window recovers after close → activate cycle', async () => {
   const { app } = ctx
 
-  // Close the window
   const firstWindow = await app.firstWindow()
+
+  // Arm the 'window' listener BEFORE close + activate so we deterministically
+  // catch the new BrowserWindow. ElectronApplication.firstWindow() is racy
+  // across a close/recreate cycle: it can return the just-closed page (dead
+  // locators) or block until test timeout because the new window isn't yet
+  // tracked internally.
+  const restoredP = app.waitForEvent('window')
   await firstWindow.close()
-
-  // Trigger activate (same code path as tray click)
   await app.evaluate(({ app: a }) => a.emit('activate'))
-  const restored = await app.firstWindow()
-  await expect(restored.locator('[data-testid="library-landing"]')).toBeVisible({ timeout: 5000 })
+  const restored = await restoredP
+  await restored.waitForLoadState('domcontentloaded')
+  await expect(restored.locator('[data-testid="library-landing"]')).toBeVisible({ timeout: 10000 })
 
-  // Second cycle — this is where the bug manifested
+  // Second cycle — this is where the original bug manifested. Same arming
+  // pattern keeps the assertion deterministic.
+  const restoredAgainP = app.waitForEvent('window')
   await restored.close()
   await app.evaluate(({ app: a }) => a.emit('activate'))
-  const restoredAgain = await app.firstWindow()
-  await expect(restoredAgain.locator('[data-testid="library-landing"]')).toBeVisible({ timeout: 5000 })
+  const restoredAgain = await restoredAgainP
+  await restoredAgain.waitForLoadState('domcontentloaded')
+  await expect(restoredAgain.locator('[data-testid="library-landing"]')).toBeVisible({ timeout: 10000 })
 })

--- a/packages/app/e2e/window-lifecycle.spec.ts
+++ b/packages/app/e2e/window-lifecycle.spec.ts
@@ -15,25 +15,33 @@ test('window recovers after close → activate cycle', async () => {
   const { app } = ctx
 
   const firstWindow = await app.firstWindow()
-
-  // Arm the 'window' listener BEFORE close + activate so we deterministically
-  // catch the new BrowserWindow. ElectronApplication.firstWindow() is racy
-  // across a close/recreate cycle: it can return the just-closed page (dead
-  // locators) or block until test timeout because the new window isn't yet
-  // tracked internally.
-  const restoredP = app.waitForEvent('window')
-  await firstWindow.close()
-  await app.evaluate(({ app: a }) => a.emit('activate'))
-  const restored = await restoredP
-  await restored.waitForLoadState('domcontentloaded')
+  await closeAndAwaitDestroy(firstWindow, app)
+  const restored = await activateAndAwaitNewWindow(app)
   await expect(restored.locator('[data-testid="library-landing"]')).toBeVisible({ timeout: 10000 })
 
-  // Second cycle — this is where the original bug manifested. Same arming
-  // pattern keeps the assertion deterministic.
-  const restoredAgainP = app.waitForEvent('window')
-  await restored.close()
-  await app.evaluate(({ app: a }) => a.emit('activate'))
-  const restoredAgain = await restoredAgainP
-  await restoredAgain.waitForLoadState('domcontentloaded')
+  // Second cycle — this is where the original bug manifested.
+  await closeAndAwaitDestroy(restored, app)
+  const restoredAgain = await activateAndAwaitNewWindow(app)
   await expect(restoredAgain.locator('[data-testid="library-landing"]')).toBeVisible({ timeout: 10000 })
 })
+
+// page.close() returns when the renderer Page is gone, but the main-process
+// BrowserWindow 'closed' event (which nulls mainWindow) fires a tick later.
+// Without this poll, showOrCreateWindow can race and hit the `.show()` branch
+// on a half-destroyed window — no new BrowserWindow is created, so the
+// 'window' event we arm below never fires and the test stalls until timeout.
+async function closeAndAwaitDestroy(page: import('@playwright/test').Page, app: import('@playwright/test').ElectronApplication) {
+  await page.close()
+  await app.evaluate(({ BrowserWindow }) => new Promise<void>((resolve) => {
+    const tick = () => BrowserWindow.getAllWindows().length === 0 ? resolve() : setTimeout(tick, 25)
+    tick()
+  }))
+}
+
+async function activateAndAwaitNewWindow(app: import('@playwright/test').ElectronApplication) {
+  const newWindow = app.waitForEvent('window')
+  await app.evaluate(({ app: a }) => a.emit('activate'))
+  const page = await newWindow
+  await page.waitForLoadState('domcontentloaded')
+  return page
+}


### PR DESCRIPTION
## What

`e2e/window-lifecycle.spec.ts › window recovers after close → activate cycle` flakes on the 1-core ubuntu CI runner. The first attempt hits the 30s test timeout; the retry passes in ~1s. Playwright reports the spec as flaky and the job exits 1.

Example: PR #281 run https://github.com/spool-lab/spool/actions/runs/26219764728/job/77151448206 (`1 flaky, 125 passed`).

## Why

The test does `firstWindow.close()` → `app.emit('activate')` → `app.firstWindow()`. `ElectronApplication.firstWindow()` is racy across a close/recreate cycle:

- It can return the **just-closed Page**, so subsequent locator assertions run against a dead context and hit the 5s `toBeVisible` timeout (then the loop continues into the second cycle and runs the clock out to 30s).
- It can **block** until the test timeout because Playwright hasn't yet registered the recreated window.

Both modes were observed in the failure trace.

## Fix

Arm `app.waitForEvent('window')` **before** `close()` + `emit('activate')`, then await the resolved Page. Add `waitForLoadState('domcontentloaded')` before the locator check, and bump the visibility timeout from 5s → 10s for renderer cold-start headroom on the 1-core runner.

No change to what the test asserts. The same `data-testid="library-landing"` check still validates the second recreated window comes up clean.

## Test plan

- [ ] CI passes on this branch
- [ ] Spec runs locally ≥10× without flake on Linux container (or 2-worker ubuntu runner)