### PR TITLE
feat(settings): enlarge Settings modal and align stacked sub-modal scrim

### DIFF
--- a/packages/app/src/renderer/components/SettingsPanel.tsx
+++ b/packages/app/src/renderer/components/SettingsPanel.tsx
@@ -141,14 +141,14 @@ export default function SettingsPanel({
   return (
     <div
       data-testid="settings-panel"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-warm-text/30 dark:bg-black/45 backdrop-blur-[2px]"
       onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div className="w-[720px] h-[560px] max-w-[calc(100vw-32px)] max-h-[calc(100vh-32px)] bg-warm-bg dark:bg-dark-bg border border-warm-border dark:border-dark-border rounded-[10px] shadow-xl overflow-hidden flex">
+      <div className="w-[960px] h-[680px] max-w-[calc(100vw-48px)] max-h-[calc(100vh-48px)] bg-warm-bg dark:bg-dark-bg border border-warm-border dark:border-dark-border rounded-[10px] shadow-xl overflow-hidden flex">
         {/* Sidebar */}
-        <div className="w-[176px] flex-none bg-warm-surface dark:bg-dark-surface border-r border-warm-border dark:border-dark-border flex flex-col py-3">
-          <div className="px-4 mb-3">
-            <h2 className="text-sm font-semibold text-warm-text dark:text-dark-text">{t('settings.title')}</h2>
+        <div className="w-[176px] flex-none bg-warm-surface dark:bg-dark-surface border-r border-warm-border dark:border-dark-border flex flex-col pt-8 pb-3">
+          <div className="px-5 mb-3">
+            <h2 className="text-xl font-semibold text-warm-text dark:text-dark-text">{t('settings.title')}</h2>
           </div>
           <div className="px-2 space-y-0.5">
             {TAB_DEFS.filter(def => def.id !== 'security' || securityFeatureEnabled()).map(def => (
@@ -157,7 +157,7 @@ export default function SettingsPanel({
                 type="button"
                 aria-pressed={tab === def.id}
                 onClick={() => setTab(def.id)}
-                className={`flex w-full items-center gap-2 rounded-[6px] px-3 py-2 text-[12px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent focus-visible:ring-offset-0 ${
+                className={`flex w-full items-center gap-2 rounded-[6px] px-3 py-2 text-[13px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent focus-visible:ring-offset-0 ${
                   tab === def.id
                     ? 'text-accent dark:text-accent-dark bg-accent-bg dark:bg-[#2A1800] font-medium'
                     : 'text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text hover:bg-warm-bg/70 dark:hover:bg-dark-bg/60'
@@ -174,8 +174,8 @@ export default function SettingsPanel({
 
         {/* Content */}
         <div className="flex-1 flex flex-col min-w-0">
-          <div className="flex items-center justify-between px-5 py-3 border-b border-warm-border dark:border-dark-border">
-            <h3 className="text-sm font-medium text-warm-text dark:text-dark-text">
+          <div className="flex items-center justify-between px-16 pt-8 pb-2">
+            <h3 className="text-xl font-semibold text-warm-text dark:text-dark-text">
               {t(TAB_DEFS.find(def => def.id === tab)?.labelKey ?? 'settings.tab_general')}
             </h3>
             <button
@@ -186,8 +186,8 @@ export default function SettingsPanel({
             >
               <svg
                 aria-hidden="true"
-                width="14"
-                height="14"
+                width="18"
+                height="18"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
@@ -199,7 +199,7 @@ export default function SettingsPanel({
               </svg>
             </button>
           </div>
-          <div className="flex-1 overflow-y-auto px-5 py-4">
+          <div className="flex-1 overflow-y-auto px-16 pb-8 pt-4">
             {tab === 'general' && <GeneralTab language={language} onLanguageChange={onLanguageChange} />}
             {tab === 'appearance' && (
               <AppearanceTab themeEditor={themeEditor} onThemeEditorChange={onThemeEditorChange} />

--- a/packages/app/src/renderer/components/security/AllowlistManageModal.tsx
+++ b/packages/app/src/renderer/components/security/AllowlistManageModal.tsx
@@ -66,11 +66,11 @@ export default function AllowlistManageModal({ onClose }: Props) {
       data-testid="allowlist-manage"
       role="dialog"
       aria-modal="true"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-warm-text/30 dark:bg-black/40"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-warm-text/50 dark:bg-black/65 backdrop-blur-md pt-[15vh]"
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
       <div
-        className="bg-warm-bg dark:bg-dark-bg rounded-[10px] w-[560px] max-w-[90vw] max-h-[80vh] flex flex-col overflow-hidden border border-warm-border dark:border-dark-border"
+        className="bg-warm-bg dark:bg-dark-bg rounded-[10px] w-[720px] max-w-[calc(100vw-64px)] max-h-[70vh] flex flex-col overflow-hidden border border-warm-border dark:border-dark-border"
         style={{ boxShadow: '0 18px 48px rgba(28,28,24,0.18), 0 2px 6px rgba(28,28,24,0.08)' }}
       >
         <header className="flex items-center justify-between px-5 pt-4 pb-3 border-b border-warm-border dark:border-dark-border">


### PR DESCRIPTION
## What

- Settings modal frame: **720×560 → 960×680**, padding **px-5 → px-16** across header + content
- Sidebar **"设置" header** bumped to `text-xl font-semibold` and lifted to `pt-8` — same baseline as the right-pane section title (`通用` / `安全` / etc.), so the two columns share one heading strip instead of one big title floating beside a small kicker
- Section title strip drops its bottom divider; the new vertical rhythm carries the separation
- AllowlistManageModal (the only sub-modal that actually stacks inside Settings today): **560 → 720** wide, anchored at **`pt-[15vh]`** instead of viewport center, scrim deepened to **`bg-warm-text/50 dark:bg-black/65` + `backdrop-blur-md`**

## Why

Two pain points the user surfaced while dogfooding the Security pane:

1. The 720-wide modal sat between "big confirm dialog" and "real settings page" and didn't feel like either. Bumping to 960 makes it a proper Notion-style focused surface — content rows breathe, the right pane reads like a page rather than a cramped strip. Padding had to go up alongside the width or rows would have looked sprawling.
2. When a sub-modal opens on top of Settings (e.g. **管理忽略列表**), the previous viewport-centered, equal-opacity scrim made the inner dialog look small and disconnected from the parent. Anchoring it to `pt-[15vh]` matches where the Settings content actually starts, and the deeper compound scrim (outer Settings panel goes monochrome behind it) snaps focus to the inner dialog the way Notion's stacking pattern does.

## How it connects

Sets the pattern for future sub-modals inside Settings — PF first-time education modal (deferred) and the Source-JSONL Restore confirm (planned as part of source-file redaction GA blocker) will both render through this same stacking convention, so the visual layering decision is locked in once instead of being re-negotiated per modal.

## Test plan

- [x] Cmd+, opens Settings, modal is now ~960×680, headers aligned, padding feels right
- [x] Switching panes (通用 / 外观 / 快捷键 / 数据源 / Agent / 实验中 / 安全) — all panes still render correctly inside the wider frame
- [x] Click Security → Allowlist → 管理 — sub-modal anchors at upper third, parent Settings goes monochrome behind it
- [x] Esc on sub-modal closes only the sub-modal; Esc on Settings (no sub-modal) closes Settings
- [x] Light + dark themes both checked