### PR TITLE
fix(settings): eliminate Toggle mount-flash on Security pane open

### DIFF
--- a/packages/app/e2e/settings-security-toggle-mount-flash.spec.ts
+++ b/packages/app/e2e/settings-security-toggle-mount-flash.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, waitForSync, type AppContext } from './helpers/launch'
+
+// Regression: when a Security pref is persisted as `true`, opening the
+// Security tab USED to render the corresponding toggle in its `??`
+// fallback ('false') for a few ms before the async getPrefs() resolved
+// and flipped it to 'true' — users saw the switch sweep on every tab
+// open. The fix gates the entire pane body behind `prefs !== null`, so
+// the toggle never enters the DOM in its fallback state.
+//
+// This spec wires a MutationObserver before navigating, so we can
+// catch a transient `aria-checked="false"` even if it lasts a single
+// frame. The observer watches the entire Settings panel subtree, so
+// the assertion is target-specific (settings-blur-page) but immune to
+// the parent's exact tree shape.
+
+let ctx: AppContext
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => { await ctx?.cleanup() })
+
+test('Security toggles never render in fallback off-state when the pref is on', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  // Seed the pref so a flash would be visible (default is false; the
+  // fallback also lands at false, so the flash needs `true` to surface).
+  await window.evaluate(async () => {
+    const api = (globalThis as { spool?: { security?: { setPrefs: (p: { securityPageValuesBlurred: boolean }) => Promise<unknown> } } }).spool?.security
+    await api!.setPrefs({ securityPageValuesBlurred: true })
+  })
+
+  // Arm a MutationObserver BEFORE opening Settings. It records any
+  // moment the target toggle is in `aria-checked="false"`, regardless
+  // of whether it arrived that way or was attribute-flipped to it.
+  await window.evaluate(() => {
+    type Holder = { __flashSeen?: boolean; __flashObs?: MutationObserver }
+    const w = window as unknown as Holder
+    w.__flashSeen = false
+    const check = () => {
+      const t = document.querySelector('[data-testid="settings-blur-page"]')
+      if (t && t.getAttribute('aria-checked') === 'false') {
+        w.__flashSeen = true
+      }
+    }
+    const obs = new MutationObserver(check)
+    obs.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['aria-checked'],
+    })
+    w.__flashObs = obs
+  })
+
+  await window.locator('[data-testid="settings-button"]').click()
+  await expect(window.locator('[data-testid="settings-panel"]')).toBeVisible()
+  await window
+    .locator('[data-testid="settings-panel"] [aria-pressed]')
+    .filter({ hasText: /Security|安全|セキュリティ|보안|Sécurité|Sicherheit/ })
+    .click()
+
+  // Wait for the toggle to mount — at this point, if the bug were
+  // present, the observer would have caught the transient false state.
+  const blurPage = window.locator('[data-testid="settings-blur-page"]')
+  await expect(blurPage).toBeVisible({ timeout: 10_000 })
+  await expect(blurPage).toHaveAttribute('aria-checked', 'true')
+
+  const sawFlash = await window.evaluate(() => {
+    type Holder = { __flashSeen?: boolean; __flashObs?: MutationObserver }
+    const w = window as unknown as Holder
+    w.__flashObs?.disconnect()
+    return w.__flashSeen === true
+  })
+  expect(sawFlash, 'toggle was rendered in aria-checked="false" before its persisted true state arrived').toBe(false)
+
+  // Reset so we don't leave the user-data dir in a non-default state
+  // for any follow-up tests in this file.
+  await window.evaluate(async () => {
+    const api = (globalThis as { spool?: { security?: { setPrefs: (p: { securityPageValuesBlurred: boolean }) => Promise<unknown> } } }).spool?.security
+    await api!.setPrefs({ securityPageValuesBlurred: false })
+  })
+})

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -35,6 +35,7 @@ import { useHotkeys } from './hooks/useHotkeys.js'
 import { useLanguageBootstrap } from './i18n/useLanguageBootstrap.js'
 import type { LanguagePreference } from '../preload/index.js'
 import { useFeature, securityFeatureEnabled } from './featureFlags.js'
