### PR TITLE
feat(security): restrict PF to high-precision PII categories

### DIFF
--- a/packages/app/src/main/security/class-mapping.test.ts
+++ b/packages/app/src/main/security/class-mapping.test.ts
@@ -6,13 +6,7 @@ const regex = (kind: SensitiveMatch['kind'], start: number, end: number): Sensit
   kind, value: '', start, end, confidence: 0.95, provider: 'regex',
 })
 
-describe('class mapping — direct mappings (openai/privacy-filter classes)', () => {
-  it('person → person-name', () => {
-    const pf: PfRawMatch = { class: 'person', value: 'Maya', start: 0, end: 4, score: 0.9 }
-    const out = mapPfMatch(pf, { regexMatches: [], fullText: 'Maya' })
-    expect(out?.kind).toBe('person-name')
-    expect(out?.provider).toBe('pf')
-  })
+describe('class mapping — kept classes (high-precision on PII-only setting)', () => {
   it('email → email', () => {
     const pf: PfRawMatch = { class: 'email', value: 'a@b.c', start: 0, end: 5, score: 0.95 }
     expect(mapPfMatch(pf, { regexMatches: [], fullText: 'a@b.c' })?.kind).toBe('email')
@@ -21,38 +15,40 @@ describe('class mapping — direct mappings (openai/privacy-filter classes)', ()
     const pf: PfRawMatch = { class: 'phone', value: '+1234567890', start: 0, end: 11, score: 0.92 }
     expect(mapPfMatch(pf, { regexMatches: [], fullText: '+1234567890' })?.kind).toBe('phone')
   })
-  it('address → street-address', () => {
-    const pf: PfRawMatch = { class: 'address', value: '1 Main St', start: 0, end: 9, score: 0.88 }
-    expect(mapPfMatch(pf, { regexMatches: [], fullText: '1 Main St' })?.kind).toBe('street-address')
+})
+
+describe('class mapping — disabled classes (precision too low without clues)', () => {
+  // person / address / url / account_number sit at P=0.62-0.82 on the
+  // model card's "PII only" setting (Spool's actual content shape).
+  // Each kind is suppressed entirely until either domain fine-tune or
+  // a shape filter that survives technical content.
+  for (const cls of ['person', 'address', 'url', 'account_number'] as const) {
+    it(`${cls} is always suppressed`, () => {
+      const pf: PfRawMatch = { class: cls, value: 'whatever', start: 0, end: 8, score: 0.99 }
+      expect(mapPfMatch(pf, { regexMatches: [], fullText: 'whatever' })).toBeNull()
+    })
+  }
+})
+
+describe('class mapping — confidence floor', () => {
+  it('drops any match below 0.85 even if class would otherwise pass', () => {
+    const pf: PfRawMatch = { class: 'email', value: 'a@b.c', start: 0, end: 5, score: 0.84 }
+    expect(mapPfMatch(pf, { regexMatches: [], fullText: 'a@b.c' })).toBeNull()
+  })
+  it('keeps matches at 0.85 exactly', () => {
+    const pf: PfRawMatch = { class: 'email', value: 'a@b.c', start: 0, end: 5, score: 0.85 }
+    expect(mapPfMatch(pf, { regexMatches: [], fullText: 'a@b.c' })?.kind).toBe('email')
   })
 })
 
 describe('class mapping — suppression rules', () => {
-  it('url with no overlapping regex url-creds is suppressed', () => {
-    const pf: PfRawMatch = { class: 'url', value: 'https://example.com', start: 0, end: 19, score: 0.9 }
-    expect(mapPfMatch(pf, { regexMatches: [], fullText: 'https://example.com' })).toBeNull()
-  })
-  it('url overlapping a regex url-creds match → url-creds (boost)', () => {
-    const pf: PfRawMatch = { class: 'url', value: 'https://u:p@x.com', start: 0, end: 17, score: 0.9 }
-    const out = mapPfMatch(pf, {
-      regexMatches: [regex('url-creds', 0, 17)],
-      fullText: 'https://u:p@x.com',
-    })
-    expect(out?.kind).toBe('url-creds')
-  })
-
-  it('account_number is always suppressed', () => {
-    const pf: PfRawMatch = { class: 'account_number', value: '4111 1111 1111 1111', start: 0, end: 19, score: 0.95 }
-    expect(mapPfMatch(pf, { regexMatches: [], fullText: '4111 1111 1111 1111' })).toBeNull()
-  })
-
   it('secret with no regex generic-secret nearby is suppressed', () => {
-    const pf: PfRawMatch = { class: 'secret', value: 'abc', start: 0, end: 3, score: 0.7 }
+    const pf: PfRawMatch = { class: 'secret', value: 'abc', start: 0, end: 3, score: 0.9 }
     expect(mapPfMatch(pf, { regexMatches: [], fullText: 'abc' })).toBeNull()
   })
 
   it('secret overlapping a regex generic-secret → generic-secret (boost)', () => {
-    const pf: PfRawMatch = { class: 'secret', value: 'xyz', start: 5, end: 8, score: 0.7 }
+    const pf: PfRawMatch = { class: 'secret', value: 'xyz', start: 5, end: 8, score: 0.9 }
     const out = mapPfMatch(pf, {
       regexMatches: [regex('generic-secret', 0, 20)],
       fullText: 'token = "xyz" plus extra',
@@ -92,11 +88,11 @@ describe('class mapping — suppression rules', () => {
 describe('mapPfMatches', () => {
   it('drops suppressed entries while keeping the rest', () => {
     const pf: PfRawMatch[] = [
-      { class: 'person', value: 'Maya', start: 0, end: 4, score: 0.9 },
-      { class: 'account_number', value: '0123456', start: 10, end: 17, score: 0.95 },
-      { class: 'email', value: 'a@b.c', start: 20, end: 25, score: 0.9 },
+      { class: 'person', value: 'Maya', start: 0, end: 4, score: 0.9 },           // disabled class
+      { class: 'account_number', value: '0123456', start: 10, end: 17, score: 0.95 }, // disabled class
+      { class: 'email', value: 'a@b.c', start: 20, end: 25, score: 0.9 },         // kept
     ]
     const out = mapPfMatches(pf, { regexMatches: [], fullText: 'Maya       0123456    a@b.c' })
-    expect(out.map(m => m.kind)).toEqual(['person-name', 'email'])
+    expect(out.map(m => m.kind)).toEqual(['email'])
   })
 })

--- a/packages/app/src/main/security/class-mapping.ts
+++ b/packages/app/src/main/security/class-mapping.ts
@@ -55,10 +55,21 @@ export interface MappingContext {
 
 const DOB_CONTEXT_RX = /\b(dob|date\s+of\s+birth|born\s+on|birthday|d\.?o\.?b\.?)\b/i
 
+/** Confidence floor for ANY PF emission. Below this the model is
+ *  effectively guessing — empirically ~40% of low-conf matches on
+ *  Spool's dev DB were obvious junk ("bgvnljn80" 0.36, "toolu_01..."
+ *  0.38, "id" 0.5). The model's own published F1 is on natural-language
+ *  PII benchmarks; our dev session text (mixed Chinese + code + tool
+ *  IDs + hashes) is well out of distribution. */
+const PF_MIN_CONFIDENCE = 0.85
+
 export function mapPfMatch(
   pf: PfRawMatch,
   ctx: MappingContext,
 ): SensitiveMatch | null {
+  // Universal confidence floor — applied before any per-class logic
+  // so noise gets dropped regardless of suppression rules.
+  if (pf.score < PF_MIN_CONFIDENCE) return null
   const kind = mapClass(pf, ctx)
   if (!kind) return null
   return {
@@ -72,36 +83,44 @@ export function mapPfMatch(
 }
 
 function mapClass(pf: PfRawMatch, ctx: MappingContext): SensitiveKind | null {
+  // Restricted to PF categories where the model's published precision
+  // is meaningfully above regex's already-strong patterns:
+  //   email  (P=0.97 even without contextual clues)
+  //   phone  (P=0.92, catches digit-word + spacing variants regex misses)
+  //   date   (P=1.00 — but only paired with a DOB context)
+  //   secret (P=1.00 — only as a regex-hit boost)
+  // We DROP person / address / url / account_number entirely. On the
+  // model card's "PII only" (no clue) numbers — which is Spool's
+  // actual setting — those four sit at P=0.62-0.82, i.e. 18-38% false
+  // positives. On out-of-distribution technical content (hashes /
+  // tool ids / split URLs) the card shows precision crashing further
+  // (line_breaks 0.45, phonetic 0.27). Regex doesn't cover these
+  // kinds either, so we accept the recall gap — coverage we can't
+  // trust isn't coverage.
   switch (pf.class) {
-    case 'person':
-      return 'person-name'
     case 'email':
       return 'email'
     case 'phone':
       return 'phone'
-    case 'address':
-      return 'street-address'
-
-    case 'url':
-      // URLs aren't secrets on their own. Only emit when the regex
-      // also saw url-creds in the same span — pf then acts as a
-      // confidence boost on the regex hit.
-      return overlapsRegexKind(pf, ctx.regexMatches, 'url-creds') ? 'url-creds' : null
 
     case 'date':
       // Dates by themselves are noisy. Only emit when the +/- 32
       // chars around the match look like a DOB context.
       return looksLikeDob(pf, ctx.fullText) ? 'date-of-birth' : null
 
-    case 'account_number':
-      // Too noisy without a Luhn-style checksum. Regex's `credit-card`
-      // already covers Luhn-valid hits; everything else is suppressed.
-      return null
-
     case 'secret':
       // Regex is authoritative for known credential prefixes. PF's
       // `secret` only fires as a boost on existing regex hits.
       return overlapsRegexKind(pf, ctx.regexMatches, 'generic-secret') ? 'generic-secret' : null
+
+    case 'person':
+    case 'address':
+    case 'url':
+    case 'account_number':
+      // See block comment above — disabled until either a domain
+      // fine-tune or a shipping shape filter that survives Spool's
+      // technical content.
+      return null
 
     default:
       // Unknown label — log once in dev, drop in prod. Only fires on

--- a/packages/app/src/main/security/model-paths.ts
+++ b/packages/app/src/main/security/model-paths.ts
@@ -33,5 +33,12 @@ export function pfManifestPath(): string {
 }
 
 /** Profile segment produced when PF is enabled. Used by
- *  `currentProfileString({ pfEnabled: true, pfVersion: ... })`. */
-export const PF_PROFILE_VERSION = PF_MODEL_VERSION
+ *  `currentProfileString({ pfEnabled: true, pfVersion: ... })`.
+ *  Tracked independently of PF_MODEL_VERSION so tuning the
+ *  class-mapping (precision/recall tradeoffs, suppressed classes)
+ *  can force a backfill rescan without re-downloading weights.
+ *  Bump suffix when scan-result shape would meaningfully differ:
+ *    r1 — initial release (all 8 classes considered)
+ *    r2 — 2026-05-21: restricted to email/phone/dob/secret-boost;
+ *         person/address/url/account dropped due to OOD precision */
+export const PF_PROFILE_VERSION = `${PF_MODEL_VERSION}.r2`

--- a/packages/app/src/renderer/components/Settings/security/PfDownloadCard.tsx
+++ b/packages/app/src/renderer/components/Settings/security/PfDownloadCard.tsx
@@ -78,7 +78,7 @@ export default function PfDownloadCard() {
           </div>
           <p className="text-[11px] leading-[16px] text-warm-faint dark:text-dark-muted mb-1.5">
             {t('settings.security.detector_pf_body', {
-              defaultValue: "PII patterns that regex can't catch — names, addresses, and similar.",
+              defaultValue: 'Catches obfuscated emails, phone numbers, and DOB that regex patterns miss.',
             })}
           </p>
           <p className="font-mono text-[10px] text-warm-faint dark:text-dark-muted/70">

--- a/packages/app/src/renderer/components/security/PfCallout.tsx
+++ b/packages/app/src/renderer/components/security/PfCallout.tsx
@@ -224,7 +224,7 @@ export default function PfCallout() {
         </span>
         <span className="text-[11px] leading-[15px] text-warm-faint dark:text-dark-muted">
           {t('security.pf_callout_body', {
-            defaultValue: "Catches names, addresses, and other patterns regex misses. On-device · {{size}}.",
+            defaultValue: 'Catches obfuscated emails, phone numbers, and DOB that regex patterns miss. On-device · {{size}}.',
             size: formatBytes(totalBytes),
           })}
         </span>

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -222,7 +222,7 @@
       "detector_pattern_footer": "13 Detektoren · unter 100 ms pro Sitzung",
       "detector_always_on": "Immer aktiv",
       "detector_pf_title": "Privacy Filter",
-      "detector_pf_body": "PII-Muster, die Regex nicht erkennen kann — Namen, Adressen und Ähnliches.",
+      "detector_pf_body": "Erkennt verschleierte E-Mails, Telefonnummern und Geburtsdaten, die Regex nicht erfasst.",
       "detector_pf_footer": "OpenAI Privacy Filter · Apache 2.0 · läuft lokal",
       "detector_pf_download": "Download",
       "detector_pf_cancel": "Cancel",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -222,7 +222,7 @@
       "detector_pattern_footer": "13 detectors · sub-100ms per session",
       "detector_always_on": "Always on",
       "detector_pf_title": "Privacy Filter",
-      "detector_pf_body": "PII patterns that regex can't catch — names, addresses, and similar.",
+      "detector_pf_body": "Catches obfuscated emails, phone numbers, and DOB that regex patterns miss.",
       "detector_pf_footer": "OpenAI Privacy Filter · Apache 2.0 · runs on-device",
       "detector_pf_download": "Download",
       "detector_pf_cancel": "Cancel",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -222,7 +222,7 @@
       "detector_pattern_footer": "13 détecteurs · moins de 100 ms par session",
       "detector_always_on": "Toujours actif",
       "detector_pf_title": "Privacy Filter",
-      "detector_pf_body": "Motifs de PII que la regex ne peut pas capturer — noms, adresses et similaires.",
+      "detector_pf_body": "Détecte les e-mails obfusqués, numéros de téléphone et dates de naissance que regex manque.",
       "detector_pf_footer": "OpenAI Privacy Filter · Apache 2.0 · exécuté sur l'appareil",
       "detector_pf_download": "Download",
       "detector_pf_cancel": "Cancel",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -216,7 +216,7 @@
       "detector_pattern_footer": "13 個の検出器 · セッションあたり 100ms 未満",
       "detector_always_on": "常時オン",
       "detector_pf_title": "Privacy Filter",
-      "detector_pf_body": "正規表現で捉えられない PII — 名前、住所など。",
+      "detector_pf_body": "正規表現では検出できない難読化メール、電話番号、生年月日を検出します。",
       "detector_pf_footer": "OpenAI Privacy Filter · Apache 2.0 · デバイス内で実行",
       "detector_pf_download": "Download",
       "detector_pf_cancel": "Cancel",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -216,7 +216,7 @@
       "detector_pattern_footer": "13개 탐지기 · 세션당 100ms 미만",
       "detector_always_on": "항상 켜짐",
       "detector_pf_title": "Privacy Filter",
-      "detector_pf_body": "정규식으로 잡지 못하는 PII — 이름, 주소 등.",
+      "detector_pf_body": "정규식으로는 잡을 수 없는 난독화된 이메일, 전화번호, 생년월일을 감지합니다.",
       "detector_pf_footer": "OpenAI Privacy Filter · Apache 2.0 · 기기 내 실행",
       "detector_pf_download": "Download",
       "detector_pf_cancel": "Cancel",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -216,7 +216,7 @@
       "detector_pattern_footer": "13 个检测器 · 单会话 < 100ms",
       "detector_always_on": "始终开启",
       "detector_pf_title": "Privacy Filter",
-      "detector_pf_body": "正则覆盖不到的 PII —— 姓名、地址等。",
+      "detector_pf_body": "抓取正则规则匹配不到的混淆邮箱、电话号码和出生日期。",
       "detector_pf_footer": "OpenAI Privacy Filter · Apache 2.0 · 本地运行",
       "detector_pf_download": "下载",
       "detector_pf_cancel": "取消",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -216,7 +216,7 @@
       "detector_pattern_footer": "13 個檢測器 · 單會話 < 100ms",
       "detector_always_on": "始終啟用",
       "detector_pf_title": "Privacy Filter",
-      "detector_pf_body": "正則覆蓋不到的 PII —— 姓名、地址等。",
+      "detector_pf_body": "抓取正規規則匹配不到的混淆郵箱、電話號碼和出生日期。",
       "detector_pf_footer": "OpenAI Privacy Filter · Apache 2.0 · 本地執行",
       "detector_pf_download": "下載",
       "detector_pf_cancel": "取消",

--- a/packages/core/src/security/profile.ts
+++ b/packages/core/src/security/profile.ts
@@ -13,11 +13,18 @@
 // `@spool-lab/redact` (added in PR 1a); we re-export it here for
 // callers that only depend on @spool-lab/core.
 
-// v4: tightened IPv6 (rejects HH:MM:SS look-alikes) + dropped
-// `.local` from internal-host TLDs (collides with `.env.local`).
-// Bumping the version forces a rescan on every session, so old
-// findings under the v3 rules get replaced with the cleaner v4 set.
-export const REDACT_DETECTOR_VERSION = 4
+// Cache-nonce for the regex detector rule set. Bumping it makes
+// `currentProfileString()` differ from what's stored on
+// `sessions.scan_profile`, which the backfill loop reads as "this
+// session needs a rescan". No semantic meaning outside that diff —
+// it's NOT a user-visible "version of the security feature".
+//
+// Scope: consumed only by code gated behind VITE_FEATURE_SECURITY.
+// While the feature is pre-GA we keep this at 1 and force rescans
+// during development via `Settings → Security → Rescan all` or a
+// direct DB wipe. Once the feature ships, bump on every rule change
+// so users with old stamps automatically pick up the new rules.
+export const REDACT_DETECTOR_VERSION = 1
 
 export interface ProfileOpts {
   /** Regex detector revision. Bump in lockstep with rule changes. */


### PR DESCRIPTION
# PR 6/7 — restrict PF to high-precision PII categories + REDACT_DETECTOR_VERSION reset

After the previous PRs landed a working end-to-end PF pipeline, dogfooding the result on real Spool content (1500+ message dev DB, mixed Chinese-English chat + code blocks + tool output) showed the model's published precision numbers don't transfer cleanly to Spool's out-of-distribution content.

This PR **trims PF's class-mapping** to the categories where we trust the precision after the OOD shift, and **resets `REDACT_DETECTOR_VERSION` to 1** since the security feature is still pre-GA and the number was incrementing for internal cache-busting reasons that don't deserve a user-visible major version.

## Class-mapping decision

```mermaid
flowchart LR
  subgraph PFOut["PF raw output (8 classes)"]
    A["private_email"]
    B["private_phone"]
    C["private_date"]
    D["secret"]
    E["private_person"]
    F["private_address"]
    G["private_url"]
    H["account_number"]
  end

  A -->|P=0.97<br/>confidence ≥0.85| AOut["✅ email"]
  B -->|P=0.92<br/>confidence ≥0.85| BOut["✅ phone"]
  C -->|P=1.00<br/>but only with DOB context| COut["⚠️ date-of-birth<br/>looksLikeDob ctx check"]
  D -->|P=1.00<br/>regex-overlap only| DOut["⚠️ generic-secret boost"]

  E -->|P=0.78 — too low, npm scope/<br/>pkg names misclassified as people| EOut["❌ dropped"]
  F -->|P=0.82 — addresses in tool<br/>output noise| FOut["❌ dropped"]
  G -->|P=0.62 — bad, regex catches<br/>url-creds reliably anyway| GOut["❌ dropped"]
  H -->|P=0.75 — credit-card already<br/>Luhn-checked elsewhere| HOut["❌ dropped"]
```

Source: OpenAI Privacy Filter model card Table 5 "PII only" column (no context). On out-of-distribution technical content the card shows precision crashing further (line_breaks 0.45, phonetic 0.27). Regex doesn't cover the dropped kinds either, so we accept the recall gap — coverage we can't trust isn't coverage.

## Why version reset

```mermaid
flowchart TB
  Q["REDACT_DETECTOR_VERSION"] -->|consumed by| P["currentProfileString"]
  P -->|compared to| SP["sessions.scan_profile"]
  SP -->|drift| BF["backfill enqueue"]

  Q -.NOT shown to user.-> X["NOT user-visible version"]
```

The version number is a **cache-nonce** for the regex detector rule set. Bumping it makes `currentProfileString()` differ from the stored `sessions.scan_profile`, which the backfill loop reads as "rescan needed". No semantic meaning outside that diff.

The number was at 4 from prior bumps during scan-rule iteration. Since the security feature is **pre-GA** (gated behind `VITE_FEATURE_SECURITY`) and there are no external consumers yet, having a "v4" implied unwarranted maturity. Reset to 1; rule-change rescans during development happen via manual "Rescan all" or DB wipe.

## `PF_PROFILE_VERSION` introduced

```ts
// Before: profile string was `regex@4,pf@1.5b-q4`
// After:  profile string is `regex@1,pf@1.5b-q4.r2`
//
// The `r2` suffix tracks class-mapping revisions independently of the
// model weight version. Tuning the suppression rules or
// adding/dropping classes can force a backfill rescan without
// re-downloading 945 MB of weights.
//
//   r1 — initial release (all 8 classes considered)
//   r2 — 2026-05-21: restricted to email/phone/dob/secret-boost;
//        person/address/url/account dropped due to OOD precision
```

## What's in this PR

- `class-mapping.ts`: switch person/address/url/account_number cases to `return null` with a block comment explaining the precision rationale
- `class-mapping.test.ts`: tests for the dropped kinds + DOB context gate
- `model-paths.ts`: introduce `PF_PROFILE_VERSION` as `${PF_MODEL_VERSION}.r2`; comment block on bump semantics
- `core/security/profile.ts`: reset `REDACT_DETECTOR_VERSION` 4 → 1; rewrite comment to explain it's a nonce, not a user-visible version
- i18n: update `detector_pf_body` copy ("PII patterns regex can't catch — names, addresses…" was now misleading)

## Test plan

- [x] App suite: 274/274
- [x] Core suite: 321/321
- [x] Manual: full backfill on dev DB after restrict — 28 PF findings (24 email + 4 phone) vs 4189 raw matches before mapping. ~10 real PII catches, ~18 model-noise survivors (npm package syntax / hex strings / placeholder values). Documented analysis in original review thread.

Builds on PR 5 (dev fixes). Followed by PR 7 (UI retreat to Experimental + final polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)