### PR TITLE
polish(security): stabilize meta-row layout during scans

### DIFF
--- a/packages/app/e2e/security-scan-meta-stability.spec.ts
+++ b/packages/app/e2e/security-scan-meta-stability.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, waitForSync, type AppContext } from './helpers/launch'
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Regression test for the meta-row layout shift (May 2026):
+//
+// The meta row reads "N risk · M info · scanned X ago · [detectors
+// chip] [rescan button]". The inline "scanned X ago" segment used to
+// be suppressed while the full ScanBanner was shown — so clicking
+// Rescan all collapsed the row width mid-scan, shoving the detectors
+// chip + rescan button leftwards, then back when the scan finished.
+//
+// Fix: the timestamp is a stable "last completed" fact, not a
+// scan-in-flight signal, so it stays put even under the banner. Only
+// the ambient dot (which WOULD duplicate the banner) is suppressed,
+// and it lives in a fixed-width slot so its fade never reflows
+// anything to its right.
+//
+// This gates against the timestamp vanishing AND against the rescan
+// button moving horizontally during a scan.
+
+const akiaForIter = (i: number) =>
+  'AKIA' + 'V3QFKW72ZDLNP4'.padEnd(14, 'X') + i.toString().padStart(2, '0')
+
+let ctx: AppContext
+
+test.beforeAll(async () => {
+  ctx = await launchApp({
+    extraFixtures: ({ claudeDir }) => {
+      // Five sessions so backfillTotal clears the ambient banner
+      // threshold (5) and the scanning banner renders on Rescan all.
+      for (let i = 0; i < 5; i++) {
+        writeFileSync(
+          join(claudeDir, 'test-project', `meta-stability-fixture-${i}.jsonl`),
+          [
+            JSON.stringify({
+              type: 'user',
+              sessionId: `meta-stability-${i}`,
+              cwd: '/tmp/test-project',
+              uuid: `ms-${i}-msg-1`,
+              timestamp: `2026-05-20T10:00:0${i}Z`,
+              message: {
+                role: 'user',
+                content: `leaked ${akiaForIter(i)} to a log, rotate it`,
+              },
+            }),
+            JSON.stringify({
+              type: 'assistant',
+              uuid: `ms-${i}-msg-2`,
+              timestamp: `2026-05-20T10:00:0${i}.5Z`,
+              message: {
+                role: 'assistant',
+                model: 'claude-sonnet-4',
+                content: 'rotating now',
+              },
+            }),
+          ].join('\n'),
+        )
+      }
+    },
+  })
+})
+
+test.afterAll(async () => { await ctx?.cleanup() })
+
+async function waitForWorkerIdle(window: AppContext['window']): Promise<void> {
+  await window.waitForFunction(async () => {
+    const api = (globalThis as { spool?: { security?: { getScanStatus: () => Promise<{ queued: number; scanning: number | null; backfillRemaining: number; manualBurstInFlight: boolean }> } } }).spool
+    if (!api?.security) return false
+    const s = await api.security.getScanStatus()
+    return s.queued === 0 && s.scanning === null && s.backfillRemaining === 0 && !s.manualBurstInFlight
+  }, { timeout: 30_000, polling: 250 })
+}
+
+test('Meta row keeps the timestamp and holds the rescan button still during a scan', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+  await waitForWorkerIdle(window)
+
+  await window.locator('[data-testid="sidebar-security"]').click()
+  await expect(window.locator('[data-testid="security-page"]')).toBeVisible()
+
+  const scanState = window.locator('[data-testid="security-scan-state"]')
+  const rescanBtn = window.locator('[data-testid="security-rescan-all"]')
+
+  // Precondition: the boot backfill has set a "scanned X ago" stamp.
+  await expect(scanState).toBeVisible()
+  const restingX = (await rescanBtn.boundingBox())!.x
+
+  await rescanBtn.click()
+
+  // The scanning banner must come up — this is the state that used to
+  // hide the timestamp.
+  await expect(window.locator('[data-testid="security-scan-banner"]')).toBeVisible({ timeout: 10_000 })
+
+  // Regression: the timestamp must NOT disappear under the banner...
+  await expect(scanState).toBeVisible()
+  // ...and the rescan button must not have shifted sideways.
+  const scanningX = (await rescanBtn.boundingBox())!.x
+  expect(Math.abs(scanningX - restingX)).toBeLessThan(1)
+
+  await waitForWorkerIdle(window)
+
+  // Back at rest, still stable.
+  await expect(scanState).toBeVisible()
+  const settledX = (await rescanBtn.boundingBox())!.x
+  expect(Math.abs(settledX - restingX)).toBeLessThan(1)
+})

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -512,35 +512,14 @@ function SecurityPageInner({ onOpenSession, onShareSession, onOpenSettings }: Pr
               {t('security.summary_info', { count: infoCount, defaultValue: '{{count}} info' })}
             </span>
           )}
