### PR TITLE
fix(security): drop persistent ⚠️ badge from sidebar Security row

### DIFF
--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -62,9 +62,6 @@ export default function App() {
   const [results, setResults] = useState<SearchResult[]>([])
   const [previewSuggestions, setPreviewSuggestions] = useState<SearchResult[]>([])
   const [selectedSession, setSelectedSession] = useState<string | null>(null)
-  // Cached total of active high-severity findings across the archive.
-  // Drives the trailing badge on the Sidebar's Security row.
-  const [securityHighCount, setSecurityHighCount] = useState(0)
   const [targetMessageId, setTargetMessageId] = useState<number | null>(null)
   const [view, setView] = useState<View>('search')
   const [homeMode, setHomeMode] = useState(true)
@@ -345,42 +342,6 @@ export default function App() {
       .finally(() => {
         themeHydrated.current = true
       })
-  }, [])
-
-  // Keep the sidebar Security badge synced with the worker. Computes a
-  // simple total of active high-severity findings from riskByCategory
-  // and re-runs on every findings-change event the IPC fires.
-  useEffect(() => {
-    let active = true
-    let off: (() => void) | null = null
-    const HIGH = new Set([
-      'private-key', 'ssh-key', 'cloud-cred-ini', 'kubeconfig-token', 'netrc',
-      'connection-string', 'url-creds', 'api-key', 'jwt', 'bearer',
-      'basic-auth', 'env-var', 'generic-secret',
-    ])
-    const recompute = async () => {
-      try {
-        const mod = await import('./api/security.js')
-        const rows = await mod.securityApi.riskByCategory()
-        if (!active) return
-        const total = rows.reduce(
-          (acc, r) => acc + (HIGH.has(r.kind) ? r.count : 0),
-          0,
-        )
-        setSecurityHighCount(total)
-      } catch {
-        if (active) setSecurityHighCount(0)
-      }
-    }
-    void recompute()
-    void import('./api/security.js').then((mod) => {
-      if (!active) return
-      off = mod.securityApi.onChange(() => { void recompute() })
-    }).catch(() => {})
-    return () => {
-      active = false
-      if (off) off()
-    }
   }, [])
 
   useEffect(() => {
@@ -824,7 +785,6 @@ export default function App() {
         setQuery('')
       }}
       isSecurityActive={isSecurityView}
-      securityHighCount={securityHighCount}
       onOpenSearch={handleSearchOpen}
       syncStatus={syncStatus}
       status={status}

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
 import type { ProjectGroup, Session, SessionSource, StatusInfo } from '@spool-lab/core'
-import { Layers3 as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, ShieldAlert as SecurityIcon, AlertTriangle, SquareTerminal, MoreHorizontal, Copy, Loader2, SquarePen, PanelLeft } from 'lucide-react'
+import { Layers3 as LibraryIcon, Search as SearchIcon, Settings as SettingsIcon, Newspaper as SharesIcon, ShieldAlert as SecurityIcon, SquareTerminal, MoreHorizontal, Copy, Loader2, SquarePen, PanelLeft } from 'lucide-react'
 import { securityFeatureEnabled } from '../featureFlags.js'
 import { useTranslation } from 'react-i18next'
 import PinIcon from './PinIcon.js'
@@ -29,10 +29,6 @@ type Props = {
   isSharesActive?: boolean
   onSelectSecurity?: () => void
   isSecurityActive?: boolean
-  /** Total active high-severity findings across all sessions. When > 0
-   *  the Security row gets a small AlertTriangle + count trailing badge
-   *  so the user can see there's work to do without opening the page. */
-  securityHighCount?: number
   onOpenSearch?: () => void
   syncStatus?: { phase: string; count: number; total: number } | null
   status?: StatusInfo | null
@@ -52,7 +48,7 @@ type Props = {
   chromeOnly?: boolean
 }
 
-export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, onSelectProject, onSelectSession, onSelectHome, isLibraryActive = false, onSelectShares, isSharesActive = false, onSelectSecurity, isSecurityActive = false, securityHighCount = 0, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true, sortOrder = DEFAULT_SIDEBAR_SORT_ORDER, onSortOrderChange, pinnedSortOrder = DEFAULT_PINNED_SORT_ORDER, onPinnedSortOrderChange, onCopySessionId, onShareSession, sidebarToggle, chromeOnly = false }: Props) {
+export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, onSelectProject, onSelectSession, onSelectHome, isLibraryActive = false, onSelectShares, isSharesActive = false, onSelectSecurity, isSecurityActive = false, onOpenSearch, syncStatus, status, onSettingsClick, showSourceDots = true, showSessionCount = true, sortOrder = DEFAULT_SIDEBAR_SORT_ORDER, onSortOrderChange, pinnedSortOrder = DEFAULT_PINNED_SORT_ORDER, onPinnedSortOrderChange, onCopySessionId, onShareSession, sidebarToggle, chromeOnly = false }: Props) {
   const { t } = useTranslation()
   const sidebarSortLabel = (value: SidebarSortOrder): string => {
     switch (value) {
@@ -166,20 +162,6 @@ export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, o
             label={t('sidebar.security')}
             active={isSecurityActive}
             onClick={onSelectSecurity}
-            {...(securityHighCount > 0
-              ? {
-                  trailing: (
-                    <span
-                      data-testid="sidebar-security-badge"
-                      className="inline-flex items-center text-accent dark:text-accent-dark"
-                      title={t('sidebar.security_badge', { count: securityHighCount, defaultValue: '{{count}} high-risk finding' })}
-                      aria-label={t('sidebar.security_badge', { count: securityHighCount, defaultValue: '{{count}} high-risk finding' })}
-                    >
-                      <AlertTriangle size={11} strokeWidth={1.6} aria-hidden />
-                    </span>
-                  ),
-                }
-              : {})}
           />
         )}
         {onOpenSearch && (

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -63,9 +63,7 @@
     "noPinned": "Noch keine angehefteten Sitzungen",
     "noProjects": "Noch keine Projekte",
     "sessionCount_one": "{{count}} Sitzung",
-    "sessionCount_other": "{{count}} Sitzungen",
-    "security_badge_one": "{{count}} Hochrisiko-Fund",
-    "security_badge_other": "{{count}} Hochrisiko-Funde"
+    "sessionCount_other": "{{count}} Sitzungen"
   },
   "search": {
     "placeholder_home": "Sitzungen durchsuchen…",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -63,9 +63,7 @@
     "noPinned": "No pinned sessions yet",
     "noProjects": "No projects yet",
     "sessionCount_one": "{{count}} session",
-    "sessionCount_other": "{{count}} sessions",
-    "security_badge_one": "{{count}} high-risk finding",
-    "security_badge_other": "{{count}} high-risk findings"
+    "sessionCount_other": "{{count}} sessions"
   },
   "search": {
     "placeholder_home": "Search your sessions…",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -63,9 +63,7 @@
     "noPinned": "Aucune session épinglée pour l'instant",
     "noProjects": "Aucun projet pour l'instant",
     "sessionCount_one": "{{count}} session",
-    "sessionCount_other": "{{count}} sessions",
-    "security_badge_one": "{{count}} découverte à haut risque",
-    "security_badge_other": "{{count}} découvertes à haut risque"
+    "sessionCount_other": "{{count}} sessions"
   },
   "search": {
     "placeholder_home": "Rechercher dans vos sessions…",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -62,8 +62,7 @@
     "sort_recent_used": "最近使用した順",
     "noPinned": "ピン留めしたセッションはまだありません",
     "noProjects": "プロジェクトはまだありません",
-    "sessionCount_other": "{{count}} セッション",
-    "security_badge_other": "高リスクの検出が {{count}} 件"
+    "sessionCount_other": "{{count}} セッション"
   },
   "search": {
     "placeholder_home": "セッションを検索…",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -62,8 +62,7 @@
     "sort_recent_used": "최근 사용순",
     "noPinned": "아직 고정된 세션이 없습니다",
     "noProjects": "아직 프로젝트가 없습니다",
-    "sessionCount_other": "{{count}}개 세션",
-    "security_badge_other": "높은 위험 발견 {{count}}건"
+    "sessionCount_other": "{{count}}개 세션"
   },
   "search": {
     "placeholder_home": "세션 검색…",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -62,8 +62,7 @@
     "sort_recent_used": "最近使用",
     "noPinned": "还没有置顶的会话",
     "noProjects": "还没有项目",
-    "sessionCount_other": "{{count}} 个会话",
-    "security_badge_other": "{{count}} 条高风险发现"
+    "sessionCount_other": "{{count}} 个会话"
   },
   "search": {
     "placeholder_home": "搜索你的会话…",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -62,8 +62,7 @@
     "sort_recent_used": "最近使用",
     "noPinned": "尚未釘選任何會話",
     "noProjects": "尚未有專案",
-    "sessionCount_other": "{{count}} 個會話",
-    "security_badge_other": "{{count}} 條高風險發現"
+    "sessionCount_other": "{{count}} 個會話"
   },
   "search": {
     "placeholder_home": "搜尋你的會話…",


### PR DESCRIPTION
## Summary

Delete the AlertTriangle badge that the Sidebar's Security row carried whenever active high-tier findings count was > 0. After watching it in real use, it's wallpaper, not signal.

## Why it doesn't earn its space

| Problem | Effect |
|---|---|
| No **freshness** | A finding from yesterday looks identical to one from a year ago — the icon can't say "something new happened" |
| No **magnitude** | 1 vs 100 same icon — no priority signal |
| Doesn't clear on visit | Unlike unread mail / GitHub's transient red dot — the icon stays until each finding is explicitly dismissed |
| **Saturation** | Any real-world DB has ≥1 high-tier hit forever → the badge becomes ambient noise (macOS-Mail "365 unread" pattern) |
| Screen-share antipattern | Silently advertises "this user has credential leaks" in pair programming |
| **Redundant** | SecurityPage meta row, ScanBanner, DetectorsChip, and the new-finding toast already carry every signal that matters — sidebar icon was weakest of the four |

The toast (per the existing three-tier feedback in `project_security_scan_feature`) handles "new since last scan" — that's the freshness signal that actually drives action. The badge could only catch cases where the user saw the toast and ignored it; persistent warning doesn't change that behaviour.

## Changes

- `Sidebar.tsx`: drop the `securityHighCount` prop, the trailing AlertTriangle block, the now-unused lucide import
- `App.tsx`: drop the `useState` + `useEffect` that wired `riskByCategory()` + `onChange` into the badge counter, drop the prop pass to `<Sidebar>`
- i18n: drop `sidebar.security_badge` plural entries from all 7 locales (en / zh-CN / zh-TW / ja / ko / de / fr)

Net: -77 lines / +9 lines.

## Test plan

- [x] `pnpm --filter @spool/app exec tsc --noEmit` clean
- [x] `pnpm --filter @spool/app test` → 229/229
- [x] grep confirms no remaining `sidebar-security-badge` selector / `securityHighCount` ref / `security_badge` i18n key
- [x] Sidebar Security row still navigates to the page (other props untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)