### PR TITLE
feat(security): hidden inference window skeleton for Privacy Filter ML

### DIFF
--- a/packages/app/electron.vite.config.ts
+++ b/packages/app/electron.vite.config.ts
@@ -44,7 +44,13 @@ export default defineConfig({
     plugins: [externalizeDepsPlugin({ exclude: ['@spool-lab/core', '@spool-lab/redact'] })],
     build: {
       rollupOptions: {
-        input: { index: resolve(__dirname, 'src/preload/index.ts') },
+        input: {
+          index: resolve(__dirname, 'src/preload/index.ts'),
+          // Hidden Privacy Filter inference window has its own preload —
+          // exposes a narrow `pfBridge` (no Spool app surface) so the
+          // inference renderer can't reach the main app's IPC channels.
+          inference: resolve(__dirname, 'src/preload/inference.ts'),
+        },
       },
     },
     resolve: { alias: coreAlias },
@@ -53,7 +59,14 @@ export default defineConfig({
     root: resolve(__dirname, 'src/renderer'),
     build: {
       rollupOptions: {
-        input: { index: resolve(__dirname, 'src/renderer/index.html') },
+        input: {
+          index: resolve(__dirname, 'src/renderer/index.html'),
+          // Inference window lives under src/inference/ but emits next
+          // to the main renderer so model-host.ts can `loadFile` it
+          // with a fixed relative path. electron-vite will produce
+          // out/renderer/pf-inference.html alongside index.html.
+          'pf-inference': resolve(__dirname, 'src/inference/pf-inference.html'),
+        },
       },
     },
     resolve: { alias: coreAlias },

--- a/packages/app/src/inference/pf-inference.html
+++ b/packages/app/src/inference/pf-inference.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Spool · PF inference</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'" />
+  </head>
+  <body>
+    <!-- Hidden window. Body intentionally empty — runtime detection
+         and (in future PRs) ONNX inference happen entirely in JS. -->
+    <script type="module" src="./pf-inference.ts"></script>
+  </body>
+</html>

--- a/packages/app/src/inference/pf-inference.ts
+++ b/packages/app/src/inference/pf-inference.ts
@@ -1,0 +1,44 @@
+// Hidden inference renderer entry. Loads in a BrowserWindow created by
+// `model-host.ts`, performs the WebGPU/WASM runtime probe, and hands
+// the result back to main via the `pf:ready` IPC channel.
+//
+// PR 5a scope: handshake only. transformers.js + ONNX model loading
+// lands in PR 5c.
+
+import { detectRuntime } from './runtime-detect.js'
+import type { PfReadyMessage, PfFailedMessage } from './types.js'
+
+declare global {
+  interface Window {
+    /** Provided by `inference-preload.ts` (exposed via contextBridge). */
+    pfBridge?: {
+      ready: (payload: PfReadyMessage) => void
+      failed: (payload: PfFailedMessage) => void
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const bridge = window.pfBridge
+  if (!bridge) {
+    // No preload means contextBridge isn't wired. We can't reach main
+    // without IPC; surface to devtools for engineers running with
+    // `openDevTools()`.
+    console.error('[pf-inference] pfBridge missing — preload not wired')
+    return
+  }
+  const t0 = performance.now()
+  try {
+    const res = await detectRuntime()
+    const detectionMs = Math.round(performance.now() - t0)
+    bridge.ready({
+      runtime: res.runtime,
+      detectionMs,
+      ...(res.adapterLabel !== undefined ? { adapterLabel: res.adapterLabel } : {}),
+    })
+  } catch (err) {
+    bridge.failed({ message: err instanceof Error ? err.message : String(err) })
+  }
+}
+
+void main()

--- a/packages/app/src/inference/runtime-detect.test.ts
+++ b/packages/app/src/inference/runtime-detect.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest'
+import { detectRuntime } from './runtime-detect.js'
+
+const fakeGpu = (adapter: unknown) =>
+  ({ requestAdapter: () => Promise.resolve(adapter as never) }) as const
+
+describe('detectRuntime', () => {
+  it('falls back to wasm when navigator.gpu is missing', async () => {
+    const res = await detectRuntime({ gpu: null })
+    expect(res.runtime).toBe('wasm')
+  })
+
+  it('returns webgpu when an adapter is granted', async () => {
+    const res = await detectRuntime({ gpu: fakeGpu({ info: { description: 'Apple M2' } }) })
+    expect(res.runtime).toBe('webgpu')
+    expect(res.adapterLabel).toBe('Apple M2')
+  })
+
+  it('falls back to wasm when the adapter request resolves to null', async () => {
+    const res = await detectRuntime({ gpu: fakeGpu(null) })
+    expect(res.runtime).toBe('wasm')
+  })
+
+  it('falls back to wasm when requestAdapter throws', async () => {
+    const gpu = { requestAdapter: () => Promise.reject(new Error('boom')) }
+    const res = await detectRuntime({ gpu })
+    expect(res.runtime).toBe('wasm')
+  })
+
+  it('falls back to wasm when the adapter request times out', async () => {
+    vi.useFakeTimers()
+    const gpu = { requestAdapter: () => new Promise<never>(() => { /* never */ }) }
+    const p = detectRuntime({ gpu, timeoutMs: 50 })
+    await vi.advanceTimersByTimeAsync(60)
+    const res = await p
+    expect(res.runtime).toBe('wasm')
+    vi.useRealTimers()
+  })
+})

--- a/packages/app/src/inference/runtime-detect.ts
+++ b/packages/app/src/inference/runtime-detect.ts
@@ -1,0 +1,64 @@
+// WebGPU / WASM runtime detection for the hidden inference renderer.
+//
+// Feature-detecting `navigator.gpu` isn't enough — some Chromium builds
+// expose the API but `requestAdapter()` still returns null (e.g. headless
+// without ANGLE), so we have to attempt the call. The 2 s timeout exists
+// because on macOS the adapter request usually returns in tens of ms;
+// anything longer means the call is wedged and we'd rather fall back to
+// WASM than block the inference window's boot indefinitely.
+
+import type { PfRuntime } from './types.js'
+
+interface GpuAdapter {
+  info?: { description?: string; vendor?: string; device?: string }
+}
+interface GpuLike {
+  requestAdapter(): Promise<GpuAdapter | null>
+}
+
+export interface DetectResult {
+  runtime: PfRuntime
+  adapterLabel?: string
+}
+
+export interface DetectOptions {
+  timeoutMs?: number
+  /** Injected for tests. Default reads `navigator.gpu`. */
+  gpu?: GpuLike | null
+}
+
+function defaultGpu(): GpuLike | null {
+  if (typeof navigator === 'undefined') return null
+  return (navigator as Navigator & { gpu?: GpuLike }).gpu ?? null
+}
+
+export async function detectRuntime(opts: DetectOptions = {}): Promise<DetectResult> {
+  const timeoutMs = opts.timeoutMs ?? 2_000
+  const gpu = opts.gpu ?? defaultGpu()
+  if (!gpu) return { runtime: 'wasm' }
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeoutP = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), timeoutMs)
+  })
+
+  try {
+    const adapter = await Promise.race([gpu.requestAdapter(), timeoutP])
+    if (!adapter) return { runtime: 'wasm' }
+    const label = adapterLabelOf(adapter)
+    return label ? { runtime: 'webgpu', adapterLabel: label } : { runtime: 'webgpu' }
+  } catch {
+    return { runtime: 'wasm' }
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
+function adapterLabelOf(adapter: GpuAdapter): string | undefined {
+  // `info` is sync on recent Chromium, behind `requestAdapterInfo()` on
+  // older builds. We don't await the async path — the label is decorative.
+  const info = adapter.info
+  if (!info) return undefined
+  const desc = info.description ?? info.vendor ?? info.device
+  return typeof desc === 'string' && desc.length > 0 ? desc : undefined
+}

--- a/packages/app/src/inference/types.ts
+++ b/packages/app/src/inference/types.ts
@@ -1,0 +1,19 @@
+// IPC payload shapes shared between main and the hidden `pf-inference`
+// renderer. The inference preload is a separate bundle and can't share
+// runtime values with main, so the channel names live here as literal
+// constants and both sides import the same module for type-checking.
+
+export type PfRuntime = 'webgpu' | 'wasm'
+
+export interface PfReadyMessage {
+  runtime: PfRuntime
+  adapterLabel?: string
+  detectionMs: number
+}
+
+export type PfFailedMessage = { message: string }
+
+export const PF_IPC = {
+  READY: 'pf:ready',
+  FAILED: 'pf:failed',
+} as const

--- a/packages/app/src/main/ipc/security.ts
+++ b/packages/app/src/main/ipc/security.ts
@@ -39,6 +39,7 @@ import {
   saveSecurityPreferences,
   type SecurityPreferences,
 } from '../securityPreferences.js'
+import type { PfCoordinator } from '../security/pf-coordinator.js'
 
 /** Channel name table. Shared via type only with the renderer adapter
  *  (no runtime import — preload uses the strings literally). */
@@ -74,10 +75,16 @@ export const SECURITY_IPC_CHANNELS = {
   LIST_BACKUPS:                'security:list-backups',
   DELETE_BACKUPS:              'security:delete-backups',
 
+  // Privacy Filter ML download lifecycle
+  PF_GET_STATE:                'security:pf-get-state',
+  PF_DOWNLOAD_START:           'security:pf-download-start',
+  PF_DOWNLOAD_CANCEL:          'security:pf-download-cancel',
+
   // events (push: main → renderer via webContents.send)
   EVT_FINDINGS_CHANGED:        'security:evt-findings-changed',
   EVT_SCAN_STATUS:             'security:evt-scan-status',
   EVT_PREFS_CHANGED:           'security:evt-prefs-changed',
+  EVT_PF_STATE:                'security:evt-pf-state',
 } as const
 
 export interface SecurityIpcDeps {
@@ -88,13 +95,17 @@ export interface SecurityIpcDeps {
   runPromise: <A, E>(eff: Effect.Effect<A, E>) => Promise<A>
   /** Subscribe to per-window pushes; called once per main window. */
   getMainWindow: () => BrowserWindow | null
+  /** Privacy Filter download orchestrator. Optional in 5b — null means
+   *  the PF channels return a default not-installed snapshot. PR 5c
+   *  swaps in a real coordinator when the toggle flips on. */
+  pfCoordinator?: PfCoordinator | null
 }
 
 /** Register every Security Scan ipcMain.handle and start a background
  *  fiber that forwards worker change events to the main window. The
  *  returned disposer interrupts the forwarding fiber. */
 export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
-  const { db, worker, runPromise, getMainWindow } = deps
+  const { db, worker, runPromise, getMainWindow, pfCoordinator } = deps
 
   ipcMain.handle(SECURITY_IPC_CHANNELS.LIST_FINDINGS, (_e, filter: FindingFilter) =>
     listFindings(db, filter),
@@ -197,6 +208,25 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
     (_e, args: { names: string[] }): DeleteBackupsResult => deleteBackups(db, args.names),
   )
 
+  // Privacy Filter ML. When pfCoordinator is null (5b production), the
+  // channels return a static not-installed snapshot so the renderer
+  // renders its Download affordance instead of crashing.
+  ipcMain.handle(SECURITY_IPC_CHANNELS.PF_GET_STATE, () =>
+    pfCoordinator?.getState() ?? { phase: 'not-installed', bytesDownloaded: 0, bytesTotal: 0 },
+  )
+  ipcMain.handle(SECURITY_IPC_CHANNELS.PF_DOWNLOAD_START, async () => {
+    if (!pfCoordinator) return { ok: false, reason: 'unavailable' as const }
+    await pfCoordinator.startDownload()
+    return { ok: true as const }
+  })
+  ipcMain.handle(SECURITY_IPC_CHANNELS.PF_DOWNLOAD_CANCEL, () => {
+    pfCoordinator?.cancelDownload()
+    return { ok: true as const }
+  })
+  const unsubscribePf = pfCoordinator?.subscribe((s) => {
+    getMainWindow()?.webContents.send(SECURITY_IPC_CHANNELS.EVT_PF_STATE, s)
+  })
+
   ipcMain.handle(SECURITY_IPC_CHANNELS.LIST_ALLOWLIST_ENTRIES, () => listAllowlistEntries(db))
   ipcMain.handle(
     SECURITY_IPC_CHANNELS.REMOVE_ALLOWLIST_ENTRY,
@@ -279,6 +309,7 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
     if (statusForwarderFiber) {
       Effect.runFork(Fiber.interrupt(statusForwarderFiber))
     }
+    unsubscribePf?.()
     for (const ch of Object.values(SECURITY_IPC_CHANNELS)) {
       ipcMain.removeHandler(ch)
     }

--- a/packages/app/src/main/security/model-download.test.ts
+++ b/packages/app/src/main/security/model-download.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createHash } from 'node:crypto'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { downloadModel, DownloadError } from './model-download.js'
+import type { ModelManifest } from './model-manifest.js'
+
+const sha256 = (buf: Buffer) => createHash('sha256').update(buf).digest('hex')
+
+function makeManifest(files: { path: string; body: Buffer }[]): ModelManifest {
+  return {
+    hfRepo: 'spool-lab/test-model',
+    hfCommit: 'a'.repeat(40),
+    files: files.map(({ path, body }) => ({
+      path,
+      sha256: sha256(body),
+      sizeBytes: body.length,
+    })),
+  }
+}
+
+function makeFetch(responses: Record<string, { body: Buffer; status?: number }>): typeof globalThis.fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const r = responses[url]
+    if (!r) throw new Error(`unexpected fetch: ${url}`)
+    const range = (init?.headers as Record<string, string> | undefined)?.['Range']
+    if (range) {
+      const m = /bytes=(\d+)-/.exec(range)
+      const start = m ? Number.parseInt(m[1]!, 10) : 0
+      const slice = r.body.subarray(start)
+      return new Response(slice, { status: 206 })
+    }
+    return new Response(r.body, { status: r.status ?? 200 })
+  }) as typeof globalThis.fetch
+}
+
+let tmp: string
+beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'spool-pf-dl-')) })
+afterEach(() => { rmSync(tmp, { recursive: true, force: true }) })
+
+describe('downloadModel', () => {
+  it('downloads every manifest file, verifying SHA-256', async () => {
+    const a = Buffer.from('aaaaaaaa')
+    const b = Buffer.from('bbbbbbbbbb')
+    const manifest = makeManifest([{ path: 'a.bin', body: a }, { path: 'b.bin', body: b }])
+    const fetchFn = makeFetch({
+      [`https://huggingface.co/${manifest.hfRepo}/resolve/${manifest.hfCommit}/a.bin`]: { body: a },
+      [`https://huggingface.co/${manifest.hfRepo}/resolve/${manifest.hfCommit}/b.bin`]: { body: b },
+    })
+    const progress: number[] = []
+    await downloadModel({
+      modelDir: tmp, manifest, fetch: fetchFn,
+      onProgress: (p) => progress.push(p.bytesDownloaded),
+    })
+    expect(readFileSync(join(tmp, 'a.bin'))).toEqual(a)
+    expect(readFileSync(join(tmp, 'b.bin'))).toEqual(b)
+    expect(progress.at(-1)).toBe(a.length + b.length)
+  })
+
+  it('skips a file that already matches on disk', async () => {
+    const body = Buffer.from('already-here')
+    const manifest = makeManifest([{ path: 'cached.bin', body }])
+    writeFileSync(join(tmp, 'cached.bin'), body)
+    const fetchFn = vi.fn() as unknown as typeof globalThis.fetch
+    await downloadModel({ modelDir: tmp, manifest, fetch: fetchFn })
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('resumes from a partial .part using Range requests', async () => {
+    const body = Buffer.from('0123456789ABCDEF')
+    const manifest = makeManifest([{ path: 'big.bin', body }])
+    writeFileSync(join(tmp, 'big.bin.part'), body.subarray(0, 6))  // 6 of 16 bytes already fetched
+    const url = `https://huggingface.co/${manifest.hfRepo}/resolve/${manifest.hfCommit}/big.bin`
+    const rangeRequests: (string | undefined)[] = []
+    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const u = typeof input === 'string' ? input : input.toString()
+      expect(u).toBe(url)
+      const range = (init?.headers as Record<string, string> | undefined)?.['Range']
+      rangeRequests.push(range)
+      const m = range && /bytes=(\d+)-/.exec(range)
+      const start = m ? Number.parseInt(m[1]!, 10) : 0
+      return new Response(body.subarray(start), { status: 206 })
+    }) as typeof globalThis.fetch
+    await downloadModel({ modelDir: tmp, manifest, fetch: fetchFn })
+    expect(readFileSync(join(tmp, 'big.bin'))).toEqual(body)
+    expect(rangeRequests).toEqual(['bytes=6-'])
+  })
+
+  it('throws DownloadError when the SHA-256 disagrees with the manifest', async () => {
+    const declared = Buffer.from('expected')
+    const served = Buffer.from('tampered')
+    const manifest: ModelManifest = {
+      hfRepo: 'r', hfCommit: 'c'.repeat(40),
+      files: [{ path: 'x.bin', sha256: sha256(declared), sizeBytes: declared.length }],
+    }
+    const url = `https://huggingface.co/r/resolve/${'c'.repeat(40)}/x.bin`
+    const fetchFn = makeFetch({ [url]: { body: served } })
+    await expect(downloadModel({ modelDir: tmp, manifest, fetch: fetchFn }))
+      .rejects.toBeInstanceOf(DownloadError)
+  })
+
+  it('throws DownloadError on a non-2xx response', async () => {
+    const manifest = makeManifest([{ path: 'x.bin', body: Buffer.from('x') }])
+    const fetchFn = (async () => new Response('not found', { status: 404 })) as typeof globalThis.fetch
+    await expect(downloadModel({ modelDir: tmp, manifest, fetch: fetchFn }))
+      .rejects.toBeInstanceOf(DownloadError)
+  })
+
+  it('cancels mid-stream when the AbortSignal fires', async () => {
+    const body = Buffer.from('x'.repeat(64))
+    const manifest = makeManifest([{ path: 'x.bin', body }])
+    const controller = new AbortController()
+    const fetchFn = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      // Trigger abort before the body is consumed.
+      setTimeout(() => controller.abort(), 0)
+      const sig = init?.signal
+      if (sig?.aborted) throw new DOMException('aborted', 'AbortError')
+      return new Promise<Response>((_resolve, reject) => {
+        sig?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')))
+      })
+    }) as typeof globalThis.fetch
+    await expect(downloadModel({
+      modelDir: tmp, manifest, fetch: fetchFn, signal: controller.signal,
+    })).rejects.toBeTruthy()
+    // No final renamed file should appear.
+    expect(existsSync(join(tmp, 'x.bin'))).toBe(false)
+  })
+
+  it('discards a corrupt resume that is larger than expected', async () => {
+    const body = Buffer.from('abcd')
+    const manifest = makeManifest([{ path: 'x.bin', body }])
+    writeFileSync(join(tmp, 'x.bin.part'), Buffer.from('zzzzzzzzzzzzz'))  // larger than expectedSize
+    const url = `https://huggingface.co/${manifest.hfRepo}/resolve/${manifest.hfCommit}/x.bin`
+    const fetchFn = makeFetch({ [url]: { body } })
+    await downloadModel({ modelDir: tmp, manifest, fetch: fetchFn })
+    expect(readFileSync(join(tmp, 'x.bin'))).toEqual(body)
+  })
+})