+import { primeSecurityPrefsCache } from './api/securityPrefsCache.js'
 
 type View = 'search' | 'session' | 'shares' | 'share-editor' | 'security'
 type SettingsTab = 'general' | 'appearance' | 'shortcuts' | 'sources' | 'agent' | 'labs' | 'security'
@@ -280,6 +281,17 @@ export default function App() {
     window.spool.getSidebarCollapsed()
       .then(setSidebarCollapsed)
       .catch(console.error)
+  }, [])
+
+  // Warm the SecurityPreferences cache at app boot so every Toggle in
+  // Settings → Security renders with its persisted state from frame 1.
+  // Without this, opening the tab cold would trigger a fetch on mount
+  // and the controls would pop in (or, before the toggle gate, flash
+  // off → on). When the feature flag is off the prime resolves to null
+  // and nothing renders — harmless.
+  useEffect(() => {
+    if (!securityFeatureEnabled()) return
+    void primeSecurityPrefsCache()
   }, [])
 
   // Restore the pre-editor sidebar state when the user leaves the

--- a/packages/app/src/renderer/api/securityPrefsCache.ts
+++ b/packages/app/src/renderer/api/securityPrefsCache.ts
@@ -1,0 +1,96 @@
+// Module-level cache for SecurityPreferences exposed via a
+// useSyncExternalStore hook. Mirrors the pattern in `featureFlags.ts`
+// (useFeature) — that's the React-18-blessed shape for "external,
+// non-React state that components read synchronously".
+//
+// Why a cache at all: every "Settings → Security" open used to mount
+// Toggle controls with a `?? false` fallback before the async
+// getPrefs resolved, causing a visible off→on sweep on every tab
+// open. With the cache primed early in app boot, by the time a user
+// can click Settings the prefs are already in memory and every
+// Toggle renders with its final state from frame 1.
+//
+// Priming is decoupled from this module's import: App.tsx calls
+// `primeSecurityPrefsCache()` from a useEffect at mount, so the
+// dependency is visible at the call site instead of being a hidden
+// side-effect of importing the file. Late callers (components that
+// mount before the prime resolves) still get a synchronous null and
+// can render a same-size placeholder to keep layout stable until
+// the subscription delivers the first value.
+
+import { useSyncExternalStore } from 'react'
+import { securityApi, type SecurityPreferences } from './security.js'
+
+let cached: SecurityPreferences | null = null
+let inflight: Promise<SecurityPreferences | null> | null = null
+const subscribers = new Set<() => void>()
+
+function emit(): void {
+  for (const fn of subscribers) {
+    try { fn() } catch (err) { console.error('[securityPrefsCache] subscriber threw:', err) }
+  }
+}
+
+function getSnapshot(): SecurityPreferences | null {
+  return cached
+}
+
+function subscribe(fn: () => void): () => void {
+  subscribers.add(fn)
+  return () => { subscribers.delete(fn) }
+}
+
+/** React hook. Returns the current cached SecurityPreferences, or
+ *  null if the cache is cold. Re-renders when the cache changes
+ *  (either from a primeSecurityPrefsCache resolve or an
+ *  onPrefsChanged broadcast). */
+export function useCachedSecurityPrefs(): SecurityPreferences | null {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+/** Optimistically merge a patch into the cache, broadcast to
+ *  subscribers, and persist via setPrefs. Callers that want the
+ *  toggle to flip instantly on click (i.e. before the IPC roundtrip
+ *  completes) use this instead of calling setPrefs directly. The
+ *  main-process EVT_PREFS_CHANGED reply still lands in the cache,
+ *  but by then the user already sees the new state. */
+export async function patchSecurityPrefs(patch: Partial<SecurityPreferences>): Promise<void> {
+  if (cached) {
+    cached = { ...cached, ...patch }
+    emit()
+  }
+  try { await securityApi.setPrefs(patch) }
+  catch (err) { console.error('[securityPrefsCache] setPrefs failed:', err) }
+}
+
+/** Idempotent prefetch. Call once at app boot (from an App-level
+ *  useEffect). Subsequent calls return the cached value. */
+export async function primeSecurityPrefsCache(): Promise<SecurityPreferences | null> {
+  if (cached) return cached
+  if (inflight) return inflight
+  inflight = securityApi.getPrefs()
+    .then((p) => {
+      cached = p
+      inflight = null
+      emit()
+      return p
+    })
+    .catch(() => {
+      inflight = null
+      return null
+    })
+  return inflight
+}
+
+// Keep the cache live across the app session. The main-process side
+// broadcasts EVT_PREFS_CHANGED on every saveSecurityPreferences, so
+// any toggle flipped from another window or from main itself updates
+// every subscriber here. This subscription is the one piece of
+// implicit module-level behaviour we accept: it's a single static
+// listener that never grows, and removing it would silently break
+// "open Settings, change pref, immediately switch tabs without
+// closing Settings".
+securityApi.onPrefsChanged((next) => {
+  cached = next
+  emit()
+})

--- a/packages/app/src/renderer/components/Settings/SecurityPane.tsx
+++ b/packages/app/src/renderer/components/Settings/SecurityPane.tsx
@@ -26,6 +26,7 @@ import {
   type SensitiveKind,
 } from '@spool-lab/redact'
 import { securityApi, type SecurityPreferences, type BackupFileInfo } from '../../api/security.js'
+import { useCachedSecurityPrefs, primeSecurityPrefsCache, patchSecurityPrefs } from '../../api/securityPrefsCache.js'
 import { formatBytes } from '../security/format.js'
 import { securityFeatureEnabled } from '../../featureFlags.js'
 import Toggle from '../Toggle.js'
@@ -90,17 +91,24 @@ function SecurityUnavailableNotice({
 function SecurityPaneInner() {
   const { t } = useTranslation()
   const [status, setStatus] = useState<ScanStatus | null>(null)
-  const [prefs, setPrefs] = useState<SecurityPreferences | null>(null)
+  // Subscribe to the shared prefs cache. Returns the cached value
+  // synchronously when warm (the typical case — App.tsx primes at
+  // mount, so by the time a user can click Settings the cache is
+  // populated). Returns null on cold-start; the controls below render
+  // null in their slot and the layout stays stable until the prime
+  // resolves and useSyncExternalStore re-renders us.
+  const prefs = useCachedSecurityPrefs()
   const [busy, setBusy] = useState(false)
   const [allowlistOpen, setAllowlistOpen] = useState(false)
   const [allowlistEntries, setAllowlistEntries] = useState<AllowlistEntryRow[]>([])
 
   useEffect(() => {
     void securityApi.getScanStatus().then(setStatus).catch(() => setStatus(null))
-    void securityApi.getPrefs().then(setPrefs).catch(() => setPrefs(null))
     void refreshAllowlist()
-    const off = securityApi.onPrefsChanged((next) => setPrefs(next))
-    return () => off()
+    if (prefs === null) {
+      void primeSecurityPrefsCache()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   async function refreshAllowlist() {
@@ -108,11 +116,10 @@ function SecurityPaneInner() {
     setAllowlistEntries(rows)
   }
 
+
   async function update(next: Partial<SecurityPreferences>) {
     if (!prefs) return
-    setPrefs({ ...prefs, ...next })
-    const saved = await securityApi.setPrefs(next)
-    setPrefs(saved)
+    await patchSecurityPrefs(next)
   }
 
   async function rescanAll() {
@@ -183,14 +190,14 @@ function SecurityPaneInner() {
             description={t('settings.security.info_default_sub', {
               defaultValue: 'Show absolute-path, ip, and internal-host in the Security page by default. Audit showed ~98% false-positive rate.',
             })}
-            control={
+            control={prefs && (
               <Toggle
-                checked={prefs?.infoDefaultVisible ?? false}
+                checked={prefs.infoDefaultVisible}
                 onChange={(v) => { void update({ infoDefaultVisible: v }) }}
                 ariaLabel={t('settings.security.info_default_label', { defaultValue: 'Informational signals' })}
                 testId="settings-info-default"
               />
-            }
+            )}
           />
           {/* Blur defaults are split per surface so the at-a-glance
               strip (session detail) and the dedicated review page can
@@ -202,37 +209,37 @@ function SecurityPaneInner() {
             description={t('settings.security.blur_page_sub', {
               defaultValue: 'Finding values render blurred on the Security page; hover or click a row to reveal. Off = always visible.',
             })}
-            control={
+            control={prefs && (
               <Toggle
-                checked={prefs?.securityPageValuesBlurred ?? false}
+                checked={prefs.securityPageValuesBlurred}
                 onChange={(v) => { void update({ securityPageValuesBlurred: v }) }}
                 ariaLabel={t('settings.security.blur_page_label', { defaultValue: 'Blur values on the Security page' })}
                 testId="settings-blur-page"
               />
-            }
+            )}
           />
           <DefaultsRow
             label={t('settings.security.blur_strip_label', { defaultValue: 'Blur values in the session strip' })}
             description={t('settings.security.blur_strip_sub', {
               defaultValue: 'Finding values render blurred in the session-detail Findings strip; hover or click to reveal. Off = always visible.',
             })}
-            control={
+            control={prefs && (
               <Toggle
-                checked={prefs?.findingsStripValuesBlurred ?? false}
+                checked={prefs.findingsStripValuesBlurred}
                 onChange={(v) => { void update({ findingsStripValuesBlurred: v }) }}
                 ariaLabel={t('settings.security.blur_strip_label', { defaultValue: 'Blur values in the session strip' })}
                 testId="settings-blur-strip"
               />
-            }
+            )}
           />
           <DefaultsRow
             label={t('settings.security.rescan_after_sync_label', { defaultValue: 'Rescan after sync' })}
             description={t('settings.security.rescan_after_sync_sub', {
               defaultValue: 'When new sessions land, automatically re-run detectors on the affected sessions in the background.',
             })}
-            control={
+            control={prefs && (
               <SmallSelect
-                value={prefs?.rescanAfterSync ?? 'auto'}
+                value={prefs.rescanAfterSync}
                 onChange={(v) => { void update({ rescanAfterSync: v as 'auto' | 'manual' }) }}
                 options={[
                   { value: 'auto', label: t('settings.security.rescan_after_sync_auto', { defaultValue: 'Auto' }) },
@@ -240,17 +247,19 @@ function SecurityPaneInner() {
                 ]}
                 testid="settings-rescan-after-sync"
               />
-            }
+            )}
           />
         </div>
       </Section>
 
       {/* Muted kinds — entire categories silently dismissed at scan time */}
       <Section title={t('settings.security.muted_kinds_title', { defaultValue: 'Muted kinds' })}>
-        <MutedKindsRow
-          value={prefs?.kindAllowlist ?? []}
-          onChange={(kinds) => { void update({ kindAllowlist: kinds }) }}
-        />
+        {prefs && (
+          <MutedKindsRow
+            value={prefs.kindAllowlist}
+            onChange={(kinds) => { void update({ kindAllowlist: kinds }) }}
+          />
+        )}
       </Section>
 
       {/* Allowlist */}

--- a/packages/app/src/renderer/components/Settings/security/PfDownloadCard.tsx
+++ b/packages/app/src/renderer/components/Settings/security/PfDownloadCard.tsx
@@ -4,7 +4,8 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Download, X, RotateCw, AlertTriangle } from 'lucide-react'
-import { securityApi, type PfDownloadState, type PfRuntimeInfo, type SecurityPreferences } from '../../../api/security.js'
+import { securityApi, type PfDownloadState, type PfRuntimeInfo } from '../../../api/security.js'
+import { useCachedSecurityPrefs, primeSecurityPrefsCache, patchSecurityPrefs } from '../../../api/securityPrefsCache.js'
 import { formatBytes } from '../../security/format.js'
 import Toggle from '../../Toggle.js'
 
@@ -14,15 +15,17 @@ export default function PfDownloadCard() {
   const { t } = useTranslation()
   const [state, setState] = useState<PfDownloadState>(INITIAL)
   const [busy, setBusy] = useState(false)
-  const [prefs, setPrefs] = useState<SecurityPreferences | null>(null)
+  const prefs = useCachedSecurityPrefs()
   const [runtime, setRuntime] = useState<PfRuntimeInfo | null>(null)
 
   useEffect(() => {
     void securityApi.pfGetState().then(setState).catch(() => setState(INITIAL))
-    void securityApi.getPrefs().then(setPrefs).catch(() => setPrefs(null))
+    if (prefs === null) {
+      void primeSecurityPrefsCache()
+    }
     const offState = securityApi.onPfState(setState)
-    const offPrefs = securityApi.onPrefsChanged(setPrefs)
-    return () => { offState(); offPrefs() }
+    return () => { offState() }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // Poll runtime info while pfEnabled is on. ModelHost handshake can
@@ -51,9 +54,7 @@ export default function PfDownloadCard() {
   const cancelDownload = () => { void securityApi.pfDownloadCancel() }
   const togglePf = async (next: boolean) => {
     if (!prefs) return
-    setPrefs({ ...prefs, pfEnabled: next })
-    const saved = await securityApi.setPrefs({ pfEnabled: next })
-    setPrefs(saved)
+    await patchSecurityPrefs({ pfEnabled: next })
   }
 
   const percent = state.bytesTotal > 0
@@ -169,9 +170,9 @@ export default function PfDownloadCard() {
               {t('settings.security.detector_pf_cancel', { defaultValue: 'Cancel' })}
             </button>
           )}
-          {state.phase === 'installed' && (
+          {state.phase === 'installed' && prefs && (
             <Toggle
-              checked={prefs?.pfEnabled ?? false}
+              checked={prefs.pfEnabled}
               onChange={(v) => { void togglePf(v) }}
               ariaLabel={t('settings.security.detector_pf_title', { defaultValue: 'Privacy Filter' })}
               testId="settings-pf-toggle"


### PR DESCRIPTION
## What

Settings → Security used to flash every Toggle from off to on (and pop the controls in from an empty slot) every time the tab opened, because every control mounted with a `?? false` / `'auto'` fallback and only got its persisted value on the first useEffect tick.

The fix is a module-level cache exposed through `useSyncExternalStore` (the React-18-blessed shape for external state read synchronously, mirroring the existing \`useFeature\` hook in this codebase).

## Why

User-reported: \"I can see the toggle from off to on, this UX isn't good — on should be on, off should be off.\" The mount-flash had two compounding pieces — a literal switch-sweep animation (~150ms) and a layout pop-in from an empty control column.

## How it connects

- New \`renderer/api/securityPrefsCache.ts\` — module-level cache + \`useCachedSecurityPrefs()\` hook + \`primeSecurityPrefsCache()\` + optimistic \`patchSecurityPrefs(patch)\`. Subscribes to \`onPrefsChanged\` once to stay coherent across surfaces.
- \`App.tsx\` — a regular \`useEffect\` at mount calls \`primeSecurityPrefsCache()\` (gated on \`securityFeatureEnabled()\`). Explicit and greppable, not a side-effect import.
- \`SecurityPaneInner\` / \`PfDownloadCard\` — read through the hook, write through \`patchSecurityPrefs\` so the toggle flips instantly without waiting on the IPC roundtrip.
- Cold-cache path (user opens Settings within ms of app launch): controls render \`null\` in their slot but labels and descriptions appear immediately, so the page never goes blank. Subscription delivers the value as soon as the prime resolves.

## Test plan

- [x] Typecheck clean
- [x] New e2e \`settings-security-toggle-mount-flash.spec.ts\` arms a MutationObserver before opening the Security tab and asserts the toggle never appears with \`aria-checked=\"false\"\` when the persisted pref is \`true\`. Catches the regression at frame granularity.
- [x] Manual dev verification: tab open → toggles in final state from frame 1; layout no longer flickers; clicking a toggle still feels instant (optimistic update).