### PR TITLE
feat(security): forward PF inference window console to main + dev devtools

### DIFF
--- a/packages/app/electron.vite.config.ts
+++ b/packages/app/electron.vite.config.ts
@@ -57,6 +57,17 @@ export default defineConfig({
   },
   renderer: {
     root: resolve(__dirname, 'src/renderer'),
+    server: {
+      fs: {
+        // The hidden inference window lives at src/inference/, outside
+        // the main renderer's root. Without explicit allow, Vite's
+        // dev server refuses to serve it AND falls back to index.html
+        // (so the inference window silently runs the main app
+        // instead — confusing). Whitelist the source dir so
+        // `${rendererBase}/@fs/<abs-path>` resolves correctly.
+        allow: [resolve(__dirname, 'src/inference'), resolve(__dirname, 'src/renderer')],
+      },
+    },
     build: {
       rollupOptions: {
         input: {

--- a/packages/app/src/inference/pf-inference.html
+++ b/packages/app/src/inference/pf-inference.html
@@ -8,7 +8,7 @@
          protocol; blob: is needed for the WebWorker shim ORT spawns.
          Network access is otherwise denied — `default-src 'self'`
          keeps the renderer offline. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' pf-model:; script-src 'self' 'wasm-unsafe-eval' blob:; worker-src 'self' blob:; connect-src 'self' pf-model: blob:; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' pf-model:; script-src 'self' 'wasm-unsafe-eval' blob:; worker-src 'self' blob:; connect-src 'self' pf-model: blob: ws: wss:; style-src 'self' 'unsafe-inline'" />
   </head>
   <body>
     <script type="module" src="./pf-inference.ts"></script>

--- a/packages/app/src/inference/pf-inference.html
+++ b/packages/app/src/inference/pf-inference.html
@@ -8,7 +8,7 @@
          protocol; blob: is needed for the WebWorker shim ORT spawns.
          Network access is otherwise denied — `default-src 'self'`
          keeps the renderer offline. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' pf-model:; script-src 'self' 'wasm-unsafe-eval' blob:; worker-src 'self' blob:; connect-src 'self' pf-model: blob: ws: wss:; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' pf-model:; script-src 'self' 'wasm-unsafe-eval' blob: pf-model:; worker-src 'self' blob: pf-model:; connect-src 'self' pf-model: blob: ws: wss:; style-src 'self' 'unsafe-inline'" />
   </head>
   <body>
     <script type="module" src="./pf-inference.ts"></script>

--- a/packages/app/src/inference/pf-inference.ts
+++ b/packages/app/src/inference/pf-inference.ts
@@ -104,23 +104,39 @@ async function analyzeOne(
 ): Promise<void> {
   try {
     const output = await pipe(req.text, { aggregation_strategy: 'simple' })
-    const matches: PfMatch[] = output
-      // Drop entries the tokenizer couldn't anchor back to the source
-      // text — start_offset / end_offset are NOT NULL in the findings
-      // schema and we'd just trigger SQLITE_CONSTRAINT_NOTNULL on
-      // insert otherwise. Span without offsets is useless anyway
-      // (can't be highlighted / purged / hover-revealed).
-      .filter((m) => Number.isFinite(m.start) && Number.isFinite(m.end))
-      .map((m) => ({
-        // openai/privacy-filter emits `private_person`, `private_email`,
-        // etc. The class-mapping module operates on the short form so
-        // the same code works for future models without the prefix.
-        class: m.entity_group.toLowerCase().replace(/^private_/, ''),
-        value: m.word,
-        start: m.start,
-        end: m.end,
-        score: m.score,
-      }))
+    // findings.start_offset + end_offset are NOT NULL in SQLite, so
+    // a match without character anchors would roll back the entire
+    // session's scan transaction (taking the regex findings down with
+    // it). transformers.js with BPE tokenizers sometimes returns
+    // start/end undefined even with aggregation_strategy='simple',
+    // so:
+    //   1) keep what the tokenizer gave us when it's there
+    //   2) otherwise re-locate the word in the source via indexOf
+    //   3) only drop if even indexOf comes up empty (rare — the word
+    //      came FROM the tokenizer over the source, so finding it
+    //      back should be almost universal)
+    let searchCursor = 0
+    const matches: PfMatch[] = output.flatMap((m) => {
+      const cls = m.entity_group.toLowerCase().replace(/^private_/, '')
+      let start = m.start
+      let end = m.end
+      if (!Number.isFinite(start) || !Number.isFinite(end)) {
+        // Use a cursor so multiple instances of the same word land at
+        // distinct offsets instead of all collapsing onto the first
+        // occurrence. transformers.js returns matches in document
+        // order, so the cursor advances monotonically.
+        const idx = req.text.indexOf(m.word, searchCursor)
+        if (idx < 0) return []  // word doesn't actually appear — drop
+        start = idx
+        end = idx + m.word.length
+        searchCursor = end
+      } else {
+        // Advance cursor past native-offset matches too so a later
+        // fallback doesn't go backwards in the text.
+        searchCursor = Math.max(searchCursor, end as number)
+      }
+      return [{ class: cls, value: m.word, start: start as number, end: end as number, score: m.score }]
+    })
     bridge.sendAnalyzeResult({ reqId: req.reqId, ok: true, matches })
   } catch (err) {
     bridge.sendAnalyzeResult({

--- a/packages/app/src/inference/pf-inference.ts
+++ b/packages/app/src/inference/pf-inference.ts
@@ -67,6 +67,14 @@ async function main(): Promise<void> {
     tx.env.allowRemoteModels = false
     tx.env.localModelPath = 'pf-model:///'
     tx.env.useBrowserCache = false
+    // ORT Runtime Web defaults to fetching its WASM / JS runtime
+    // from cdn.jsdelivr.net — incompatible with the offline guarantee
+    // + blocked by our strict CSP. Point it at our protocol's `ort/`
+    // subpath; main serves those files out of onnxruntime-web's dist.
+    // The wasm field is loosely typed via `?` — guard the assignment.
+    if (tx.env.backends.onnx.wasm) {
+      tx.env.backends.onnx.wasm.wasmPaths = 'pf-model:///ort/'
+    }
     const built = await tx.pipeline('token-classification', PF_MODEL_ID, {
       device: runtime === 'webgpu' ? 'webgpu' : 'wasm',
       dtype: 'q4',

--- a/packages/app/src/inference/pf-inference.ts
+++ b/packages/app/src/inference/pf-inference.ts
@@ -104,16 +104,23 @@ async function analyzeOne(
 ): Promise<void> {
   try {
     const output = await pipe(req.text, { aggregation_strategy: 'simple' })
-    const matches: PfMatch[] = output.map((m) => ({
-      // openai/privacy-filter emits `private_person`, `private_email`,
-      // etc. The class-mapping module operates on the short form so
-      // the same code works for future models without the prefix.
-      class: m.entity_group.toLowerCase().replace(/^private_/, ''),
-      value: m.word,
-      start: m.start,
-      end: m.end,
-      score: m.score,
-    }))
+    const matches: PfMatch[] = output
+      // Drop entries the tokenizer couldn't anchor back to the source
+      // text — start_offset / end_offset are NOT NULL in the findings
+      // schema and we'd just trigger SQLITE_CONSTRAINT_NOTNULL on
+      // insert otherwise. Span without offsets is useless anyway
+      // (can't be highlighted / purged / hover-revealed).
+      .filter((m) => Number.isFinite(m.start) && Number.isFinite(m.end))
+      .map((m) => ({
+        // openai/privacy-filter emits `private_person`, `private_email`,
+        // etc. The class-mapping module operates on the short form so
+        // the same code works for future models without the prefix.
+        class: m.entity_group.toLowerCase().replace(/^private_/, ''),
+        value: m.word,
+        start: m.start,
+        end: m.end,
+        score: m.score,
+      }))
     bridge.sendAnalyzeResult({ reqId: req.reqId, ok: true, matches })
   } catch (err) {
     bridge.sendAnalyzeResult({

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -111,7 +111,7 @@ let acpManager: AcpManager
 let isSyncActive = false
 let scanWorker: ScanWorkerProxy | null = null
 let disposeSecurityIpc: (() => void) | null = null
-const pfRuntime = makePfRuntime()
+const pfRuntime = makePfRuntime({ run: runWithObservability })
 // Lazily resolved on first access — pfModelsRoot() reads app.getPath
 // which throws before app.ready, but this module evaluates at boot.
 let pfCoordinator: ReturnType<typeof makePfCoordinator> | null = null
@@ -227,42 +227,54 @@ async function shutdownScanWorker(): Promise<void> {
  *  needs to drop the moment the runtime + backfill have settled
  *  (success or fail). The ScanBanner then takes over visually. */
 async function syncPfRuntime(pfEnabled: boolean): Promise<void> {
-  try {
-    if (pfEnabled && pfModelInstalled()) {
-      await pfRuntime.start()
-      // pfRuntime.start() resolves even when the handshake failed —
-      // the hidden window might be up but transformers.js / ONNX
-      // crashed during model load. Check the actual runtime state
-      // before telling the scan worker pf is online: otherwise
-      // currentProfile drifts to `regex@4,pf@1.5b-q4`, every analyze
-      // round-trips to a dead host that returns [], and the user
-      // sees regex-only findings tagged with a profile string that
-      // lies about what scanned them.
-      const state = await pfRuntime.getState()
-      if (state?.status === 'ready') {
-        scanWorker?.notifyPfOnline()
+  await runWithObservability(
+    Effect.gen(function* () {
+      yield* Effect.annotateCurrentSpan('pf.enabled', pfEnabled)
+      if (pfEnabled && pfModelInstalled()) {
+        yield* Effect.promise(() => pfRuntime.start())
+        // pfRuntime.start() resolves even when the handshake failed —
+        // the hidden window might be up but transformers.js / ONNX
+        // crashed during model load. Check the actual runtime state
+        // before telling the scan worker pf is online: otherwise
+        // currentProfile drifts to `regex@4,pf@1.5b-q4`, every analyze
+        // round-trips to a dead host that returns [], and the user
+        // sees regex-only findings tagged with a profile string that
+        // lies about what scanned them.
+        const state = yield* Effect.promise(() => pfRuntime.getState())
+        yield* Effect.annotateCurrentSpan('pf.runtime.status', state?.status ?? 'null')
+        if (state?.runtime) yield* Effect.annotateCurrentSpan('pf.runtime.kind', state.runtime)
+        if (state?.error) yield* Effect.annotateCurrentSpan('pf.runtime.error', state.error)
+        if (state?.status === 'ready') {
+          yield* Effect.sync(() => scanWorker?.notifyPfOnline())
+          yield* Effect.annotateCurrentSpan('pf.notified', 'online')
+        } else {
+          yield* Effect.logError(
+            `[security] pf runtime failed to reach ready (status=${state?.status ?? 'unknown'}, error=${state?.error ?? 'unknown'})`,
+          )
+          yield* Effect.sync(() => scanWorker?.notifyPfOffline())
+          yield* Effect.annotateCurrentSpan('pf.notified', 'offline')
+        }
       } else {
-        console.error(
-          '[security] pf runtime failed to reach ready (status=%s, error=%s) — keeping worker pfOnline=false',
-          state?.status ?? 'unknown',
-          state?.error ?? 'unknown',
-        )
-        scanWorker?.notifyPfOffline()
+        yield* Effect.sync(() => scanWorker?.notifyPfOffline())
+        yield* Effect.promise(() => pfRuntime.stop())
       }
-    } else {
-      scanWorker?.notifyPfOffline()
-      await pfRuntime.stop()
-    }
-    if (scanWorker) {
-      await runWithObservability(scanWorker.backfill())
-    }
-  } finally {
-    const cur = loadSecurityPreferences()
-    if (cur.pfActivationPending) {
-      const next = saveSecurityPreferences({ pfActivationPending: false })
-      mainWindow?.webContents.send(SECURITY_IPC_CHANNELS.EVT_PREFS_CHANGED, next)
-    }
-  }
+      if (scanWorker) {
+        yield* scanWorker.backfill()
+      }
+    }).pipe(
+      // pfActivationPending clears on the way out (success OR fail) so
+      // the callout's "Activating…" state stops hanging on a permanent
+      // failure. ScanBanner takes over visually once backfill enqueues.
+      Effect.ensuring(Effect.sync(() => {
+        const cur = loadSecurityPreferences()
+        if (cur.pfActivationPending) {
+          const next = saveSecurityPreferences({ pfActivationPending: false })
+          mainWindow?.webContents.send(SECURITY_IPC_CHANNELS.EVT_PREFS_CHANGED, next)
+        }
+      })),
+      Effect.withSpan('pf.sync_runtime'),
+    ),
+  )
 }
 
 function createWindow(): BrowserWindow {
@@ -467,6 +479,7 @@ app.whenReady().then(async () => {
     pfCoordinator = makePfCoordinator({
       modelDir: pfModelDir(),
       fetch: ((url, init) => net.fetch(url as string, init)) as typeof globalThis.fetch,
+      run: runWithObservability,
     })
     // When a download initiated from the callout completes, finish
     // the activation handshake on the user's behalf — flip pfEnabled

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -230,7 +230,25 @@ async function syncPfRuntime(pfEnabled: boolean): Promise<void> {
   try {
     if (pfEnabled && pfModelInstalled()) {
       await pfRuntime.start()
-      scanWorker?.notifyPfOnline()
+      // pfRuntime.start() resolves even when the handshake failed —
+      // the hidden window might be up but transformers.js / ONNX
+      // crashed during model load. Check the actual runtime state
+      // before telling the scan worker pf is online: otherwise
+      // currentProfile drifts to `regex@4,pf@1.5b-q4`, every analyze
+      // round-trips to a dead host that returns [], and the user
+      // sees regex-only findings tagged with a profile string that
+      // lies about what scanned them.
+      const state = await pfRuntime.getState()
+      if (state?.status === 'ready') {
+        scanWorker?.notifyPfOnline()
+      } else {
+        console.error(
+          '[security] pf runtime failed to reach ready (status=%s, error=%s) — keeping worker pfOnline=false',
+          state?.status ?? 'unknown',
+          state?.error ?? 'unknown',
+        )
+        scanWorker?.notifyPfOffline()
+      }
     } else {
       scanWorker?.notifyPfOffline()
       await pfRuntime.stop()

--- a/packages/app/src/main/scan-worker-thread.ts
+++ b/packages/app/src/main/scan-worker-thread.ts
@@ -149,7 +149,13 @@ void (async () => {
       // the scan engine already ran regex over upstream, but we don't
       // have access to those matches here.
       const regexMatches = detectWithRegex(text, 'regex')
-      return mapPfMatches(raw as PfRawMatch[], { regexMatches, fullText: text })
+      const mapped = mapPfMatches(raw as PfRawMatch[], { regexMatches, fullText: text })
+      // Diagnostic: see at a glance what % of raw matches survive
+      // class-mapping suppression. raw=N → mapped=M tells us if
+      // suppression rules are too aggressive or if labels are landing
+      // in the default-drop branch.
+      console.log(`[pf provider] raw=${raw.length} mapped=${mapped.length} kinds=${raw.map(m => m.class).join(',')}`)
+      return mapped
     },
   }
 

--- a/packages/app/src/main/scan-worker-thread.ts
+++ b/packages/app/src/main/scan-worker-thread.ts
@@ -128,6 +128,11 @@ void (async () => {
     displayName: 'Privacy Filter (ML)',
     available: () => pfOnline && loadSecurityPreferences().pfEnabled,
     analyze: async (text: string): Promise<SensitiveMatch[]> => {
+      // Short-circuit empty / whitespace-only chunks. The model's
+      // GatherBlockQuantized op fails with "Invalid dispatch group
+      // size (0, 1, 1)" on zero-token input; cheaper for everyone to
+      // skip the IPC round-trip entirely.
+      if (text.trim().length === 0) return []
       const reqId = pfNextReqId++
       const raw: PfRawMatchWire[] = await new Promise((resolve, reject) => {
         pfPending.set(reqId, { resolve, reject })

--- a/packages/app/src/main/security/pf-coordinator.ts
+++ b/packages/app/src/main/security/pf-coordinator.ts
@@ -3,6 +3,7 @@
 // so the renderer's `evt-pf-state` always agrees with what the user
 // can act on. ModelHost spawn/unload lands in PR 5c.
 
+import { Effect } from 'effect'
 import { downloadModel, type DownloadProgress } from './model-download.js'
 import { MODEL_MANIFEST, manifestTotalBytes } from './model-manifest.js'
 import { pfInstallStatus } from './model-state.js'
@@ -31,6 +32,11 @@ export interface PfCoordinator {
 export interface PfCoordinatorDeps {
   modelDir: string
   fetch?: typeof globalThis.fetch
+  /** Effect runner that carries the main-process observability
+   *  layer. Defaults to bare `Effect.runPromise` for tests; main
+   *  passes `runWithObservability` so `pf.coordinator.download`
+   *  spans land in the same OTel pipeline as the rest of Spool. */
+  run?: <A, E>(eff: Effect.Effect<A, E>) => Promise<A>
 }
 
 export function makePfCoordinator(deps: PfCoordinatorDeps): PfCoordinator {
@@ -38,6 +44,7 @@ export function makePfCoordinator(deps: PfCoordinatorDeps): PfCoordinator {
   const totalBytes = manifestTotalBytes(MODEL_MANIFEST)
   let abortController: AbortController | null = null
   let state = initialState(deps.modelDir)
+  const run = (deps.run ?? Effect.runPromise) as <A, E>(eff: Effect.Effect<A, E>) => Promise<A>
 
   function publish(): void {
     for (const fn of subscribers) {
@@ -54,39 +61,56 @@ export function makePfCoordinator(deps: PfCoordinatorDeps): PfCoordinator {
       bytesTotal: state.bytesTotal,
     }
     publish()
-    try {
-      await downloadModel({
-        modelDir: deps.modelDir,
-        manifest: MODEL_MANIFEST,
-        ...(deps.fetch ? { fetch: deps.fetch } : {}),
-        signal: abortController.signal,
-        onProgress: (p: DownloadProgress) => {
-          state = {
-            phase: 'downloading',
-            bytesDownloaded: p.bytesDownloaded,
-            bytesTotal: p.bytesTotal,
+    await run(
+      Effect.tryPromise({
+        try: () => downloadModel({
+          modelDir: deps.modelDir,
+          manifest: MODEL_MANIFEST,
+          ...(deps.fetch ? { fetch: deps.fetch } : {}),
+          signal: abortController!.signal,
+          onProgress: (p: DownloadProgress) => {
+            state = {
+              phase: 'downloading',
+              bytesDownloaded: p.bytesDownloaded,
+              bytesTotal: p.bytesTotal,
+            }
+            publish()
+          },
+        }),
+        catch: (err) => err,
+      }).pipe(
+        Effect.tap(() => Effect.sync(() => {
+          state = { phase: 'installed', bytesDownloaded: totalBytes, bytesTotal: totalBytes }
+        })),
+        Effect.tap(() => Effect.annotateCurrentSpan('pf.download.outcome', 'installed')),
+        Effect.catchAll((err) => Effect.sync(() => {
+          const aborted = (err as { name?: string } | undefined)?.name === 'AbortError'
+          if (aborted) {
+            state = initialState(deps.modelDir)
+          } else {
+            state = {
+              phase: 'failed',
+              bytesDownloaded: state.bytesDownloaded,
+              bytesTotal: state.bytesTotal,
+              error: err instanceof Error ? err.message : String(err),
+            }
           }
+        }).pipe(Effect.tap(() => Effect.annotateCurrentSpan(
+          'pf.download.outcome',
+          (err as { name?: string } | undefined)?.name === 'AbortError' ? 'cancelled' : 'failed',
+        )))),
+        Effect.ensuring(Effect.sync(() => {
+          abortController = null
           publish()
-        },
-      })
-      state = { phase: 'installed', bytesDownloaded: totalBytes, bytesTotal: totalBytes }
-    } catch (err) {
-      const aborted = (err as { name?: string } | undefined)?.name === 'AbortError'
-      if (aborted) {
-        // Cancel → drop back to whatever the filesystem says now.
-        state = initialState(deps.modelDir)
-      } else {
-        state = {
-          phase: 'failed',
-          bytesDownloaded: state.bytesDownloaded,
-          bytesTotal: state.bytesTotal,
-          error: err instanceof Error ? err.message : String(err),
-        }
-      }
-    } finally {
-      abortController = null
-      publish()
-    }
+        })),
+        Effect.withSpan('pf.coordinator.download', {
+          attributes: {
+            'pf.download.total_bytes': totalBytes,
+            'pf.download.files': MODEL_MANIFEST.files.length,
+          },
+        }),
+      ),
+    )
   }
 
   function cancelDownload(): void {

--- a/packages/app/src/main/security/pf-model-protocol.ts
+++ b/packages/app/src/main/security/pf-model-protocol.ts
@@ -46,6 +46,13 @@ export function registerPfModelScheme(): void {
       standard: true,
       secure: true,
       supportFetchAPI: true,
+      // The inference renderer is loaded from http://localhost in dev
+      // (Vite) and file:// in prod; either way the document origin
+      // differs from pf-model:// so Chromium's CORS layer would block
+      // the fetch without explicit allow. Our handler only serves files
+      // inside pfModelsRoot() (path-traversal refused with 403), no
+      // sensitive surface to widen.
+      corsEnabled: true,
       bypassCSP: false,
       stream: true,
     },

--- a/packages/app/src/main/security/pf-model-protocol.ts
+++ b/packages/app/src/main/security/pf-model-protocol.ts
@@ -13,9 +13,36 @@
 import { protocol } from 'electron'
 import { createReadStream } from 'node:fs'
 import { stat } from 'node:fs/promises'
-import { resolve, sep } from 'node:path'
+import { createRequire } from 'node:module'
+import { dirname, resolve, sep } from 'node:path'
 import { Readable } from 'node:stream'
 import { pfModelsRoot } from './model-paths.js'
+
+/** ORT WASM/JS files are loaded by the inference renderer at runtime
+ *  — by default ORT fetches them from cdn.jsdelivr.net, which the
+ *  Privacy-Filter-on-device promise won't allow. Resolve onnxruntime-web's
+ *  bundled `dist/` and serve those files through this protocol under
+ *  the `ort/` prefix instead. transformers.js's
+ *  `env.backends.onnx.wasm.wasmPaths` points back at us.
+ *
+ *  Lazy + memoised — `app.getPath('userData')` isn't safe pre-ready,
+ *  but createRequire is. Throws if onnxruntime-web isn't in the
+ *  resolution scope (would only happen if @huggingface/transformers
+ *  was uninstalled). */
+let ortDistRoot: string | null = null
+function getOrtDistRoot(): string {
+  if (ortDistRoot) return ortDistRoot
+  // onnxruntime-web is a TRANSITIVE dep of @huggingface/transformers,
+  // so it doesn't sit in main's direct resolution scope under pnpm
+  // (which doesn't hoist by default). Resolve transformers first,
+  // then resolve onnxruntime-web from transformers' own scope — that
+  // path always sees it because transformers depends on it directly.
+  const reqFromMain = createRequire(__filename)
+  const txEntry = reqFromMain.resolve('@huggingface/transformers')
+  const reqFromTx = createRequire(txEntry)
+  ortDistRoot = dirname(reqFromTx.resolve('onnxruntime-web'))
+  return ortDistRoot
+}
 
 const MIME_BY_EXT: Record<string, string> = {
   '.json': 'application/json',
@@ -23,6 +50,12 @@ const MIME_BY_EXT: Record<string, string> = {
   '.onnx_data': 'application/octet-stream',
   '.bin': 'application/octet-stream',
   '.txt': 'text/plain',
+  // ORT Runtime Web ships its WASM glue as ESM; dynamic import() in
+  // the renderer needs the response MIME to be a recognised JS type
+  // or Chromium refuses to evaluate it as a module.
+  '.mjs': 'text/javascript',
+  '.js': 'text/javascript',
+  '.wasm': 'application/wasm',
 }
 
 function mimeForPath(path: string): string {
@@ -47,9 +80,21 @@ export function registerPfModelProtocol(): void {
     // sits under "Application Support") don't mis-resolve.
     const combined = (url.host ? `/${url.host}` : '') + url.pathname
     const relPath = decodeURIComponent(combined).replace(/^\/+/, '')
-    const root = pfModelsRoot()
-    const target = resolve(root, relPath)
-    // Refuse anything that escapes the models parent directory.
+    // Two distinct subspaces share this protocol:
+    //   ort/<file>  → onnxruntime-web's dist (runtime binaries)
+    //   <anything>  → model bundle (weights, tokenizer, config)
+    // The `ort/` prefix is stripped before resolve so the join lands
+    // directly inside onnxruntime-web/dist/.
+    let root: string
+    let target: string
+    if (relPath === 'ort' || relPath.startsWith('ort/')) {
+      root = getOrtDistRoot()
+      target = resolve(root, relPath.slice('ort/'.length))
+    } else {
+      root = pfModelsRoot()
+      target = resolve(root, relPath)
+    }
+    // Refuse anything that escapes the resolved root.
     if (target !== root && !target.startsWith(root + sep)) {
       return new Response('forbidden', { status: 403 })
     }

--- a/packages/app/src/main/security/pf-model-protocol.ts
+++ b/packages/app/src/main/security/pf-model-protocol.ts
@@ -10,10 +10,25 @@
 // so we treat any pf-model:// path as a relative join against the
 // model directory and refuse to escape it.
 
-import { protocol, net } from 'electron'
+import { protocol } from 'electron'
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
 import { resolve, sep } from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { Readable } from 'node:stream'
 import { pfModelsRoot } from './model-paths.js'
+
+const MIME_BY_EXT: Record<string, string> = {
+  '.json': 'application/json',
+  '.onnx': 'application/octet-stream',
+  '.onnx_data': 'application/octet-stream',
+  '.bin': 'application/octet-stream',
+  '.txt': 'text/plain',
+}
+
+function mimeForPath(path: string): string {
+  const m = path.match(/\.[^./]+$/)
+  return (m && MIME_BY_EXT[m[0].toLowerCase()]) || 'application/octet-stream'
+}
 
 let registered = false
 
@@ -22,16 +37,42 @@ export function registerPfModelProtocol(): void {
   registered = true
   protocol.handle('pf-model', async (req) => {
     const url = new URL(req.url)
-    // Strip leading slashes from the path so `pf-model:///foo/bar.bin`
-    // resolves under pfModelsRoot(), not the filesystem root.
-    const relPath = url.pathname.replace(/^\/+/, '')
+    // With `standard: true` Chromium treats the first path segment
+    // after `://` as a HOST. transformers.js fetches
+    // `pf-model:///openai-privacy-filter-q4/config.json` — Electron
+    // collapses `///` and parses it as host=`openai-privacy-filter-q4`,
+    // pathname=`/config.json`. We need the full "host + path" to
+    // resolve back to the real file location.
+    // Decode %20 etc. so paths with spaces (Spool DEV's userData
+    // sits under "Application Support") don't mis-resolve.
+    const combined = (url.host ? `/${url.host}` : '') + url.pathname
+    const relPath = decodeURIComponent(combined).replace(/^\/+/, '')
     const root = pfModelsRoot()
     const target = resolve(root, relPath)
     // Refuse anything that escapes the models parent directory.
     if (target !== root && !target.startsWith(root + sep)) {
       return new Response('forbidden', { status: 403 })
     }
-    return net.fetch(pathToFileURL(target).toString())
+    try {
+      const s = await stat(target)
+      // Stream large weight files (917 MB onnx_data) instead of
+      // buffering — net.fetch(file://) chokes on path encoding in
+      // app.getPath('userData') (paths containing spaces).
+      const nodeStream = createReadStream(target)
+      // Cast to ReadableStream<Uint8Array> — Node's Readable is
+      // compatible with the Web Streams API surface that fetch needs.
+      const body = Readable.toWeb(nodeStream) as ReadableStream<Uint8Array>
+      return new Response(body, {
+        status: 200,
+        headers: {
+          'Content-Type': mimeForPath(target),
+          'Content-Length': String(s.size),
+        },
+      })
+    } catch (err) {
+      console.error('[pf-model] read failed', target, err)
+      return new Response('not found', { status: 404 })
+    }
   })
 }
 

--- a/packages/app/src/main/security/pf-runtime.ts
+++ b/packages/app/src/main/security/pf-runtime.ts
@@ -146,11 +146,16 @@ async function defaultSpawnWindow(): Promise<BrowserWindow> {
   // renderer's index.html into the hidden window (the symptom: a
   // bunch of Sidebar / LibraryLanding "undefined" errors and pf:ready
   // never arrives). Use Vite's @fs/<abs-path> escape hatch, paired
-  // with server.fs.allow in electron.vite.config.ts. Devtools opens
-  // detached in dev so a failed model load is immediately inspectable.
+  // with server.fs.allow in electron.vite.config.ts.
+  // Devtools are opt-in via SPOOL_PF_DEVTOOLS=1 — the console-message
+  // forwarder above already pipes pf-inference logs into main's
+  // stdout, so a detached devtools window every restart is just noise
+  // unless we're actively debugging this surface.
   const rendererBase = process.env['ELECTRON_RENDERER_URL']
   if (rendererBase) {
-    win.webContents.openDevTools({ mode: 'detach' })
+    if (process.env['SPOOL_PF_DEVTOOLS']) {
+      win.webContents.openDevTools({ mode: 'detach' })
+    }
     // __dirname in dev = packages/app/out/main → ../.. = packages/app
     const inferenceHtml = join(__dirname, '../../src/inference/pf-inference.html')
     await win.loadURL(`${rendererBase.replace(/\/$/, '')}/@fs${inferenceHtml}`)

--- a/packages/app/src/main/security/pf-runtime.ts
+++ b/packages/app/src/main/security/pf-runtime.ts
@@ -104,11 +104,26 @@ async function defaultSpawnWindow(): Promise<BrowserWindow> {
       nodeIntegration: false,
     },
   })
+  // The inference renderer is hidden, so its console + uncaught
+  // exceptions never surface otherwise. Without this forward,
+  // transformers.js / ONNX failures look like a stuck handshake from
+  // main's POV. Production logs land in the same OTel pipeline that
+  // captures other main-side console output.
+  win.webContents.on('console-message', (_event, level, message, line, sourceId) => {
+    const tag = level >= 2 ? 'ERR' : level === 1 ? 'WARN' : 'LOG'
+    console.log(`[pf-inference ${tag}]`, message, sourceId ? `(${sourceId}:${line})` : '')
+  })
+  win.webContents.on('render-process-gone', (_e, details) => {
+    console.error('[pf-inference] render process gone:', details.reason, details.exitCode)
+  })
   // Prod: electron-vite emits pf-inference.html under out/renderer/.
   // Dev: ELECTRON_RENDERER_URL points at src/renderer/, so climb one
-  // level up to reach src/inference/pf-inference.html.
+  // level up to reach src/inference/pf-inference.html. Open devtools
+  // detached in dev so a failed model load is immediately
+  // inspectable without manually invoking webContents.openDevTools.
   const rendererBase = process.env['ELECTRON_RENDERER_URL']
   if (rendererBase) {
+    win.webContents.openDevTools({ mode: 'detach' })
     await win.loadURL(`${rendererBase}/../inference/pf-inference.html`)
   } else {
     await win.loadFile(join(app.getAppPath(), 'out/renderer/pf-inference.html'))

--- a/packages/app/src/main/security/pf-runtime.ts
+++ b/packages/app/src/main/security/pf-runtime.ts
@@ -33,6 +33,11 @@ export interface PfRuntimeDeps {
   spawnWindow?: () => Promise<BrowserWindow>
   /** Override `ipcMain` for tests. */
   ipc?: ModelHostDeps['ipc']
+  /** Effect runner that carries the main-process observability
+   *  layer. Defaults to bare `Effect.runPromise` for tests; main
+   *  passes `runWithObservability` so PF spans land in the same
+   *  OTel pipeline as scan-worker / sync-worker / IPC spans. */
+  run?: <A, E>(eff: Effect.Effect<A, E>) => Promise<A>
 }
 
 export function makePfRuntime(deps: PfRuntimeDeps = {}): PfRuntime {
@@ -42,22 +47,29 @@ export function makePfRuntime(deps: PfRuntimeDeps = {}): PfRuntime {
 
   const spawnWindow = deps.spawnWindow ?? defaultSpawnWindow
   const ipc = deps.ipc ?? ipcMain
+  // Cast: Effect.runPromise's generic shape is wider than what we
+  // need (it also accepts a Scope.Scope requirement). The override
+  // pin to <A, E> matches what main supplies.
+  const run = (deps.run ?? Effect.runPromise) as <A, E>(eff: Effect.Effect<A, E>) => Promise<A>
 
   async function start(): Promise<void> {
     if (host) return
     if (starting) return starting
-    starting = (async () => {
-      const fresh = await Effect.runPromise(Scope.make())
-      const builtHost = await Effect.runPromise(
-        Effect.provideService(
-          makeModelHost({ spawnWindow, ipc }),
-          Scope.Scope,
-          fresh,
-        ),
-      )
-      host = builtHost
-      scope = fresh
-    })().finally(() => { starting = null })
+    starting = run(
+      Effect.gen(function* () {
+        const fresh = yield* Scope.make()
+        const builtHost = yield* Effect.provideService(makeModelHost({ spawnWindow, ipc }), Scope.Scope, fresh)
+        host = builtHost
+        scope = fresh
+        // Annotate after we have a state — useful when scrolling OTel
+        // for "what runtime did we land on this start cycle".
+        const settled = yield* builtHost.getState
+        yield* Effect.annotateCurrentSpan('pf.status', settled.status)
+        if (settled.runtime) yield* Effect.annotateCurrentSpan('pf.runtime', settled.runtime)
+        if (settled.adapterLabel) yield* Effect.annotateCurrentSpan('pf.adapter', settled.adapterLabel)
+        if (settled.error) yield* Effect.annotateCurrentSpan('pf.error', settled.error)
+      }).pipe(Effect.withSpan('pf.runtime.start')),
+    ).finally(() => { starting = null })
     await starting
   }
 
@@ -65,18 +77,28 @@ export function makePfRuntime(deps: PfRuntimeDeps = {}): PfRuntime {
     const s = scope
     host = null
     scope = null
-    if (s) await Effect.runPromise(Scope.close(s, Exit.void))
+    if (s) {
+      await run(Scope.close(s, Exit.void).pipe(Effect.withSpan('pf.runtime.stop')))
+    }
   }
 
   async function getState(): Promise<PfState | null> {
     if (!host) return null
-    return Effect.runPromise(host.getState)
+    return run(host.getState)
   }
 
   async function analyze(text: string): Promise<unknown[]> {
     if (!host) return []
-    return Effect.runPromise(
-      host.analyze(text).pipe(Effect.catchAll(() => Effect.succeed<unknown[]>([]))),
+    return run(
+      host.analyze(text).pipe(
+        Effect.tap((matches) =>
+          Effect.annotateCurrentSpan('pf.matches', matches.length)),
+        Effect.catchAll((err) =>
+          Effect.annotateCurrentSpan('pf.error', String(err.cause)).pipe(
+            Effect.as<unknown[]>([]),
+          )),
+        Effect.withSpan('pf.analyze', { attributes: { text_len: text.length } }),
+      ),
     )
   }
 

--- a/packages/app/src/main/security/pf-runtime.ts
+++ b/packages/app/src/main/security/pf-runtime.ts
@@ -117,14 +117,21 @@ async function defaultSpawnWindow(): Promise<BrowserWindow> {
     console.error('[pf-inference] render process gone:', details.reason, details.exitCode)
   })
   // Prod: electron-vite emits pf-inference.html under out/renderer/.
-  // Dev: ELECTRON_RENDERER_URL points at src/renderer/, so climb one
-  // level up to reach src/inference/pf-inference.html. Open devtools
-  // detached in dev so a failed model load is immediately
-  // inspectable without manually invoking webContents.openDevTools.
+  // Dev: Vite roots the renderer at src/renderer/, but our HTML lives
+  // at src/inference/pf-inference.html — outside that root. A relative
+  // `/../inference/...` URL gets normalised by the URL parser and ends
+  // up hitting Vite's SPA fallback, which silently serves the main
+  // renderer's index.html into the hidden window (the symptom: a
+  // bunch of Sidebar / LibraryLanding "undefined" errors and pf:ready
+  // never arrives). Use Vite's @fs/<abs-path> escape hatch, paired
+  // with server.fs.allow in electron.vite.config.ts. Devtools opens
+  // detached in dev so a failed model load is immediately inspectable.
   const rendererBase = process.env['ELECTRON_RENDERER_URL']
   if (rendererBase) {
     win.webContents.openDevTools({ mode: 'detach' })
-    await win.loadURL(`${rendererBase}/../inference/pf-inference.html`)
+    // __dirname in dev = packages/app/out/main → ../.. = packages/app
+    const inferenceHtml = join(__dirname, '../../src/inference/pf-inference.html')
+    await win.loadURL(`${rendererBase.replace(/\/$/, '')}/@fs${inferenceHtml}`)
   } else {
     await win.loadFile(join(app.getAppPath(), 'out/renderer/pf-inference.html'))
   }

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -37,6 +37,7 @@ import { securityApi } from '../api/security.js'
 import { securityFeatureEnabled } from '../featureFlags.js'
 import PurgeConfirmDialog from './security/PurgeConfirmDialog.js'
 import PfCallout from './security/PfCallout.js'
+import DetectorsChip from './security/DetectorsChip.js'
 import { parseQualifier, toggleKindQualifier } from './security/parse-qualifier.js'
 import { truncateValue } from './security/truncate-value.js'
 import {
@@ -474,6 +475,12 @@ function SecurityPageInner({ onOpenSession, onShareSession }: Props) {
               >
                 {t('security.filter_clear', { defaultValue: 'clear' })}
               </button>
+            </>
+          )}
+          {scanStatus?.currentProfile && (
+            <>
+              {' · '}
+              <DetectorsChip profile={scanStatus.currentProfile} />
             </>
           )}
         </span>

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -1017,9 +1017,21 @@ function SessionCard({
       sessionId: session.id,
       state: 'active',
       limit: findingsPageCount * FINDINGS_PAGE_SIZE,
+      // Without this, a session with 800+ absolute-path findings would
+      // page-window-shove every env-var / api-key off the first page
+      // and the strip would render empty. Skip info-tier at the SQL
+      // layer; the Info drawer at the bottom of the page is where
+      // those audit records surface.
+      excludeInfo: true,
     }
     if (activeKinds.length > 0) {
       f.kinds = activeKinds as NonNullable<FindingFilter['kinds']>
+      // When the user pins an info kind explicitly, we DO want it back.
+      // listFindings already ignores excludeInfo if `kinds` contains an
+      // info kind, but flip the flag here too so the contract is
+      // obvious at the call site.
+      const someInfo = activeKinds.some(k => INFO_SEVERITY_KINDS.has(k as SensitiveKind))
+      if (someInfo) f.excludeInfo = false
     }
     try {
       const page = await securityApi.listFindingsPage(f)

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -737,9 +737,26 @@ function ScanBanner({ status }: { status: ScanStatus }) {
         <span className="text-[13px] font-medium text-accent dark:text-accent-dark">
           {t('security.scanning', { defaultValue: 'Scanning' })}
         </span>
-        <span className="font-mono text-[11px] text-warm-muted dark:text-dark-muted tabular-nums">
-          {status.currentProfile}
-        </span>
+        {/* Burst-scoped progress count: "23 of 145 rescans" makes it
+         *  obvious this is the active re-scan batch (sessions whose
+         *  scan_profile drifted from current), not the library total.
+         *  Without the verb "rescans" the slash format invites
+         *  comparison with the sidebar's total-sessions number — which
+         *  is a different denominator and would feel inconsistent.
+         *  Only show once we have a stable total; suppress while
+         *  inFlight=0 (terminal moment before the banner hides). */}
+        {total > 0 && (
+          <span
+            data-testid="security-scan-banner-progress"
+            className="font-mono text-[11px] text-warm-muted dark:text-dark-muted tabular-nums whitespace-nowrap"
+          >
+            {t('security.scanning_progress', {
+              done,
+              total,
+              defaultValue: '{{done}} of {{total}} rescans',
+            })}
+          </span>
+        )}
       </div>
       <span aria-hidden />
       {/* Deterministic progress strip. The pct read here is fine

--- a/packages/app/src/renderer/components/security/DetectorsChip.tsx
+++ b/packages/app/src/renderer/components/security/DetectorsChip.tsx
@@ -78,12 +78,16 @@ function DetectorPill({
   return (
     <span
       data-tone={tone}
-      className={`inline-flex items-center gap-1 h-5 px-1.5 rounded-[5px] border bg-warm-surface dark:bg-dark-surface text-[11px] ${palette}`}
+      // font-mono matches the meta row's "{N} 项风险 · {N} 项信息"
+      // typography exactly — sans-at-same-px optically reads bigger
+      // than the mono digits next to it, which made the chips bulge
+      // out of the row.
+      className={`inline-flex items-center gap-1 h-5 px-1.5 rounded-[5px] border bg-warm-surface dark:bg-dark-surface font-mono text-[11px] ${palette}`}
     >
       {icon}
       <span>{label}</span>
       {meta && (
-        <span className="font-mono text-warm-faint dark:text-dark-muted tabular-nums">{meta}</span>
+        <span className="text-warm-faint dark:text-dark-muted tabular-nums">{meta}</span>
       )}
     </span>
   )

--- a/packages/app/src/renderer/components/security/DetectorsChip.tsx
+++ b/packages/app/src/renderer/components/security/DetectorsChip.tsx
@@ -1,0 +1,119 @@
+// Inline detector summary for the Security page meta row.
+//
+// Surfaces what's actively producing findings — not just the opaque
+// `regex@4,pf@1.5b-q4` profile string, but a human-readable list with
+// each detector's live status. The PF runtime can fail silently
+// (model load throw, GPU adapter rejection) and the only signal used
+// to be in Settings → Security. With this chip the user sees
+// "Privacy Filter · failed" right next to the findings count and
+// knows the scan didn't get the boost it claims to have.
+//
+// Polls pfGetRuntimeInfo at 3 s while PF is in the profile so a
+// loading → ready / loading → failed transition surfaces without a
+// page refresh.
+
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
+import { Sparkles, AlertTriangle, Loader2, Shield } from 'lucide-react'
+import { securityApi, type PfRuntimeInfo } from '../../api/security.js'
+
+export default function DetectorsChip({ profile }: { profile: string | null }) {
+  const { t } = useTranslation()
+  const [pfRuntime, setPfRuntime] = useState<PfRuntimeInfo | null>(null)
+
+  const hasPf = !!profile && /(^|,)pf@/.test(profile)
+  const regexVersion = profile?.match(/regex@(\d+)/)?.[1] ?? null
+
+  useEffect(() => {
+    if (!hasPf) { setPfRuntime(null); return }
+    let cancelled = false
+    const tick = async () => {
+      const info = await securityApi.pfGetRuntimeInfo().catch(() => null)
+      if (!cancelled) setPfRuntime(info)
+    }
+    void tick()
+    const id = setInterval(() => { void tick() }, 3000)
+    return () => { cancelled = true; clearInterval(id) }
+  }, [hasPf])
+
+  if (!profile) return null
+
+  return (
+    <span
+      data-testid="security-detectors-chip"
+      className="inline-flex items-center gap-1.5 align-baseline"
+    >
+      <DetectorPill
+        label={t('security.detector_pattern_short', { defaultValue: 'Pattern matching' })}
+        meta={regexVersion ? `v${regexVersion}` : null}
+        tone="active"
+        icon={<Shield size={10} strokeWidth={1.8} aria-hidden />}
+      />
+      {hasPf && (
+        <DetectorPill
+          label={t('security.detector_pf_short', { defaultValue: 'Privacy Filter' })}
+          meta={pfMetaText(pfRuntime, t)}
+          tone={pfTone(pfRuntime)}
+          icon={pfIcon(pfRuntime)}
+        />
+      )}
+    </span>
+  )
+}
+
+function DetectorPill({
+  label, meta, tone, icon,
+}: {
+  label: string
+  meta: string | null
+  tone: 'active' | 'loading' | 'failed'
+  icon: React.ReactNode
+}) {
+  const palette = tone === 'failed'
+    ? 'text-accent dark:text-accent-dark border-accent/40 dark:border-accent-dark/40'
+    : tone === 'loading'
+      ? 'text-warm-muted dark:text-dark-muted border-warm-border dark:border-dark-border'
+      : 'text-warm-muted dark:text-dark-muted border-warm-border dark:border-dark-border'
+  return (
+    <span
+      data-tone={tone}
+      className={`inline-flex items-center gap-1 h-5 px-1.5 rounded-[5px] border bg-warm-surface dark:bg-dark-surface text-[11px] ${palette}`}
+    >
+      {icon}
+      <span>{label}</span>
+      {meta && (
+        <span className="font-mono text-warm-faint dark:text-dark-muted tabular-nums">{meta}</span>
+      )}
+    </span>
+  )
+}
+
+function pfTone(info: PfRuntimeInfo | null): 'active' | 'loading' | 'failed' {
+  if (!info) return 'loading'  // null = host not yet running
+  if (info.status === 'failed') return 'failed'
+  if (info.status === 'ready') return 'active'
+  return 'loading'
+}
+
+function pfMetaText(
+  info: PfRuntimeInfo | null,
+  t: TFunction,
+): string | null {
+  if (!info) return t('security.detector_pf_runtime_loading', { defaultValue: 'starting…' })
+  if (info.status === 'ready') {
+    return info.runtime === 'webgpu'
+      ? t('security.detector_pf_runtime_webgpu', { defaultValue: 'WebGPU' })
+      : t('security.detector_pf_runtime_wasm', { defaultValue: 'WASM (CPU)' })
+  }
+  if (info.status === 'failed') {
+    return t('security.detector_pf_runtime_failed', { defaultValue: 'failed' })
+  }
+  return t('security.detector_pf_runtime_loading', { defaultValue: 'loading…' })
+}
+
+function pfIcon(info: PfRuntimeInfo | null): React.ReactNode {
+  if (info?.status === 'failed') return <AlertTriangle size={10} strokeWidth={1.9} aria-hidden />
+  if (info?.status === 'ready') return <Sparkles size={10} strokeWidth={1.9} aria-hidden />
+  return <Loader2 size={10} strokeWidth={1.9} className="animate-spin" aria-hidden />
+}

--- a/packages/app/src/renderer/components/security/DetectorsChip.tsx
+++ b/packages/app/src/renderer/components/security/DetectorsChip.tsx
@@ -48,7 +48,7 @@ export default function DetectorsChip({ profile }: { profile: string | null }) {
         label={t('security.detector_pattern_short', { defaultValue: 'Pattern matching' })}
         meta={regexVersion ? `v${regexVersion}` : null}
         tone="active"
-        icon={<Shield size={10} strokeWidth={1.8} aria-hidden />}
+        icon={<Shield size={9} strokeWidth={1.8} aria-hidden />}
       />
       {hasPf && (
         <DetectorPill
@@ -82,7 +82,7 @@ function DetectorPill({
       // typography exactly — sans-at-same-px optically reads bigger
       // than the mono digits next to it, which made the chips bulge
       // out of the row.
-      className={`inline-flex items-center gap-1 h-5 px-1.5 rounded-[5px] border bg-warm-surface dark:bg-dark-surface font-mono text-[11px] ${palette}`}
+      className={`inline-flex items-center gap-[3px] h-[18px] px-1.5 rounded-[4px] border bg-warm-surface dark:bg-dark-surface font-mono text-[10px] ${palette}`}
     >
       {icon}
       <span>{label}</span>
@@ -117,7 +117,7 @@ function pfMetaText(
 }
 
 function pfIcon(info: PfRuntimeInfo | null): React.ReactNode {
-  if (info?.status === 'failed') return <AlertTriangle size={10} strokeWidth={1.9} aria-hidden />
-  if (info?.status === 'ready') return <Sparkles size={10} strokeWidth={1.9} aria-hidden />
-  return <Loader2 size={10} strokeWidth={1.9} className="animate-spin" aria-hidden />
+  if (info?.status === 'failed') return <AlertTriangle size={9} strokeWidth={1.9} aria-hidden />
+  if (info?.status === 'ready') return <Sparkles size={9} strokeWidth={1.9} aria-hidden />
+  return <Loader2 size={9} strokeWidth={1.9} className="animate-spin" aria-hidden />
 }

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -340,6 +340,7 @@
     "show_values_full": "Werte anzeigen",
     "hide_values_full": "Werte für Bildschirmfreigabe verbergen",
     "scanning": "Scan läuft",
+    "scanning_progress": "{{done}} of {{total}} rescans",
     "scan_done": "Scan abgeschlossen",
     "scan_done_clean": "nichts Hochriskantes gefunden",
     "scan_done_high_one": "{{count}} hoch",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -340,6 +340,7 @@
     "show_values_full": "Show values",
     "hide_values_full": "Hide values for screen-share",
     "scanning": "Scanning",
+    "scanning_progress": "{{done}} of {{total}} rescans",
     "scan_done": "Scan complete",
     "scan_done_clean": "nothing high-risk found",
     "scan_done_high_one": "{{count}} high",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -340,6 +340,7 @@
     "show_values_full": "Afficher les valeurs",
     "hide_values_full": "Masquer les valeurs pour le partage d'écran",
     "scanning": "Analyse en cours",
+    "scanning_progress": "{{done}} of {{total}} rescans",
     "scan_done": "Analyse terminée",
     "scan_done_clean": "rien à haut risque trouvé",
     "scan_done_high_one": "{{count}} élevé",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -323,6 +323,7 @@
     "show_values_full": "値を表示",
     "hide_values_full": "画面共有用に値を隠す",
     "scanning": "スキャン中",
+    "scanning_progress": "{{done}} of {{total}} rescans",
     "scan_done": "スキャン完了",
     "scan_done_clean": "高リスクは見つかりませんでした",
     "scan_done_high_other": "高 {{count}} 件",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -323,6 +323,7 @@
     "show_values_full": "값 표시",
     "hide_values_full": "화면 공유용으로 값 숨기기",
     "scanning": "스캔 중",
+    "scanning_progress": "{{done}} of {{total}} rescans",
     "scan_done": "스캔 완료",
     "scan_done_clean": "높은 위험 항목 없음",
     "scan_done_high_other": "높음 {{count}}건",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -323,6 +323,7 @@
     "show_values_full": "显示原值",
     "hide_values_full": "隐藏原值",
     "scanning": "扫描中",
+    "scanning_progress": "已重扫 {{done}} / {{total}}",
     "scan_done": "扫描完成",
     "scan_done_clean": "未发现高风险项",
     "scan_done_high_other": "{{count}} 条高风险",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -323,6 +323,7 @@
     "show_values_full": "顯示原值",
     "hide_values_full": "隱藏原值",
     "scanning": "掃描中",
+    "scanning_progress": "已重掃 {{done}} / {{total}}",
     "scan_done": "掃描完成",
     "scan_done_clean": "未發現高風險項目",
     "scan_done_high_other": "{{count}} 條高風險",

--- a/packages/core/src/security/repo.ts
+++ b/packages/core/src/security/repo.ts
@@ -65,6 +65,14 @@ export interface FindingFilter {
   kinds?: readonly SensitiveKind[]
   state?: FindingState | 'any'
   severity?: 'high' | 'low'
+  /** When true, info-tier kinds (absolute-path / ip / internal-host)
+   *  are excluded at the SQL layer. Needed by SessionCard fetches —
+   *  a session with 800+ absolute-path + a handful of api-keys would
+   *  otherwise have its non-info findings shoved off the first page
+   *  by `detected_at DESC` ordering, and the client-side info filter
+   *  has nothing left to render. Ignored when `kind` or `kinds`
+   *  explicitly includes an info kind. */
+  excludeInfo?: boolean
   limit?: number
   offset?: number
 }
@@ -291,6 +299,18 @@ export function listFindings(db: Database.Database, filter: FindingFilter): Find
   } else if (filter.severity === 'low') {
     where.push(`kind NOT IN (${highKindsPlaceholders()})`)
     params.push(...HIGH_SEVERITY_KINDS_ARRAY)
+  }
+  // Skip info-tier kinds unless the caller is explicitly asking for
+  // one. Saves the renderer from paging through 800+ absolute-path
+  // findings before reaching the api-key that actually matters.
+  const explicitKindsInclude = (kinds: readonly SensitiveKind[] | undefined, kind: SensitiveKind | undefined): boolean => {
+    if (kinds && kinds.length > 0) return kinds.some(k => INFO_SEVERITY_KINDS.has(k))
+    if (kind !== undefined) return INFO_SEVERITY_KINDS.has(kind)
+    return false
+  }
+  if (filter.excludeInfo && !explicitKindsInclude(filter.kinds, filter.kind)) {
+    where.push(`kind NOT IN (${infoKindsPlaceholders()})`)
+    params.push(...INFO_SEVERITY_KINDS_ARRAY)
   }
   let pagination = ''
   if (filter.limit !== undefined) {


### PR DESCRIPTION
feat(security): forward PF inference window console to main + dev devtools

The hidden inference renderer used to swallow its own console.log /
console.error / uncaught exceptions, which made silent transformers.js
or ONNX Runtime Web failures indistinguishable from a stuck handshake
on main's side — pfRuntime.start() resolved after the 90 s timeout
without surfacing why.

- Listen to webContents 'console-message' + 'render-process-gone' on
  defaultSpawnWindow, prefix log lines with [pf-inference] + level tag
  so they're greppable in main's stdout / OTel pipeline
- In dev (ELECTRON_RENDERER_URL set), openDevTools({mode:'detach'})
  on the inference window so model-load errors are immediately
  inspectable. Production builds skip this entirely

fix(security): gate notifyPfOnline on the runtime actually reaching ready

pfRuntime.start() resolves even when the handshake failed — the hidden
inference window might be up but transformers.js / ONNX crashed
loading the model, leaving state.status='failed'. syncPfRuntime used
to call scanWorker.notifyPfOnline() unconditionally after start(),
which:

  - drifted the scan profile to `regex@4,pf@1.5b-q4`, claiming PF
    participated when it actually didn't
  - made every analyze IPC round-trip to a dead host that returned []
    via the catchAll, producing regex-only findings tagged with a
    profile string that lies about what scanned them
  - made the symptom invisible from main's logs (no failure surface)

Now check `pfRuntime.getState().status === 'ready'` before notifying
the worker. Failure path logs the state + error and calls
notifyPfOffline so worker's pfOnline stays false and the profile
correctly reflects regex@4 only.

The pf-coordinator's failed state already surfaces via the Settings
runtime badge + the new Security-page DetectorsChip — users see
"Privacy Filter · failed" instead of a phantom-active claim.

fix(security): exclude info-tier kinds from per-session listFindings

A session with 800+ absolute-path findings (info-tier, default
hidden) and a handful of env-var / api-key findings (high-tier,
the actual leak) would render with no inline findings on the
Security page. SessionCard fetched the first 200 rows ordered by
detected_at DESC, the latest scan put all the absolute-paths in
that window, and the client-side `filter(!INFO_SEVERITY_KINDS)`
had nothing left to show.

- listFindings: new `excludeInfo: boolean` filter that drops
  info-tier kinds (absolute-path / ip / internal-host) at the SQL
  layer. Ignored when the caller explicitly includes an info kind
  via `kind` / `kinds`, so the "pin info kind" filter pill still
  works.
- SessionCard.load: pass `excludeInfo: true` by default; flip back
  to false only when the user has pinned an info kind. The
  existing client-side filter stays as defense-in-depth.

Pre-existing bug, surfaced while debugging PF rescans — independent
of the PF stack but committed here for convenience.

feat(security): detector status chip in Security page meta row

Surface which detectors are actively producing findings, with live
status — not just the opaque `regex@4,pf@1.5b-q4` profile string.
Before this, the only way to tell whether Privacy Filter was
actually contributing (vs. crashed and silently returning []) was
to dig into Settings → Security and check the runtime badge.

- new DetectorsChip component, renders inline pills:
  - "Pattern matching v4" — always shown
  - "Privacy Filter · WebGPU / WASM (CPU) / starting… / failed" —
    only when the profile string includes pf@
- polls pfGetRuntimeInfo at 3 s while pf is in profile so a
  loading → ready / loading → failed transition shows without a
  page refresh
- wires into the existing meta row after the activeKinds filter
  block. ScanBanner / ScanResultBanner sit above it as before;
  scanStatus is already available

Now a failing inference window (model load throw, GPU adapter
rejection, missing CSP) shows "Privacy Filter · failed" right next
to the findings count — same surface where the rest of the
detector summary lives.

fix(security): make PF inference window actually loadable in dev

Three independent bugs that combined to make pfRuntime.start()
silently fail before reaching pf:ready in dev mode. The bug 2-a
console forwarder added in an earlier commit is what finally
surfaced them — until then they looked like a stuck handshake.

1. Wrong dev URL → main app rendered inside the hidden window
   Vite roots the renderer at src/renderer/; pf-inference.html
   lives at src/inference/. The previous loadURL traversal
   `${rendererBase}/../inference/pf-inference.html` got
   URL-normalised down to `/inference/...`, which Vite's SPA
   fallback served as the main index.html. Result: the hidden
   window mounted the entire main app, blew up with `window.spool`
   undefined in <Sidebar> / <LibraryLanding>, and never reached
   the inference entry. Use Vite's `@fs/<abs-path>` escape hatch
   to address the source file directly + whitelist
   `src/inference/` in `server.fs.allow` so the dev server
   actually serves it.

2. pf-model:// fetch CORS-blocked across origins
   Document origin is http://localhost in dev / file:// in prod,
   protocol origin is pf-model:// — different by definition.
   Chromium's CORS layer blocks cross-origin fetch by default for
   privileged schemes. Set `corsEnabled: true` on the privileged
   scheme registration. The handler only serves files under
   pfModelsRoot() with path-traversal refused → no widened
   surface, just CORS unlock.

3. CSP didn't allow Vite's HMR WebSocket
   `connect-src 'self'` matches http://localhost but not the
   `ws://localhost` HMR socket Vite injects. Surfaced as console
   noise + a permanently-pending HMR client. Add `ws: wss:` to
   connect-src; the inference page never opens a WebSocket itself
   in prod, so the only thing that can actually use this is the
   Vite client.

fix(security): correct pf-model:// URL parsing + stream large files

Two follow-on bugs from the dev-load fix:

1. Chromium's URL parser, with our `standard: true` privileged scheme,
   treats the first path segment after `://` as a HOST. transformers.js
   fetches `pf-model:///openai-privacy-filter-q4/config.json`; Electron
   normalises the `///` and reports it back as
   host=`openai-privacy-filter-q4`, pathname=`/config.json`. The
   handler used pathname only, resolved to
   `<userData>/models/config.json`, returned ENOENT. Combine host + path
   before joining. Also URL-decode so paths with spaces
   ("Application Support") resolve correctly.

2. `net.fetch(pathToFileURL(target))` was hitting `ERR_FILE_NOT_FOUND`
   for the same reason + a separate encoding quirk. Switched to
   `createReadStream` + a Web Streams `Response`, which keeps the
   stream behaviour (917 MB onnx_data should never buffer in memory)
   while sidestepping the encoded-file-URL issues entirely.

refactor(security): Effect-ify PF runtime/coordinator/sync + OTel spans

Until now the Privacy Filter download + activation flow was all
hand-rolled Promises. When the inference window silently failed it
took ages to find out because nothing wrote into the OTel pipeline
that already collects every scan + sync span. This commit closes that
gap by routing the load-bearing PF paths through Effect.withSpan +
Effect.annotateCurrentSpan, wired to main's runWithObservability.

- pf-runtime.ts: makePfRuntime accepts a `run` dep (defaults to bare
  `Effect.runPromise` for tests; main injects `runWithObservability`).
  start() / stop() / analyze() each run their bodies inside an
  Effect block with a span name:
    pf.runtime.start  — annotated with pf.status / pf.runtime /
                        pf.adapter / pf.error
    pf.runtime.stop
    pf.analyze        — annotated with text_len + pf.matches
- pf-coordinator.ts: startDownload moves into Effect.tryPromise +
  Effect.ensuring (replaces the try/finally); wrapped with
    pf.coordinator.download
  annotated with total_bytes + file count + pf.download.outcome
  (installed / cancelled / failed)
- main/index.ts: syncPfRuntime is now a Promise wrapper around an
  Effect.gen body with span `pf.sync_runtime`. Annotations: pf.enabled,
  pf.runtime.status, pf.runtime.kind, pf.runtime.error, pf.notified
  (online / offline). Uses Effect.logError for the failed-handshake
  message so it carries fiber id + structured fields. Effect.ensuring
  clears pfActivationPending on every exit path (success and fail).

Tests unchanged — `run` is optional, defaults to Effect.runPromise.
Full app suite 273/273. Restart with this code shows:
  [pf.runtime.start]  (2.68s)  pf.status=failed pf.error=…
  [pf.sync_runtime]   (3.19s)  pf.enabled=true pf.notified=offline …
exactly what diagnosing PF startup issues should feel like.

fix(security): self-host ORT WASM + correct MIME + skip empty analyze

ONNX Runtime Web defaults to fetching its WASM + JS-glue runtime
from cdn.jsdelivr.net. Incompatible with both Privacy Filter's
on-device guarantee and our strict CSP. Pin it to a local source
served through the existing pf-model:// protocol:

- pf-model-protocol.ts: route `pf-model:///ort/<file>` to
  onnxruntime-web/dist/. Resolution hops through @huggingface/transformers's
  scope (createRequire chain) because onnxruntime-web is a transitive
  dep — pnpm doesn't expose it directly in main's resolution scope.
- MIME table extended with .mjs / .js / .wasm — Chromium refuses to
  dynamic-import() a response unless the Content-Type is a recognised
  JS module type. Without this, the bytes arrived but ORT's
  asyncify.mjs / jsep.mjs were rejected at the module boundary.
- pf-inference.ts: env.backends.onnx.wasm.wasmPaths = 'pf-model:///ort/'
- pf-inference.html CSP: pf-model: added to script-src + worker-src
  (ORT's WASM glue is loaded both as script-elem and as Worker
  source). connect-src + default-src already had it.
- scan-worker-thread.ts pfProvider: short-circuit empty / whitespace
  text. GatherBlockQuantized in the model's embed_tokens layer fails
  with "Invalid dispatch group size (0, 1, 1)" on zero-token input;
  cheaper to skip the IPC entirely.

End-to-end status: with these changes pf:ready handshake completes
in ~2.5 s, scan worker is notified online, profile drifts to
regex@4,pf@1.5b-q4, and pf.analyze spans start landing for real
text. Outstanding: investigate the GatherBlockQuantized error on
non-empty inputs (may be tokenizer / quantization mismatch in the
q4 build — separate diagnosis).

fix(security): drop PF matches without offsets + diag mapping log

Two follow-ons from end-to-end PF inference debugging:

1. SQLITE_CONSTRAINT_NOTNULL on insertFindings
   findings.start_offset and findings.end_offset are NOT NULL.
   transformers.js's `aggregation_strategy: 'simple'` returns
   `start: undefined` / `end: undefined` for some matches when the
   tokenizer can't anchor them to source offsets. Filter those out
   in pf-inference.ts BEFORE crossing the IPC — a match without a
   span is useless in Spool anyway (can't highlight, purge, or hover-
   reveal). Stops every PF-containing scan from rolling back with
   db-failed.

2. Diagnostic console line in pfProvider
   Added one-shot `[pf provider] raw=N mapped=M kinds=...` line so
   the suppression behaviour of class-mapping is visible without
   reading the source. Already paid off — confirms we see
   "raw=2 mapped=1 kinds=person,secret" (person → person-name kept,
   secret suppressed because no overlapping regex hit).
   Leaving in for now; will move into a span attribute on the next
   sweep if we keep it.

feat(security): show rescan progress in ScanBanner instead of raw profile

Replaces \`regex@4,pf@1.5b-q4\` in the ScanBanner with a human-readable
count of the active rescan batch. The version string was dev jargon
that other products universally hide from users — VS Code / Spotlight /
1Password Watchtower / Tailscale all show only status + progress
during active operations, never engine versions. The DetectorsChip
in the meta row above already surfaces the same info as friendly
labels ("Pattern matching v4" · "Privacy Filter · WebGPU"), so the
banner was double-stating it in raw form.

- ScanBanner: profile chip → "23 of 145 rescans" (en) / "已重扫 23 / 145"
  (zh). Uses the existing burst-scoped backfillTotal high-water mark
  (PR #271 — stable, doesn't rewind on tab switch). Explicit "rescans"
  / "重扫" verb signals this is the active batch, NOT total sessions
  in the library — pre-empts the natural "this number doesn't match
  the sidebar's session count" question without needing a tooltip.
- i18n: settings.security.scanning_progress key for en + zh-CN +
  zh-TW + ja/ko/de/fr placeholder (English).

fix(security): match DetectorsChip typography to surrounding meta row

The meta row uses font-mono 11px for the "{N} 项风险 · {N} 项信息" text
but the chip's label was sans 11px — Geist Sans at the same px is
optically larger than Geist Mono, so the chips read as a different
"size class" than the row they sit in. Switch the entire chip to
font-mono so labels + version meta + neighbour text all render at
the same visual scale.

fix(security): shrink DetectorsChip to read as inline meta, not buttons

Chips at h-5 + 11px text were closer to button-sized than to the
"180 项风险 · 8342 项信息" meta-row neighbours. Drop one notch each:
h-[18px], text-[10px], icon size 9, gap-[3px], border-radius 4px.
Still legible (10px Geist Mono is the same scale as other meta-row
inline tokens elsewhere in the app), but feels embedded in the row
instead of floating above it.

fix(security): gate PF inference devtools behind SPOOL_PF_DEVTOOLS

Was opening devtools on every dev start since PR 5c — useful while
the inference window was a black box, but the console-message
forwarder already pipes [pf-inference LOG/WARN/ERR] lines into
main's stdout, so the detached devtools window is just visual
clutter unless we're actively debugging this surface.

Opt in with `SPOOL_PF_DEVTOOLS=1 pnpm dev` when needed.

fix(security): re-locate PF matches via indexOf when tokenizer lacks offsets

transformers.js with BPE tokenizers occasionally returns matches with
`start: undefined / end: undefined` even when aggregation_strategy is
'simple'. Hard-filtering those out earlier (PR …7b08fa7) silenced the
SQLITE_CONSTRAINT_NOTNULL crash but also dropped every PF match —
post-restart we saw 2000+ pf.analyze calls with 0 surviving matches.

Better fallback: when offsets are missing, locate the matched word
in the source text via indexOf advancing a cursor so duplicates land
at distinct positions (matches arrive in document order). Drop only
when even indexOf can't find the word — should be rare since the
word came from the tokenizer reading the same source.

Keeps the NOT NULL safety while not throwing away real findings.