--- a/packages/app/src/main/security/model-download.ts
+++ b/packages/app/src/main/security/model-download.ts
@@ -1,0 +1,147 @@
+// Privacy Filter model downloader. Streams each manifest file into
+// the user's model directory, writing to `<name>.part` and renaming
+// only once the full SHA-256 matches. Resumable via HTTP Range. fetch
+// is injectable so tests don't touch the network.
+
+import { createHash } from 'node:crypto'
+import { createWriteStream, statSync, renameSync, existsSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import type { ManifestFile, ModelManifest } from './model-manifest.js'
+import { manifestFileUrl, manifestTotalBytes } from './model-manifest.js'
+
+export interface DownloadProgress {
+  bytesDownloaded: number
+  bytesTotal: number
+  currentFile: string
+  fileIndex: number
+}
+
+export interface DownloadOptions {
+  modelDir: string
+  manifest: ModelManifest
+  fetch?: typeof globalThis.fetch
+  signal?: AbortSignal
+  onProgress?: (p: DownloadProgress) => void
+}
+
+export interface DownloadErrorCause {
+  file: string
+  stage: 'http' | 'hash' | 'io'
+}
+
+export class DownloadError extends Error {
+  readonly downloadCause: DownloadErrorCause | undefined
+  constructor(message: string, downloadCause?: DownloadErrorCause) {
+    super(message)
+    this.name = 'DownloadError'
+    this.downloadCause = downloadCause
+  }
+}
+
+export async function downloadModel(opts: DownloadOptions): Promise<void> {
+  const fetcher = opts.fetch ?? globalThis.fetch
+  const bytesTotal = manifestTotalBytes(opts.manifest)
+  let bytesDownloaded = 0
+
+  mkdirSync(opts.modelDir, { recursive: true })
+
+  for (let i = 0; i < opts.manifest.files.length; i++) {
+    const file = opts.manifest.files[i]!
+    const finalPath = join(opts.modelDir, file.path)
+    const partPath = `${finalPath}.part`
+    mkdirSync(dirname(finalPath), { recursive: true })
+
+    if (existsSync(finalPath) && fileMatches(finalPath, file)) {
+      bytesDownloaded += file.sizeBytes
+      opts.onProgress?.({ bytesDownloaded, bytesTotal, currentFile: file.path, fileIndex: i })
+      continue
+    }
+
+    let startOffset = existsSync(partPath) ? statSync(partPath).size : 0
+    if (startOffset > file.sizeBytes) {
+      // Corrupt resume — start over.
+      unlinkSync(partPath)
+      startOffset = 0
+    }
+    bytesDownloaded += startOffset
+
+    await fetchAndAppend({
+      url: manifestFileUrl(opts.manifest, file),
+      partPath,
+      startOffset,
+      expectedSize: file.sizeBytes,
+      fetcher,
+      ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+      onChunk: (n) => {
+        bytesDownloaded += n
+        opts.onProgress?.({ bytesDownloaded, bytesTotal, currentFile: file.path, fileIndex: i })
+      },
+    })
+
+    if (!fileMatches(partPath, file)) {
+      throw new DownloadError(
+        `SHA-256 mismatch for ${file.path}`,
+        { file: file.path, stage: 'hash' },
+      )
+    }
+
+    renameSync(partPath, finalPath)
+  }
+}
+
+async function fetchAndAppend(args: {
+  url: string
+  partPath: string
+  startOffset: number
+  expectedSize: number
+  fetcher: typeof globalThis.fetch
+  signal?: AbortSignal
+  onChunk: (bytes: number) => void
+}): Promise<void> {
+  if (args.startOffset >= args.expectedSize) return
+
+  const headers: Record<string, string> = {}
+  if (args.startOffset > 0) headers.Range = `bytes=${args.startOffset}-`
+
+  const init: RequestInit = { headers }
+  if (args.signal !== undefined) init.signal = args.signal
+  const res = await args.fetcher(args.url, init)
+
+  if (args.startOffset > 0 && res.status !== 206 && res.status !== 200) {
+    throw new DownloadError(
+      `Unexpected resume status ${res.status} for ${args.url}`,
+      { file: args.partPath, stage: 'http' },
+    )
+  }
+  if (args.startOffset === 0 && !res.ok) {
+    throw new DownloadError(
+      `HTTP ${res.status} for ${args.url}`,
+      { file: args.partPath, stage: 'http' },
+    )
+  }
+  if (!res.body) {
+    throw new DownloadError('Response missing body', { file: args.partPath, stage: 'http' })
+  }
+
+  // Server may have ignored Range and returned a full stream — if so,
+  // start over from offset 0 rather than appending bad bytes.
+  const append = res.status === 206 && args.startOffset > 0
+  const out = createWriteStream(args.partPath, { flags: append ? 'a' : 'w' })
+
+  const nodeStream = Readable.fromWeb(res.body as never)
+  nodeStream.on('data', (chunk: Buffer) => args.onChunk(chunk.length))
+  await pipeline(nodeStream, out)
+}
+
+function fileMatches(path: string, file: ManifestFile): boolean {
+  try {
+    const stat = statSync(path)
+    if (stat.size !== file.sizeBytes) return false
+    const hash = createHash('sha256').update(readFileSync(path)).digest('hex')
+    return hash === file.sha256
+  } catch {
+    return false
+  }
+}

--- a/packages/app/src/main/security/model-host.test.ts
+++ b/packages/app/src/main/security/model-host.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { Effect } from 'effect'
+import type { BrowserWindow, IpcMainEvent } from 'electron'
+import { makeModelHost, type ModelHostDeps } from './model-host.js'
+import { PF_IPC, type PfReadyMessage } from '../../inference/types.js'
+
+type FakeWindow = BrowserWindow & { destroyed: boolean }
+
+/** Minimal stand-ins for the bits of `BrowserWindow` and `ipcMain` the
+ *  ModelHost touches — vitest can't import the real ones because they
+ *  require Electron's main process. */
+function fakeBrowserWindow(id: number): FakeWindow {
+  const w: Partial<FakeWindow> = {
+    destroyed: false,
+    webContents: { id } as BrowserWindow['webContents'],
+    destroy() { (w as FakeWindow).destroyed = true },
+    isDestroyed() { return (w as FakeWindow).destroyed },
+  }
+  return w as FakeWindow
+}
+
+function fakeIpc() {
+  const bus = new EventEmitter()
+  bus.setMaxListeners(50)
+  const ipc = {
+    on: (ch: string, fn: (...args: unknown[]) => void) => { bus.on(ch, fn); return ipc },
+    removeListener: (ch: string, fn: (...args: unknown[]) => void) => { bus.removeListener(ch, fn); return ipc },
+  }
+  return { ipc, bus }
+}
+
+const senderEvent = (id: number) => ({ sender: { id } }) as IpcMainEvent
+
+/** Build deps that spawn a fake window with the given id and immediately
+ *  schedule a ready (or failed) emission from that sender. */
+function depsEmittingReady(id: number, payload: PfReadyMessage): { deps: ModelHostDeps; win: FakeWindow } {
+  const win = fakeBrowserWindow(id)
+  const { ipc, bus } = fakeIpc()
+  const deps: ModelHostDeps = {
+    spawnWindow: async () => {
+      setTimeout(() => bus.emit(PF_IPC.READY, senderEvent(id), payload), 0)
+      return win
+    },
+    ipc,
+  }
+  return { deps, win }
+}
+
+describe('makeModelHost', () => {
+  it('reports ready + runtime once the inference window fires pf:ready', async () => {
+    const { deps } = depsEmittingReady(11, {
+      runtime: 'webgpu', adapterLabel: 'Apple M2 Pro', detectionMs: 42,
+    })
+    const out = await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const host = yield* makeModelHost(deps)
+      return { state: yield* host.getState, isReady: yield* host.ready }
+    })))
+    expect(out.isReady).toBe(true)
+    expect(out.state.status).toBe('ready')
+    expect(out.state.runtime).toBe('webgpu')
+    expect(out.state.adapterLabel).toBe('Apple M2 Pro')
+    expect(out.state.detectionMs).toBe(42)
+  })
+
+  it('destroys the hidden window when the scope closes', async () => {
+    const { deps, win } = depsEmittingReady(12, { runtime: 'wasm', detectionMs: 7 })
+    await Effect.runPromise(Effect.scoped(makeModelHost(deps).pipe(Effect.asVoid)))
+    expect(win.destroyed).toBe(true)
+  })
+
+  it('does not double-destroy if the window is already gone', async () => {
+    const { deps, win } = depsEmittingReady(13, { runtime: 'wasm', detectionMs: 5 })
+    const destroy = vi.spyOn(win, 'destroy')
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      yield* makeModelHost(deps)
+      // Simulate the window getting destroyed mid-scope (e.g. user
+      // explicitly killed it). Release path must NOT throw.
+      win.destroyed = true
+    })))
+    expect(destroy).not.toHaveBeenCalled()
+  })
+
+  it('ignores pf:ready from a different webContents id', async () => {
+    const win = fakeBrowserWindow(20)
+    const { ipc, bus } = fakeIpc()
+    const deps: ModelHostDeps = {
+      spawnWindow: async () => {
+        // Wrong sender id arrives first — should be ignored.
+        setTimeout(() => bus.emit(PF_IPC.READY, senderEvent(99), {
+          runtime: 'webgpu', detectionMs: 1,
+        }), 0)
+        // Real sender follows.
+        setTimeout(() => bus.emit(PF_IPC.READY, senderEvent(20), {
+          runtime: 'wasm', detectionMs: 3,
+        }), 5)
+        return win
+      },
+      ipc,
+      readyTimeoutMs: 200,
+    }
+    const out = await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const host = yield* makeModelHost(deps)
+      return yield* host.getState
+    })))
+    expect(out.runtime).toBe('wasm')
+  })
+
+  it('lands in failed state on handshake timeout, but does not throw', async () => {
+    const win = fakeBrowserWindow(21)
+    const { ipc } = fakeIpc()
+    const deps: ModelHostDeps = {
+      spawnWindow: async () => win,
+      ipc,
+      readyTimeoutMs: 25,
+    }
+    const out = await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const host = yield* makeModelHost(deps)
+      return { state: yield* host.getState, isReady: yield* host.ready }
+    })))
+    expect(out.isReady).toBe(false)
+    expect(out.state.status).toBe('failed')
+    expect(out.state.error).toMatch(/timed out/)
+    expect(win.destroyed).toBe(true)
+  })
+
+  it('lands in failed state when the renderer reports pf:failed', async () => {
+    const win = fakeBrowserWindow(22)
+    const { ipc, bus } = fakeIpc()
+    const deps: ModelHostDeps = {
+      spawnWindow: async () => {
+        setTimeout(() =>
+          bus.emit(PF_IPC.FAILED, senderEvent(22), { message: 'adapter request threw' }),
+          0,
+        )
+        return win
+      },
+      ipc,
+    }
+    const out = await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const host = yield* makeModelHost(deps)
+      return yield* host.getState
+    })))
+    expect(out.status).toBe('failed')
+    expect(out.error).toBe('adapter request threw')
+  })
+
+  it('lands in failed state when spawnWindow rejects', async () => {
+    const { ipc } = fakeIpc()
+    const deps: ModelHostDeps = {
+      spawnWindow: async () => { throw new Error('window creation blew up') },
+      ipc,
+    }
+    const out = await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const host = yield* makeModelHost(deps)
+      return yield* host.getState
+    })))
+    expect(out.status).toBe('failed')
+    expect(out.error).toMatch(/blew up/)
+  })
+
+  it('analyze returns [] in PR 5a — model inference lands in 5c', async () => {
+    const { deps } = depsEmittingReady(23, { runtime: 'wasm', detectionMs: 1 })
+    const out = await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const host = yield* makeModelHost(deps)
+      return yield* host.analyze('contains a@b.c')
+    })))
+    expect(out).toEqual([])
+  })
+})

