### PR TITLE
fix(security): worker.backfill() resets burst state + signals user-initiated

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -266,7 +266,11 @@ async function syncPfRuntime(pfEnabled: boolean): Promise<void> {
         yield* Effect.promise(() => pfRuntime.stop())
       }
       if (scanWorker) {
-        yield* scanWorker.backfill()
+        // User flipped the PF toggle (or completed the callout's
+        // "Activate" flow) — mark this backfill as user-initiated so
+        // the renderer shows a result banner on busy→idle, instead
+        // of treating it as background work.
+        yield* scanWorker.backfill({ userInitiated: true })
       }
     }).pipe(
       // pfActivationPending clears on the way out (success OR fail) so

--- a/packages/app/src/main/ipc/security.ts
+++ b/packages/app/src/main/ipc/security.ts
@@ -257,7 +257,11 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
         [...prevKinds].some(k => !nextKinds.has(k)) ||
         [...nextKinds].some(k => !prevKinds.has(k))
       if (changed) {
-        await runPromise(worker.backfill())
+        // User clicked a kind-mute toggle — propagate the
+        // user-initiated marker so the renderer's busy→idle edge
+        // surfaces a "Scan complete" result banner instead of
+        // silently letting the progress banner vanish.
+        await runPromise(worker.backfill({ userInitiated: true }))
       }
       if (prev.pfEnabled !== saved.pfEnabled) {
         try { onPfEnabledChanged?.(saved.pfEnabled) }

--- a/packages/app/src/main/scan-worker-proxy.ts
+++ b/packages/app/src/main/scan-worker-proxy.ts
@@ -192,7 +192,7 @@ export async function spawnScanWorker(
   return {
     enqueue: (sessionId) => Effect.promise(() => send<void>({ cmd: 'enqueue', sessionId })),
     rescanAll: () => Effect.promise(() => send<number>({ cmd: 'rescanAll' })),
-    backfill: () => Effect.promise(() => send<number>({ cmd: 'backfill' })),
+    backfill: (opts) => Effect.promise(() => send<number>({ cmd: 'backfill', userInitiated: opts?.userInitiated === true })),
     // getStatus uses the last pushed status when available — saves a
     // round-trip on every renderer mount. Falls back to a real call
     // before the first push lands (boolean sentinel because an empty

--- a/packages/app/src/main/scan-worker-thread.ts
+++ b/packages/app/src/main/scan-worker-thread.ts
@@ -49,7 +49,7 @@ const port = parentPort
 export type ScanCommand =
   | { cmd: 'enqueue'; sessionId: number }
   | { cmd: 'rescanAll' }
-  | { cmd: 'backfill' }
+  | { cmd: 'backfill'; userInitiated?: boolean }
   | { cmd: 'getStatus' }
 
 export interface PfRawMatchWire {
@@ -246,7 +246,7 @@ void (async () => {
             result = await runEff(worker.rescanAll())
             break
           case 'backfill':
-            result = await runEff(worker.backfill())
+            result = await runEff(worker.backfill({ userInitiated: payload.userInitiated === true }))
             break
           case 'getStatus':
             result = await runEff(worker.getStatus)

--- a/packages/core/src/security/worker.test.ts
+++ b/packages/core/src/security/worker.test.ts
@@ -300,6 +300,125 @@ describe('ScanWorker', () => {
     })
   })
 
+  // Regression: backfill({ userInitiated: true }) sets the manual
+  // burst marker so the renderer's busy→idle edge surfaces a "Scan
+  // complete" result banner for user-driven pref changes (mute kind,
+  // toggle PF). Default backfill (boot, post-sync) stays silent.
+  it('backfill({ userInitiated: true }) raises manualBurstInFlight', async () => {
+    const multiDb = setupDb(3)
+    await withWorker(multiDb, async (worker) => {
+      const collectFiber = Effect.runFork(
+        Stream.takeUntil(worker.statusChanges, (s) =>
+          s.queued === 0 && s.scanning === null && s.backfillRemaining === 0,
+        ).pipe(Stream.runCollect),
+      )
+      await new Promise<void>((r) => setTimeout(r, 20))
+      await Effect.runPromise(worker.backfill({ userInitiated: true }))
+      await Effect.runPromise(waitForIdle(worker))
+      const collected = Chunk.toReadonlyArray(
+        await Effect.runPromise(Fiber.join(collectFiber)),
+      )
+      expect(collected.some(s =>
+        s.manualBurstInFlight === true &&
+        (s.backfillRemaining > 0 || s.scanning !== null || s.queued > 0),
+      )).toBe(true)
+      expect(collected[collected.length - 1]!.manualBurstInFlight).toBe(false)
+    })
+  })
+
+  it('backfill() default does NOT raise manualBurstInFlight', async () => {
+    const multiDb = setupDb(3)
+    await withWorker(multiDb, async (worker) => {
+      const collectFiber = Effect.runFork(
+        Stream.takeUntil(worker.statusChanges, (s) =>
+          s.queued === 0 && s.scanning === null && s.backfillRemaining === 0,
+        ).pipe(Stream.runCollect),
+      )
+      await new Promise<void>((r) => setTimeout(r, 20))
+      await Effect.runPromise(worker.backfill())
+      await Effect.runPromise(waitForIdle(worker))
+      const collected = Chunk.toReadonlyArray(
+        await Effect.runPromise(Fiber.join(collectFiber)),
+      )
+      expect(collected.every(s => s.manualBurstInFlight === false)).toBe(true)
+    })
+  })
+
+  // Regression for the "toggle PF off mid-scan leaves progress bar
+  // pinned at 100% for seconds" bug. The wrapper's sticky-max guard
+  // (Math.max(prev.backfillTotal, after.backfillRemaining)) was
+  // designed to keep total monotonic during a SINGLE burst — but
+  // when a new burst arrives mid-flight (kindAllowlist toggle, PF
+  // toggle), it bled the OLD burst's total into the new burst's
+  // progress display. backfill() now goes through resetBurst, which
+  // bypasses the guard and sets backfillTotal directly from the
+  // freshly-computed stale set.
+  it('successive backfill() does not carry the prior burst total into the new one', async () => {
+    const multiDb = setupDb(5)
+    await withWorker(multiDb, async (worker) => {
+      // First burst: 5 stale, fully drains.
+      await Effect.runPromise(worker.backfill())
+      await Effect.runPromise(waitForIdle(worker))
+      const afterFirst = await Effect.runPromise(worker.getStatus)
+      // After full drain the wrapper resets total to 0 — sanity check.
+      expect(afterFirst.backfillTotal).toBe(0)
+      expect(afterFirst.backfillRemaining).toBe(0)
+
+      // Second burst against the same DB with the SAME profile finds
+      // no stale work. The OLD bug would leave backfillTotal sticky
+      // at 5 because Math.max(prev=5, 0) = 5 — even though there is
+      // nothing to do. With resetBurst the new burst owns the total
+      // directly: 0 in, 0 out.
+      const count = await Effect.runPromise(worker.backfill())
+      expect(count).toBe(0)
+      const afterSecond = await Effect.runPromise(worker.getStatus)
+      expect(afterSecond.backfillTotal).toBe(0)
+      expect(afterSecond.backfillRemaining).toBe(0)
+      expect(afterSecond.queued).toBe(0)
+    })
+  })
+
+  // Tighter regression for the exact toggle-PF-off scenario: a
+  // backfill arrives while a previous burst is still mid-flight, and
+  // the new stale set is strictly smaller than what was already
+  // scheduled. Pre-fix: backfillTotal stayed at the OLD burst's max
+  // and the progress bar visually pinned at ~100%. Post-fix:
+  // backfillTotal tracks the new burst's stale count.
+  it('backfill() mid-burst with a smaller stale set resets backfillTotal downward', async () => {
+    const multiDb = setupDb(5)
+    await withWorker(multiDb, async (worker) => {
+      // Kick off the first burst: 5 stale sessions.
+      await Effect.runPromise(worker.backfill())
+      // Wait until enough sessions have finished that the next
+      // `listSessionsNeedingScan` returns a smaller set. The 50ms
+      // sleep between scanOne calls (in worker.ts drain) gives us
+      // discrete status events to watch.
+      await Effect.runPromise(
+        Stream.takeUntil(worker.statusChanges, (s) =>
+          s.backfillRemaining <= 2,
+        ).pipe(Stream.runDrain),
+      )
+      const midSnap = await Effect.runPromise(worker.getStatus)
+      // Confirm we're observing the sticky-max in action: total still
+      // says 5 while remaining has shrunk.
+      expect(midSnap.backfillTotal).toBe(5)
+
+      // Now trigger a fresh backfill. The stale set is whatever the
+      // DB currently reports (the in-flight session is mid-scan, so
+      // scan_profile is still NULL or matches depending on timing).
+      // Either way it MUST be ≤ midSnap.backfillRemaining + 1 (the
+      // worst case of including the in-flight session). The key
+      // assertion: backfillTotal is the freshly-computed count, NOT
+      // the old burst's 5.
+      await Effect.runPromise(worker.backfill())
+      const afterReset = await Effect.runPromise(worker.getStatus)
+      expect(afterReset.backfillTotal).toBeLessThan(5)
+      expect(afterReset.backfillTotal).toBe(afterReset.backfillRemaining)
+
+      await Effect.runPromise(waitForIdle(worker))
+    })
+  })
+
   // Regression for the "progress bar rewinds when switching back
   // mid-scan" bug. Anchoring backfillTotal to backfillRemaining
   // (which only ever decrements at scanOne end) — instead of to

--- a/packages/core/src/security/worker.ts
+++ b/packages/core/src/security/worker.ts
@@ -53,8 +53,22 @@ export interface ScanWorker {
    *  "Rescan all" and by provider-set changes. */
   rescanAll: () => Effect.Effect<number>
   /** Enqueue every session whose scan_profile != currentProfile.
-   *  Called once on boot. */
-  backfill: () => Effect.Effect<number>
+   *  Called on boot AND on every profile-affecting pref change
+   *  (kindAllowlist toggle, PF on/off, etc.).
+   *
+   *  Treated as a fresh burst: any leftover items still in the queue
+   *  from the previous burst are discarded (they were enqueued against
+   *  an outdated profile; the current `listSessionsNeedingScan` call
+   *  is the authoritative new work set). `backfillTotal` resets to the
+   *  new stale-set size instead of sticky-maxing with the old burst's
+   *  value, so the renderer's progress bar reflects the new work
+   *  rather than the union of the two.
+   *
+   *  Pass `userInitiated: true` when the caller is a SET_PREFS / PF
+   *  toggle handler so the renderer's busy→idle edge surfaces a
+   *  "Scan complete" result banner the same way it does for the
+   *  Rescan-all button. */
+  backfill: (opts?: { userInitiated?: boolean }) => Effect.Effect<number>
   /** Stream of finding change events. Translator in main process
    *  subscribes and forwards over IPC. */
   changes: Stream.Stream<FindingsChange>
@@ -132,6 +146,43 @@ export function makeScanWorker(
         Effect.flatMap((s) => PubSub.publish(statusEvents, s)),
         Effect.asVoid,
       )
+
+    // Burst-reset variant for backfill() (and any future caller that
+    // means "start a fresh burst, discard whatever the previous one
+    // had queued"). Two differences from updateStatus:
+    //
+    //   1. The `Math.max(prev.backfillTotal, after.backfillRemaining)`
+    //      sticky guard is BYPASSED — the caller is declaring a brand-
+    //      new burst, so its new `backfillRemaining` becomes the
+    //      authoritative `backfillTotal`. Without this, a toggle-pref
+    //      mid-scan would leave the renderer showing the OLD burst's
+    //      total while the new burst's much smaller stale set drives
+    //      the remaining count → progress bar visually pinned at
+    //      ~100% for as long as the queue takes to drain.
+    //
+    //   2. The Effect Queue is drained synchronously. Items left in
+    //      it were enqueued against the previous profile and were
+    //      already accounted for in the OLD burst's
+    //      backfillRemaining. With the new totals in force they'd
+    //      keep `nowBusy = queued > 0` true (banner-stuck-at-100%
+    //      problem) and waste regex-only scans on sessions whose
+    //      profile already matches the current one.
+    const resetBurst = (f: (s: ScanStatus) => ScanStatus) =>
+      Effect.gen(function* () {
+        yield* Queue.takeAll(queue)
+        yield* Ref.update(statusRef, (prev) => {
+          const after = f(prev)
+          const fullyIdle =
+            after.backfillRemaining === 0 &&
+            after.queued === 0 &&
+            after.scanning === null
+          const backfillTotal = fullyIdle ? 0 : after.backfillRemaining
+          const manualBurstInFlight = fullyIdle ? false : after.manualBurstInFlight
+          return { ...after, backfillTotal, manualBurstInFlight }
+        })
+        const snap = yield* Ref.get(statusRef)
+        yield* PubSub.publish(statusEvents, snap)
+      })
 
     const scanOne = (sessionId: number) =>
       Effect.gen(function* () {
@@ -223,21 +274,33 @@ export function makeScanWorker(
         return all.length
       }).pipe(Effect.withSpan('security.worker.rescan_all'))
 
-    const backfill = () =>
+    const backfill = (opts?: { userInitiated?: boolean }) =>
       Effect.gen(function* () {
         // Re-resolve the profile each call so a SET_PREFS handler that
         // changed kindAllowlist sees the updated hash before invoking
-        // backfill. Keep the per-call status snapshot in sync too.
+        // backfill.
         const profile = resolveProfile(config)
-        yield* updateStatus((s) => ({ ...s, currentProfile: profile }))
         const stale = yield* Effect.sync(() =>
           listSessionsNeedingScan(config.db, profile),
         )
-        yield* updateStatus((s) => ({ ...s, backfillRemaining: stale.length }))
+        // Fresh burst: drain any leftover queue items (they belong to
+        // a previous profile snapshot — see `resetBurst` notes), reset
+        // queued/backfillRemaining/backfillTotal to this burst's stale
+        // count, and stamp the user-initiated flag if applicable. The
+        // wrapper bypasses the sticky-max guard so the renderer's
+        // progress bar tracks the new burst, not the old.
+        yield* resetBurst((s) => ({
+          ...s,
+          currentProfile: profile,
+          queued: 0,
+          backfillRemaining: stale.length,
+          manualBurstInFlight: opts?.userInitiated === true,
+        }))
         for (const id of stale) {
           yield* enqueue(id)
         }
         yield* Effect.annotateCurrentSpan('enqueued', stale.length)
+        yield* Effect.annotateCurrentSpan('userInitiated', opts?.userInitiated === true)
         return stale.length
       }).pipe(Effect.withSpan('security.worker.backfill'))
 


### PR DESCRIPTION
## What

Two related corrections to how the scan worker treats backfill calls that arrive while a previous burst is still draining.

### P0 — burst-state reset

\`backfill()\` going through the wrapper's \`Math.max(prev.backfillTotal, after.backfillRemaining)\` sticky guard left the OLD burst's total in place when a NEW burst arrived mid-flight. The renderer's progress bar took (oldTotal − newRemaining)/oldTotal — jumped from a low percentage to nearly 100% the moment the new burst landed, then stayed pinned at 100% for as long as the OLD burst's queue residue took to drain (often tens of seconds), then silently vanished.

User-visible: toggle PF off mid-rescan → progress jumps to 100% instantly → banner sits there for many seconds → disappears without ever showing a result. Reported with screenshot; confirmed via code trace of \`worker.ts\` + \`scan-worker-thread.ts\` + \`SecurityPage.tsx\`.

The fix: a new \`resetBurst\` helper drains leftover queue items (they were enqueued under a now-stale profile snapshot; \`listSessionsNeedingScan\` for the new profile is the authoritative work set) and sets \`backfillTotal\` from the new \`backfillRemaining\` directly, no sticky max. \`backfill()\` uses it; \`rescanAll()\` doesn't need to because it always sets remaining to \`all.length\`.

### P1 — \`userInitiated\` marker

The renderer's "Scan complete" result banner fires only when \`manualBurstInFlight\` was observed. Today only Rescan-all sets that flag. Every other user pref change (mute kind, toggle PF, allowlist edit) shows progress during the burst but no completion ack — feels like the system silently swallowed the action.

\`backfill(opts?: { userInitiated?: boolean })\` now accepts a marker. SET_PREFS-driven backfills and syncPfRuntime pass \`true\`. Boot / post-sync stay on default (\`false\`).

## Why

- The P0 bug is correctness — progress display lies about scan state.
- The P1 gap is UX — clicking a switch should produce visible feedback comparable to clicking Rescan.

Both stem from the same place: backfill being treated as identical to background enqueue work, when in fact it's the worker-side equivalent of "user changed the rules, re-derive."

## How it connects

- \`packages/core/src/security/worker.ts\` — new \`resetBurst\` alongside \`updateStatus\`; \`backfill\` accepts \`opts\`
- \`packages/app/src/main/scan-worker-{proxy,thread}.ts\` — thread cmd payload carries \`userInitiated\`
- \`packages/app/src/main/ipc/security.ts\` — pass \`{userInitiated: true}\` when kindAllowlist changed
- \`packages/app/src/main/index.ts\` — pass \`{userInitiated: true}\` from \`syncPfRuntime\` (covers toggle PF on/off + PF callout auto-activation)

## Test plan

- [x] typecheck clean (both packages)
- [x] 325/325 core unit tests pass (was 321; +4 regression cases)
- [x] 4 new regression tests in \`worker.test.ts\`:
   - \`backfill({ userInitiated: true })\` raises \`manualBurstInFlight\`
   - default \`backfill()\` does not raise it
   - successive idle backfill calls don't carry prior totals
   - mid-burst smaller stale set resets \`backfillTotal\` downward (the exact reported symptom)
- [x] dev verification: toggle PF off mid-burst — progress bar no longer pins at 100%; banner correctly hides; result banner appears for user-driven bursts that crossed the 5-session threshold; small bursts (single session) stay ambient

## Notes

The first regression test exercises the \`userInitiated\` path explicitly. The fourth exercises the exact in-flight state-machine scenario from the bug report — drives backfillRemaining down to 2 in the OLD burst, then triggers a fresh \`backfill()\` and asserts \`backfillTotal === backfillRemaining\` (not the stale max of 5).