### PR TITLE
fix(security): eliminate IPC boot race + surface scanner-unavailable state

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -39,7 +39,7 @@ import {
 } from '@spool-lab/core'
 import { spawnScanWorker, type ScanWorkerProxy } from './scan-worker-proxy.js'
 import { Effect } from 'effect'
-import { registerSecurityIpc, SECURITY_IPC_CHANNELS } from './ipc/security.js'
+import { registerSecurityIpc, registerSecurityReadinessIpc, SECURITY_IPC_CHANNELS, type SecurityReadiness } from './ipc/security.js'
 import { loadSecurityPreferences, saveSecurityPreferences } from './securityPreferences.js'
 import { makePfRuntime, pfModelInstalled } from './security/pf-runtime.js'
 import { registerPfModelProtocol, registerPfModelScheme } from './security/pf-model-protocol.js'
@@ -111,6 +111,8 @@ let acpManager: AcpManager
 let isSyncActive = false
 let scanWorker: ScanWorkerProxy | null = null
 let disposeSecurityIpc: (() => void) | null = null
+let setSecurityReadiness: ((next: SecurityReadiness) => void) | null = null
+let disposeSecurityReadinessIpc: (() => void) | null = null
 const pfRuntime = makePfRuntime({ run: runWithObservability })
 // Lazily resolved on first access — pfModelsRoot() reads app.getPath
 // which throws before app.ready, but this module evaluates at boot.