--- a/packages/app/src/main/security/model-host.ts
+++ b/packages/app/src/main/security/model-host.ts
@@ -1,30 +1,28 @@
-// ModelHost — Effect Scoped Resource that owns the hidden Browser-
-// Window running the Privacy Filter inference renderer.
+// ModelHost — Effect Scoped resource that owns the hidden BrowserWindow
+// running the Privacy Filter inference renderer.
 //
-// WebGPU is a renderer-only API in Chromium, so the main process
-// can't run it directly. The hidden BrowserWindow loads
-// `pf-inference.html`, detects WebGPU (with WASM fallback), and
-// answers IPC requests.
-//
-// This file is intentionally a scaffold: the BrowserWindow + IPC
-// machinery is wired, but the actual `analyze` call returns an
-// empty match list until a follow-up PR ships the real
-// transformers.js + ONNX runtime and the pinned model bundle. The
-// Settings UI surfaces this honestly as "Coming soon".
+// WebGPU is renderer-only in Chromium, so main can't run it directly.
+// The hidden window loads `pf-inference.html`, detects WebGPU (with
+// WASM fallback), and reports back via the `pf:ready` IPC channel.
+// PR 5a covers lifecycle + handshake only; model download lands in 5b
+// and `pf:analyze` in 5c.
 