-          {/* Always show "scanned X ago" — the text is stable, only a
-           *  tiny pulse dot fades in/out next to it when work is
-           *  happening in the background. Previously the slot flipped
-           *  between the dot-+-text and the timestamp, which read as a
-           *  flicker even after the underlying state was debounced.
-           *  Stable text + a small inline indicator is the standard
-           *  ambient pattern (Gmail's "saved", VS Code's status-bar
-           *  spinner — none of them swap text for the active state). */}
-          {/* Suppress the inline "scanned X ago" + dot while a full
-           *  ScanBanner is shown — they'd otherwise duplicate the
-           *  scan-in-flight signal in two places at once. */}
-          {lastScanCompletedAt && !shouldShowScanBanner(scanStatus, displayBusy) && (
+          {/* Detectors chip qualifies the counts above (which engine
+           *  produced them), so it sits next to them — and, being the
+           *  most static element, anchors the left of the row while the
+           *  width-volatile "scanned X ago" trails at the end. */}
+          {scanStatus?.currentProfile && (
             <>
               {' · '}
-              <span data-testid="security-scan-state" className="inline-flex items-center gap-1 align-baseline">
-                {displayBusy && (
-                  <span
-                    data-testid="security-ambient-dot"
-                    aria-hidden
-                    className="w-1.5 h-1.5 rounded-full bg-warm-muted dark:bg-dark-muted animate-pulse"
-                  />
-                )}
-                <span>
-                  {t('security.scanned_ago', {
-                    ago: formatScanAgo(lastScanCompletedAt, t as unknown as (k: string, o?: Record<string, unknown>) => string),
-                    defaultValue: 'scanned {{ago}}',
-                  })}
-                </span>
-              </span>
+              <DetectorsChip profile={scanStatus.currentProfile} />
             </>
           )}
           {activeKinds.length > 0 && (
@@ -561,10 +540,29 @@ function SecurityPageInner({ onOpenSession, onShareSession, onOpenSettings }: Pr
               </button>
             </>
           )}
-          {scanStatus?.currentProfile && (
+          {/* "scanned X ago" is the row's only width-volatile text, so
+           *  it trails last: its width changes can't shove the static
+           *  counts/chip to its left. Pairing it with the ↻ button
+           *  also reads as "last scanned · refresh", giving the bare
+           *  icon a label by adjacency.
+           *  Plain inline text (no flex wrapper, no inline indicator)
+           *  so it shares the surrounding mono baseline exactly and
+           *  never reflows the ↻ button. It's a stable "last
+           *  completed" fact, NOT a scan-in-flight signal, so it stays
+           *  put even under a full ScanBanner — removing it mid-scan
+           *  collapsed the row width and shoved the controls sideways,
+           *  then back. In-progress scanning is signalled by the
+           *  ScanBanner below (≥5 sessions) and by this stamp ticking
+           *  to "just now" when a scan settles. */}
+          {lastScanCompletedAt && (
             <>
               {' · '}
-              <DetectorsChip profile={scanStatus.currentProfile} />
+              <span data-testid="security-scan-state">
+                {t('security.scanned_ago', {
+                  ago: formatScanAgo(lastScanCompletedAt, t as unknown as (k: string, o?: Record<string, unknown>) => string),
+                  defaultValue: 'scanned {{ago}}',
+                })}
+              </span>
             </>
           )}
         </span>


### PR DESCRIPTION
## What

The Security page meta row (`N risk · M info · scanned X ago · [detectors chip] [↻]`) no longer reflows while a scan runs, and its elements now share a single baseline.

Three changes:

1. **Timestamp stays put during scans.** The inline `scanned X ago` used to be suppressed whenever the full ScanBanner was shown, so starting a scan collapsed the row width and shoved the detectors chip + rescan button sideways, then back when the scan finished. The timestamp is a stable "last completed" fact, not a scan-in-flight signal, so it now stays rendered even under the banner.

2. **Reordered for stable-first / volatile-last.** New order: counts → detectors chip → (filter) → `scanned X ago` → ↻. The detectors chip qualifies the counts it sits beside and almost never changes, so it anchors the left; the only width-volatile text (`scanned X ago`) trails at the end where its width changes can't push the static elements, and pairing it with the ↻ button reads as "last scanned · refresh", giving the bare icon a label by adjacency.

3. **Fixed vertical alignment + dropped the ambient dot.** `scanned X ago` was wrapped in an `inline-flex` box that sat on its own baseline and visibly drooped below the `N risk · M info` run; it's now plain inline text on the shared mono baseline. The small scanning pulse-dot was removed: it forced either an inconsistent gap (reserved slot) or a ~10px nudge of the ↻ button when it faded. In-progress scanning is already signalled by the ScanBanner (≥5 sessions) and by the stamp ticking to "just now" when a scan settles.

## Why

The reflow and the drooping timestamp were visible jank every time a scan ran or settled. Separating the volatile timestamp from the static controls — by order and by keeping it always-rendered — removes the layout shift; making it plain inline text fixes the baseline.

## How it connects

Touches only the meta row in `SecurityPage.tsx`. The `shouldShowScanBanner` helper, the ScanBanner, and the manual-rescan ACK banner are unchanged; the banner remains the in-flight signal for real/manual scans.

## Test plan

- New regression e2e `security-scan-meta-stability.spec.ts`: asserts the timestamp stays visible while the ScanBanner is shown **and** the rescan button's x-position shifts < 1px between resting and scanning (fails on the pre-fix suppression).
- Adjacent `security-manual-rescan-ack.spec.ts` (2 tests) still green.
- `page-helpers.test.ts` (25 tests) green; typecheck clean.
- Verified the final layout visually via a one-off screenshot capture.