### PR TITLE
feat(security): in-page Privacy Filter discovery callout

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -39,8 +39,8 @@ import {
 } from '@spool-lab/core'
 import { spawnScanWorker, type ScanWorkerProxy } from './scan-worker-proxy.js'
 import { Effect } from 'effect'
-import { registerSecurityIpc } from './ipc/security.js'
-import { loadSecurityPreferences } from './securityPreferences.js'
+import { registerSecurityIpc, SECURITY_IPC_CHANNELS } from './ipc/security.js'
+import { loadSecurityPreferences, saveSecurityPreferences } from './securityPreferences.js'
 import { makePfRuntime, pfModelInstalled } from './security/pf-runtime.js'
 import { registerPfModelProtocol, registerPfModelScheme } from './security/pf-model-protocol.js'
 import { makePfCoordinator } from './security/pf-coordinator.js'
@@ -220,22 +220,30 @@ async function shutdownScanWorker(): Promise<void> {
  *  the download hasn't finished would just spawn a window with
  *  nothing to load. Tells the scan worker about the transition so its
  *  pfProvider.available() agrees with reality and `scan_profile`
- *  drifts (triggering a backfill rescan via worker.backfill()). */
+ *  drifts (triggering a backfill rescan via worker.backfill()).
+ *
+ *  Also clears pfActivationPending on the way out — the callout's
+ *  "Activating Privacy Filter…" state hangs on that flag, so it
+ *  needs to drop the moment the runtime + backfill have settled
+ *  (success or fail). The ScanBanner then takes over visually. */
 async function syncPfRuntime(pfEnabled: boolean): Promise<void> {
-  if (pfEnabled && pfModelInstalled()) {
-    await pfRuntime.start()
-    scanWorker?.notifyPfOnline()
-  } else {
-    scanWorker?.notifyPfOffline()
-    await pfRuntime.stop()
-  }
-  // The profile string changes on every transition — kick a backfill
-  // so sessions whose stored scan_profile no longer matches get
-  // re-enqueued.
-  if (scanWorker) {
-    runWithObservability(scanWorker.backfill()).catch((err) => {
-      console.error('[security] pf-driven backfill failed:', err)
-    })
+  try {
+    if (pfEnabled && pfModelInstalled()) {
+      await pfRuntime.start()
+      scanWorker?.notifyPfOnline()
+    } else {
+      scanWorker?.notifyPfOffline()
+      await pfRuntime.stop()
+    }
+    if (scanWorker) {
+      await runWithObservability(scanWorker.backfill())
+    }
+  } finally {
+    const cur = loadSecurityPreferences()
+    if (cur.pfActivationPending) {
+      const next = saveSecurityPreferences({ pfActivationPending: false })
+      mainWindow?.webContents.send(SECURITY_IPC_CHANNELS.EVT_PREFS_CHANGED, next)
+    }
   }
 }
 
@@ -441,6 +449,23 @@ app.whenReady().then(async () => {
     pfCoordinator = makePfCoordinator({
       modelDir: pfModelDir(),
       fetch: ((url, init) => net.fetch(url as string, init)) as typeof globalThis.fetch,
+    })
+    // When a download initiated from the callout completes, finish
+    // the activation handshake on the user's behalf — flip pfEnabled
+    // so syncPfRuntime spawns the inference window + kicks backfill.
+    // The callout self-renders an "Activating..." state until
+    // syncPfRuntime clears pfActivationPending below.
+    pfCoordinator.subscribe((s) => {
+      if (s.phase !== 'installed') return
+      const prefs = loadSecurityPreferences()
+      if (!prefs.pfActivationPending || prefs.pfEnabled) return
+      void (async () => {
+        const next = saveSecurityPreferences({ pfEnabled: true })
+        mainWindow?.webContents.send(SECURITY_IPC_CHANNELS.EVT_PREFS_CHANGED, next)
+        await syncPfRuntime(true).catch((err) => {
+          console.error('[security] callout-driven activation failed:', err)
+        })
+      })()
     })
     void bootScanWorker().then(() => {
       if (!scanWorker) return

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, ipcMain, Menu, nativeTheme, nativeImage, shell } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain, Menu, nativeTheme, nativeImage, net, shell } from 'electron'
 import { join } from 'node:path'
 import { Worker } from 'node:worker_threads'
 
@@ -434,7 +434,14 @@ app.whenReady().then(async () => {
   if (securityFeatureEnabled()) {
     // Has to happen post-ready (uses protocol.handle + app.getPath).
     registerPfModelProtocol()
-    pfCoordinator = makePfCoordinator({ modelDir: pfModelDir() })
+    // Electron's `net.fetch` honours system proxy + custom CA bundle;
+    // globalThis.fetch (undici) bypasses both. Per bug_electron_proxy
+    // memory: stealer logs / corp proxies / mainland China all need
+    // this for outbound HF traffic.
+    pfCoordinator = makePfCoordinator({
+      modelDir: pfModelDir(),
+      fetch: ((url, init) => net.fetch(url as string, init)) as typeof globalThis.fetch,
+    })
     void bootScanWorker().then(() => {
       if (!scanWorker) return
       disposeSecurityIpc = registerSecurityIpc({

--- a/packages/app/src/main/security/model-download.ts
+++ b/packages/app/src/main/security/model-download.ts
@@ -107,7 +107,24 @@ async function fetchAndAppend(args: {
 
   const init: RequestInit = { headers }
   if (args.signal !== undefined) init.signal = args.signal
-  const res = await args.fetcher(args.url, init)
+  let res: Response
+  try {
+    res = await args.fetcher(args.url, init)
+  } catch (cause) {
+    // Preserve AbortError so the coordinator's cancel branch (which
+    // checks err.name === 'AbortError') still drops back to
+    // not-installed instead of flipping to failed.
+    if ((cause as { name?: string } | undefined)?.name === 'AbortError') throw cause
+    // Network-level failure (DNS, TLS, proxy, connection reset) —
+    // re-raise as DownloadError so the coordinator surfaces a
+    // useful message instead of a bare "fetch failed".
+    const host = safeHost(args.url)
+    const detail = cause instanceof Error ? cause.message : String(cause)
+    throw new DownloadError(
+      `Couldn't reach ${host} (${detail}). Check network / proxy.`,
+      { file: args.partPath, stage: 'http' },
+    )
+  }
 
   if (args.startOffset > 0 && res.status !== 206 && res.status !== 200) {
     throw new DownloadError(
@@ -144,4 +161,8 @@ function fileMatches(path: string, file: ManifestFile): boolean {
   } catch {
     return false
   }
+}
+
+function safeHost(url: string): string {
+  try { return new URL(url).host } catch { return url }
 }

--- a/packages/app/src/main/securityPreferences.test.ts
+++ b/packages/app/src/main/securityPreferences.test.ts
@@ -46,6 +46,7 @@ describe('loadSecurityPreferences', () => {
       revealValuesOnHoverOnly: false,
       pfEnabled: false,
       pfCalloutDismissed: false,
+      pfActivationPending: false,
     })
   })
 
@@ -196,6 +197,7 @@ describe('saveSecurityPreferences', () => {
       // also auto-sets pfCalloutDismissed so the in-page discovery
       // banner doesn't re-appear after the user opts in.
       pfCalloutDismissed: true,
+      pfActivationPending: false,
     })
   })
 

--- a/packages/app/src/main/securityPreferences.test.ts
+++ b/packages/app/src/main/securityPreferences.test.ts
@@ -45,6 +45,7 @@ describe('loadSecurityPreferences', () => {
       rescanAfterSync: 'auto',
       revealValuesOnHoverOnly: false,
       pfEnabled: false,
+      pfCalloutDismissed: false,
     })
   })
 
@@ -191,7 +192,24 @@ describe('saveSecurityPreferences', () => {
       rescanAfterSync: 'manual',
       revealValuesOnHoverOnly: true,
       pfEnabled: true,
+      // Side-effect of saveSecurityPreferences: flipping pfEnabled on
+      // also auto-sets pfCalloutDismissed so the in-page discovery
+      // banner doesn't re-appear after the user opts in.
+      pfCalloutDismissed: true,
     })
+  })
+
+  it('flipping pfEnabled off does NOT touch pfCalloutDismissed', () => {
+    mod.saveSecurityPreferences({ pfCalloutDismissed: true })
+    mod.saveSecurityPreferences({ pfEnabled: false })
+    expect(mod.loadSecurityPreferences().pfCalloutDismissed).toBe(true)
+  })
+
+  it('explicit pfCalloutDismissed:false can re-arm the callout', () => {
+    mod.saveSecurityPreferences({ pfEnabled: true })  // also flips dismissed to true
+    expect(mod.loadSecurityPreferences().pfCalloutDismissed).toBe(true)
+    mod.saveSecurityPreferences({ pfEnabled: false, pfCalloutDismissed: false })
+    expect(mod.loadSecurityPreferences().pfCalloutDismissed).toBe(false)
   })
 
   // Filesystem-error path is exercised on platforms where chmod is

--- a/packages/app/src/main/securityPreferences.ts
+++ b/packages/app/src/main/securityPreferences.ts
@@ -46,9 +46,14 @@ export interface SecurityPreferences {
   /** True once the user has dismissed the in-page PF discovery callout
    *  on the Security page. Permanent — the Settings card stays as the
    *  ongoing management surface, the callout is only an acquisition
-   *  prompt. Auto-set to true the moment pfEnabled flips on so users
-   *  who came in through Settings never see a redundant nudge. */
+   *  prompt. */
   pfCalloutDismissed: boolean
+  /** Survives renderer remounts + app restarts. True between the moment
+   *  the user clicks Enable in the callout and the moment the runtime
+   *  + backfill have settled. Lets main know to auto-flip pfEnabled
+   *  the moment the download lands, and lets the callout render an
+   *  "Activating..." state instead of vanishing into a silent gap. */
+  pfActivationPending: boolean
 }
 
 const DEFAULTS: SecurityPreferences = {
@@ -58,6 +63,7 @@ const DEFAULTS: SecurityPreferences = {
   revealValuesOnHoverOnly: false,
   pfEnabled: false,
   pfCalloutDismissed: false,
+  pfActivationPending: false,
 }
 
 interface SecurityConfigFile {
@@ -67,6 +73,7 @@ interface SecurityConfigFile {
   revealValuesOnHoverOnly?: unknown
   pfEnabled?: unknown
   pfCalloutDismissed?: unknown
+  pfActivationPending?: unknown
   [key: string]: unknown
 }
 
@@ -102,6 +109,7 @@ export function loadSecurityPreferences(): SecurityPreferences {
     revealValuesOnHoverOnly: c.revealValuesOnHoverOnly === true,
     pfEnabled: c.pfEnabled === true,
     pfCalloutDismissed: c.pfCalloutDismissed === true,
+    pfActivationPending: c.pfActivationPending === true,
   }
 }
 
@@ -115,12 +123,15 @@ export function saveSecurityPreferences(next: Partial<SecurityPreferences>): Sec
   if (next.revealValuesOnHoverOnly !== undefined) merged.revealValuesOnHoverOnly = next.revealValuesOnHoverOnly === true
   if (next.pfEnabled !== undefined) {
     merged.pfEnabled = next.pfEnabled === true
-    // Enabling pf supersedes the in-page nudge — once a user actually
-    // turns it on (via Settings or the callout itself) the callout
-    // becomes redundant and should never appear again.
+    // Enabling pf supersedes the in-page discovery nudge — once a user
+    // actually turns it on (via Settings or the callout itself) the
+    // "Add Privacy Filter" prompt becomes redundant and should never
+    // re-appear. The callout's Activating / Re-scanning states are
+    // separate signals gated by pfActivationPending, not by this flag.
     if (next.pfEnabled === true) merged.pfCalloutDismissed = true
   }
   if (next.pfCalloutDismissed !== undefined) merged.pfCalloutDismissed = next.pfCalloutDismissed === true
+  if (next.pfActivationPending !== undefined) merged.pfActivationPending = next.pfActivationPending === true
   writeFile(merged)
   return loadSecurityPreferences()
 }

--- a/packages/app/src/main/securityPreferences.ts
+++ b/packages/app/src/main/securityPreferences.ts
@@ -43,6 +43,12 @@ export interface SecurityPreferences {
    *  The provider is a stub today; this preference is the toggle UI
    *  state so the user's choice survives a restart once ML lands. */
   pfEnabled: boolean
+  /** True once the user has dismissed the in-page PF discovery callout
+   *  on the Security page. Permanent — the Settings card stays as the
+   *  ongoing management surface, the callout is only an acquisition
+   *  prompt. Auto-set to true the moment pfEnabled flips on so users
+   *  who came in through Settings never see a redundant nudge. */
+  pfCalloutDismissed: boolean
 }
 
 const DEFAULTS: SecurityPreferences = {
@@ -51,6 +57,7 @@ const DEFAULTS: SecurityPreferences = {
   rescanAfterSync: 'auto',
   revealValuesOnHoverOnly: false,
   pfEnabled: false,
+  pfCalloutDismissed: false,
 }
 
 interface SecurityConfigFile {
@@ -59,6 +66,7 @@ interface SecurityConfigFile {
   rescanAfterSync?: unknown
   revealValuesOnHoverOnly?: unknown
   pfEnabled?: unknown
+  pfCalloutDismissed?: unknown
   [key: string]: unknown
 }
 
@@ -93,6 +101,7 @@ export function loadSecurityPreferences(): SecurityPreferences {
     rescanAfterSync: normalizeRescan(c.rescanAfterSync),
     revealValuesOnHoverOnly: c.revealValuesOnHoverOnly === true,
     pfEnabled: c.pfEnabled === true,
+    pfCalloutDismissed: c.pfCalloutDismissed === true,
   }
 }
 
@@ -104,7 +113,14 @@ export function saveSecurityPreferences(next: Partial<SecurityPreferences>): Sec
   if (next.infoDefaultVisible !== undefined) merged.infoDefaultVisible = next.infoDefaultVisible === true
   if (next.rescanAfterSync !== undefined) merged.rescanAfterSync = normalizeRescan(next.rescanAfterSync)
   if (next.revealValuesOnHoverOnly !== undefined) merged.revealValuesOnHoverOnly = next.revealValuesOnHoverOnly === true
-  if (next.pfEnabled !== undefined) merged.pfEnabled = next.pfEnabled === true
+  if (next.pfEnabled !== undefined) {
+    merged.pfEnabled = next.pfEnabled === true
+    // Enabling pf supersedes the in-page nudge — once a user actually
+    // turns it on (via Settings or the callout itself) the callout
+    // becomes redundant and should never appear again.
+    if (next.pfEnabled === true) merged.pfCalloutDismissed = true
+  }
+  if (next.pfCalloutDismissed !== undefined) merged.pfCalloutDismissed = next.pfCalloutDismissed === true
   writeFile(merged)
   return loadSecurityPreferences()
 }

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -19,6 +19,7 @@ export interface SecurityPreferences {
   revealValuesOnHoverOnly: boolean
   pfEnabled: boolean
   pfCalloutDismissed: boolean
+  pfActivationPending: boolean
 }
 
 export type PfPhase =

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -18,6 +18,7 @@ export interface SecurityPreferences {
   rescanAfterSync: 'auto' | 'manual'
   revealValuesOnHoverOnly: boolean
   pfEnabled: boolean
+  pfCalloutDismissed: boolean
 }
 
 export type PfPhase =

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -36,6 +36,7 @@ import {
 import { securityApi } from '../api/security.js'
 import { securityFeatureEnabled } from '../featureFlags.js'
 import PurgeConfirmDialog from './security/PurgeConfirmDialog.js'
+import PfCallout from './security/PfCallout.js'
 import { parseQualifier, toggleKindQualifier } from './security/parse-qualifier.js'
 import { truncateValue } from './security/truncate-value.js'
 import {
@@ -523,6 +524,13 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
               result={scanResult}
               onDismiss={() => setScanResult(null)}
             />
+          )}
+          {/* PF discovery callout — sits below any transient scan
+           *  banner so the active-scan signal always wins for
+           *  attention. Self-gates on pfCalloutDismissed + pfEnabled;
+           *  parent doesn't need to know the state. */}
+          {!shouldShowScanBanner(scanStatus, displayBusy) && !scanResult && (
+            <PfCallout />
           )}
           {loading ? null : error ? (
             <p className="text-sm text-warm-muted dark:text-dark-muted py-4">

--- a/packages/app/src/renderer/components/Settings/security/PfDownloadCard.tsx
+++ b/packages/app/src/renderer/components/Settings/security/PfDownloadCard.tsx
@@ -108,8 +108,12 @@ export default function PfDownloadCard() {
                   style={{ width: `${percent}%` }}
                 />
               </div>
-              <p className="mt-1 font-mono text-[10px] text-warm-faint dark:text-dark-muted tabular-nums">
-                {formatBytes(state.bytesDownloaded)} / {formatBytes(state.bytesTotal)} · {percent}%
+              <p className="mt-1 font-mono text-[10px] text-warm-faint dark:text-dark-muted tabular-nums whitespace-nowrap">
+                <span className="inline-block w-[5.5em] text-right">{formatBytes(state.bytesDownloaded)}</span>
+                {' / '}
+                <span className="inline-block w-[5.5em] text-right">{formatBytes(state.bytesTotal)}</span>
+                {' · '}
+                <span className="inline-block w-[3em] text-right">{percent}%</span>
               </p>
             </div>
           )}

--- a/packages/app/src/renderer/components/security/PfCallout.tsx
+++ b/packages/app/src/renderer/components/security/PfCallout.tsx
@@ -1,0 +1,219 @@
+// In-page Privacy Filter discovery callout. Sits at the top of the
+// Security page when the model isn't installed + enabled yet, so users
+// who land here while reviewing findings get nudged to upgrade
+// detection without having to dig through Settings.
+//
+// Visual rhythm matches ScanBanner / ScanResultBanner (same height,
+// rounded-lg, mb-5) so when one banner is replaced by another the
+// layout doesn't jump. The parent page decides whether to mount this
+// component — see `hidden` prop usage in SecurityPage.
+
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Sparkles, X, RotateCw, AlertTriangle, Download, Loader2 } from 'lucide-react'
+import { securityApi, type PfDownloadState, type SecurityPreferences } from '../../api/security.js'
+import { formatBytes } from './format.js'
+
+const INITIAL: PfDownloadState = { phase: 'not-installed', bytesDownloaded: 0, bytesTotal: 0 }
+
+export default function PfCallout() {
+  const { t } = useTranslation()
+  const [prefs, setPrefs] = useState<SecurityPreferences | null>(null)
+  const [state, setState] = useState<PfDownloadState>(INITIAL)
+  const [busy, setBusy] = useState(false)
+  // Tracks whether THIS callout instance kicked off the download. We
+  // only auto-flip pfEnabled on install if the user opted in here —
+  // a download started from Settings should leave the toggle alone.
+  const intendingToEnable = useRef(false)
+
+  useEffect(() => {
+    void securityApi.getPrefs().then(setPrefs).catch(() => { /* keep null → no render */ })
+    void securityApi.pfGetState().then(setState).catch(() => { /* keep INITIAL */ })
+    const offPrefs = securityApi.onPrefsChanged(setPrefs)
+    const offState = securityApi.onPfState(setState)
+    return () => { offPrefs(); offState() }
+  }, [])
+
+  // Auto-enable after the download we started completes. We don't
+  // need to clear `intendingToEnable` afterwards — setPrefs flipping
+  // pfEnabled also auto-sets pfCalloutDismissed, which unmounts us.
+  useEffect(() => {
+    if (state.phase !== 'installed') return
+    if (!intendingToEnable.current) return
+    if (prefs?.pfEnabled) return
+    void securityApi.setPrefs({ pfEnabled: true })
+  }, [state.phase, prefs?.pfEnabled])
+
+  if (!prefs) return null
+  if (prefs.pfCalloutDismissed) return null
+  if (prefs.pfEnabled) return null
+
+  const startDownload = async () => {
+    intendingToEnable.current = true
+    if (state.phase === 'installed') {
+      await securityApi.setPrefs({ pfEnabled: true })
+      return
+    }
+    setBusy(true)
+    try { await securityApi.pfDownloadStart() } finally { setBusy(false) }
+  }
+
+  const cancelDownload = () => {
+    intendingToEnable.current = false
+    void securityApi.pfDownloadCancel()
+  }
+
+  const dismiss = () => {
+    intendingToEnable.current = false
+    void securityApi.setPrefs({ pfCalloutDismissed: true })
+  }
+
+  const totalBytes = state.bytesTotal || 945_000_000
+  const percent = state.bytesTotal > 0
+    ? Math.min(100, Math.round((state.bytesDownloaded / state.bytesTotal) * 100))
+    : 0
+
+  if (state.phase === 'downloading') {
+    return (
+      <Shell testId="security-pf-callout" phase="downloading">
+        <span className="inline-flex items-center justify-center w-4 h-4 text-accent dark:text-accent-dark">
+          <Loader2 size={14} strokeWidth={2} className="animate-spin" aria-hidden />
+        </span>
+        <div className="flex flex-col gap-1 min-w-0">
+          <span className="text-[13px] font-medium text-warm-text dark:text-dark-text">
+            {t('security.pf_callout_downloading', { defaultValue: 'Downloading Privacy Filter' })}
+          </span>
+          <span className="font-mono text-[11px] text-warm-faint dark:text-dark-muted tabular-nums">
+            {formatBytes(state.bytesDownloaded)} / {formatBytes(state.bytesTotal)} · {percent}%
+          </span>
+        </div>
+        <button
+          type="button"
+          data-testid="security-pf-callout-cancel"
+          onClick={cancelDownload}
+          className="inline-flex items-center gap-1.5 h-7 rounded-[6px] border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface hover:border-warm-border2 dark:hover:border-dark-border2 px-2.5 text-[12px] text-warm-text dark:text-dark-text transition-colors"
+        >
+          <X size={11} strokeWidth={1.8} aria-hidden />
+          {t('common.cancel', { defaultValue: 'Cancel' })}
+        </button>
+        <Progress percent={percent} />
+      </Shell>
+    )
+  }
+
+  if (state.phase === 'failed') {
+    return (
+      <Shell testId="security-pf-callout" phase="failed">
+        <span className="inline-flex items-center justify-center w-4 h-4 text-accent dark:text-accent-dark">
+          <AlertTriangle size={13} strokeWidth={1.9} aria-hidden />
+        </span>
+        <div className="flex flex-col gap-1 min-w-0">
+          <span className="text-[13px] font-medium text-warm-text dark:text-dark-text">
+            {t('security.pf_callout_failed', { defaultValue: "Couldn't download Privacy Filter" })}
+          </span>
+          {state.error && (
+            <span className="text-[11px] text-warm-faint dark:text-dark-muted truncate">
+              {state.error}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            data-testid="security-pf-callout-retry"
+            onClick={() => { void startDownload() }}
+            className="inline-flex items-center gap-1.5 h-7 rounded-[6px] border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface hover:border-warm-border2 dark:hover:border-dark-border2 px-2.5 text-[12px] text-warm-text dark:text-dark-text transition-colors"
+          >
+            <RotateCw size={11} strokeWidth={1.8} aria-hidden />
+            {t('common.retry', { defaultValue: 'Retry' })}
+          </button>
+          <DismissButton onClick={dismiss} />
+        </div>
+      </Shell>
+    )
+  }
+
+  // not-installed (or installed but user hasn't enabled yet — both
+  // surface the same primary CTA).
+  return (
+    <Shell testId="security-pf-callout" phase={state.phase}>
+      <span className="inline-flex items-center justify-center w-4 h-4 text-accent dark:text-accent-dark">
+        <Sparkles size={13} strokeWidth={1.9} aria-hidden />
+      </span>
+      <div className="flex flex-col gap-0.5 min-w-0">
+        <span className="text-[13px] font-medium text-warm-text dark:text-dark-text">
+          {t('security.pf_callout_title', {
+            defaultValue: 'Add Privacy Filter for richer detection',
+          })}
+        </span>
+        <span className="text-[11px] leading-[15px] text-warm-faint dark:text-dark-muted">
+          {t('security.pf_callout_body', {
+            defaultValue: "Catches names, addresses, and other patterns regex misses. On-device · {{size}}.",
+            size: formatBytes(totalBytes),
+          })}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          data-testid="security-pf-callout-enable"
+          disabled={busy}
+          onClick={() => { void startDownload() }}
+          className="inline-flex items-center gap-1.5 h-7 rounded-[6px] border border-accent/40 dark:border-accent-dark/40 bg-accent dark:bg-accent-dark text-white dark:text-warm-bg hover:opacity-90 px-2.5 text-[12px] font-medium disabled:opacity-60 transition-opacity"
+        >
+          {state.phase === 'installed'
+            ? t('security.pf_callout_enable', { defaultValue: 'Enable' })
+            : <>
+                <Download size={11} strokeWidth={1.9} aria-hidden />
+                {t('security.pf_callout_enable', { defaultValue: 'Enable' })}
+              </>}
+        </button>
+        <DismissButton onClick={dismiss} />
+      </div>
+    </Shell>
+  )
+}
+
+function Shell({
+  testId, phase, children,
+}: {
+  testId: string
+  phase: PfDownloadState['phase']
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      data-testid={testId}
+      data-phase={phase}
+      className="relative grid items-center gap-3 mb-5 px-4 py-2.5 rounded-lg bg-warm-surface dark:bg-dark-surface border border-warm-border dark:border-dark-border overflow-hidden"
+      style={{ gridTemplateColumns: 'auto 1fr auto' }}
+    >
+      {children}
+    </div>
+  )
+}
+
+function Progress({ percent }: { percent: number }) {
+  return (
+    <div
+      className="absolute left-0 right-0 bottom-0 h-[2px] bg-accent dark:bg-accent-dark transition-[width] duration-300"
+      style={{ width: `${percent}%`, gridColumn: '1 / -1' }}
+      aria-hidden
+    />
+  )
+}
+
+function DismissButton({ onClick }: { onClick: () => void }) {
+  const { t } = useTranslation()
+  return (
+    <button
+      type="button"
+      data-testid="security-pf-callout-dismiss"
+      onClick={onClick}
+      aria-label={t('common.close', { defaultValue: 'Close' })}
+      className="inline-flex items-center justify-center w-6 h-6 rounded-[5px] text-warm-faint dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text hover:bg-warm-surface2 dark:hover:bg-dark-surface2 transition-colors"
+    >
+      <X size={12} strokeWidth={1.8} aria-hidden />
+    </button>
+  )
+}

--- a/packages/app/src/renderer/components/security/PfCallout.tsx
+++ b/packages/app/src/renderer/components/security/PfCallout.tsx
@@ -1,16 +1,33 @@
-// In-page Privacy Filter discovery callout. Sits at the top of the
-// Security page when the model isn't installed + enabled yet, so users
-// who land here while reviewing findings get nudged to upgrade
-// detection without having to dig through Settings.
+// In-page Privacy Filter discovery + activation callout. Sits at the
+// top of the Security page so users who land here while reviewing
+// findings get nudged + walked through the full activation flow
+// without having to dig through Settings.
 //
 // Visual rhythm matches ScanBanner / ScanResultBanner (same height,
 // rounded-lg, mb-5) so when one banner is replaced by another the
-// layout doesn't jump. The parent page decides whether to mount this
-// component — see `hidden` prop usage in SecurityPage.
+// layout doesn't jump. Parent gates: hidden while ScanBanner /
+// ScanResultBanner are active so transient scan signals win.
+//
+// State machine (UI states it can render):
+//
+//   - failed                       : "Couldn't download" + Retry + ×
+//   - downloading                  : "Downloading X / Y · Z%" + Cancel
+//   - installed + activationPending: "Activating Privacy Filter…"
+//   - installed + bytesDownloaded>0: "Resume Privacy Filter" + Resume + ×
+//                                    (a partial download from a prior
+//                                    cancel / app kill — Settings
+//                                    callers see this too via the
+//                                    download card progress)
+//   - not-installed default        : "Add Privacy Filter" discovery
+//
+// Hidden when:
+//   - prefs.pfCalloutDismissed (user clicked × explicitly), AND
+//     none of the operational states above apply
 
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Sparkles, X, RotateCw, AlertTriangle, Download, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
 import { securityApi, type PfDownloadState, type SecurityPreferences } from '../../api/security.js'
 import { formatBytes } from './format.js'
 
@@ -20,11 +37,7 @@ export default function PfCallout() {
   const { t } = useTranslation()
   const [prefs, setPrefs] = useState<SecurityPreferences | null>(null)
   const [state, setState] = useState<PfDownloadState>(INITIAL)
-  const [busy, setBusy] = useState(false)
-  // Tracks whether THIS callout instance kicked off the download. We
-  // only auto-flip pfEnabled on install if the user opted in here —
-  // a download started from Settings should leave the toggle alone.
-  const intendingToEnable = useRef(false)
+  const prevActivationPending = useRef<boolean>(false)
 
   useEffect(() => {
     void securityApi.getPrefs().then(setPrefs).catch(() => { /* keep null → no render */ })
@@ -34,65 +47,67 @@ export default function PfCallout() {
     return () => { offPrefs(); offState() }
   }, [])
 
-  // Auto-enable after the download we started completes. We don't
-  // need to clear `intendingToEnable` afterwards — setPrefs flipping
-  // pfEnabled also auto-sets pfCalloutDismissed, which unmounts us.
+  // Sonner toast when the activation cycle finishes — fired by main
+  // clearing pfActivationPending after pfRuntime starts + backfill
+  // kicks. The toast keeps the user informed even after the callout
+  // hands off to ScanBanner.
   useEffect(() => {
-    if (state.phase !== 'installed') return
-    if (!intendingToEnable.current) return
-    if (prefs?.pfEnabled) return
-    void securityApi.setPrefs({ pfEnabled: true })
-  }, [state.phase, prefs?.pfEnabled])
+    const prev = prevActivationPending.current
+    const now = prefs?.pfActivationPending ?? false
+    if (prev && !now && prefs?.pfEnabled) {
+      toast.success(t('security.pf_callout_activated', {
+        defaultValue: 'Privacy Filter enabled · re-scanning your sessions',
+      }))
+    }
+    prevActivationPending.current = now
+  }, [prefs?.pfActivationPending, prefs?.pfEnabled, t])
 
   if (!prefs) return null
-  if (prefs.pfCalloutDismissed) return null
-  if (prefs.pfEnabled) return null
 
   const startDownload = async () => {
-    intendingToEnable.current = true
+    // Persisting the intent in prefs (not a useRef) lets it survive
+    // page navigation + the activation handshake spanning multiple
+    // remounts. Main's pf-coordinator subscriber reads it on
+    // phase=installed and finishes the activation on our behalf.
+    await securityApi.setPrefs({ pfActivationPending: true })
     if (state.phase === 'installed') {
       await securityApi.setPrefs({ pfEnabled: true })
       return
     }
-    setBusy(true)
-    try { await securityApi.pfDownloadStart() } finally { setBusy(false) }
+    await securityApi.pfDownloadStart()
   }
 
   const cancelDownload = () => {
-    intendingToEnable.current = false
+    void securityApi.setPrefs({ pfActivationPending: false })
     void securityApi.pfDownloadCancel()
   }
 
   const dismiss = () => {
-    intendingToEnable.current = false
-    void securityApi.setPrefs({ pfCalloutDismissed: true })
+    void securityApi.setPrefs({
+      pfActivationPending: false,
+      pfCalloutDismissed: true,
+    })
   }
 
   const totalBytes = state.bytesTotal || 945_000_000
   const percent = state.bytesTotal > 0
     ? Math.min(100, Math.round((state.bytesDownloaded / state.bytesTotal) * 100))
     : 0
+  const hasPartial = state.phase === 'not-installed' && state.bytesDownloaded > 0
+
+  // ── render branches ────────────────────────────────────────────
 
   if (state.phase === 'downloading') {
     return (
       <Shell testId="security-pf-callout" phase="downloading">
-        <span className="inline-flex items-center justify-center w-4 h-4 mt-0.5 text-accent dark:text-accent-dark">
+        <IconSlot>
           <Loader2 size={14} strokeWidth={2} className="animate-spin" aria-hidden />
-        </span>
+        </IconSlot>
         <div className="flex flex-col gap-1 min-w-0">
           <span className="text-[13px] font-medium text-warm-text dark:text-dark-text">
             {t('security.pf_callout_downloading', { defaultValue: 'Downloading Privacy Filter' })}
           </span>
-          {/* Each value lives in a right-aligned fixed-width slot so
-            * digit-count changes (47.3 MB → 100 MB; 5% → 10% → 100%)
-            * don't reflow the row width on every progress tick. */}
-          <span className="font-mono text-[11px] text-warm-faint dark:text-dark-muted tabular-nums whitespace-nowrap">
-            <span className="inline-block w-[5.5em] text-right">{formatBytes(state.bytesDownloaded)}</span>
-            {' / '}
-            <span className="inline-block w-[5.5em] text-right">{formatBytes(state.bytesTotal)}</span>
-            {' · '}
-            <span className="inline-block w-[3em] text-right">{percent}%</span>
-          </span>
+          <ProgressLine bytesDownloaded={state.bytesDownloaded} bytesTotal={state.bytesTotal} percent={percent} />
         </div>
         <button
           type="button"
@@ -103,7 +118,7 @@ export default function PfCallout() {
           <X size={11} strokeWidth={1.8} aria-hidden />
           {t('common.cancel', { defaultValue: 'Cancel' })}
         </button>
-        <Progress percent={percent} />
+        <ProgressBar percent={percent} />
       </Shell>
     )
   }
@@ -111,9 +126,9 @@ export default function PfCallout() {
   if (state.phase === 'failed') {
     return (
       <Shell testId="security-pf-callout" phase="failed">
-        <span className="inline-flex items-center justify-center w-4 h-4 mt-0.5 text-accent dark:text-accent-dark">
+        <IconSlot>
           <AlertTriangle size={13} strokeWidth={1.9} aria-hidden />
-        </span>
+        </IconSlot>
         <div className="flex flex-col gap-1 min-w-0">
           <span className="text-[13px] font-medium text-warm-text dark:text-dark-text">
             {t('security.pf_callout_failed', { defaultValue: "Couldn't download Privacy Filter" })}
@@ -125,28 +140,82 @@ export default function PfCallout() {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <button
-            type="button"
-            data-testid="security-pf-callout-retry"
-            onClick={() => { void startDownload() }}
-            className="inline-flex items-center gap-1.5 h-7 rounded-[6px] border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface hover:border-warm-border2 dark:hover:border-dark-border2 px-2.5 text-[12px] text-warm-text dark:text-dark-text transition-colors"
-          >
+          <PrimaryButton testId="security-pf-callout-retry" onClick={() => { void startDownload() }} variant="quiet">
             <RotateCw size={11} strokeWidth={1.8} aria-hidden />
             {t('common.retry', { defaultValue: 'Retry' })}
-          </button>
+          </PrimaryButton>
           <DismissButton onClick={dismiss} />
         </div>
       </Shell>
     )
   }
 
-  // not-installed (or installed but user hasn't enabled yet — both
-  // surface the same primary CTA).
+  // phase === 'installed' with activation pending → Activating bridge
+  // (lives between download-complete and the moment ScanBanner takes
+  // over). Parent unmounts us once scan kicks in.
+  if (state.phase === 'installed' && prefs.pfActivationPending) {
+    return (
+      <Shell testId="security-pf-callout" phase="activating">
+        <IconSlot>
+          <Loader2 size={14} strokeWidth={2} className="animate-spin" aria-hidden />
+        </IconSlot>
+        <div className="flex flex-col gap-1 min-w-0">
+          <span className="text-[13px] font-medium text-warm-text dark:text-dark-text">
+            {t('security.pf_callout_activating', { defaultValue: 'Activating Privacy Filter' })}
+          </span>
+          <span className="text-[11px] text-warm-faint dark:text-dark-muted">
+            {t('security.pf_callout_activating_body', {
+              defaultValue: 'Loading the model and queuing your sessions for a fresh scan.',
+            })}
+          </span>
+        </div>
+        <span aria-hidden />
+      </Shell>
+    )
+  }
+
+  // Below this point the only visible states are discovery / resume,
+  // both gated by !pfEnabled (already on → nothing to discover) and
+  // by !pfCalloutDismissed (user has × dismissed → leave them alone).
+  if (prefs.pfEnabled) return null
+  if (prefs.pfCalloutDismissed) return null
+
+  if (hasPartial) {
+    return (
+      <Shell testId="security-pf-callout" phase="partial">
+        <IconSlot>
+          <Sparkles size={13} strokeWidth={1.9} aria-hidden />
+        </IconSlot>
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <span className="text-[13px] font-medium text-warm-text dark:text-dark-text">
+            {t('security.pf_callout_partial_title', {
+              defaultValue: 'Resume Privacy Filter download',
+            })}
+          </span>
+          <span className="font-mono text-[11px] text-warm-faint dark:text-dark-muted tabular-nums">
+            <span className="inline-block w-[5.5em] text-right">{formatBytes(state.bytesDownloaded)}</span>
+            {' / '}
+            <span className="inline-block w-[5.5em] text-right">{formatBytes(totalBytes)}</span>
+            {' '}
+            {t('security.pf_callout_partial_suffix', { defaultValue: 'already downloaded.' })}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <PrimaryButton testId="security-pf-callout-resume" onClick={() => { void startDownload() }}>
+            <Download size={11} strokeWidth={1.9} aria-hidden />
+            {t('security.pf_callout_resume', { defaultValue: 'Resume' })}
+          </PrimaryButton>
+          <DismissButton onClick={dismiss} />
+        </div>
+      </Shell>
+    )
+  }
+
   return (
     <Shell testId="security-pf-callout" phase={state.phase}>
-      <span className="inline-flex items-center justify-center w-4 h-4 mt-0.5 text-accent dark:text-accent-dark">
+      <IconSlot>
         <Sparkles size={13} strokeWidth={1.9} aria-hidden />
-      </span>
+      </IconSlot>
       <div className="flex flex-col gap-0.5 min-w-0">
         <span className="text-[13px] font-medium text-warm-text dark:text-dark-text">
           {t('security.pf_callout_title', {
@@ -161,20 +230,10 @@ export default function PfCallout() {
         </span>
       </div>
       <div className="flex items-center gap-2">
-        <button
-          type="button"
-          data-testid="security-pf-callout-enable"
-          disabled={busy}
-          onClick={() => { void startDownload() }}
-          className="inline-flex items-center gap-1.5 h-7 rounded-[6px] border border-accent/40 dark:border-accent-dark/40 bg-accent dark:bg-accent-dark text-white dark:text-warm-bg hover:opacity-90 px-2.5 text-[12px] font-medium disabled:opacity-60 transition-opacity"
-        >
-          {state.phase === 'installed'
-            ? t('security.pf_callout_enable', { defaultValue: 'Enable' })
-            : <>
-                <Download size={11} strokeWidth={1.9} aria-hidden />
-                {t('security.pf_callout_enable', { defaultValue: 'Enable' })}
-              </>}
-        </button>
+        <PrimaryButton testId="security-pf-callout-enable" onClick={() => { void startDownload() }}>
+          <Download size={11} strokeWidth={1.9} aria-hidden />
+          {t('security.pf_callout_enable', { defaultValue: 'Enable' })}
+        </PrimaryButton>
         <DismissButton onClick={dismiss} />
       </div>
     </Shell>
@@ -185,15 +244,13 @@ function Shell({
   testId, phase, children,
 }: {
   testId: string
-  phase: PfDownloadState['phase']
+  phase: string
   children: React.ReactNode
 }) {
-  // items-start (not items-center) so the leading icon + trailing
-  // actions sit at the TITLE baseline rather than the midpoint of
-  // the 2-line title+body block. A 13px icon centered between two
-  // lines visually floats — top-aligned with a tiny pt offset
-  // anchors it to the title, matching shadcn / Notion / GitHub
-  // inline alerts.
+  // items-start so the leading icon + trailing actions sit at the
+  // title baseline rather than between two text lines. 13px icons
+  // get a small mt-0.5 below so they optically baseline-align with
+  // the 13px title text.
   return (
     <div
       data-testid={testId}
@@ -206,13 +263,64 @@ function Shell({
   )
 }
 
-function Progress({ percent }: { percent: number }) {
+function IconSlot({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center justify-center w-4 h-4 mt-0.5 text-accent dark:text-accent-dark">
+      {children}
+    </span>
+  )
+}
+
+function ProgressLine({
+  bytesDownloaded, bytesTotal, percent,
+}: {
+  bytesDownloaded: number
+  bytesTotal: number
+  percent: number
+}) {
+  // Each value gets its own fixed-width right-aligned slot so digit
+  // count transitions (47.3 MB → 100 MB; 5% → 100%) don't reflow.
+  return (
+    <span className="font-mono text-[11px] text-warm-faint dark:text-dark-muted tabular-nums whitespace-nowrap">
+      <span className="inline-block w-[5.5em] text-right">{formatBytes(bytesDownloaded)}</span>
+      {' / '}
+      <span className="inline-block w-[5.5em] text-right">{formatBytes(bytesTotal)}</span>
+      {' · '}
+      <span className="inline-block w-[3em] text-right">{percent}%</span>
+    </span>
+  )
+}
+
+function ProgressBar({ percent }: { percent: number }) {
   return (
     <div
       className="absolute left-0 right-0 bottom-0 h-[2px] bg-accent dark:bg-accent-dark transition-[width] duration-300"
       style={{ width: `${percent}%`, gridColumn: '1 / -1' }}
       aria-hidden
     />
+  )
+}
+
+function PrimaryButton({
+  testId, onClick, variant = 'accent', children,
+}: {
+  testId: string
+  onClick: () => void
+  variant?: 'accent' | 'quiet'
+  children: React.ReactNode
+}) {
+  const cls = variant === 'accent'
+    ? 'border border-accent/40 dark:border-accent-dark/40 bg-accent dark:bg-accent-dark text-white dark:text-warm-bg hover:opacity-90 font-medium transition-opacity'
+    : 'border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface hover:border-warm-border2 dark:hover:border-dark-border2 text-warm-text dark:text-dark-text transition-colors'
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      onClick={onClick}
+      className={`inline-flex items-center gap-1.5 h-7 rounded-[6px] px-2.5 text-[12px] ${cls}`}
+    >
+      {children}
+    </button>
   )
 }
 

--- a/packages/app/src/renderer/components/security/PfCallout.tsx
+++ b/packages/app/src/renderer/components/security/PfCallout.tsx
@@ -83,8 +83,15 @@ export default function PfCallout() {
           <span className="text-[13px] font-medium text-warm-text dark:text-dark-text">
             {t('security.pf_callout_downloading', { defaultValue: 'Downloading Privacy Filter' })}
           </span>
-          <span className="font-mono text-[11px] text-warm-faint dark:text-dark-muted tabular-nums">
-            {formatBytes(state.bytesDownloaded)} / {formatBytes(state.bytesTotal)} · {percent}%
+          {/* Each value lives in a right-aligned fixed-width slot so
+            * digit-count changes (47.3 MB → 100 MB; 5% → 10% → 100%)
+            * don't reflow the row width on every progress tick. */}
+          <span className="font-mono text-[11px] text-warm-faint dark:text-dark-muted tabular-nums whitespace-nowrap">
+            <span className="inline-block w-[5.5em] text-right">{formatBytes(state.bytesDownloaded)}</span>
+            {' / '}
+            <span className="inline-block w-[5.5em] text-right">{formatBytes(state.bytesTotal)}</span>
+            {' · '}
+            <span className="inline-block w-[3em] text-right">{percent}%</span>
           </span>
         </div>
         <button

--- a/packages/app/src/renderer/components/security/PfCallout.tsx
+++ b/packages/app/src/renderer/components/security/PfCallout.tsx
@@ -76,7 +76,7 @@ export default function PfCallout() {
   if (state.phase === 'downloading') {
     return (
       <Shell testId="security-pf-callout" phase="downloading">
-        <span className="inline-flex items-center justify-center w-4 h-4 text-accent dark:text-accent-dark">
+        <span className="inline-flex items-center justify-center w-4 h-4 mt-0.5 text-accent dark:text-accent-dark">
           <Loader2 size={14} strokeWidth={2} className="animate-spin" aria-hidden />
         </span>
         <div className="flex flex-col gap-1 min-w-0">
@@ -104,7 +104,7 @@ export default function PfCallout() {
   if (state.phase === 'failed') {
     return (
       <Shell testId="security-pf-callout" phase="failed">
-        <span className="inline-flex items-center justify-center w-4 h-4 text-accent dark:text-accent-dark">
+        <span className="inline-flex items-center justify-center w-4 h-4 mt-0.5 text-accent dark:text-accent-dark">
           <AlertTriangle size={13} strokeWidth={1.9} aria-hidden />
         </span>
         <div className="flex flex-col gap-1 min-w-0">
@@ -137,7 +137,7 @@ export default function PfCallout() {
   // surface the same primary CTA).
   return (
     <Shell testId="security-pf-callout" phase={state.phase}>
-      <span className="inline-flex items-center justify-center w-4 h-4 text-accent dark:text-accent-dark">
+      <span className="inline-flex items-center justify-center w-4 h-4 mt-0.5 text-accent dark:text-accent-dark">
         <Sparkles size={13} strokeWidth={1.9} aria-hidden />
       </span>
       <div className="flex flex-col gap-0.5 min-w-0">
@@ -181,11 +181,17 @@ function Shell({
   phase: PfDownloadState['phase']
   children: React.ReactNode
 }) {
+  // items-start (not items-center) so the leading icon + trailing
+  // actions sit at the TITLE baseline rather than the midpoint of
+  // the 2-line title+body block. A 13px icon centered between two
+  // lines visually floats — top-aligned with a tiny pt offset
+  // anchors it to the title, matching shadcn / Notion / GitHub
+  // inline alerts.
   return (
     <div
       data-testid={testId}
       data-phase={phase}
-      className="relative grid items-center gap-3 mb-5 px-4 py-2.5 rounded-lg bg-warm-surface dark:bg-dark-surface border border-warm-border dark:border-dark-border overflow-hidden"
+      className="relative grid items-start gap-3 mb-5 px-4 py-2.5 rounded-lg bg-warm-surface dark:bg-dark-surface border border-warm-border dark:border-dark-border overflow-hidden"
       style={{ gridTemplateColumns: 'auto 1fr auto' }}
     >
       {children}


### PR DESCRIPTION
feat(security): in-page Privacy Filter discovery callout

Adds a dismissable callout on the Security page itself so the PF
opt-in surface isn't buried in Settings → Security. Users see the
nudge while reviewing findings — the moment they're most likely
wondering "am I catching everything?".

Layout coordination:
- Sits BELOW any active ScanBanner / ScanResultBanner so transient
  scan signals always win for attention; reappears once they clear
- Same shape as the existing banners (mb-5 + rounded-lg + 3-col
  grid + neutral surface) so swapping between them doesn't jump
- Accent-colored leading icon (Sparkles) signals "feature upgrade"
  without competing with the ScanBanner's pulsing amber dot

UX flow:
- not-installed → "Add Privacy Filter for richer detection" + body
  copy + accent-filled Enable button + × dismiss
- Click Enable → starts inline download (no jump to Settings); card
  switches to "Downloading · X / Y MB · N%" with progress bar at
  the bottom edge and Cancel
- Download completes → auto-flips pfEnabled (only when the download
  was initiated from this callout — tracked via a ref so a
  Settings-initiated download is left alone); pfCalloutDismissed
  auto-true via saveSecurityPreferences side-effect; callout
  unmounts; pfRuntime spawns; backfill kicks in and ScanBanner
  takes the top spot
- Failed → "Couldn't download Privacy Filter" + error detail +
  Retry + ×
- Dismissed → permanent (Settings card stays the management path)

Files:
- securityPreferences.ts: pfCalloutDismissed: boolean field. The
  setter auto-flips it to true whenever pfEnabled goes on so users
  who came in via Settings never see a redundant nudge
- preload + renderer api: PfCalloutDismissed flows through the
  existing SET_PREFS partial handler — no new IPC channels
- SecurityPage.tsx: <PfCallout /> mounted between the two banners
  and the loading/error/empty branch; self-gates on prefs so the
  parent doesn't need to know the state
- New PfCallout.tsx component

Tests: 2 new prefs cases (pf-off doesn't touch dismissed; explicit
false re-arms). Existing prefs round-trip tests updated to expect
the auto-dismiss side-effect. Full app suite 273/273.

fix(security): route PF downloads through electron.net + better error

`globalThis.fetch` (undici) inside Electron's main process ignores the
system proxy + custom CA bundle. On a corporate network or behind GFW
the PF download would silently die with "fetch failed" and the
callout / Settings card had no clue why.

- main/index.ts: pass `net.fetch` (Electron's HTTP stack that honours
  app-level proxy + cert overrides) into the pfCoordinator instead of
  letting model-download.ts fall back to globalThis.fetch
- model-download.ts: catch the network-level failure and re-raise as
  DownloadError("Couldn't reach huggingface.co (<detail>). Check
  network / proxy.") so the surface error is actionable. AbortError
  still propagates unwrapped so the coordinator's cancel branch
  (which keys off err.name) drops back to not-installed cleanly

fixup! feat(security): in-page Privacy Filter discovery callout

fix(security): pin PF progress text width to stop layout jitter

The byte / percent numbers re-flow the row on every download tick
because formatBytes drops decimals at the 100 boundary
(99.9 MB → 100 MB) and the % column ranges 5% → 100%. tabular-nums
only keeps digits equal-width; the total string still shrinks/grows.

Wrap each value in a fixed-width right-aligned inline-block so the
right edge stays put regardless of digit count. Applied to both
PfCallout (Security page) and PfDownloadCard (Settings).

feat(security): callout activation handoff + resume + toast ack

Tackles the gaps the user surfaced on the PF callout flow:

1. Cancel / page-switch / app-kill: download state already survived
   (pf-coordinator lives in main, .part files on disk). But the
   "user clicked Enable" intent was a useRef in the callout, so a
   page switch mid-download dropped it on the floor — the auto-
   enable never fired and the user had to re-flip the toggle in
   Settings. Persist that intent in prefs (pfActivationPending) so
   it survives any remount or restart.
2. Silent gap between download-complete and ScanBanner: there's a
   5-90 s window where pfRuntime is loading the ONNX model (in the
   hidden inference window) and the scan worker hasn't been told
   pf is online yet. Callout used to vanish the moment phase
   flipped to 'installed', leaving the user staring at nothing.
   Add an "Activating Privacy Filter…" callout state that bridges
   from download-complete to backfill-start; ScanBanner then takes
   over as before.
3. Partial download not acknowledged: previously a user who
   cancelled then revisited the page saw "Add Privacy Filter ·
   945 MB" with no hint that 47 MB was already on disk. Now the
   not-installed state detects bytesDownloaded > 0 and renders a
   distinct "Resume Privacy Filter download · 47 / 901 MB already
   downloaded" with a Resume button.
4. After-activation acknowledgement: sonner toast "Privacy Filter
   enabled · re-scanning your sessions" fires the moment
   pfActivationPending clears with pfEnabled=true. Shows even when
   the user has navigated away from the Security page.

Implementation:

- securityPreferences.ts: pfActivationPending: boolean field with
  the same normalize / save / load semantics as the other flags.
  Defaults to false. Existing pfEnabled→pfCalloutDismissed side
  effect stays.
- preload/index.ts: surfaced on the SecurityPreferences interface
  (no new IPC channel — flows through SET_PREFS partial).
- main/index.ts: pfCoordinator.subscribe(s) — when s.phase ===
  'installed' AND prefs.pfActivationPending AND !pfEnabled, main
  flips pfEnabled itself and runs syncPfRuntime. syncPfRuntime now
  wraps its body in try/finally and clears pfActivationPending on
  the way out so the callout's "Activating…" state drops.
- PfCallout.tsx: rewritten around prefs.pfActivationPending instead
  of the renderer ref. Five visible states: failed / downloading /
  activating / partial-resume / discovery. Pulled shared
  Shell + IconSlot + ProgressLine + ProgressBar + PrimaryButton +
  DismissButton helpers so each state body reads as a flat tree.
  Sonner toast fired on the prev-true → now-false transition.

Tests: prefs defaults / round-trip updated to include the new field.
Full app suite 273/273.

Not done (documented gaps):
- SHA-256 mismatch recovery still requires manual rm of .part
  files. Rare in practice but no "Reset & retry" button.