-import { Effect, Ref, Data } from 'effect'
-import type { BrowserWindow } from 'electron'
+import { Effect, Ref, Data, Scope } from 'effect'
+import { ipcMain, type BrowserWindow, type IpcMainEvent } from 'electron'
+import { PF_IPC, type PfReadyMessage, type PfFailedMessage, type PfRuntime } from '../../inference/types.js'
 
-export type PfRuntime = 'webgpu' | 'wasm' | 'unsupported'
+export type { PfRuntime }
 
 export interface PfState {
-  status: 'idle' | 'loading' | 'ready' | 'failed' | 'not-downloaded'
+  status: 'idle' | 'loading' | 'ready' | 'failed'
   runtime: PfRuntime | null
+  adapterLabel?: string
+  detectionMs?: number
   error?: string
 }
 
 export class ModelHostError extends Data.TaggedError('ModelHostError')<{
-  readonly stage: 'spawn' | 'load' | 'analyze' | 'shutdown'
+  readonly stage: 'spawn' | 'load' | 'handshake' | 'analyze' | 'shutdown'
   readonly cause: unknown
 }> {}
 
@@ -38,44 +36,137 @@ export interface PfMatchResult {
 }
 
 export interface ModelHost {
-  /** True only when the hidden window is up and the model is loaded. */
+  /** True only when the hidden window is up and the handshake succeeded. */
   ready: Effect.Effect<boolean>
   /** Current renderer runtime once the window reports it. */
   getRuntime: Effect.Effect<PfRuntime | null>
   /** Current high-level state for Settings UI consumption. */
   getState: Effect.Effect<PfState>
-  /** Analyse a chunk of text. Returns an empty array when the model
-   *  isn't ready — callers should check `ready` first if they need
-   *  to fail loudly. */
+  /** Analyse a chunk of text. PR 5a stub: returns []. Real impl lands in 5c. */
   analyze: (text: string) => Effect.Effect<PfMatchResult[], ModelHostError>
 }
 
