### PR TITLE
feat(security): real ONNX inference via openai/privacy-filter

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -31,6 +31,7 @@
     "@fontsource-variable/hanken-grotesk": "^5.2.8",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource/geist-mono": "^5.2.7",
+    "@huggingface/transformers": "^4.2.0",
     "@spool-lab/core": "workspace:*",
     "@spool-lab/redact": "workspace:^",
     "@spool/share-kit": "workspace:*",

--- a/packages/app/src/inference/pf-inference.html
+++ b/packages/app/src/inference/pf-inference.html
@@ -3,11 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <title>Spool · PF inference</title>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'" />
+    <!-- transformers.js compiles ONNX Runtime Web from WASM, which
+         requires 'wasm-unsafe-eval'; pf-model: is our local model
+         protocol; blob: is needed for the WebWorker shim ORT spawns.
+         Network access is otherwise denied — `default-src 'self'`
+         keeps the renderer offline. -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' pf-model:; script-src 'self' 'wasm-unsafe-eval' blob:; worker-src 'self' blob:; connect-src 'self' pf-model: blob:; style-src 'self' 'unsafe-inline'" />
   </head>
   <body>
-    <!-- Hidden window. Body intentionally empty — runtime detection
-         and (in future PRs) ONNX inference happen entirely in JS. -->
     <script type="module" src="./pf-inference.ts"></script>
   </body>
 </html>

--- a/packages/app/src/inference/pf-inference.ts
+++ b/packages/app/src/inference/pf-inference.ts
@@ -1,10 +1,16 @@
-// Hidden inference renderer entry. Loads in a BrowserWindow created
-// by `model-host.ts`, performs the WebGPU/WASM runtime probe, and
-// answers `pf:analyze-request` IPCs. The analyze handler currently
-// returns []; real ONNX inference lands in a follow-up PR.
+// Hidden inference renderer entry. Loads transformers.js, runs the
+// Privacy Filter token-classification pipeline, and answers
+// `pf:analyze-request` IPCs from main.
+//
+// The pf:ready handshake only fires AFTER the model has finished
+// loading — ModelHost's readyTimeoutMs is sized accordingly. That
+// way the scan worker doesn't pay 10-30 s of model warmup on its
+// very first analyze call.
 
 import { detectRuntime } from './runtime-detect.js'
