### PR TITLE
feat(sidebar): swap Security and Shares positions

### DIFF
--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -146,15 +146,6 @@ export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, o
             onClick={onSelectHome}
           />
         )}
-        {onSelectShares && (
-          <NavRow
-            testId="sidebar-shares"
-            icon={<SharesIcon size={14} strokeWidth={1.75} />}
-            label={t('sidebar.shares')}
-            active={isSharesActive}
-            onClick={onSelectShares}
-          />
-        )}
         {onSelectSecurity && securityFeatureEnabled() && (
           <NavRow
             testId="sidebar-security"
@@ -162,6 +153,15 @@ export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, o
             label={t('sidebar.security')}
             active={isSecurityActive}
             onClick={onSelectSecurity}
+          />
+        )}
+        {onSelectShares && (
+          <NavRow
+            testId="sidebar-shares"
+            icon={<SharesIcon size={14} strokeWidth={1.75} />}
+            label={t('sidebar.shares')}
+            active={isSharesActive}
+            onClick={onSelectShares}
           />
         )}
         {onOpenSearch && (


### PR DESCRIPTION
## What
Swap the order of the **Security** and **Shares** rows in the left sidebar.

Before: Library → Shares → Security → Search
After:  Library → Security → Shares → Search

## Why
Security is a trust/state surface for the whole library; it reads more naturally grouped right under Library/Sessions. Shares is an outbound action surface and sits comfortably next to Search at the bottom of the nav.

## How it connects
- Pure reorder in `packages/app/src/renderer/components/Sidebar.tsx`. The two `NavRow` blocks just swap places; props, gating (`securityFeatureEnabled()`), and `data-testid`s are unchanged, so e2e selectors (`sidebar-security`, `sidebar-shares`) continue to work without edits.

## Test plan
- [ ] Visual: open app, confirm sidebar order is Library / Security / Shares / Search
- [ ] e2e: `pnpm --filter @spool/app exec playwright test settings-labs share-new-draft-picker-scope picker-browse-scope security-mute-refresh security-manual-rescan-ack` still green