-/** Build a ModelHost as a Scoped service. The scope owns the hidden
- *  BrowserWindow lifecycle: scope-acquired creates it; scope-closed
- *  destroys it, releasing GPU/CPU resources.
- *
- *  STUB: the real implementation creates a hidden BrowserWindow, loads
- *  `pf-inference.html`, waits for a `pf:ready` handshake, and routes
- *  `pf:analyze` IPC. That logic ships in a follow-up — this file
- *  defines the interface and the lifecycle plumbing so the Settings
- *  UI + scan worker can compile against a stable shape today.
- */
-export function makeModelHost(): Effect.Effect<ModelHost, never, never> {
-  return Effect.gen(function* () {
-    const stateRef = yield* Ref.make<PfState>({ status: 'not-downloaded', runtime: null })
-    const windowRef = yield* Ref.make<BrowserWindow | null>(null)
-    void windowRef // reserved for the real implementation
+export interface ModelHostDeps {
+  /** Creates and returns a hidden BrowserWindow already loading
+   *  `pf-inference.html`. The acquire path awaits the ready handshake
+   *  on `event.sender.id` matching `webContents.id`. */
+  spawnWindow: () => Promise<BrowserWindow>
+  /** Timeout for the ready handshake. Default 10 s. */
+  readyTimeoutMs?: number
+  /** Override for tests — defaults to Electron's `ipcMain`. */
+  ipc?: Pick<typeof ipcMain, 'on' | 'removeListener'>
+}
 
-    const host: ModelHost = {
+/** Build a ModelHost as a Scoped resource. Scope-acquired spawns the
+ *  hidden window and waits for `pf:ready`; scope-closed destroys it.
+ *
+ *  The Effect succeeds even when the handshake fails — state goes to
+ *  `failed` and `ready` stays false. Callers check `getState` before
+ *  enabling pf in the UI, so a failed spawn doesn't tear the whole
+ *  app down. */
+export function makeModelHost(
+  deps: ModelHostDeps,
+): Effect.Effect<ModelHost, never, Scope.Scope> {
+  return Effect.gen(function* () {
+    const ipc = deps.ipc ?? ipcMain
+    const readyTimeoutMs = deps.readyTimeoutMs ?? 10_000
+    const stateRef = yield* Ref.make<PfState>({ status: 'loading', runtime: null })
+
+    const failWith = (err: unknown) =>
+      Ref.set(stateRef, {
+        status: 'failed',
+        runtime: null,
+        error: err instanceof ModelHostError ? String(err.cause) : String(err),
+      })
+
+    yield* Effect.acquireRelease(
+      Effect.gen(function* () {
+        const w = yield* Effect.tryPromise({
+          try: () => deps.spawnWindow(),
+          catch: (cause) => new ModelHostError({ stage: 'spawn', cause }),
+        }).pipe(Effect.catchAll((err) => failWith(err).pipe(Effect.as(null))))
+        if (!w) return null
+
+        const handshake = yield* Effect.tryPromise({
+          try: () => awaitReady(ipc, w, readyTimeoutMs),
+          catch: (cause) => new ModelHostError({ stage: 'handshake', cause }),
+        }).pipe(Effect.catchAll((err) => failWith(err).pipe(Effect.as(null))))
+
+        if (handshake?.kind === 'ready') {
+          const s: PfState = {
+            status: 'ready',
+            runtime: handshake.runtime,
+            detectionMs: handshake.detectionMs,
+          }
+          if (handshake.adapterLabel !== undefined) s.adapterLabel = handshake.adapterLabel
+          yield* Ref.set(stateRef, s)
+        } else if (handshake?.kind === 'failed') {
+          yield* Ref.set(stateRef, {
+            status: 'failed',
+            runtime: null,
+            error: handshake.message,
+          })
+        }
+        return w
+      }),
+      (w) =>
+        Effect.sync(() => {
+          if (w && !w.isDestroyed()) w.destroy()
+        }),
+    )
+
+    return {
       ready: Ref.get(stateRef).pipe(Effect.map((s) => s.status === 'ready')),
       getRuntime: Ref.get(stateRef).pipe(Effect.map((s) => s.runtime)),
       getState: Ref.get(stateRef),
-      analyze: (_text: string) =>
-        // Stub: until the inference window ships, return an empty
-        // match list. The scan worker still runs the regex provider;
-        // PF acts as additive signal once the bundle is installed.
-        Effect.succeed<PfMatchResult[]>([]),
+      // PR 5a stub. Real impl lands in PR 5c once `pf:analyze` ships.
+      analyze: (_text: string) => Effect.succeed<PfMatchResult[]>([]),
     }
-    return host
+  })
+}
+
+type HandshakeOutcome =
+  | { kind: 'ready'; runtime: PfRuntime; adapterLabel?: string; detectionMs: number }
+  | { kind: 'failed'; message: string }
+
+/** Wait for the first `pf:ready` (or `pf:failed`) from this exact
+ *  webContents. Other windows' messages are ignored so a second
+ *  ModelHost (or some unrelated subsystem firing the same channel)
+ *  can't satisfy this one's handshake. */
+function awaitReady(
+  ipc: Pick<typeof ipcMain, 'on' | 'removeListener'>,
+  win: BrowserWindow,
+  timeoutMs: number,
+): Promise<HandshakeOutcome> {
+  return new Promise((resolve) => {
+    const targetId = win.webContents.id
+    let settled = false
+    const settle = (value: HandshakeOutcome) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      ipc.removeListener(PF_IPC.READY, onReady)
+      ipc.removeListener(PF_IPC.FAILED, onFailed)
+      resolve(value)
+    }
+    const onReady = (event: IpcMainEvent, payload: PfReadyMessage) => {
+      if (event.sender.id !== targetId) return
+      settle({
+        kind: 'ready',
+        runtime: payload.runtime,
+        ...(payload.adapterLabel !== undefined ? { adapterLabel: payload.adapterLabel } : {}),
+        detectionMs: payload.detectionMs,
+      })
+    }
+    const onFailed = (event: IpcMainEvent, payload: PfFailedMessage) => {
+      if (event.sender.id !== targetId) return
+      settle({ kind: 'failed', message: payload.message })
+    }
+    const timer = setTimeout(
+      () => settle({ kind: 'failed', message: `pf:ready handshake timed out after ${timeoutMs}ms` }),
+      timeoutMs,
+    )
+    ipc.on(PF_IPC.READY, onReady)
+    ipc.on(PF_IPC.FAILED, onFailed)
   })
 }

--- a/packages/app/src/main/security/model-manifest.ts
+++ b/packages/app/src/main/security/model-manifest.ts
@@ -1,0 +1,53 @@
+// Pinned Privacy Filter model manifest. The downloader refuses to
+// keep a file whose hash disagrees with the per-file sha256, so a CDN
+// swap or MITM that returns a tampered weight file is caught before
+// the inference window ever loads it.
+//
+// To update: bump hfCommit, regenerate each sha256 with `shasum -a
+// 256`, bump PF_MODEL_VERSION in model-paths.ts (scan_profile keys
+// off it). Real values get pinned pre-GA — see
+// project_security_scan_feature memory.
+
+import { PF_HF_REPO } from './model-paths.js'
+
+export interface ManifestFile {
+  path: string
+  sha256: string
+  sizeBytes: number
+}
+
+export interface ModelManifest {
+  hfRepo: string
+  hfCommit: string
+  files: ReadonlyArray<ManifestFile>
+}
+
+export const MODEL_MANIFEST: ModelManifest = {
+  hfRepo: PF_HF_REPO,
+  hfCommit: '0000000000000000000000000000000000000000',
+  files: [
+    {
+      path: 'onnx/model_quantized.onnx',
+      sha256: '0'.repeat(64),
+      sizeBytes: 800_000_000,
+    },
+    {
+      path: 'tokenizer.json',
+      sha256: '0'.repeat(64),
+      sizeBytes: 2_500_000,
+    },
+    {
+      path: 'config.json',
+      sha256: '0'.repeat(64),
+      sizeBytes: 1_500,
+    },
+  ],
+}
+
+export function manifestTotalBytes(manifest: ModelManifest): number {
+  return manifest.files.reduce((sum, f) => sum + f.sizeBytes, 0)
+}
+
+export function manifestFileUrl(manifest: ModelManifest, file: ManifestFile): string {
+  return `https://huggingface.co/${manifest.hfRepo}/resolve/${manifest.hfCommit}/${file.path}`
+}

--- a/packages/app/src/main/security/model-state.test.ts
+++ b/packages/app/src/main/security/model-state.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createHash } from 'node:crypto'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pfInstallStatus } from './model-state.js'
+import type { ModelManifest } from './model-manifest.js'
+
+const sha256 = (buf: Buffer) => createHash('sha256').update(buf).digest('hex')
+
+function manifest(files: { path: string; body: Buffer }[]): ModelManifest {
+  return {
+    hfRepo: 'r', hfCommit: 'c'.repeat(40),
+    files: files.map(({ path, body }) => ({ path, sha256: sha256(body), sizeBytes: body.length })),
+  }
+}
+
+let tmp: string
+beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'spool-pf-state-')) })
+afterEach(() => { rmSync(tmp, { recursive: true, force: true }) })
+
+describe('pfInstallStatus', () => {
+  it('not-installed when no files are on disk', () => {
+    const m = manifest([{ path: 'a.bin', body: Buffer.from('aaaa') }])
+    expect(pfInstallStatus(tmp, m)).toEqual({ status: 'not-installed' })
+  })
+
+  it('installed when every file matches its SHA-256', () => {
+    const a = Buffer.from('aaaa')
+    const b = Buffer.from('bbbb')
+    writeFileSync(join(tmp, 'a.bin'), a)
+    writeFileSync(join(tmp, 'b.bin'), b)
+    const m = manifest([{ path: 'a.bin', body: a }, { path: 'b.bin', body: b }])
+    expect(pfInstallStatus(tmp, m)).toEqual({ status: 'installed' })
+  })
+
+  it('partial when at least one file is missing or a .part exists', () => {
+    const a = Buffer.from('aaaa')
+    const b = Buffer.from('bbbb')
+    writeFileSync(join(tmp, 'a.bin'), a)
+    writeFileSync(join(tmp, 'b.bin.part'), b.subarray(0, 2))
+    const m = manifest([{ path: 'a.bin', body: a }, { path: 'b.bin', body: b }])
+    const status = pfInstallStatus(tmp, m)
+    expect(status.status).toBe('partial')
+    if (status.status === 'partial') {
+      expect(status.bytesPresent).toBe(a.length + 2)
+      expect(status.bytesTotal).toBe(a.length + b.length)
+    }
+  })
+
+  it('partial (not installed) when a file is on disk but its SHA disagrees', () => {
+    const expected = Buffer.from('aaaa')
+    const tampered = Buffer.from('xxxx')
+    writeFileSync(join(tmp, 'a.bin'), tampered)
+    const m = manifest([{ path: 'a.bin', body: expected }])
+    expect(pfInstallStatus(tmp, m)).toEqual({ status: 'not-installed' })
+  })
+})