@@ -204,6 +206,11 @@ async function shutdownScanWorker(): Promise<void> {
   if (disposeSecurityIpc) {
     try { disposeSecurityIpc() } catch { /* best effort */ }
     disposeSecurityIpc = null
+  }
+  if (disposeSecurityReadinessIpc) {
+    try { disposeSecurityReadinessIpc() } catch { /* best effort */ }
+    disposeSecurityReadinessIpc = null
+    setSecurityReadiness = null
   }
   if (scanWorker) {
     try {
@@ -470,6 +477,15 @@ app.whenReady().then(async () => {
   // Gated by VITE_FEATURE_SECURITY so production builds (where the
   // env var stays unset) never start the scanner.
   if (securityFeatureEnabled()) {
+    // Register the readiness IPC eagerly so the renderer can wait for
+    // (or banner against) the worker boot. Without this, any Settings
+    // → Security or SecurityPage mount during the boot window hit
+    // unregistered handlers and surfaced as raw "No handler registered
+    // for security:..." errors.
+    const readiness = registerSecurityReadinessIpc(() => mainWindow)
+    setSecurityReadiness = readiness.setReadiness
+    disposeSecurityReadinessIpc = readiness.dispose
+
     // Has to happen post-ready (uses protocol.handle + app.getPath).
     registerPfModelProtocol()
     // Electron's `net.fetch` honours system proxy + custom CA bundle;
@@ -513,7 +529,10 @@ app.whenReady().then(async () => {
       })()
     })
     void bootScanWorker().then(() => {
-      if (!scanWorker) return
+      if (!scanWorker) {
+        setSecurityReadiness?.({ ready: false, reason: 'scanner-unavailable' })
+        return
+      }
       disposeSecurityIpc = registerSecurityIpc({
         db,
         worker: scanWorker,
@@ -527,6 +546,7 @@ app.whenReady().then(async () => {
           })
         },
       })
+      setSecurityReadiness?.({ ready: true })
       runWithObservability(scanWorker.backfill()).catch((err) => {
         console.error('[security] boot backfill failed:', err)
       })

--- a/packages/app/src/main/ipc/security.test.ts
+++ b/packages/app/src/main/ipc/security.test.ts
@@ -42,6 +42,7 @@ vi.mock('electron', () => ({
 
 // Imported AFTER vi.mock so the stub is the one electron resolves to.
 let registerSecurityIpc: typeof import('./security.js')['registerSecurityIpc']
+let registerSecurityReadinessIpc: typeof import('./security.js')['registerSecurityReadinessIpc']
 let SECURITY_IPC_CHANNELS: typeof import('./security.js')['SECURITY_IPC_CHANNELS']
 
 let tmp: string
@@ -54,6 +55,7 @@ beforeAll(async () => {
   process.env['SPOOL_DATA_DIR'] = tmp
   const mod = await import('./security.js')
   registerSecurityIpc = mod.registerSecurityIpc
+  registerSecurityReadinessIpc = mod.registerSecurityReadinessIpc
   SECURITY_IPC_CHANNELS = mod.SECURITY_IPC_CHANNELS
 })
 
@@ -161,7 +163,10 @@ describe('registerSecurityIpc', () => {
   describe('channel registration', () => {
     it('registers every channel in SECURITY_IPC_CHANNELS that is not an EVT_*', () => {
       const expected = Object.entries(SECURITY_IPC_CHANNELS)
-        .filter(([key]) => !key.startsWith('EVT_'))
+        // GET_READINESS is owned by registerSecurityReadinessIpc and
+        // registered eagerly before bootScanWorker resolves; it does
+        // not live in this surface.
+        .filter(([key]) => !key.startsWith('EVT_') && key !== 'GET_READINESS')
         .map(([, value]) => value)
       for (const ch of expected) {
         expect(handlers.has(ch), `missing handler for ${ch}`).toBe(true)
@@ -379,5 +384,79 @@ describe('registerSecurityIpc', () => {
       )
       expect(leaked).toBeUndefined()
     })
+  })
+})
+
+// Regression guard for the two reliability issues this commit fixes:
+//   - IPC boot race: GET_READINESS must be registered the moment
+//     readiness IPC is wired (i.e. eagerly, before bootScanWorker
+//     resolves) so the renderer never hits "No handler registered for
+//     security:get-readiness" during the boot window.
+//   - scan-worker silent failure: the boot success/failure transition
+//     must broadcast a readiness event so the renderer can switch
+//     from skeleton → ready or → "Scanner unavailable" banner instead
+//     of swallowing IPC errors.
+describe('registerSecurityReadinessIpc', () => {
+  let fakeWin: { sent: Array<{ channel: string; payload: unknown }> }
+  let getWindow: () => import('electron').BrowserWindow | null
+  beforeEach(() => {
+    handlers.clear()
+    sentEvents.length = 0
+    fakeWin = { sent: [] }
+    const win = {
+      webContents: {
+        send: (channel: string, payload: unknown) => {
+          fakeWin.sent.push({ channel, payload })
+        },
+      },
+    } as unknown as import('electron').BrowserWindow
+    getWindow = () => win
+  })
+
+  it('registers GET_READINESS handler immediately and reports booting state', async () => {
+    registerSecurityReadinessIpc(getWindow)
+    const state = await invoke<{ ready: boolean; reason?: string }>(
+      SECURITY_IPC_CHANNELS.GET_READINESS,
+    )
+    expect(state).toEqual({ ready: false, reason: 'booting' })
+  })
+
+  it('setReadiness(ready=true) flips state and broadcasts EVT_READINESS_CHANGED', async () => {
+    const { setReadiness } = registerSecurityReadinessIpc(getWindow)
+    setReadiness({ ready: true })
+    expect(fakeWin.sent.at(-1)).toEqual({
+      channel: SECURITY_IPC_CHANNELS.EVT_READINESS_CHANGED,
+      payload: { ready: true },
+    })
+    const after = await invoke<{ ready: boolean }>(SECURITY_IPC_CHANNELS.GET_READINESS)
+    expect(after).toEqual({ ready: true })
+  })
+
+  it('setReadiness(scanner-unavailable) surfaces the failure state to the renderer', async () => {
+    const { setReadiness } = registerSecurityReadinessIpc(getWindow)
+    setReadiness({ ready: false, reason: 'scanner-unavailable' })
+    expect(fakeWin.sent.at(-1)).toEqual({
+      channel: SECURITY_IPC_CHANNELS.EVT_READINESS_CHANGED,
+      payload: { ready: false, reason: 'scanner-unavailable' },
+    })
+    const after = await invoke<{ ready: boolean; reason: string }>(
+      SECURITY_IPC_CHANNELS.GET_READINESS,
+    )
+    expect(after).toEqual({ ready: false, reason: 'scanner-unavailable' })
+  })
+
+  it('does not re-broadcast when readiness state is unchanged', () => {
+    const { setReadiness } = registerSecurityReadinessIpc(getWindow)
+    setReadiness({ ready: true })
+    const after = fakeWin.sent.length
+    setReadiness({ ready: true })
+    expect(fakeWin.sent.length).toBe(after)
+  })
+
+  it('dispose() removes the GET_READINESS handler', () => {
+    const { dispose } = registerSecurityReadinessIpc(getWindow)
+    expect(handlers.has(SECURITY_IPC_CHANNELS.GET_READINESS)).toBe(true)
+    dispose()
+    expect(handlers.has(SECURITY_IPC_CHANNELS.GET_READINESS)).toBe(false)
   })
 })

--- a/packages/app/src/main/ipc/security.ts
+++ b/packages/app/src/main/ipc/security.ts
@@ -84,12 +84,65 @@ export const SECURITY_IPC_CHANNELS = {
    *  isn't running. Polled by PfDownloadCard for the runtime badge. */
   PF_GET_RUNTIME_INFO:         'security:pf-get-runtime-info',
 
+  // readiness — eagerly registered so the renderer can wait for the
+  // scan worker without bumping into "No handler registered" errors
+  // when Settings → Security opens during boot, and so a worker-boot
+  // failure surfaces as a "Scanner unavailable" banner instead of a
+  // dead UI.
+  GET_READINESS:               'security:get-readiness',
+
   // events (push: main → renderer via webContents.send)
   EVT_FINDINGS_CHANGED:        'security:evt-findings-changed',
   EVT_SCAN_STATUS:             'security:evt-scan-status',
   EVT_PREFS_CHANGED:           'security:evt-prefs-changed',
   EVT_PF_STATE:                'security:evt-pf-state',
+  EVT_READINESS_CHANGED:       'security:evt-readiness-changed',
 } as const
+
+export type SecurityReadiness =
+  | { ready: true }
+  | { ready: false; reason: 'booting' | 'scanner-unavailable' }
+
+/** Register the readiness handler + return a setter the boot sequence
+ *  calls when the scan worker either comes up (`{ ready: true }`) or
+ *  fails to spawn (`{ ready: false, reason: 'scanner-unavailable' }`).
+ *
+ *  Registered eagerly (before `bootScanWorker()` resolves) so the
+ *  renderer can ALWAYS query readiness — opening Settings → Security
+ *  the millisecond the window appears no longer races the worker
+ *  boot, which used to produce "No handler registered for
+ *  security:list-backups" errors. */
+export function registerSecurityReadinessIpc(
+  getMainWindow: () => BrowserWindow | null,
+): {
+  setReadiness: (next: SecurityReadiness) => void
+  dispose: () => void
+} {
+  let current: SecurityReadiness = { ready: false, reason: 'booting' }
+  ipcMain.handle(SECURITY_IPC_CHANNELS.GET_READINESS, () => current)
+  return {
+    setReadiness: (next) => {
+      // Same-value transitions are a no-op so the renderer doesn't
+      // re-render its skeleton on every boot retry.
+      if (next.ready === current.ready &&
+        (next.ready || next.reason === (current as { reason: string }).reason)) {
+        return
+      }
+      current = next
+      try {
+        getMainWindow()?.webContents.send(
+          SECURITY_IPC_CHANNELS.EVT_READINESS_CHANGED,
+          next,
+        )
+      } catch (err) {
+        console.error('[security] readiness broadcast failed:', err)
+      }
+    },
+    dispose: () => {
+      ipcMain.removeHandler(SECURITY_IPC_CHANNELS.GET_READINESS)
+    },
+  }
+}
 
 export interface SecurityIpcDeps {
   db: Database.Database

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -43,6 +43,10 @@ export interface PfRuntimeInfo {
   detectionMs?: number
   error?: string
 }
+
+export type SecurityReadiness =
+  | { ready: true }
+  | { ready: false; reason: 'booting' | 'scanner-unavailable' }
 import type { SearchSortOrder } from '../shared/searchSort.js'
 import type { SidebarSortOrder } from '../shared/sidebarSort.js'
 import type { PinnedSortOrder } from '../shared/pinnedSort.js'
@@ -328,6 +332,14 @@ const api = {
       const handler = (_: Electron.IpcRendererEvent, data: unknown) => cb(data as PfDownloadState)
       ipcRenderer.on('security:evt-pf-state', handler)
       return () => ipcRenderer.removeListener('security:evt-pf-state', handler)
+    },
+
+    getReadiness: (): Promise<SecurityReadiness> =>
+      ipcRenderer.invoke('security:get-readiness'),
+    onReadinessChanged: (cb: (state: SecurityReadiness) => void) => {
+      const handler = (_: Electron.IpcRendererEvent, data: unknown) => cb(data as SecurityReadiness)
+      ipcRenderer.on('security:evt-readiness-changed', handler)
+      return () => ipcRenderer.removeListener('security:evt-readiness-changed', handler)
     },
   },
 }

--- a/packages/app/src/renderer/api/security.ts
+++ b/packages/app/src/renderer/api/security.ts
@@ -21,9 +21,9 @@ import type {
 
 export type { BackupFileInfo }
 import type { SensitiveKind } from '@spool-lab/redact'
-import type { SecurityPreferences, PfDownloadState, PfRuntimeInfo } from '../../preload/index.js'
+import type { SecurityPreferences, PfDownloadState, PfRuntimeInfo, SecurityReadiness } from '../../preload/index.js'
 
-export type { SecurityPreferences, AllowlistEntryRow, PfDownloadState, PfRuntimeInfo }
+export type { SecurityPreferences, AllowlistEntryRow, PfDownloadState, PfRuntimeInfo, SecurityReadiness }
 
 /** Single source of truth for the renderer-side adapter. Components
  *  hold this object, not `window.spool.security` — keeps replaceability
@@ -95,6 +95,11 @@ export const securityApi = {
     window.spool.security.pfGetRuntimeInfo(),
   onPfState: (handler: (s: PfDownloadState) => void): (() => void) =>
     window.spool.security.onPfState(handler),
+
+  getReadiness: (): Promise<SecurityReadiness> =>
+    window.spool.security.getReadiness(),
+  onReadinessChanged: (handler: (s: SecurityReadiness) => void): (() => void) =>
+    window.spool.security.onReadinessChanged(handler),
 }
 
 export type SecurityApi = typeof securityApi

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -35,6 +35,7 @@ import {
 } from '@spool-lab/redact'
 import { securityApi } from '../api/security.js'
 import { securityFeatureEnabled } from '../featureFlags.js'
+import { useSecurityReadiness } from '../hooks/useSecurityReadiness.js'
 import PurgeConfirmDialog from './security/PurgeConfirmDialog.js'
 import DetectorsChip from './security/DetectorsChip.js'
 import { parseQualifier, toggleKindQualifier } from './security/parse-qualifier.js'
@@ -68,7 +69,56 @@ export default function SecurityPage(props: Props) {
   // return ABOVE the hooks would violate Rules of Hooks the moment
   // the flag becomes anything other than a build-time constant.
   if (!securityFeatureEnabled()) return null
+  return <SecurityPageGate {...props} />
+}
+
+function SecurityPageGate(props: Props) {
+  const { t } = useTranslation()
+  const readiness = useSecurityReadiness()
+  if (!readiness.ready) {
+    return <SecurityPageNotice reason={readiness.reason} t={t} />
+  }
   return <SecurityPageInner {...props} />
+}
+
+function SecurityPageNotice({
+  reason,
+  t,
+}: {
+  reason: 'booting' | 'scanner-unavailable'
+  t: ReturnType<typeof useTranslation>['t']
+}) {
+  if (reason === 'booting') {
+    return (
+      <div
+        data-testid="security-readiness-booting"
+        className="p-6 space-y-3 animate-pulse"
+        aria-busy="true"
+      >
+        <div className="h-3 w-40 rounded bg-warm-border/60 dark:bg-dark-border/60" />
+        <div className="h-20 rounded-[8px] border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface" />
+        <div className="h-3 w-32 rounded bg-warm-border/60 dark:bg-dark-border/60" />
+      </div>
+    )
+  }
+  return (
+    <div className="p-6">
+      <div
+        data-testid="security-unavailable"
+        role="alert"
+        className="rounded-[8px] border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface px-4 py-3.5 max-w-2xl"
+      >
+        <p className="text-sm font-medium text-warm-text dark:text-dark-text mb-1">
+          {t('security.unavailable_title', { defaultValue: 'Scanner unavailable' })}
+        </p>
+        <p className="text-[12px] leading-[18px] text-warm-faint dark:text-dark-muted">
+          {t('security.unavailable_body', {
+            defaultValue: 'Spool could not start the security scan worker. Findings cannot be loaded until it recovers. Restarting the app usually resolves this; if it persists, check the developer console for the boot error.',
+          })}
+        </p>
+      </div>
+    </div>
+  )
 }
 
 function SecurityPageInner({ onOpenSession, onShareSession, onOpenSettings }: Props) {

--- a/packages/app/src/renderer/components/Settings/SecurityPane.tsx
+++ b/packages/app/src/renderer/components/Settings/SecurityPane.tsx
@@ -32,10 +32,59 @@ import Toggle from '../Toggle.js'
 import Menu from '../Menu.js'
 import AllowlistManageModal from '../security/AllowlistManageModal.js'
 import PfDownloadCard from './security/PfDownloadCard.js'
+import { useSecurityReadiness } from '../../hooks/useSecurityReadiness.js'
 
 export default function SecurityPane() {
   if (!securityFeatureEnabled()) return null
+  return <SecurityPaneGate />
+}
+
+function SecurityPaneGate() {
+  const { t } = useTranslation()
+  const readiness = useSecurityReadiness()
+  if (!readiness.ready) {
+    return <SecurityUnavailableNotice reason={readiness.reason} t={t} />
+  }
   return <SecurityPaneInner />
+}
+
+function SecurityUnavailableNotice({
+  reason,
+  t,
+}: {
+  reason: 'booting' | 'scanner-unavailable'
+  t: ReturnType<typeof useTranslation>['t']
+}) {
+  if (reason === 'booting') {
+    return (
+      <div
+        data-testid="security-readiness-booting"
+        className="space-y-3 animate-pulse"
+        aria-busy="true"
+      >
+        <div className="h-3 w-32 rounded bg-warm-border/60 dark:bg-dark-border/60" />
+        <div className="h-16 rounded-[8px] border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface" />
+        <div className="h-3 w-20 rounded bg-warm-border/60 dark:bg-dark-border/60" />
+        <div className="h-24 rounded-[8px] border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface" />
+      </div>
+    )
+  }
+  return (
+    <div
+      data-testid="security-unavailable"
+      role="alert"
+      className="rounded-[8px] border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface px-3.5 py-3"
+    >
+      <p className="text-xs font-medium text-warm-text dark:text-dark-text mb-1">
+        {t('settings.security.unavailable_title', { defaultValue: 'Scanner unavailable' })}
+      </p>
+      <p className="text-[11px] leading-[16px] text-warm-faint dark:text-dark-muted">
+        {t('settings.security.unavailable_body', {
+          defaultValue: 'Spool could not start the security scan worker. Settings here are inactive until it recovers. Restarting the app usually resolves this; if it persists, check the developer console for the boot error.',
+        })}
+      </p>
+    </div>
+  )
 }
 
 function SecurityPaneInner() {

--- a/packages/app/src/renderer/hooks/useSecurityReadiness.ts
+++ b/packages/app/src/renderer/hooks/useSecurityReadiness.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+import { securityApi, type SecurityReadiness } from '../api/security.js'
+
+/** Tracks the main-process scan-worker boot state.
+ *
+ *  Returns `{ ready: false, reason: 'booting' }` while the worker is
+ *  still spawning (covers the IPC race when Settings → Security opens
+ *  during boot) and `{ ready: false, reason: 'scanner-unavailable' }`
+ *  if the worker failed to spawn (e.g. better-sqlite3 native binding
+ *  mis-built). Components use this to gate worker-dependent IPC calls
+ *  and to render a banner instead of swallowing "No handler
+ *  registered" errors.
+ *
+ *  The initial value is `booting` so the first render never tries a
+ *  worker-dependent call before the async getReadiness resolves. */
+export function useSecurityReadiness(): SecurityReadiness {
+  const [readiness, setReadiness] = useState<SecurityReadiness>({ ready: false, reason: 'booting' })
+  useEffect(() => {
+    let cancelled = false
+    void securityApi.getReadiness().then((r) => {
+      if (!cancelled) setReadiness(r)
+    }).catch(() => {
+      // Eager registration means this rejection only happens if the
+      // feature flag is off — leave the initial 'booting' state in
+      // place; the parent feature-flag gate keeps the surface hidden.
+    })
+    const off = securityApi.onReadinessChanged((next) => {
+      setReadiness(next)
+    })
+    return () => { cancelled = true; off() }
+  }, [])
+  return readiness
+}

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -292,7 +292,9 @@
       "backups_delete_partial_desc": "Freed {{size}}. Some files could not be removed — they may have been deleted by another process.",
       "experimental_title": "Experimentell",
       "experimental_intro": "Opt-in-Detektoren, die noch nicht für den täglichen Einsatz empfohlen werden. Bei code-lastigen Inhalten können Falsch-Positiv-Raten hoch sein.",
-      "detector_pf_resume": "Fortsetzen"
+      "detector_pf_resume": "Fortsetzen",
+      "unavailable_title": "Scanner nicht verfügbar",
+      "unavailable_body": "Spool konnte den Security-Scan-Worker nicht starten. Bis er wieder läuft sind die Einstellungen hier inaktiv. Ein Neustart der App behebt das meist; bleibt das Problem bestehen, prüfe die Entwicklerkonsole auf den Boot-Fehler."
     }
   },
   "security": {
@@ -393,7 +395,9 @@
     "diff_pattern": "Muster",
     "scanning_ambient": "Scan läuft…",
     "scan_toast_new_findings_one": "{{count}} neuer Hochrisiko-Fund",
-    "scan_toast_new_findings_other": "{{count}} neue Hochrisiko-Funde"
+    "scan_toast_new_findings_other": "{{count}} neue Hochrisiko-Funde",
+    "unavailable_title": "Scanner nicht verfügbar",
+    "unavailable_body": "Spool konnte den Security-Scan-Worker nicht starten. Bis er wieder läuft können Funde nicht geladen werden. Ein Neustart der App behebt das meist; bleibt das Problem bestehen, prüfe die Entwicklerkonsole auf den Boot-Fehler."
   },
   "shares": {
     "title": "Entwürfe",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -292,7 +292,9 @@
       "backups_delete_partial_desc": "Freed {{size}}. Some files could not be removed — they may have been deleted by another process.",
       "experimental_title": "Experimental",
       "experimental_intro": "Opt-in detectors that are not yet recommended for daily use. False-positive rates may be high on code-heavy content.",
-      "detector_pf_resume": "Resume"
+      "detector_pf_resume": "Resume",
+      "unavailable_title": "Scanner unavailable",
+      "unavailable_body": "Spool could not start the security scan worker. Settings here are inactive until it recovers. Restarting the app usually resolves this; if it persists, check the developer console for the boot error."
     }
   },
   "security": {
@@ -393,7 +395,9 @@
     "diff_pattern": "pattern",
     "scanning_ambient": "scanning…",
     "scan_toast_new_findings_one": "Found {{count}} new high-risk finding",
-    "scan_toast_new_findings_other": "Found {{count}} new high-risk findings"
+    "scan_toast_new_findings_other": "Found {{count}} new high-risk findings",
+    "unavailable_title": "Scanner unavailable",
+    "unavailable_body": "Spool could not start the security scan worker. Findings cannot be loaded until it recovers. Restarting the app usually resolves this; if it persists, check the developer console for the boot error."
   },
   "shares": {
     "title": "Drafts",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -292,7 +292,9 @@
       "backups_delete_partial_desc": "Freed {{size}}. Some files could not be removed — they may have been deleted by another process.",
       "experimental_title": "Expérimental",
       "experimental_intro": "Détecteurs facultatifs non encore recommandés pour un usage quotidien. Les taux de faux positifs peuvent être élevés sur du contenu riche en code.",
-      "detector_pf_resume": "Reprendre"
+      "detector_pf_resume": "Reprendre",
+      "unavailable_title": "Scanner indisponible",
+      "unavailable_body": "Spool n'a pas pu démarrer le worker d'analyse de sécurité. Les paramètres ici sont inactifs jusqu'à sa reprise. Redémarrer l'application résout généralement ce problème ; s'il persiste, consultez la console développeur pour l'erreur de démarrage."
     }
   },
   "security": {
@@ -393,7 +395,9 @@
     "diff_pattern": "motif",
     "scanning_ambient": "analyse…",
     "scan_toast_new_findings_one": "{{count}} nouvelle découverte à haut risque",
-    "scan_toast_new_findings_other": "{{count}} nouvelles découvertes à haut risque"
+    "scan_toast_new_findings_other": "{{count}} nouvelles découvertes à haut risque",
+    "unavailable_title": "Scanner indisponible",
+    "unavailable_body": "Spool n'a pas pu démarrer le worker d'analyse de sécurité. Les découvertes ne peuvent pas être chargées tant qu'il ne fonctionne pas. Redémarrer l'application résout généralement ce problème ; s'il persiste, consultez la console développeur pour l'erreur de démarrage."
   },
   "shares": {
     "title": "Brouillons",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -284,7 +284,9 @@
       "backups_delete_partial_desc": "Freed {{size}}. Some files could not be removed — they may have been deleted by another process.",
       "experimental_title": "実験的機能",
       "experimental_intro": "オプトインの検出器。日常的な使用はまだ推奨されません。コード中心のコンテンツでは誤検出率が高くなる可能性があります。",
-      "detector_pf_resume": "再開"
+      "detector_pf_resume": "再開",
+      "unavailable_title": "スキャナーを利用できません",
+      "unavailable_body": "Spool はセキュリティスキャンワーカーを起動できませんでした。復旧するまでこの設定は無効です。通常はアプリを再起動すると解決します。再発する場合は開発者コンソールで起動エラーを確認してください。"
     }
   },
   "security": {
@@ -367,7 +369,9 @@
     "diff_becomes": "結果",
     "diff_pattern": "パターン",
     "scanning_ambient": "スキャン中…",
-    "scan_toast_new_findings_other": "新たに {{count}} 件の高リスクを検出"
+    "scan_toast_new_findings_other": "新たに {{count}} 件の高リスクを検出",
+    "unavailable_title": "スキャナーを利用できません",
+    "unavailable_body": "Spool はセキュリティスキャンワーカーを起動できませんでした。復旧するまで検出結果を読み込めません。通常はアプリを再起動すると解決します。再発する場合は開発者コンソールで起動エラーを確認してください。"
   },
   "shares": {
     "title": "下書き",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -284,7 +284,9 @@
       "backups_delete_partial_desc": "Freed {{size}}. Some files could not be removed — they may have been deleted by another process.",
       "experimental_title": "실험적 기능",
       "experimental_intro": "옵트인 감지기. 일상적 사용은 아직 권장되지 않습니다. 코드 중심 콘텐츠에서는 거짓 양성 비율이 높을 수 있습니다.",
-      "detector_pf_resume": "계속"
+      "detector_pf_resume": "계속",
+      "unavailable_title": "스캐너를 사용할 수 없습니다",
+      "unavailable_body": "Spool이 보안 스캔 워커를 시작하지 못했습니다. 복구되기 전까지 이 설정은 적용되지 않습니다. 보통 앱을 재시작하면 해결됩니다. 계속되면 개발자 콘솔에서 부팅 오류를 확인하세요."
     }
   },
   "security": {
@@ -367,7 +369,9 @@
     "diff_becomes": "결과",
     "diff_pattern": "패턴",
     "scanning_ambient": "스캔 중…",
-    "scan_toast_new_findings_other": "높은 위험 항목 {{count}}건 새로 발견"
+    "scan_toast_new_findings_other": "높은 위험 항목 {{count}}건 새로 발견",
+    "unavailable_title": "스캐너를 사용할 수 없습니다",
+    "unavailable_body": "Spool이 보안 스캔 워커를 시작하지 못했습니다. 복구되기 전까지 발견 항목을 불러올 수 없습니다. 보통 앱을 재시작하면 해결됩니다. 계속되면 개발자 콘솔에서 부팅 오류를 확인하세요."
   },
   "shares": {
     "title": "초안",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -284,7 +284,9 @@
       "backups_delete_partial_desc": "已释放 {{size}}。部分文件无法删除——可能已被其他进程清理。",
       "experimental_title": "实验性",
       "experimental_intro": "可选启用的检测器，目前不推荐日常使用。在代码密集型内容上误报率可能较高。",
-      "detector_pf_resume": "继续下载"
+      "detector_pf_resume": "继续下载",
+      "unavailable_title": "扫描器不可用",
+      "unavailable_body": "Spool 无法启动安全扫描工作进程。在它恢复前，此处的设置无效。通常重启应用即可解决；若问题持续，请查看开发者控制台中的启动错误。"
     }
   },
   "security": {
@@ -367,7 +369,9 @@
     "diff_becomes": "变为",
     "diff_pattern": "模式",
     "scanning_ambient": "扫描中…",
-    "scan_toast_new_findings_other": "发现 {{count}} 项新的高风险"
+    "scan_toast_new_findings_other": "发现 {{count}} 项新的高风险",
+    "unavailable_title": "扫描器不可用",
+    "unavailable_body": "Spool 无法启动安全扫描工作进程。在它恢复前，无法加载发现项。通常重启应用即可解决；若问题持续，请查看开发者控制台中的启动错误。"
   },
   "shares": {
     "title": "草稿",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -284,7 +284,9 @@
       "backups_delete_partial_desc": "已釋放 {{size}}。部分檔案無法刪除——可能已被其他程序清理。",
       "experimental_title": "實驗性",
       "experimental_intro": "可選啟用的檢測器，目前不推薦日常使用。在程式碼密集型內容上誤報率可能較高。",
-      "detector_pf_resume": "繼續下載"
+      "detector_pf_resume": "繼續下載",
+      "unavailable_title": "掃描器無法使用",
+      "unavailable_body": "Spool 無法啟動安全掃描工作行程。在它恢復前，此處的設定無效。通常重新啟動應用程式即可解決；若問題持續，請查看開發者主控台中的啟動錯誤。"
     }
   },
   "security": {
@@ -367,7 +369,9 @@
     "diff_becomes": "變為",
     "diff_pattern": "模式",
     "scanning_ambient": "掃描中…",
-    "scan_toast_new_findings_other": "發現 {{count}} 項新的高風險"
+    "scan_toast_new_findings_other": "發現 {{count}} 項新的高風險",
+    "unavailable_title": "掃描器無法使用",
+    "unavailable_body": "Spool 無法啟動安全掃描工作行程。在它恢復前，無法載入發現項目。通常重新啟動應用程式即可解決；若問題持續，請查看開發者主控台中的啟動錯誤。"
   },
   "shares": {
     "title": "草稿",


### PR DESCRIPTION
## What

Adds a single `security:get-readiness` IPC channel (registered eagerly before `bootScanWorker()` resolves) plus a `security:evt-readiness-changed` push event. `SecurityPane` and `SecurityPage` now gate their inner UI on a `useSecurityReadiness()` hook — rendering a small skeleton while the worker is booting, or a "Scanner unavailable" banner if the spawn failed.

## Why

Two reliability issues were piggy-backing on the same boot path:

- **IPC boot race.** Every security IPC handler was registered inside `bootScanWorker().then(...)`. Opening Settings → Security in the boot window produced raw `Error invoking remote method 'security:list-backups': No handler registered` errors.
- **Silent scan-worker failure.** When `spawnScanWorker` threw (e.g. better-sqlite3 native ABI mismatch), `scanWorker = null` and the `.then(...)` short-circuited. No handlers were registered, and the renderer had no signal — Settings → Security still rendered every control, and each click failed identically. Users on broken-binding machines were stuck.

A single readiness signal covers both: eager registration means the renderer can always query state during boot; the boot success/failure transition flips readiness so the UI knows to swap the banner in.

## How it connects

- `registerSecurityReadinessIpc(getMainWindow)` registers the eager handler + returns a `setReadiness` setter and a `dispose` cleanup. Called from `main/index.ts` immediately when `securityFeatureEnabled()`, before `bootScanWorker()` is invoked.
- `bootScanWorker().then(...)` either flips readiness to `{ ready: true }` after `registerSecurityIpc` succeeds, or `{ ready: false, reason: 'scanner-unavailable' }` if `scanWorker` is null.
- Renderer gets a typed `SecurityReadiness` via preload + `securityApi.getReadiness` / `onReadinessChanged`, consumed by a new `useSecurityReadiness` hook.

## Tests

- New unit tests in `packages/app/src/main/ipc/security.test.ts > registerSecurityReadinessIpc` (5 cases): handler-registered-immediately (regression for the IPC race), `setReadiness` broadcasts on transition, scanner-unavailable propagates correctly, unchanged state is not re-broadcast, dispose removes the handler.
- Existing channel-registration test updated to exclude `GET_READINESS` (now owned by the eager registrar, not `registerSecurityIpc`).
- Full vitest suite: 285/285 (was 280/280, +5).
- Security e2e suite: 11/11 green.
- Type check clean.