### PR TITLE
Add pin, unpin, and pinned commands to the CLI

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -49,6 +49,16 @@ spool sync                     # Index new AI sessions (Claude, Codex, Gemini)
 spool sync --watch             # Keep watching for new sessions
 ```
 
+### Doctor
+
+```bash
+spool doctor                   # Diagnose your environment, database, and config
+spool doctor db.integrity      # Run a single check by id
+spool doctor --json            # Machine-readable output
+spool doctor --fix             # Apply safe fixes for failing checks
+spool doctor --fix --force     # Also apply destructive fixes
+```
+
 ## Data location
 
 All data is stored locally in `~/.spool/`:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,6 +30,18 @@ spool show <uuid> --json       # Output as JSON
 spool status                   # Show index stats (session count, DB size)
 ```
 
+### Pin
+
+```bash
+spool pin <uuid>               # Pin a session to the top of your library
+spool unpin <uuid>             # Remove a session from the pinned list
+spool pinned                   # List pinned sessions
+spool pinned --json            # Output as JSON
+```
+
+Pins are shared with the Spool desktop app — pinning here surfaces the
+session in the app's library on its next refresh, and vice versa.
+
 ### Sync
 
 ```bash

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
 import { execFileSync } from 'node:child_process'
 import { resolve, join } from 'node:path'
 import { existsSync, statSync, rmSync, mkdtempSync } from 'node:fs'
@@ -334,6 +334,61 @@ describe('search', () => {
   it('exits with error when query is missing', () => {
     const out = runFail(['search'], { SPOOL_DATA_DIR: seeded.dir })
     expect(out).toContain("missing required argument")
+  })
+})
+
+describe('pin / unpin / pinned', () => {
+  let seeded: ReturnType<typeof createSeededDir>
+  beforeEach(() => { seeded = createSeededDir() })
+  afterEach(() => { seeded.cleanup() })
+
+  it('pins a session and pinned lists it', () => {
+    const pinOut = run(['pin', SESSION_UUID_1], { SPOOL_DATA_DIR: seeded.dir })
+    expect(pinOut).toContain('Pinned')
+    expect(pinOut).toContain('Debugging authentication flow')
+
+    const listed = run(['pinned'], { SPOOL_DATA_DIR: seeded.dir })
+    expect(listed).toContain('Debugging authentication flow')
+    expect(listed).not.toContain('Refactoring database queries')
+  })
+
+  it('is idempotent when already pinned', () => {
+    run(['pin', SESSION_UUID_1], { SPOOL_DATA_DIR: seeded.dir })
+    const again = run(['pin', SESSION_UUID_1], { SPOOL_DATA_DIR: seeded.dir })
+    expect(again).toContain('Already pinned')
+  })
+
+  it('unpin removes a session from the pinned list', () => {
+    run(['pin', SESSION_UUID_1], { SPOOL_DATA_DIR: seeded.dir })
+    const unpinOut = run(['unpin', SESSION_UUID_1], { SPOOL_DATA_DIR: seeded.dir })
+    expect(unpinOut).toContain('Unpinned')
+
+    const listed = run(['pinned'], { SPOOL_DATA_DIR: seeded.dir })
+    expect(listed).toContain('No pinned sessions')
+  })
+
+  it('pin exits with error for unknown UUID', () => {
+    const out = runFail(['pin', 'nonexistent-uuid'], { SPOOL_DATA_DIR: seeded.dir })
+    expect(out).toContain('not found')
+  })
+
+  it('unpin reports when a session was not pinned', () => {
+    const out = run(['unpin', SESSION_UUID_1], { SPOOL_DATA_DIR: seeded.dir })
+    expect(out).toContain('Not pinned')
+  })
+
+  it('pinned outputs JSON', () => {
+    run(['pin', SESSION_UUID_1], { SPOOL_DATA_DIR: seeded.dir })
+    const out = run(['pinned', '--json'], { SPOOL_DATA_DIR: seeded.dir })
+    const parsed = JSON.parse(out)
+    expect(Array.isArray(parsed)).toBe(true)
+    expect(parsed.length).toBe(1)
+    expect(parsed[0].sessionUuid).toBe(SESSION_UUID_1)
+  })
+
+  it('pinned prints empty message when nothing pinned', () => {
+    const out = run(['pinned'], { SPOOL_DATA_DIR: seeded.dir })
+    expect(out).toContain('No pinned sessions')
   })
 })
 

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander'
 import { getDB, listRecentSessionsPage } from '@spool-lab/core'
-import type { Session } from '@spool-lab/core'
+import { printSession } from '../format.js'
 
 const SESSION_SOURCES = new Set(['claude', 'codex', 'gemini'])
 
@@ -38,19 +38,3 @@ export const listCommand = new Command('list')
       printSession(s)
     }
   })
-
-function printSession(s: Session): void {
-  const date = formatDate(s.startedAt)
-  const source = s.source.padEnd(7)
-  const project = s.projectDisplayName.slice(0, 20).padEnd(20)
-  const title = (s.title ?? '(no title)').slice(0, 50)
-  console.log(`${source} ${date}  ${project}  ${title}`)
-}
-
-function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toLocaleDateString()
-  } catch {
-    return iso.slice(0, 10)
-  }
-}

--- a/packages/cli/src/commands/pin.ts
+++ b/packages/cli/src/commands/pin.ts
@@ -1,0 +1,65 @@
+import { Command } from 'commander'
+import {
+  getDB,
+  getSessionWithMessages,
+  isPinned,
+  listPinnedSessions,
+  pinSession,
+  unpinSession,
+} from '@spool-lab/core'
+import { printSession } from '../format.js'
+
+export const pinCommand = new Command('pin')
+  .description('Pin a session so it stays at the top of your library')
+  .argument('<uuid>', 'Session UUID')
+  .action((uuid: string) => {
+    const db = getDB(true)
+    const result = getSessionWithMessages(db, uuid)
+    if (!result) {
+      console.error(`Session not found: ${uuid}`)
+      process.exit(1)
+    }
+
+    const label = result.session.title ?? uuid
+    if (isPinned(db, uuid)) {
+      console.log(`Already pinned: ${label}`)
+      return
+    }
+    pinSession(db, uuid)
+    console.log(`Pinned: ${label}`)
+  })
+
+export const unpinCommand = new Command('unpin')
+  .description('Remove a session from your pinned list')
+  .argument('<uuid>', 'Session UUID')
+  .action((uuid: string) => {
+    const db = getDB(true)
+    if (!isPinned(db, uuid)) {
+      console.log(`Not pinned: ${uuid}`)
+      return
+    }
+    unpinSession(db, uuid)
+    console.log(`Unpinned: ${uuid}`)
+  })
+
+export const pinnedCommand = new Command('pinned')
+  .description('List pinned sessions')
+  .option('--json', 'Output as JSON')
+  .action((opts: { json?: boolean }) => {
+    const db = getDB(true)
+    const sessions = listPinnedSessions(db)
+
+    if (opts.json) {
+      console.log(JSON.stringify(sessions, null, 2))
+      return
+    }
+
+    if (sessions.length === 0) {
+      console.log('No pinned sessions. Pin one with `spool pin <uuid>`.')
+      return
+    }
+
+    for (const s of sessions) {
+      printSession(s)
+    }
+  })

--- a/packages/cli/src/format.ts
+++ b/packages/cli/src/format.ts
@@ -1,0 +1,17 @@
+import type { Session } from '@spool-lab/core'
+
+export function printSession(s: Session): void {
+  const date = formatDate(s.startedAt)
+  const source = s.source.padEnd(7)
+  const project = s.projectDisplayName.slice(0, 20).padEnd(20)
+  const title = (s.title ?? '(no title)').slice(0, 50)
+  console.log(`${source} ${date}  ${project}  ${title}`)
+}
+
+export function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString()
+  } catch {
+    return iso.slice(0, 10)
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import { syncCommand } from './commands/sync.js'
 import { listCommand } from './commands/list.js'
 import { statusCommand } from './commands/status.js'
 import { showCommand } from './commands/show.js'
+import { pinCommand, unpinCommand, pinnedCommand } from './commands/pin.js'
 import { doctorCommand } from './commands/doctor.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -22,6 +23,9 @@ program.addCommand(syncCommand)
 program.addCommand(listCommand)
 program.addCommand(statusCommand)
 program.addCommand(showCommand)
+program.addCommand(pinCommand)
+program.addCommand(unpinCommand)
+program.addCommand(pinnedCommand)
 program.addCommand(doctorCommand)
 
 program.parse()


### PR DESCRIPTION
## What
Adds three terminal commands for session pinning, and documents the existing `doctor` command that had shipped without a README entry.

- `spool pin <uuid>` / `spool unpin <uuid>` — toggle a session's pin. `pin` validates the UUID against the index (same as `show`), is idempotent ("Already pinned"), and `unpin` reports "Not pinned" cleanly.
- `spool pinned [--json]` — list pinned sessions, reusing the same row format as `list`.
- README: new Pin section, plus a Doctor section (single-check filtering, `--json`, `--fix`/`--force`).

## Why
The CLI had no way to pin sessions even though core already exposed the helpers and the desktop app surfaced them — terminal users had no equivalent. `doctor` was also undocumented.

## How it connects
`pin`/`unpin`/`pinned` go through the shared `@spool-lab/core` helpers (`pinSession`, `unpinSession`, `listPinnedSessions`) against the same `~/.spool/spool.db` the app's main process uses — a single source of truth, no divergent pin logic. Concurrent access is safe via `journal_mode=WAL` + `busy_timeout=5000`. The app reflects CLI-side pin changes on its next refetch (no live push), which is noted in the README.

The shared list-row formatter was extracted from `list.ts` into `format.ts` so `pinned` and `list` print identically.

## Test plan
- New tests cover pin → pinned round-trip, idempotent re-pin, unpin, unknown-UUID error, `pinned --json`, and the empty state.
- Full CLI suite green (42 tests).