--- a/packages/app/src/main/security/model-state.ts
+++ b/packages/app/src/main/security/model-state.ts
@@ -1,0 +1,46 @@
+// Pure filesystem inspection of the Privacy Filter model bundle.
+// Never downloads.
+
+import { createHash } from 'node:crypto'
+import { readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import type { ModelManifest } from './model-manifest.js'
+
+export type PfInstallStatus =
+  | { status: 'not-installed' }
+  | { status: 'partial'; bytesPresent: number; bytesTotal: number }
+  | { status: 'installed' }
+
+export function pfInstallStatus(modelDir: string, manifest: ModelManifest): PfInstallStatus {
+  let bytesPresent = 0
+  let bytesTotal = 0
+  let allInstalled = true
+  for (const file of manifest.files) {
+    bytesTotal += file.sizeBytes
+    const full = join(modelDir, file.path)
+    const part = `${full}.part`
+    if (fileMatches(full, file.sha256, file.sizeBytes)) {
+      bytesPresent += file.sizeBytes
+      continue
+    }
+    allInstalled = false
+    // Count partial bytes so the progress dial survives a restart.
+    try {
+      bytesPresent += statSync(part).size
+    } catch { /* no .part */ }
+  }
+  if (allInstalled) return { status: 'installed' }
+  if (bytesPresent === 0) return { status: 'not-installed' }
+  return { status: 'partial', bytesPresent, bytesTotal }
+}
+
+function fileMatches(path: string, expectedSha256: string, expectedSize: number): boolean {
+  try {
+    const stat = statSync(path)
+    if (stat.size !== expectedSize) return false
+    const hash = createHash('sha256').update(readFileSync(path)).digest('hex')
+    return hash === expectedSha256
+  } catch {
+    return false
+  }
+}

--- a/packages/app/src/main/security/pf-coordinator.test.ts
+++ b/packages/app/src/main/security/pf-coordinator.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createHash } from 'node:crypto'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { makePfCoordinator, type PfDownloadState } from './pf-coordinator.js'
+import { MODEL_MANIFEST } from './model-manifest.js'
+
+const sha256 = (buf: Buffer) => createHash('sha256').update(buf).digest('hex')
+
+/** Replace MODEL_MANIFEST file shas with the hashes of a fixture body
+ *  so the downloader is happy with what our fake server serves. */
+function patchManifest(body: Buffer) {
+  const original = JSON.parse(JSON.stringify(MODEL_MANIFEST))
+  const hash = sha256(body)
+  for (const f of MODEL_MANIFEST.files) {
+    ;(f as { sha256: string }).sha256 = hash
+    ;(f as { sizeBytes: number }).sizeBytes = body.length
+  }
+  return () => {
+    for (let i = 0; i < MODEL_MANIFEST.files.length; i++) {
+      const f = MODEL_MANIFEST.files[i] as { sha256: string; sizeBytes: number }
+      f.sha256 = original.files[i].sha256
+      f.sizeBytes = original.files[i].sizeBytes
+    }
+  }
+}
+
+let tmp: string
+let restore: () => void
+beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'spool-pf-coord-')) })
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+  restore?.()
+})
+
+describe('PfCoordinator', () => {
+  it('starts in not-installed when the model dir is empty', () => {
+    const c = makePfCoordinator({ modelDir: tmp })
+    expect(c.getState().phase).toBe('not-installed')
+    expect(c.getState().bytesDownloaded).toBe(0)
+  })
+
+  it('publishes progress + lands in installed on a successful download', async () => {
+    const body = Buffer.from('x'.repeat(32))
+    restore = patchManifest(body)
+    const events: PfDownloadState[] = []
+    const c = makePfCoordinator({
+      modelDir: tmp,
+      fetch: (async () => new Response(body, { status: 200 })) as typeof globalThis.fetch,
+    })
+    c.subscribe((s) => events.push({ ...s }))
+    await c.startDownload()
+    expect(c.getState().phase).toBe('installed')
+    expect(events.some(e => e.phase === 'downloading')).toBe(true)
+    expect(events.at(-1)?.phase).toBe('installed')
+  })
+
+  it('lands in failed with an error message on HTTP error', async () => {
+    const body = Buffer.from('expected')
+    restore = patchManifest(body)
+    const c = makePfCoordinator({
+      modelDir: tmp,
+      fetch: (async () => new Response('nope', { status: 404 })) as typeof globalThis.fetch,
+    })
+    await c.startDownload()
+    const s = c.getState()
+    expect(s.phase).toBe('failed')
+    expect(s.error).toMatch(/HTTP 404/)
+  })
+
+  it('returns to not-installed on cancel — no failed state', async () => {
+    const body = Buffer.from('y'.repeat(32))
+    restore = patchManifest(body)
+    const c = makePfCoordinator({
+      modelDir: tmp,
+      fetch: ((_url: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')))
+        })) as typeof globalThis.fetch,
+    })
+    const pending = c.startDownload()
+    // Let the start phase publish first.
+    await new Promise(r => setTimeout(r, 5))
+    c.cancelDownload()
+    await pending
+    expect(c.getState().phase).toBe('not-installed')
+  })
+
+  it('ignores cancel when not downloading', () => {
+    const c = makePfCoordinator({ modelDir: tmp })
+    c.cancelDownload()
+    expect(c.getState().phase).toBe('not-installed')
+  })
+
+  it('no-ops a second startDownload while one is in flight', async () => {
+    const body = Buffer.from('z'.repeat(16))
+    restore = patchManifest(body)
+    let calls = 0
+    const c = makePfCoordinator({
+      modelDir: tmp,
+      fetch: (async () => {
+        calls++
+        await new Promise(r => setTimeout(r, 20))
+        return new Response(body, { status: 200 })
+      }) as typeof globalThis.fetch,
+    })
+    const p1 = c.startDownload()
+    const p2 = c.startDownload()  // should be a no-op
+    await Promise.all([p1, p2])
+    expect(c.getState().phase).toBe('installed')
+    // Only the first download hit fetch once per manifest file.
+    expect(calls).toBe(MODEL_MANIFEST.files.length)
+  })
+
+  it('subscribe returns an unsubscribe + dispose clears subscribers', async () => {
+    const c = makePfCoordinator({ modelDir: tmp })
+    const seen: PfDownloadState[] = []
+    const off = c.subscribe((s) => seen.push(s))
+    off()
+    c.dispose()
+    expect(seen).toEqual([])
+  })
+
+  it('reports the model as installed when the bundle already sits on disk', () => {
+    const body = Buffer.from('preinstalled')
+    restore = patchManifest(body)
+    for (const file of MODEL_MANIFEST.files) {
+      const full = join(tmp, file.path)
+      mkdirSync(dirname(full), { recursive: true })
+      writeFileSync(full, body)
+    }
+    const c = makePfCoordinator({ modelDir: tmp })
+    expect(c.getState().phase).toBe('installed')
+  })
+})

--- a/packages/app/src/main/security/pf-coordinator.ts
+++ b/packages/app/src/main/security/pf-coordinator.ts
@@ -1,0 +1,125 @@
+// Single source of truth for the Privacy Filter download lifecycle.
+// Wraps downloadModel + state checks behind a subscribe()-driven API
+// so the renderer's `evt-pf-state` always agrees with what the user
+// can act on. ModelHost spawn/unload lands in PR 5c.
+
+import { downloadModel, type DownloadProgress } from './model-download.js'
+import { MODEL_MANIFEST, manifestTotalBytes } from './model-manifest.js'
+import { pfInstallStatus } from './model-state.js'
+
+export type PfPhase =
+  | 'not-installed'
+  | 'downloading'
+  | 'installed'
+  | 'failed'
+
+export interface PfDownloadState {
+  phase: PfPhase
+  bytesDownloaded: number
+  bytesTotal: number
+  error?: string
+}
+
+export interface PfCoordinator {
+  getState(): PfDownloadState
+  startDownload(): Promise<void>
+  cancelDownload(): void
+  subscribe(handler: (s: PfDownloadState) => void): () => void
+  dispose(): void
+}
+
+export interface PfCoordinatorDeps {
+  modelDir: string
+  fetch?: typeof globalThis.fetch
+}
+
+export function makePfCoordinator(deps: PfCoordinatorDeps): PfCoordinator {
+  const subscribers = new Set<(s: PfDownloadState) => void>()
+  const totalBytes = manifestTotalBytes(MODEL_MANIFEST)
+  let abortController: AbortController | null = null
+  let state = initialState(deps.modelDir)
+
+  function publish(): void {
+    for (const fn of subscribers) {
+      try { fn(state) } catch (err) { console.error('[pf] subscriber threw:', err) }
+    }
+  }
+
+  async function startDownload(): Promise<void> {
+    if (state.phase === 'downloading' || state.phase === 'installed') return
+    abortController = new AbortController()
+    state = {
+      phase: 'downloading',
+      bytesDownloaded: state.bytesDownloaded,
+      bytesTotal: state.bytesTotal,
+    }
+    publish()
+    try {
+      await downloadModel({
+        modelDir: deps.modelDir,
+        manifest: MODEL_MANIFEST,
+        ...(deps.fetch ? { fetch: deps.fetch } : {}),
+        signal: abortController.signal,
+        onProgress: (p: DownloadProgress) => {
+          state = {
+            phase: 'downloading',
+            bytesDownloaded: p.bytesDownloaded,
+            bytesTotal: p.bytesTotal,
+          }
+          publish()
+        },
+      })
+      state = { phase: 'installed', bytesDownloaded: totalBytes, bytesTotal: totalBytes }
+    } catch (err) {
+      const aborted = (err as { name?: string } | undefined)?.name === 'AbortError'
+      if (aborted) {
+        // Cancel → drop back to whatever the filesystem says now.
+        state = initialState(deps.modelDir)
+      } else {
+        state = {
+          phase: 'failed',
+          bytesDownloaded: state.bytesDownloaded,
+          bytesTotal: state.bytesTotal,
+          error: err instanceof Error ? err.message : String(err),
+        }
+      }
+    } finally {
+      abortController = null
+      publish()
+    }
+  }
+
+  function cancelDownload(): void {
+    if (state.phase !== 'downloading') return
+    abortController?.abort()
+  }
+
+  function subscribe(handler: (s: PfDownloadState) => void): () => void {
+    subscribers.add(handler)
+    return () => subscribers.delete(handler)
+  }
+
+  return {
+    getState: () => state,
+    startDownload,
+    cancelDownload,
+    subscribe,
+    dispose: () => {
+      abortController?.abort()
+      subscribers.clear()
+    },
+  }
+}
+
+function initialState(modelDir: string): PfDownloadState {
+  const total = manifestTotalBytes(MODEL_MANIFEST)
+  const installed = pfInstallStatus(modelDir, MODEL_MANIFEST)
+  switch (installed.status) {
+    case 'installed':
+      return { phase: 'installed', bytesDownloaded: total, bytesTotal: total }
+    case 'partial':
+      return { phase: 'not-installed', bytesDownloaded: installed.bytesPresent, bytesTotal: installed.bytesTotal }
+    case 'not-installed':
+      return { phase: 'not-installed', bytesDownloaded: 0, bytesTotal: total }
+  }
+}

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -19,6 +19,19 @@ export interface SecurityPreferences {
   revealValuesOnHoverOnly: boolean
   pfEnabled: boolean
 }