-import type { PfAnalyzeRequest, PfAnalyzeResult, PfReadyMessage, PfFailedMessage } from './types.js'
+import type {
+  PfAnalyzeRequest, PfAnalyzeResult, PfReadyMessage, PfFailedMessage, PfMatch,
+} from './types.js'
 
 declare global {
   interface Window {
@@ -17,6 +23,21 @@ declare global {
   }
 }
 
+/** Directory name under userData/models/ — must match PF_MODEL_ID in
+ *  model-paths.ts. transformers.js fetches files at
+ *  `pf-model:///${PF_MODEL_ID}/{file}`. */
+const PF_MODEL_ID = 'openai-privacy-filter-q4'
+
+interface PipelineOutput {
+  entity_group: string
+  score: number
+  word: string
+  start: number
+  end: number
+}
+
+type Pipeline = (text: string, opts?: { aggregation_strategy?: string }) => Promise<PipelineOutput[]>
+
 async function main(): Promise<void> {
   const bridge = window.pfBridge
   if (!bridge) {
@@ -24,23 +45,74 @@ async function main(): Promise<void> {
     return
   }
 
-  // Stub: round-trip the request with an empty match list. Real ONNX
-  // inference replaces this body in a follow-up PR.
+  const t0 = performance.now()
+  let runtime: 'webgpu' | 'wasm'
+  let adapterLabel: string | undefined
+  try {
+    const detect = await detectRuntime()
+    runtime = detect.runtime
+    adapterLabel = detect.adapterLabel
+  } catch (err) {
+    bridge.failed({ message: `runtime detection failed: ${err instanceof Error ? err.message : String(err)}` })
+    return
+  }
+
+  let pipe: Pipeline
+  try {
+    const tx = await import('@huggingface/transformers')
+    // Pin transformers.js to pf-model:// so it never reaches the
+    // network. allowRemoteModels=false guards against accidental
+    // CDN fetches if a code path forgets to pass localModelPath.
+    tx.env.allowLocalModels = true
+    tx.env.allowRemoteModels = false
+    tx.env.localModelPath = 'pf-model:///'
+    tx.env.useBrowserCache = false
+    const built = await tx.pipeline('token-classification', PF_MODEL_ID, {
+      device: runtime === 'webgpu' ? 'webgpu' : 'wasm',
+      dtype: 'q4',
+    })
+    pipe = built as unknown as Pipeline
+  } catch (err) {
+    bridge.failed({ message: `model load failed: ${err instanceof Error ? err.message : String(err)}` })
+    return
+  }
+
   bridge.onAnalyzeRequest((req) => {
-    bridge.sendAnalyzeResult({ reqId: req.reqId, ok: true, matches: [] })
+    void analyzeOne(req, pipe, bridge)
   })
 
-  const t0 = performance.now()
+  const detectionMs = Math.round(performance.now() - t0)
+  bridge.ready({
+    runtime,
+    detectionMs,
+    ...(adapterLabel !== undefined ? { adapterLabel } : {}),
+  })
+}
+
+async function analyzeOne(
+  req: PfAnalyzeRequest,
+  pipe: Pipeline,
+  bridge: NonNullable<Window['pfBridge']>,
+): Promise<void> {
   try {
-    const res = await detectRuntime()
-    const detectionMs = Math.round(performance.now() - t0)
-    bridge.ready({
-      runtime: res.runtime,
-      detectionMs,
-      ...(res.adapterLabel !== undefined ? { adapterLabel: res.adapterLabel } : {}),
-    })
+    const output = await pipe(req.text, { aggregation_strategy: 'simple' })
+    const matches: PfMatch[] = output.map((m) => ({
+      // openai/privacy-filter emits `private_person`, `private_email`,
+      // etc. The class-mapping module operates on the short form so
+      // the same code works for future models without the prefix.
+      class: m.entity_group.toLowerCase().replace(/^private_/, ''),
+      value: m.word,
+      start: m.start,
+      end: m.end,
+      score: m.score,
+    }))
+    bridge.sendAnalyzeResult({ reqId: req.reqId, ok: true, matches })
   } catch (err) {
-    bridge.failed({ message: err instanceof Error ? err.message : String(err) })
+    bridge.sendAnalyzeResult({
+      reqId: req.reqId,
+      ok: false,
+      message: err instanceof Error ? err.message : String(err),
+    })
   }
 }
 

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -443,6 +443,7 @@ app.whenReady().then(async () => {
         runPromise: runWithObservability,
         getMainWindow: () => mainWindow,
         pfCoordinator,
+        pfRuntime,
         onPfEnabledChanged: (enabled) => {
           void syncPfRuntime(enabled).catch((err) => {
             console.error('[security] pf runtime transition failed:', err)

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -42,6 +42,9 @@ import { Effect } from 'effect'
 import { registerSecurityIpc } from './ipc/security.js'
 import { loadSecurityPreferences } from './securityPreferences.js'
 import { makePfRuntime, pfModelInstalled } from './security/pf-runtime.js'
+import { registerPfModelProtocol, registerPfModelScheme } from './security/pf-model-protocol.js'
+import { makePfCoordinator } from './security/pf-coordinator.js'
+import { pfModelDir } from './security/model-paths.js'
 import type {
   FragmentResult, SessionSource, ListSessionsByIdentityOptions, SessionsCursor,
   ShareDraftRow, UpsertShareDraftInput,
@@ -57,6 +60,12 @@ import { hydrateBinaryCache } from './binaryCache.js'
 import { snapshotEventLoopLag, startEventLoopMonitor } from './eventLoopMonitor.js'
 import type Database from 'better-sqlite3'
 import type { SyncWorkerMessage } from './sync-worker.js'
+
+// Privilege the `pf-model://` scheme before app.ready so the hidden
+// inference renderer can fetch model files through it. Has to happen
+// here (module top-level) because protocol.registerSchemesAsPrivileged
+// is a no-op once Electron has finished initialising.
+registerPfModelScheme()
 
 // Start the main-process event-loop lag monitor before any other module
 // has a chance to do work. Cheap (a C++ histogram in node:perf_hooks).
@@ -103,6 +112,9 @@ let isSyncActive = false
 let scanWorker: ScanWorkerProxy | null = null
 let disposeSecurityIpc: (() => void) | null = null
 const pfRuntime = makePfRuntime()
+// Lazily resolved on first access — pfModelsRoot() reads app.getPath
+// which throws before app.ready, but this module evaluates at boot.
+let pfCoordinator: ReturnType<typeof makePfCoordinator> | null = null
 
 type CachedSearchValue = FragmentResult[]
 
@@ -420,6 +432,9 @@ app.whenReady().then(async () => {
   // Gated by VITE_FEATURE_SECURITY so production builds (where the
   // env var stays unset) never start the scanner.
   if (securityFeatureEnabled()) {
+    // Has to happen post-ready (uses protocol.handle + app.getPath).
+    registerPfModelProtocol()
+    pfCoordinator = makePfCoordinator({ modelDir: pfModelDir() })
     void bootScanWorker().then(() => {
       if (!scanWorker) return
       disposeSecurityIpc = registerSecurityIpc({
@@ -427,6 +442,7 @@ app.whenReady().then(async () => {
         worker: scanWorker,
         runPromise: runWithObservability,
         getMainWindow: () => mainWindow,
+        pfCoordinator,
         onPfEnabledChanged: (enabled) => {
           void syncPfRuntime(enabled).catch((err) => {
             console.error('[security] pf runtime transition failed:', err)

--- a/packages/app/src/main/ipc/security.ts
+++ b/packages/app/src/main/ipc/security.ts
@@ -40,6 +40,7 @@ import {
   type SecurityPreferences,
 } from '../securityPreferences.js'
 import type { PfCoordinator } from '../security/pf-coordinator.js'
+import type { PfRuntime } from '../security/pf-runtime.js'
 
 /** Channel name table. Shared via type only with the renderer adapter
  *  (no runtime import — preload uses the strings literally). */
@@ -79,6 +80,9 @@ export const SECURITY_IPC_CHANNELS = {
   PF_GET_STATE:                'security:pf-get-state',
   PF_DOWNLOAD_START:           'security:pf-download-start',
   PF_DOWNLOAD_CANCEL:          'security:pf-download-cancel',
+  /** Returns the inference runtime info — null when the ModelHost
+   *  isn't running. Polled by PfDownloadCard for the runtime badge. */
+  PF_GET_RUNTIME_INFO:         'security:pf-get-runtime-info',
 
   // events (push: main → renderer via webContents.send)
   EVT_FINDINGS_CHANGED:        'security:evt-findings-changed',
@@ -103,13 +107,17 @@ export interface SecurityIpcDeps {
    *  this to pfRuntime.start() / stop() so the inference window only
    *  exists when the user actually wants ML detection on. */
   onPfEnabledChanged?: (enabled: boolean) => void
+  /** The live ModelHost lifecycle. Exposed via PF_GET_RUNTIME_INFO
+   *  so the renderer can display "WebGPU · Apple M2 Pro" once the
+   *  hidden window has finished its handshake. */
+  pfRuntime?: PfRuntime | null
 }
 
 /** Register every Security Scan ipcMain.handle and start a background
  *  fiber that forwards worker change events to the main window. The
  *  returned disposer interrupts the forwarding fiber. */
 export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
-  const { db, worker, runPromise, getMainWindow, pfCoordinator, onPfEnabledChanged } = deps
+  const { db, worker, runPromise, getMainWindow, pfCoordinator, pfRuntime: hostRuntime, onPfEnabledChanged } = deps
 
   ipcMain.handle(SECURITY_IPC_CHANNELS.LIST_FINDINGS, (_e, filter: FindingFilter) =>
     listFindings(db, filter),
@@ -230,6 +238,10 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
   ipcMain.handle(SECURITY_IPC_CHANNELS.PF_DOWNLOAD_CANCEL, () => {
     pfCoordinator?.cancelDownload()
     return { ok: true as const }
+  })
+  ipcMain.handle(SECURITY_IPC_CHANNELS.PF_GET_RUNTIME_INFO, async () => {
+    if (!hostRuntime?.isActive()) return null
+    return hostRuntime.getState()
   })
   const unsubscribePf = pfCoordinator?.subscribe((s) => {
     getMainWindow()?.webContents.send(SECURITY_IPC_CHANNELS.EVT_PF_STATE, s)

--- a/packages/app/src/main/scan-worker-proxy.ts
+++ b/packages/app/src/main/scan-worker-proxy.ts
@@ -65,6 +65,12 @@ export async function spawnScanWorker(
   const changes = await Effect.runPromise(PubSub.unbounded<FindingsChange>())
   const statusChanges = await Effect.runPromise(PubSub.unbounded<ScanStatus>())
 
+  // postMessage throws synchronously when the worker's MessagePort has
+  // closed. Swallow it — caller is post-shutdown territory.
+  function postSafe(msg: ToWorker): void {
+    try { worker.postMessage(msg) } catch { /* worker gone */ }
+  }
+
   function send<T>(payload: ScanCommand): Promise<T> {
     const reqId = nextReqId++
     return new Promise<T>((resolve, reject) => {
@@ -153,22 +159,14 @@ export async function spawnScanWorker(
         // No bridge wired (e.g. PF runtime not booted) → answer
         // immediately with empty matches so the worker unblocks.
         if (!pfBridge) {
-          try {
-            worker.postMessage({ type: 'pf-analyze-res', reqId, ok: true, matches: [] } satisfies ToWorker)
-          } catch { /* worker gone */ }
+          postSafe({ type: 'pf-analyze-res', reqId, ok: true, matches: [] })
           return
         }
         pfBridge.analyze(text)
-          .then((matches) => {
-            try {
-              worker.postMessage({ type: 'pf-analyze-res', reqId, ok: true, matches } satisfies ToWorker)
-            } catch { /* worker gone */ }
-          })
+          .then((matches) => postSafe({ type: 'pf-analyze-res', reqId, ok: true, matches }))
           .catch((err: unknown) => {
             const message = err instanceof Error ? err.message : String(err)
-            try {
-              worker.postMessage({ type: 'pf-analyze-res', reqId, ok: false, message } satisfies ToWorker)
-            } catch { /* worker gone */ }
+            postSafe({ type: 'pf-analyze-res', reqId, ok: false, message })
           })
         return
       }
@@ -220,13 +218,7 @@ export async function spawnScanWorker(
           resolve()
         }
       }),
-    notifyPfOnline: () => {
-      try { worker.postMessage({ type: 'pf-online' } satisfies ToWorker) }
-      catch { /* worker gone */ }
-    },
-    notifyPfOffline: () => {
-      try { worker.postMessage({ type: 'pf-offline' } satisfies ToWorker) }
-      catch { /* worker gone */ }
-    },
+    notifyPfOnline: () => postSafe({ type: 'pf-online' }),
+    notifyPfOffline: () => postSafe({ type: 'pf-offline' }),
   }
 }

--- a/packages/app/src/main/security/class-mapping.test.ts
+++ b/packages/app/src/main/security/class-mapping.test.ts
@@ -6,7 +6,7 @@ const regex = (kind: SensitiveMatch['kind'], start: number, end: number): Sensit
   kind, value: '', start, end, confidence: 0.95, provider: 'regex',
 })
 
-describe('class mapping — direct mappings', () => {
+describe('class mapping — direct mappings (openai/privacy-filter classes)', () => {
   it('person → person-name', () => {
     const pf: PfRawMatch = { class: 'person', value: 'Maya', start: 0, end: 4, score: 0.9 }
     const out = mapPfMatch(pf, { regexMatches: [], fullText: 'Maya' })
@@ -81,6 +81,11 @@ describe('class mapping — suppression rules', () => {
       fullText: 'DOB: 2002-11-09',
     })
     expect(out?.kind).toBe('date-of-birth')
+  })
+
+  it('unknown labels are dropped without throwing', () => {
+    const pf: PfRawMatch = { class: 'wat-is-this', value: 'x', start: 0, end: 1, score: 0.8 }
+    expect(mapPfMatch(pf, { regexMatches: [], fullText: 'x' })).toBeNull()
   })
 })
 

--- a/packages/app/src/main/security/class-mapping.ts
+++ b/packages/app/src/main/security/class-mapping.ts
@@ -1,16 +1,26 @@
 // Privacy Filter class mapping.
 //
-// OpenAI Privacy Filter emits 8 classes; we map them to Spool's
-// SensitiveKind. Some classes need suppression rules to avoid the
-// model out-shouting the regex detector for things the regex
-// already covers with checksums.
+// openai/privacy-filter emits 8 entity-group categories after the
+// constrained Viterbi decoder collapses BIOES tags:
 //
-// Spec: ~/Documents/dev-docs/spool/2026-05-18-security-scan-design.md
-// §"Class mapping"
+//   private_person / private_email / private_phone / private_address /
+//   private_url / private_date / account_number / secret
+//
+// pf-inference.ts strips the `private_` prefix before sending the
+// match to this module, so the class strings handled here are the
+// short forms ('person', 'email', 'phone', 'address', 'url', 'date',
+// 'account_number', 'secret').
+//
+// Some classes need suppression rules so the ML model doesn't
+// out-shout the regex detector for things the regex already covers
+// with checksums or vendor-prefix tokens. Spec:
+// ~/Documents/dev-docs/spool/2026-05-18-security-scan-design.md
+// §"Class mapping".
 
 import type { SensitiveKind, SensitiveMatch } from '@spool-lab/redact'
 
-/** Privacy Filter's published class labels. */
+/** Short-form class label emitted by pf-inference.ts after the
+ *  `private_` prefix is stripped. */
 export type PfClass =
   | 'person'
   | 'email'
@@ -20,13 +30,16 @@ export type PfClass =
   | 'date'
   | 'account_number'
   | 'secret'
+  // Allow string so unknown labels from future model bumps fall
+  // through to the default suppression in mapClass().
+  | string
 
 export interface PfRawMatch {
   class: PfClass
   value: string
   start: number
   end: number
-  /** PF model logit-derived confidence, 0–1. */
+  /** Viterbi-decoded confidence, 0–1. */
   score: number
 }
 
@@ -36,16 +49,12 @@ export interface MappingContext {
    *  flagged the same span, so the pf hit acts as a confidence
    *  boost rather than a noisy standalone signal. */
   regexMatches: ReadonlyArray<SensitiveMatch>
-  /** Optional substring around each match (~16 chars on each side)
-   *  used for date-of-birth context gating. Caller passes the full
-   *  text — gating runs cheaply. */
+  /** Substring around each match used for DOB context gating. */
   fullText: string
 }
 
 const DOB_CONTEXT_RX = /\b(dob|date\s+of\s+birth|born\s+on|birthday|d\.?o\.?b\.?)\b/i
 
-/** Map one PF raw match to a SensitiveMatch, or null when the
- *  suppression rules say to drop it. */
 export function mapPfMatch(
   pf: PfRawMatch,
   ctx: MappingContext,
@@ -72,23 +81,35 @@ function mapClass(pf: PfRawMatch, ctx: MappingContext): SensitiveKind | null {
       return 'phone'
     case 'address':
       return 'street-address'
+
     case 'url':
-      // URLs are not secrets on their own. Only emit when the regex
-      // already saw url-creds in the same span — pf then acts as a
+      // URLs aren't secrets on their own. Only emit when the regex
+      // also saw url-creds in the same span — pf then acts as a
       // confidence boost on the regex hit.
       return overlapsRegexKind(pf, ctx.regexMatches, 'url-creds') ? 'url-creds' : null
+
     case 'date':
       // Dates by themselves are noisy. Only emit when the +/- 32
       // chars around the match look like a DOB context.
       return looksLikeDob(pf, ctx.fullText) ? 'date-of-birth' : null
+
     case 'account_number':
       // Too noisy without a Luhn-style checksum. Regex's `credit-card`
       // already covers Luhn-valid hits; everything else is suppressed.
       return null
+
     case 'secret':
       // Regex is authoritative for known credential prefixes. PF's
       // `secret` only fires as a boost on existing regex hits.
       return overlapsRegexKind(pf, ctx.regexMatches, 'generic-secret') ? 'generic-secret' : null
+
+    default:
+      // Unknown label — log once in dev, drop in prod. Only fires on
+      // model swaps that forgot to update this switch.
+      if (process.env['NODE_ENV'] !== 'production') {
+        console.warn('[pf class-mapping] unknown label:', pf.class)
+      }
+      return null
   }
 }
 

--- a/packages/app/src/main/security/model-host.ts
+++ b/packages/app/src/main/security/model-host.ts
@@ -76,7 +76,11 @@ export function makeModelHost(
 ): Effect.Effect<ModelHost, never, Scope.Scope> {
   return Effect.gen(function* () {
     const ipc = deps.ipc ?? ipcMain
-    const readyTimeoutMs = deps.readyTimeoutMs ?? 10_000
+    // The renderer signals pf:ready AFTER transformers.js has finished
+    // loading + warming up the model. On a cold WASM path that can run
+    // close to a minute; 90 s gives headroom without inviting an
+    // indefinite hang.
+    const readyTimeoutMs = deps.readyTimeoutMs ?? 90_000
     const analyzeTimeoutMs = deps.analyzeTimeoutMs ?? 30_000
     const stateRef = yield* Ref.make<PfState>({ status: 'loading', runtime: null })
     const pending = new Map<number, {

--- a/packages/app/src/main/security/model-host.ts
+++ b/packages/app/src/main/security/model-host.ts
@@ -76,10 +76,8 @@ export function makeModelHost(
 ): Effect.Effect<ModelHost, never, Scope.Scope> {
   return Effect.gen(function* () {
     const ipc = deps.ipc ?? ipcMain
-    // The renderer signals pf:ready AFTER transformers.js has finished
-    // loading + warming up the model. On a cold WASM path that can run
-    // close to a minute; 90 s gives headroom without inviting an
-    // indefinite hang.
+    // 90 s default for pf:ready — cold WASM model load can take close
+    // to a minute; this gives headroom without inviting indefinite hang.
     const readyTimeoutMs = deps.readyTimeoutMs ?? 90_000
     const analyzeTimeoutMs = deps.analyzeTimeoutMs ?? 30_000
     const stateRef = yield* Ref.make<PfState>({ status: 'loading', runtime: null })
@@ -111,19 +109,14 @@ export function makeModelHost(
         }).pipe(Effect.catchAll((err) => failWith(err).pipe(Effect.as(null))))
 
         if (handshake?.kind === 'ready') {
-          const s: PfState = {
+          yield* Ref.set(stateRef, {
             status: 'ready',
             runtime: handshake.runtime,
             detectionMs: handshake.detectionMs,
-          }
-          if (handshake.adapterLabel !== undefined) s.adapterLabel = handshake.adapterLabel
-          yield* Ref.set(stateRef, s)
-        } else if (handshake?.kind === 'failed') {
-          yield* Ref.set(stateRef, {
-            status: 'failed',
-            runtime: null,
-            error: handshake.message,
+            ...(handshake.adapterLabel !== undefined ? { adapterLabel: handshake.adapterLabel } : {}),
           })
+        } else if (handshake?.kind === 'failed') {
+          yield* Ref.set(stateRef, { status: 'failed', runtime: null, error: handshake.message })
         }
         return w
       }),
@@ -232,13 +225,12 @@ function awaitReady(
       settle({
         kind: 'ready',
         runtime: payload.runtime,
-        ...(payload.adapterLabel !== undefined ? { adapterLabel: payload.adapterLabel } : {}),
         detectionMs: payload.detectionMs,
+        ...(payload.adapterLabel !== undefined ? { adapterLabel: payload.adapterLabel } : {}),
       })
     }
     const onFailed = (event: IpcMainEvent, payload: PfFailedMessage) => {
-      if (event.sender.id !== targetId) return
-      settle({ kind: 'failed', message: payload.message })
+      if (event.sender.id === targetId) settle({ kind: 'failed', message: payload.message })
     }
     const timer = setTimeout(
       () => settle({ kind: 'failed', message: `pf:ready handshake timed out after ${timeoutMs}ms` }),

--- a/packages/app/src/main/security/model-manifest.ts
+++ b/packages/app/src/main/security/model-manifest.ts
@@ -1,46 +1,56 @@
-// Pinned Privacy Filter model manifest. The downloader refuses to
-// keep a file whose hash disagrees with the per-file sha256, so a CDN
-// swap or MITM that returns a tampered weight file is caught before
-// the inference window ever loads it.
+// Pinned Privacy Filter model manifest.
 //
-// To update: bump hfCommit, regenerate each sha256 with `shasum -a
-// 256`, bump PF_MODEL_VERSION in model-paths.ts (scan_profile keys
-// off it). Real values get pinned pre-GA — see
-// project_security_scan_feature memory.
+// SOURCE OF TRUTH: this file declares which files we download, where
+// from, and what SHA-256 they MUST match. The downloader refuses to
+// keep a file whose hash disagrees with the manifest, so a CDN swap
+// or MITM that returns a tampered weight file is caught before the
+// inference window ever loads it.
+//
+// MODEL: openai/privacy-filter (Apache 2.0, 1.5B params / 50M active
+// MoE, 8-class PII token classifier with Viterbi span decoding).
+// Outputs entity_group strings prefixed `private_` (e.g. private_email)
+// plus the unprefixed `account_number` and `secret` classes — see
+// class-mapping.ts for the kind mapping.
+//
+// To update the model:
+//   1. bump PF_HF_REPO + PF_MODEL_ID + PF_PROFILE_VERSION in model-paths.ts
+//   2. regenerate the per-file sha256s against the new commit
+//   3. update class-mapping.ts if the label set changed
 
 import { PF_HF_REPO } from './model-paths.js'
 
 export interface ManifestFile {
+  /** Relative path inside the model directory + the path the file is
+   *  fetched at on huggingface.co/<repo>/resolve/<commit>/<this>. */
   path: string
+  /** Lowercase hex SHA-256 of the complete file. */
   sha256: string
+  /** Expected file size in bytes — used as a progress denominator and
+   *  to short-circuit obviously truncated resumes. */
   sizeBytes: number
 }
 
 export interface ModelManifest {
   hfRepo: string
+  /** Pinned commit hash on HF. Must be a 40-char SHA. */
   hfCommit: string
+  /** Files to fetch, in download order. */
   files: ReadonlyArray<ManifestFile>
 }
 
 export const MODEL_MANIFEST: ModelManifest = {
   hfRepo: PF_HF_REPO,
-  hfCommit: '0000000000000000000000000000000000000000',
+  hfCommit: '7ffa9a043d54d1be65afb281eddf0ffbe629385b',
   files: [
-    {
-      path: 'onnx/model_quantized.onnx',
-      sha256: '0'.repeat(64),
-      sizeBytes: 800_000_000,
-    },
-    {
-      path: 'tokenizer.json',
-      sha256: '0'.repeat(64),
-      sizeBytes: 2_500_000,
-    },
-    {
-      path: 'config.json',
-      sha256: '0'.repeat(64),
-      sizeBytes: 1_500,
-    },
+    { path: 'config.json',              sha256: 'b2b26a4a4a000639ad30b0c264adbefe365bdb567fbd7bb27303b8c438375bd1', sizeBytes: 3039 },
+    { path: 'tokenizer.json',           sha256: '0614fe83cadab421296e664e1f48f4261fa8fef6e03e63bb75c20f38e37d07d3', sizeBytes: 27868174 },
+    { path: 'tokenizer_config.json',    sha256: '6c14af9ce1a284d3c3c5146b26efe4cd589c68e1dd4e9d94455606ec911ba774', sizeBytes: 234 },
+    { path: 'viterbi_calibration.json', sha256: 'bbc8611ef08a55ed72d64856cbbbb9a91db8dfa881f0a92e2afbad6e4bbc775a', sizeBytes: 372 },
+    { path: 'onnx/model_q4.onnx',       sha256: '8f7dee8b46d096f052b359375dfba5d983cc4d18c44a783bf548615c472f8dea', sizeBytes: 160219 },
+    // Weights spill into an external `.onnx_data` file when the ONNX
+    // graph exceeds protobuf's 2 GB limit. transformers.js loads it
+    // automatically as long as it sits next to the .onnx graph.
+    { path: 'onnx/model_q4.onnx_data',  sha256: 'f30998e28c71c5374cc7e8b7de8f0f83e981592c0c2d652d2ad4928454dbb496', sizeBytes: 917120144 },
   ],
 }
 

--- a/packages/app/src/main/security/model-paths.ts
+++ b/packages/app/src/main/security/model-paths.ts
@@ -1,18 +1,31 @@
-// Filesystem paths + version constants for the OpenAI Privacy Filter
-// model bundle. Centralised so the download / load / unload code
-// agrees, and so the path appears in one place in Settings.
+// Filesystem paths + version constants for the Privacy Filter ONNX
+// model bundle. Centralised so download / load / unload code agrees
+// and the directory shows up in one place in Settings.
 
 import { app } from 'electron'
 import { join } from 'node:path'
 
+/** Directory name under userData/models/. Bumped any time the model
+ *  changes — the scan profile string keys off PF_PROFILE_VERSION so
+ *  a model swap forces a full rescan. */
 export const PF_MODEL_ID = 'openai-privacy-filter-q4'
 export const PF_MODEL_VERSION = '1.5b-q4'
 /** HuggingFace repository — pinned to a specific commit at download
- *  time. Source of truth is `manifest.json` colocated with the bundle. */
+ *  time. transformers.js loads the model files via the pf-model://
+ *  protocol against the local copy; this URL is only used by the
+ *  downloader, never by the inference renderer. */
 export const PF_HF_REPO = 'openai/privacy-filter'
 
+/** Parent directory for all model bundles. transformers.js fetches
+ *  files at `${env.localModelPath}/${modelId}/${file}`, so the
+ *  protocol resolves relative to this and not to the model-specific
+ *  subdirectory. */
+export function pfModelsRoot(): string {
+  return join(app.getPath('userData'), 'models')
+}
+
 export function pfModelDir(): string {
-  return join(app.getPath('userData'), 'models', PF_MODEL_ID)
+  return join(pfModelsRoot(), PF_MODEL_ID)
 }
 
 export function pfManifestPath(): string {

--- a/packages/app/src/main/security/pf-model-protocol.ts
+++ b/packages/app/src/main/security/pf-model-protocol.ts
@@ -1,0 +1,53 @@
+// Custom `pf-model://` protocol — serves files from pfModelDir() to
+// the hidden inference renderer.
+//
+// Why not file://: with sandbox=true the inference renderer can't read
+// arbitrary file:// URLs, and weakening webPreferences just to load a
+// local model would be a bigger compromise than registering one
+// narrow protocol that ONLY answers for paths under pfModelDir().
+//
+// transformers.js issues fetches against `${env.localModelPath}/${modelId}/${file}`,
+// so we treat any pf-model:// path as a relative join against the
+// model directory and refuse to escape it.
+
+import { protocol, net } from 'electron'
+import { resolve, sep } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { pfModelsRoot } from './model-paths.js'
+
+let registered = false
+
+export function registerPfModelProtocol(): void {
+  if (registered) return
+  registered = true
+  protocol.handle('pf-model', async (req) => {
+    const url = new URL(req.url)
+    // Strip leading slashes from the path so `pf-model:///foo/bar.bin`
+    // resolves under pfModelsRoot(), not the filesystem root.
+    const relPath = url.pathname.replace(/^\/+/, '')
+    const root = pfModelsRoot()
+    const target = resolve(root, relPath)
+    // Refuse anything that escapes the models parent directory.
+    if (target !== root && !target.startsWith(root + sep)) {
+      return new Response('forbidden', { status: 403 })
+    }
+    return net.fetch(pathToFileURL(target).toString())
+  })
+}
+
+/** electron.protocol can ONLY be called before app.ready, so the
+ *  scheme has to be marked privileged at import time. Otherwise the
+ *  renderer treats `pf-model://` as an opaque origin and CSP/fetch
+ *  reject it silently. */
+export function registerPfModelScheme(): void {
+  protocol.registerSchemesAsPrivileged([{
+    scheme: 'pf-model',
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      bypassCSP: false,
+      stream: true,
+    },
+  }])
+}

--- a/packages/app/src/main/security/pf-runtime.ts
+++ b/packages/app/src/main/security/pf-runtime.ts
@@ -104,13 +104,9 @@ async function defaultSpawnWindow(): Promise<BrowserWindow> {
       nodeIntegration: false,
     },
   })
-  // Prod: electron-vite emits `pf-inference.html` next to the main
-  // renderer's `index.html` under `out/renderer/` (see the rollup
-  // `input` map in electron.vite.config.ts).
-  // Dev: ELECTRON_RENDERER_URL points at the renderer dev server
-  // rooted at `src/renderer/`; the inference HTML source lives at
-  // `src/inference/pf-inference.html`, so we climb one level up
-  // through the dev server to reach it.
+  // Prod: electron-vite emits pf-inference.html under out/renderer/.
+  // Dev: ELECTRON_RENDERER_URL points at src/renderer/, so climb one
+  // level up to reach src/inference/pf-inference.html.
   const rendererBase = process.env['ELECTRON_RENDERER_URL']
   if (rendererBase) {
     await win.loadURL(`${rendererBase}/../inference/pf-inference.html`)

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -32,6 +32,14 @@ export interface PfDownloadState {
   bytesTotal: number
   error?: string
 }
+
+export interface PfRuntimeInfo {
+  status: 'idle' | 'loading' | 'ready' | 'failed'
+  runtime: 'webgpu' | 'wasm' | null
+  adapterLabel?: string
+  detectionMs?: number
+  error?: string
+}
 import type { SearchSortOrder } from '../shared/searchSort.js'
 import type { SidebarSortOrder } from '../shared/sidebarSort.js'
 import type { PinnedSortOrder } from '../shared/pinnedSort.js'
@@ -311,6 +319,8 @@ const api = {
       ipcRenderer.invoke('security:pf-download-start'),
     pfDownloadCancel: (): Promise<{ ok: boolean }> =>
       ipcRenderer.invoke('security:pf-download-cancel'),
+    pfGetRuntimeInfo: (): Promise<PfRuntimeInfo | null> =>
+      ipcRenderer.invoke('security:pf-get-runtime-info'),
     onPfState: (cb: (state: PfDownloadState) => void) => {
       const handler = (_: Electron.IpcRendererEvent, data: unknown) => cb(data as PfDownloadState)
       ipcRenderer.on('security:evt-pf-state', handler)

--- a/packages/app/src/renderer/api/security.ts
+++ b/packages/app/src/renderer/api/security.ts
@@ -21,9 +21,9 @@ import type {
 
 export type { BackupFileInfo }
 import type { SensitiveKind } from '@spool-lab/redact'
-import type { SecurityPreferences, PfDownloadState } from '../../preload/index.js'
+import type { SecurityPreferences, PfDownloadState, PfRuntimeInfo } from '../../preload/index.js'
 
-export type { SecurityPreferences, AllowlistEntryRow, PfDownloadState }
+export type { SecurityPreferences, AllowlistEntryRow, PfDownloadState, PfRuntimeInfo }
 
 /** Single source of truth for the renderer-side adapter. Components
  *  hold this object, not `window.spool.security` — keeps replaceability
@@ -91,6 +91,8 @@ export const securityApi = {
     window.spool.security.pfDownloadStart(),
   pfDownloadCancel: (): Promise<{ ok: boolean }> =>
     window.spool.security.pfDownloadCancel(),
+  pfGetRuntimeInfo: (): Promise<PfRuntimeInfo | null> =>
+    window.spool.security.pfGetRuntimeInfo(),
   onPfState: (handler: (s: PfDownloadState) => void): (() => void) =>
     window.spool.security.onPfState(handler),
 }

--- a/packages/app/src/renderer/components/Settings/security/PfDownloadCard.tsx
+++ b/packages/app/src/renderer/components/Settings/security/PfDownloadCard.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Download, X, RotateCw, AlertTriangle } from 'lucide-react'
-import { securityApi, type PfDownloadState, type SecurityPreferences } from '../../../api/security.js'
+import { securityApi, type PfDownloadState, type PfRuntimeInfo, type SecurityPreferences } from '../../../api/security.js'
 import { formatBytes } from '../../security/format.js'
 import Toggle from '../../Toggle.js'
 
@@ -15,6 +15,7 @@ export default function PfDownloadCard() {
   const [state, setState] = useState<PfDownloadState>(INITIAL)
   const [busy, setBusy] = useState(false)
   const [prefs, setPrefs] = useState<SecurityPreferences | null>(null)
+  const [runtime, setRuntime] = useState<PfRuntimeInfo | null>(null)
 
   useEffect(() => {
     void securityApi.pfGetState().then(setState).catch(() => setState(INITIAL))
@@ -23,6 +24,25 @@ export default function PfDownloadCard() {
     const offPrefs = securityApi.onPrefsChanged(setPrefs)
     return () => { offState(); offPrefs() }
   }, [])
+
+  // Poll runtime info while pfEnabled is on. ModelHost handshake can
+  // take up to 90 s on cold WASM; 2 s lets the badge update without
+  // spamming the IPC.
+  useEffect(() => {
+    if (!prefs?.pfEnabled || state.phase !== 'installed') {
+      setRuntime(null)
+      return
+    }
+    let cancelled = false
+    const tick = () => {
+      securityApi.pfGetRuntimeInfo()
+        .catch(() => null)
+        .then((info) => { if (!cancelled) setRuntime(info) })
+    }
+    tick()
+    const id = setInterval(tick, 2000)
+    return () => { cancelled = true; clearInterval(id) }
+  }, [prefs?.pfEnabled, state.phase])
 
   const startDownload = async () => {
     setBusy(true)
@@ -66,6 +86,19 @@ export default function PfDownloadCard() {
               defaultValue: 'OpenAI Privacy Filter · Apache 2.0 · runs on-device',
             })}
           </p>
+
+          {runtime?.status === 'ready' && runtime.runtime && (
+            <p
+              data-testid="settings-pf-runtime"
+              data-runtime={runtime.runtime}
+              className="mt-1.5 font-mono text-[10px] text-accent dark:text-accent-dark"
+            >
+              {runtime.runtime === 'webgpu'
+                ? t('settings.security.detector_pf_runtime_webgpu', { defaultValue: 'WebGPU' })
+                : t('settings.security.detector_pf_runtime_wasm', { defaultValue: 'WASM (CPU)' })}
+              {runtime.adapterLabel ? ` · ${runtime.adapterLabel}` : ''}
+            </p>
+          )}
 
           {state.phase === 'downloading' && (
             <div className="mt-2.5" data-testid="settings-pf-progress">

--- a/packages/app/src/renderer/components/Settings/security/PfDownloadCard.tsx
+++ b/packages/app/src/renderer/components/Settings/security/PfDownloadCard.tsx
@@ -53,7 +53,7 @@ export default function PfDownloadCard() {
               {t('settings.security.detector_pf_title', { defaultValue: 'Privacy Filter' })}
             </span>
             <code className="font-mono text-[10px] text-warm-faint dark:text-dark-muted bg-warm-surface dark:bg-dark-surface px-1.5 py-0.5 rounded">
-              {formatBytes(state.bytesTotal || 800_000_000)}
+              {formatBytes(state.bytesTotal || 945_000_000)}
             </code>
           </div>
           <p className="text-[11px] leading-[16px] text-warm-faint dark:text-dark-muted mb-1.5">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       '@fontsource/geist-mono':
         specifier: ^5.2.7
         version: 5.2.7
+      '@huggingface/transformers':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@spool-lab/core':
         specifier: workspace:*
         version: link:../core
@@ -1213,6 +1216,16 @@ packages:
     peerDependencies:
       hono: '>=3.0.0'
 
+  '@huggingface/jinja@0.5.9':
+    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
+    engines: {node: '>=18'}
+
+  '@huggingface/tokenizers@0.1.3':
+    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
+
+  '@huggingface/transformers@4.2.0':
+    resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1898,6 +1911,36 @@ packages:
 
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -2744,6 +2787,10 @@ packages:
 
   acp-extension-core@0.0.5:
     resolution: {integrity: sha512-dv1/3AvFBPpzQoMnzUMpj46XascOwTsGoEgM2z5vAeWQ2QOiluydZXmJEU0R5ItKsVFUo2RW4AbfgzvUcbcd3A==}
+
+  adm-zip@0.5.17:
+    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
+    engines: {node: '>=12.0'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -3659,6 +3706,9 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
@@ -3783,6 +3833,9 @@ packages:
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
+
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -4179,6 +4232,9 @@ packages:
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -4614,6 +4670,19 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
+    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
+
+  onnxruntime-common@1.24.3:
+    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
+
+  onnxruntime-node@1.24.3:
+    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -4757,6 +4826,9 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
@@ -4839,6 +4911,10 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  protobufjs@7.6.0:
+    resolution: {integrity: sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==}
+    engines: {node: '>=12.0.0'}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -6463,6 +6539,18 @@ snapshots:
     dependencies:
       hono: 4.12.18
 
+  '@huggingface/jinja@0.5.9': {}
+
+  '@huggingface/tokenizers@0.1.3': {}
+
+  '@huggingface/transformers@4.2.0':
+    dependencies:
+      '@huggingface/jinja': 0.5.9
+      '@huggingface/tokenizers': 0.1.3
+      onnxruntime-node: 1.24.3
+      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
+      sharp: 0.34.5
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -6784,7 +6872,7 @@ snapshots:
       '@opentelemetry/api-logs': 0.218.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -6972,6 +7060,28 @@ snapshots:
       supports-color: 10.2.2
 
   '@poppinss/exception@1.2.3': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -7775,6 +7885,8 @@ snapshots:
 
   acp-extension-core@0.0.5: {}
 
+  adm-zip@0.5.17: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -7983,8 +8095,7 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  boolean@3.2.0:
-    optional: true
+  boolean@3.2.0: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -8253,14 +8364,12 @@ snapshots:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
-    optional: true
 
   define-properties@1.2.1:
     dependencies:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-    optional: true
 
   defu@6.1.7: {}
 
@@ -8270,8 +8379,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  detect-node@2.1.0:
-    optional: true
+  detect-node@2.1.0: {}
 
   devlop@1.1.0:
     dependencies:
@@ -8497,8 +8605,7 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  es6-error@4.1.1:
-    optional: true
+  es6-error@4.1.1: {}
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -8736,6 +8843,8 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
 
+  flatbuffers@25.9.23: {}
+
   flatted@3.4.2: {}
 
   foreground-child@3.3.1:
@@ -8872,13 +8981,11 @@ snapshots:
       roarr: 2.15.4
       semver: 7.7.4
       serialize-error: 7.0.1
-    optional: true
 
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
-    optional: true
 
   gopd@1.2.0: {}
 
@@ -8905,12 +9012,13 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
+  guid-typescript@1.0.9: {}
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
-    optional: true
 
   has-symbols@1.1.0: {}
 
@@ -9155,8 +9263,7 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stringify-safe@5.0.1:
-    optional: true
+  json-stringify-safe@5.0.1: {}
 
   json5@2.2.3: {}
 
@@ -9265,6 +9372,8 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   loupe@3.2.1: {}
@@ -9370,7 +9479,6 @@ snapshots:
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
-    optional: true
 
   math-intrinsics@1.1.0: {}
 
@@ -9919,8 +10027,7 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
-  object-keys@1.1.1:
-    optional: true
+  object-keys@1.1.1: {}
 
   obug@2.1.1: {}
 
@@ -9945,6 +10052,25 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
+
+  onnxruntime-common@1.24.3: {}
+
+  onnxruntime-node@1.24.3:
+    dependencies:
+      adm-zip: 0.5.17
+      global-agent: 3.0.0
+      onnxruntime-common: 1.24.3
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
+      platform: 1.3.6
+      protobufjs: 7.6.0
 
   optionator@0.9.4:
     dependencies:
@@ -10131,6 +10257,8 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
+  platform@1.3.6: {}
+
   playwright-core@1.59.1: {}
 
   playwright@1.59.1:
@@ -10205,6 +10333,21 @@ snapshots:
       signal-exit: 3.0.7
 
   property-information@7.1.0: {}
+
+  protobufjs@7.6.0:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.19.17
+      long: 5.3.2
 
   pump@3.0.4:
     dependencies:
@@ -10414,7 +10557,6 @@ snapshots:
       json-stringify-safe: 5.0.1
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
-    optional: true
 
   rollup@4.60.0:
     dependencies:
@@ -10466,8 +10608,7 @@ snapshots:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
 
-  semver-compare@1.0.0:
-    optional: true
+  semver-compare@1.0.0: {}
 
   semver@5.7.2: {}
 
@@ -10478,7 +10619,6 @@ snapshots:
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
-    optional: true
 
   set-cookie-parser@3.1.0: {}
 
@@ -10615,8 +10755,7 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  sprintf-js@1.1.3:
-    optional: true
+  sprintf-js@1.1.3: {}
 
   ssri@12.0.0:
     dependencies:
@@ -10824,8 +10963,7 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@0.13.1:
-    optional: true
+  type-fest@0.13.1: {}
 
   typescript@5.9.3: {}
 


### PR DESCRIPTION
feat(security): real ONNX inference via openai/privacy-filter

PR 5f of the Privacy Filter ML stack. Replaces the stub pf:analyze
handler with a real transformers.js + ONNX Runtime Web pipeline
running openai/privacy-filter, and pins the manifest to the
matching HF commit so the downloader actually fetches verified
weights.

Model:
- openai/privacy-filter pinned at commit 7ffa9a0 (Apache 2.0, 1.5B
  params / 50M active MoE, 8-class PII token classifier with
  Viterbi span decoder, official transformers.js support)
- Total ~945 MB q4 (917 MB onnx_data weights + 27 MB tokenizer +
  small json files); SHA-256 verified per file against the HF
  mirror
- Output entity_groups are `private_*` prefixed (private_person /
  private_email / private_phone / private_address / private_url /
  private_date) plus `account_number` and `secret`

Plumbing:
- @huggingface/transformers added as an app dependency
- pf-model:// custom Electron protocol serving files from
  userData/models/, registered as privileged at module load + via
  protocol.handle at app.ready. Path traversal refused with 403
- pf-inference.ts: lazy import of transformers.js, env wired to
  pf-model:// + allowRemoteModels=false (renderer can't reach the
  network), pipeline('token-classification', PF_MODEL_ID) with q4
  dtype against the detected runtime; pf:ready now fires only AFTER
  warmup so the first analyze call doesn't pay 10-30 s of cold
  start. Strips the `private_` prefix before sending so the class
  mapping module stays model-agnostic
- pf-inference.html CSP: allows pf-model:, blob:, and
  'wasm-unsafe-eval' (ORT WASM backend requires it); default-src
  stays 'self' otherwise — no other network reachable
- ModelHost readyTimeoutMs bumped 10 s → 90 s to cover cold WASM
  warmup
- model-paths.ts: pfModelsRoot() helper so the protocol resolves the
  PARENT of the model directory (transformers.js appends modelId to
  the base URL)
- main/index.ts: pfCoordinator now actually instantiated + handed to
  registerSecurityIpc — the Download button + progress events were
  wired in 5b but never reached the coordinator; this finishes the
  loop so the user can actually trigger a download

Class mapping (8 classes after `private_` strip):
- person → person-name, email → email, phone → phone, address →
  street-address (direct)
- url + secret only emit when overlapping a regex hit (boost
  pattern; regex stays authoritative for credentials)
- date gated by ±32-char DOB-keyword context
- account_number suppressed entirely (regex's Luhn-validated
  credit-card already covers checksum-valid hits)

Full app suite 271/271. Typecheck clean.

feat(security): surface PF inference runtime in Settings card

PR 5h of the Privacy Filter ML stack — final polish + GA closeout.

- New IPC channel PF_GET_RUNTIME_INFO + matching preload + renderer
  api passthrough. Returns null when ModelHost isn't running so the
  card can hide the badge without an extra "not running" branch.
- registerSecurityIpc accepts an optional pfRuntime dep; main wires
  the global pfRuntime singleton in
- PfDownloadCard: in the installed phase, polls runtime info at 2 s
  and renders a "WebGPU · Apple M2 Pro" / "WASM (CPU)" badge under
  the model footer once the hidden window has reported ready. Polling
  stops when pfEnabled is off

Manual verification procedure (since e2e of real ONNX inference would
require shipping the ~145 MB model bundle):
  1. Launch app, enable VITE_FEATURE_SECURITY in dev
  2. Settings → Security → click Download on the PF card
  3. Watch the progress bar advance; ~145 MB total
  4. After install, flip the PF toggle on
  5. Inference window boots (no UI; ~3-10 s on WebGPU, longer on WASM)
  6. Watch the runtime badge appear ("WebGPU · ..." / "WASM (CPU)")
  7. Worker backfills sessions whose scan_profile is regex@4 only
  8. Person-name / long-form street-address findings tagged
     provider='pf' should appear on the Security page

What's still required before flipping VITE_FEATURE_SECURITY in
release.yml — see project_security_scan_feature memory for the full
list. Highlights:
  - Native i18n review on ja/ko/de/fr stubs (placeholder English copy
    landed in 5e)
  - Prod-DB migration smoke on a real user's 5k+ session library
  - User dogfoods the whole flow end-to-end + confirms it feels smooth
  - Decide whether bert-base-NER's general NER coverage is enough for
    GA or whether to ship with a purpose-built PII model (Piiranha is
    NC-ND so not commercially shippable today; a custom fine-tune or
    a re-licensed derivative would be the path forward)

Full app suite 274/274. Typecheck clean.