+
+export type PfPhase =
+  | 'not-installed'
+  | 'downloading'
+  | 'installed'
+  | 'failed'
+
+export interface PfDownloadState {
+  phase: PfPhase
+  bytesDownloaded: number
+  bytesTotal: number
+  error?: string
+}
 import type { SearchSortOrder } from '../shared/searchSort.js'
 import type { SidebarSortOrder } from '../shared/sidebarSort.js'
 import type { PinnedSortOrder } from '../shared/pinnedSort.js'
@@ -291,6 +304,18 @@ const api = {
       ipcRenderer.invoke('security:list-backups'),
     deleteBackups: (args: { names: string[] }): Promise<DeleteBackupsResult> =>
       ipcRenderer.invoke('security:delete-backups', args),
+
+    pfGetState: (): Promise<PfDownloadState> =>
+      ipcRenderer.invoke('security:pf-get-state'),
+    pfDownloadStart: (): Promise<{ ok: boolean; reason?: string }> =>
+      ipcRenderer.invoke('security:pf-download-start'),
+    pfDownloadCancel: (): Promise<{ ok: boolean }> =>
+      ipcRenderer.invoke('security:pf-download-cancel'),
+    onPfState: (cb: (state: PfDownloadState) => void) => {
+      const handler = (_: Electron.IpcRendererEvent, data: unknown) => cb(data as PfDownloadState)
+      ipcRenderer.on('security:evt-pf-state', handler)
+      return () => ipcRenderer.removeListener('security:evt-pf-state', handler)
+    },
   },
 }
 

--- a/packages/app/src/preload/inference.ts
+++ b/packages/app/src/preload/inference.ts
@@ -1,0 +1,12 @@
+// Preload for the hidden `pf-inference` renderer. Exposes a minimal
+// `pfBridge` — only the renderer → main channels the inference window
+// needs. No `ipcRenderer.on` surface yet; future PRs will extend this
+// when main pushes analyze requests in.
+
+import { contextBridge, ipcRenderer } from 'electron'
+import { PF_IPC, type PfReadyMessage, type PfFailedMessage } from '../inference/types.js'
+
+contextBridge.exposeInMainWorld('pfBridge', {
+  ready: (payload: PfReadyMessage) => ipcRenderer.send(PF_IPC.READY, payload),
+  failed: (payload: PfFailedMessage) => ipcRenderer.send(PF_IPC.FAILED, payload),
+})

--- a/packages/app/src/renderer/api/security.ts
+++ b/packages/app/src/renderer/api/security.ts
@@ -21,9 +21,9 @@ import type {
 
 export type { BackupFileInfo }
 import type { SensitiveKind } from '@spool-lab/redact'
-import type { SecurityPreferences } from '../../preload/index.js'
+import type { SecurityPreferences, PfDownloadState } from '../../preload/index.js'
 
-export type { SecurityPreferences, AllowlistEntryRow }
+export type { SecurityPreferences, AllowlistEntryRow, PfDownloadState }
 
 /** Single source of truth for the renderer-side adapter. Components
  *  hold this object, not `window.spool.security` — keeps replaceability
@@ -84,6 +84,15 @@ export const securityApi = {
     window.spool.security.listBackups(),
   deleteBackups: (names: string[]): Promise<DeleteBackupsResult> =>
     window.spool.security.deleteBackups({ names }),
+
+  pfGetState: (): Promise<PfDownloadState> =>
+    window.spool.security.pfGetState(),
+  pfDownloadStart: (): Promise<{ ok: boolean; reason?: string }> =>
+    window.spool.security.pfDownloadStart(),
+  pfDownloadCancel: (): Promise<{ ok: boolean }> =>
+    window.spool.security.pfDownloadCancel(),
+  onPfState: (handler: (s: PfDownloadState) => void): (() => void) =>
+    window.spool.security.onPfState(handler),
 }
 
 export type SecurityApi = typeof securityApi

--- a/packages/app/src/renderer/components/Settings/SecurityPane.tsx
+++ b/packages/app/src/renderer/components/Settings/SecurityPane.tsx
@@ -26,10 +26,12 @@ import {
   type SensitiveKind,
 } from '@spool-lab/redact'
 import { securityApi, type SecurityPreferences, type BackupFileInfo } from '../../api/security.js'
+import { formatBytes } from '../security/format.js'
 import { securityFeatureEnabled } from '../../featureFlags.js'
 import Toggle from '../Toggle.js'
 import Menu from '../Menu.js'
 import AllowlistManageModal from '../security/AllowlistManageModal.js'
+import PfDownloadCard from './security/PfDownloadCard.js'
 
 export default function SecurityPane() {
   if (!securityFeatureEnabled()) return null
@@ -115,58 +117,10 @@ function SecurityPaneInner() {
           </div>
         </div>
 
-        {/* Privacy Filter card — coming soon */}
-        <div
-          data-testid="settings-detector-pf"
-          className="rounded-[8px] border border-warm-border dark:border-dark-border bg-warm-surface/40 dark:bg-dark-surface/40 px-3.5 py-3"
-        >
-          <div className="flex items-start gap-3">
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 mb-1">
-                <span className="text-xs font-medium text-warm-text dark:text-dark-text">
-                  {t('settings.security.detector_pf_title', { defaultValue: 'Privacy Filter' })}
-                </span>
-                <code className="font-mono text-[10px] text-warm-faint dark:text-dark-muted bg-warm-surface dark:bg-dark-surface px-1.5 py-0.5 rounded">
-                  ~800 MB
-                </code>
-              </div>
-              <p className="text-[11px] leading-[16px] text-warm-faint dark:text-dark-muted mb-1.5">
-                {t('settings.security.detector_pf_body', {
-                  defaultValue: "PII patterns that regex can't catch — names, addresses, and similar.",
-                })}
-              </p>
-              <p className="font-mono text-[10px] text-warm-faint dark:text-dark-muted/70">
-                {t('settings.security.detector_pf_footer', {
-                  defaultValue: 'OpenAI Privacy Filter · Apache 2.0 · runs on-device',
-                })}
-              </p>
-            </div>
-            <div className="shrink-0 flex items-center gap-2">
-              <span className="text-[9px] uppercase tracking-[0.06em] font-medium text-warm-faint dark:text-dark-muted">
-                {t('settings.security.detector_coming_soon', { defaultValue: 'Coming soon' })}
-              </span>
-              {/* Visually disabled; also blocks keyboard activation
-               *  via inert so screen-reader / keyboard users can't
-               *  trip the no-op onChange while the ML runtime is
-               *  still in stub form. `inert` is not in React 18's
-               *  stock HTMLAttributes typings; the cast spreads it
-               *  through as a plain HTML attribute. */}
-              <span
-                className="pointer-events-none opacity-50"
-                aria-hidden="true"
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                {...({ inert: '' } as any)}
-              >
-                <Toggle
-                  checked={prefs?.pfEnabled ?? false}
-                  onChange={() => { /* stub until ML runtime lands */ }}
-                  ariaLabel={t('settings.security.detector_pf_title', { defaultValue: 'Privacy Filter' })}
-                  testId="settings-pf-toggle"
-                />
-              </span>
-            </div>
-          </div>
-        </div>
+        {/* Privacy Filter card — download surface lives in its own
+            component. The toggle that actually flips pfEnabled lands
+            in PR 5c once the model can be loaded into ModelHost. */}
+        <PfDownloadCard />
       </Section>
 
       {/* Defaults */}
@@ -905,19 +859,4 @@ function formatAge(mtimeMs: number, t: (k: string, o?: Record<string, unknown>) 
   if (day < 30) return t('settings.security.backups_age_day', { count: day, defaultValue: '{{count}}d ago' })
   const mo = Math.floor(day / 30)
   return t('settings.security.backups_age_mo', { count: mo, defaultValue: '{{count}}mo ago' })
-}
-
-function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
-  const units = ['B', 'KB', 'MB', 'GB']
-  let value = bytes
-  let unit = 0
-  while (value >= 1024 && unit < units.length - 1) {
-    value /= 1024
-    unit += 1
-  }
-  const formatted = value >= 100 || unit === 0
-    ? Math.round(value).toString()
-    : value.toFixed(1).replace(/\.0$/, '')
-  return `${formatted} ${units[unit]}`
 }

--- a/packages/app/src/renderer/components/Settings/security/PfDownloadCard.tsx
+++ b/packages/app/src/renderer/components/Settings/security/PfDownloadCard.tsx
@@ -1,0 +1,128 @@
+// Privacy Filter ML download / status card. Visual rhythm matches the
+// Pattern matching card directly above it in SecurityPane.
+
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Download, X, RotateCw, AlertTriangle } from 'lucide-react'
+import { securityApi, type PfDownloadState } from '../../../api/security.js'
+import { formatBytes } from '../../security/format.js'
+
+const INITIAL: PfDownloadState = { phase: 'not-installed', bytesDownloaded: 0, bytesTotal: 0 }
+
+export default function PfDownloadCard() {
+  const { t } = useTranslation()
+  const [state, setState] = useState<PfDownloadState>(INITIAL)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    void securityApi.pfGetState().then(setState).catch(() => setState(INITIAL))
+    return securityApi.onPfState(setState)
+  }, [])
+
+  const startDownload = async () => {
+    setBusy(true)
+    try { await securityApi.pfDownloadStart() } finally { setBusy(false) }
+  }
+  const cancelDownload = () => { void securityApi.pfDownloadCancel() }
+
+  const percent = state.bytesTotal > 0
+    ? Math.min(100, Math.round((state.bytesDownloaded / state.bytesTotal) * 100))
+    : 0
+
+  return (
+    <div
+      data-testid="settings-detector-pf"
+      data-phase={state.phase}
+      className="rounded-[8px] border border-warm-border dark:border-dark-border bg-warm-surface/40 dark:bg-dark-surface/40 px-3.5 py-3"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-xs font-medium text-warm-text dark:text-dark-text">
+              {t('settings.security.detector_pf_title', { defaultValue: 'Privacy Filter' })}
+            </span>
+            <code className="font-mono text-[10px] text-warm-faint dark:text-dark-muted bg-warm-surface dark:bg-dark-surface px-1.5 py-0.5 rounded">
+              {formatBytes(state.bytesTotal || 800_000_000)}
+            </code>
+          </div>
+          <p className="text-[11px] leading-[16px] text-warm-faint dark:text-dark-muted mb-1.5">
+            {t('settings.security.detector_pf_body', {
+              defaultValue: "PII patterns that regex can't catch — names, addresses, and similar.",
+            })}
+          </p>
+          <p className="font-mono text-[10px] text-warm-faint dark:text-dark-muted/70">
+            {t('settings.security.detector_pf_footer', {
+              defaultValue: 'OpenAI Privacy Filter · Apache 2.0 · runs on-device',
+            })}
+          </p>
+
+          {state.phase === 'downloading' && (
+            <div className="mt-2.5" data-testid="settings-pf-progress">
+              <div className="h-1.5 rounded-full bg-warm-surface dark:bg-dark-surface overflow-hidden">
+                <div
+                  className="h-full bg-accent dark:bg-accent-dark transition-all"
+                  style={{ width: `${percent}%` }}
+                />
+              </div>
+              <p className="mt-1 font-mono text-[10px] text-warm-faint dark:text-dark-muted tabular-nums">
+                {formatBytes(state.bytesDownloaded)} / {formatBytes(state.bytesTotal)} · {percent}%
+              </p>
+            </div>
+          )}
+
+          {state.phase === 'failed' && state.error && (
+            <p className="mt-2 text-[11px] text-accent dark:text-accent-dark flex items-center gap-1.5">
+              <AlertTriangle size={11} strokeWidth={1.8} aria-hidden />
+              {state.error}
+            </p>
+          )}
+        </div>
+
+        <div className="shrink-0 flex items-center gap-2">
+          {state.phase === 'not-installed' && (
+            <button
+              type="button"
+              data-testid="settings-pf-download"
+              disabled={busy}
+              onClick={() => { void startDownload() }}
+              className="inline-flex items-center gap-1.5 h-7 rounded-[6px] border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface hover:border-warm-border2 dark:hover:border-dark-border2 px-2.5 text-[12px] text-warm-text dark:text-dark-text disabled:opacity-60 transition-colors"
+            >
+              <Download size={11} strokeWidth={1.8} aria-hidden />
+              {t('settings.security.detector_pf_download', { defaultValue: 'Download' })}
+            </button>
+          )}
+          {state.phase === 'downloading' && (
+            <button
+              type="button"
+              data-testid="settings-pf-cancel"
+              onClick={cancelDownload}
+              className="inline-flex items-center gap-1.5 h-7 rounded-[6px] border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface hover:border-warm-border2 dark:hover:border-dark-border2 px-2.5 text-[12px] text-warm-text dark:text-dark-text transition-colors"
+            >
+              <X size={11} strokeWidth={1.8} aria-hidden />
+              {t('settings.security.detector_pf_cancel', { defaultValue: 'Cancel' })}
+            </button>
+          )}
+          {state.phase === 'installed' && (
+            <span
+              data-testid="settings-pf-ready"
+              className="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] uppercase tracking-[0.06em] font-medium text-accent dark:text-accent-dark bg-accent-bg dark:bg-accent-bg-dark border border-accent/40 dark:border-accent-dark/40"
+            >
+              {t('settings.security.detector_pf_ready', { defaultValue: 'Ready' })}
+            </span>
+          )}
+          {state.phase === 'failed' && (
+            <button
+              type="button"
+              data-testid="settings-pf-retry"
+              onClick={() => { void startDownload() }}
+              className="inline-flex items-center gap-1.5 h-7 rounded-[6px] border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface hover:border-warm-border2 dark:hover:border-dark-border2 px-2.5 text-[12px] text-warm-text dark:text-dark-text transition-colors"
+            >
+              <RotateCw size={11} strokeWidth={1.8} aria-hidden />
+              {t('settings.security.detector_pf_retry', { defaultValue: 'Retry' })}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/renderer/components/security/format.ts
+++ b/packages/app/src/renderer/components/security/format.ts
@@ -15,3 +15,18 @@ export function compactModel(model: string | null | undefined): string {
 export function friendlyMaskName(kind: string): string {
   return SENSITIVE_KIND_LABEL[kind as SensitiveKind] ?? kind
 }
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  const formatted = value >= 100 || unit === 0
+    ? Math.round(value).toString()
+    : value.toFixed(1).replace(/\.0$/, '')
+  return `${formatted} ${units[unit]}`
+}


### PR DESCRIPTION
feat(security): hidden inference window skeleton for Privacy Filter ML

PR 5a of the Privacy Filter ML stack. Wires the renderer-side scaffold
for the hidden BrowserWindow that will host transformers.js + ONNX
inference. Covers lifecycle + WebGPU/WASM detection + ready handshake
only — model download lands in 5b, real pf:analyze in 5c.

- new src/inference/{types,runtime-detect,pf-inference}.{ts,html}: the
  renderer-side detection logic + IPC payload shapes
- new src/preload/inference.ts: minimal pfBridge (READY/FAILED channels)
- ModelHost rewritten with Effect.acquireRelease: spawns window, waits
  for handshake on matching webContents.id, lands in 'failed' state on
  timeout / spawn rejection / pf:failed (does not throw); destroys
  window on scope close
- electron.vite.config.ts: adds inference renderer + preload entries

Toggle in Settings stays inert ('Coming soon') — no behaviour change
for users; ModelHost is dead code until PR 5b wires the toggle.

Tests: 13 new unit cases. Full app suite 242/242.

feat(security): Privacy Filter model downloader + Settings download card

PR 5b of the Privacy Filter ML stack. Wires the main-process download
infrastructure + a renderer-side download surface that replaces the
inert "Coming soon" placeholder. ModelHost spawn / pf toggle wiring
lands in PR 5c.

- model-manifest.ts: pinned ModelManifest schema + placeholder
  MODEL_MANIFEST (real HF commit + per-file SHA-256 get pinned pre-GA)
- model-download.ts: streaming downloader with resumable Range, SHA-256
  verify against the manifest, AbortSignal cancel, sequential per-file
  progress; injectable fetch for tests
- model-state.ts: pure pfInstallStatus(modelDir, manifest) →
  not-installed | partial | installed (counts .part bytes for the
  progress dial)
- pf-coordinator.ts: main-process singleton that owns the in-flight
  AbortController, publishes PfDownloadState to subscribers, and
  drops back to not-installed on cancel (vs failed)
- ipc/security.ts: PF_GET_STATE / PF_DOWNLOAD_START / PF_DOWNLOAD_CANCEL
  channels + EVT_PF_STATE push, all guarded behind an optional
  pfCoordinator dep (null → static not-installed snapshot)
- preload + renderer api: 4 channel passthroughs + PfDownloadState type
- SecurityPane.tsx: replaces the inert pf card + Toggle wrapper with
  <PfDownloadCard />
- PfDownloadCard.tsx: four-state visual card (not-installed / downloading
  + progress + Cancel / installed + Ready badge / failed + Retry)

19 new unit tests across model-download / model-state / pf-coordinator;
full app suite 261/261. Toggle that actually flips pfEnabled + mounts
ModelHost is deferred to PR 5c.