### PR TITLE
Add projects command to the CLI

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,8 +30,13 @@ spool show <uuid> --json       # Output as JSON
 spool status                   # Show index stats (session count, DB size)
 
 spool projects                 # List projects, grouped across sources
-spool projects --json          # Output as JSON
+spool projects spool           # List sessions in a project (by name or identity)
+spool projects spool -n 50     # Limit how many sessions are shown
+spool projects spool --json    # Output as JSON
 ```
+
+A project query matches its name or identity key — an exact name wins over
+partial matches, and ambiguous queries list the candidates so you can refine.
 
 ### Pin
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,6 +28,9 @@ spool show <uuid>              # Print full session content
 spool show <uuid> --json       # Output as JSON
 
 spool status                   # Show index stats (session count, DB size)
+
+spool projects                 # List projects, grouped across sources
+spool projects --json          # Output as JSON
 ```
 
 ### Pin

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -423,6 +423,25 @@ describe('projects', () => {
       rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  it('lists the sessions in a project when given a query', () => {
+    const out = run(['projects', 'my-project'], { SPOOL_DATA_DIR: seeded.dir })
+    expect(out).toContain('Debugging authentication flow')
+    expect(out).toContain('Refactoring database queries')
+  })
+
+  it('outputs project sessions as JSON', () => {
+    const out = run(['projects', 'my-project', '--json'], { SPOOL_DATA_DIR: seeded.dir })
+    const parsed = JSON.parse(out)
+    expect(Array.isArray(parsed)).toBe(true)
+    expect(parsed.length).toBe(2)
+    expect(parsed[0].sessionUuid).toBeTruthy()
+  })
+
+  it('errors when no project matches the query', () => {
+    const out = runFail(['projects', 'zzz-no-such-project'], { SPOOL_DATA_DIR: seeded.dir })
+    expect(out).toContain('No project matching')
+  })
 })
 
 describe('sync', () => {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -392,6 +392,39 @@ describe('pin / unpin / pinned', () => {
   })
 })
 
+describe('projects', () => {
+  let seeded: ReturnType<typeof createSeededDir>
+  beforeAll(() => { seeded = createSeededDir() })
+  afterAll(() => { seeded.cleanup() })
+
+  it('lists project groups with session counts', () => {
+    const out = run(['projects'], { SPOOL_DATA_DIR: seeded.dir })
+    expect(out).toContain('my-project')
+    expect(out).toContain('claude')
+    expect(out).toMatch(/\b2\b/)
+  })
+
+  it('outputs JSON', () => {
+    const out = run(['projects', '--json'], { SPOOL_DATA_DIR: seeded.dir })
+    const parsed = JSON.parse(out)
+    expect(Array.isArray(parsed)).toBe(true)
+    expect(parsed.length).toBe(1)
+    expect(parsed[0].displayName).toBe('my-project')
+    expect(parsed[0].sessionCount).toBe(2)
+    expect(parsed[0].sources).toContain('claude')
+  })
+
+  it('prints empty message when no projects', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'spool-cli-empty-'))
+    try {
+      const out = run(['projects'], { SPOOL_DATA_DIR: dir })
+      expect(out).toContain('No projects found')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('sync', () => {
   it('runs against empty session dirs', () => {
     const dir = mkdtempSync(join(tmpdir(), 'spool-cli-sync-'))

--- a/packages/cli/src/commands/projects.test.ts
+++ b/packages/cli/src/commands/projects.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import type { ProjectGroup } from '@spool-lab/core'
+import { resolveProjectQuery } from './projects.js'
+
+function group(displayName: string, identityKey: string): ProjectGroup {
+  return {
+    identityKind: 'path',
+    identityKey,
+    displayName,
+    sources: ['claude'],
+    sessionCount: 1,
+    lastSessionAt: '2026-04-10T10:00:00Z',
+  }
+}
+
+const groups: ProjectGroup[] = [
+  group('spool', 'github.com/spool-lab/spool'),
+  group('spool-daemon', 'github.com/spool-lab/spool-daemon'),
+  group('quilt', 'github.com/graydawnc/quilt'),
+  group('Asks', 'ask'),
+]
+
+describe('resolveProjectQuery', () => {
+  it('resolves a unique substring match', () => {
+    expect(resolveProjectQuery(groups, 'quilt')).toEqual({ kind: 'match', group: groups[2] })
+  })
+
+  it('is case-insensitive', () => {
+    expect(resolveProjectQuery(groups, 'ASKS')).toEqual({ kind: 'match', group: groups[3] })
+  })
+
+  it('prefers an exact name match over substring matches', () => {
+    // "spool" is a substring of "spool-daemon" too, but the exact name wins.
+    expect(resolveProjectQuery(groups, 'spool')).toEqual({ kind: 'match', group: groups[0] })
+  })
+
+  it('resolves on a full identity key', () => {
+    expect(resolveProjectQuery(groups, 'github.com/spool-lab/spool-daemon'))
+      .toEqual({ kind: 'match', group: groups[1] })
+  })
+
+  it('matches against the identity key as well as the name', () => {
+    expect(resolveProjectQuery(groups, 'graydawnc')).toEqual({ kind: 'match', group: groups[2] })
+  })
+
+  it('reports ambiguity when several projects match a substring', () => {
+    const res = resolveProjectQuery(groups, 'spool-lab')
+    expect(res.kind).toBe('ambiguous')
+    if (res.kind === 'ambiguous') {
+      expect(res.groups).toEqual([groups[0], groups[1]])
+    }
+  })
+
+  it('reports none when nothing matches', () => {
+    expect(resolveProjectQuery(groups, 'nonexistent')).toEqual({ kind: 'none' })
+  })
+})

--- a/packages/cli/src/commands/projects.test.ts
+++ b/packages/cli/src/commands/projects.test.ts
@@ -51,6 +51,23 @@ describe('resolveProjectQuery', () => {
     }
   })
 
+  it('reports ambiguity when two projects share the same name', () => {
+    // Same display name, different identities (e.g. a local path vs a git
+    // remote) — an exact name hit can't pick one, so disambiguate by key.
+    const sameName = [
+      group('openclaw', '/Users/me/openclaw'),
+      group('openclaw', 'github.com/openclaw/openclaw'),
+    ]
+    const res = resolveProjectQuery(sameName, 'openclaw')
+    expect(res.kind).toBe('ambiguous')
+    if (res.kind === 'ambiguous') {
+      expect(res.groups).toEqual(sameName)
+    }
+    // The full identity key still resolves uniquely.
+    expect(resolveProjectQuery(sameName, 'github.com/openclaw/openclaw'))
+      .toEqual({ kind: 'match', group: sameName[1] })
+  })
+
   it('reports none when nothing matches', () => {
     expect(resolveProjectQuery(groups, 'nonexistent')).toEqual({ kind: 'none' })
   })

--- a/packages/cli/src/commands/projects.ts
+++ b/packages/cli/src/commands/projects.ts
@@ -1,29 +1,102 @@
 import { Command } from 'commander'
-import { getDB, listProjectGroups } from '@spool-lab/core'
-import { formatDate } from '../format.js'
+import { getDB, listProjectGroups, listSessionsByIdentity } from '@spool-lab/core'
+import type { ProjectGroup } from '@spool-lab/core'
+import { formatDate, printSession } from '../format.js'
+
+export type ProjectResolution =
+  | { kind: 'match'; group: ProjectGroup }
+  | { kind: 'ambiguous'; groups: ProjectGroup[] }
+  | { kind: 'none' }
+
+/**
+ * Resolve a free-text query to a single project group. An exact (case-
+ * insensitive) hit on the display name or identity key wins outright, so
+ * `projects spool` picks "spool" over the "spool-daemon" substring and a
+ * pasted identity key always lands uniquely. Otherwise fall back to
+ * substring matching, reporting ambiguity when more than one group matches.
+ */
+export function resolveProjectQuery(groups: ProjectGroup[], query: string): ProjectResolution {
+  const q = query.toLowerCase()
+
+  const exact = groups.filter(
+    g => g.displayName.toLowerCase() === q || g.identityKey.toLowerCase() === q,
+  )
+  if (exact.length > 0) return pick(exact)
+
+  const partial = groups.filter(
+    g => g.displayName.toLowerCase().includes(q) || g.identityKey.toLowerCase().includes(q),
+  )
+  if (partial.length === 0) return { kind: 'none' }
+  return pick(partial)
+}
+
+function pick(matches: ProjectGroup[]): ProjectResolution {
+  const [first, ...rest] = matches
+  if (first && rest.length === 0) return { kind: 'match', group: first }
+  return { kind: 'ambiguous', groups: matches }
+}
 
 export const projectsCommand = new Command('projects')
-  .description('List your projects, grouped across sources')
+  .description('List your projects, or the sessions in one')
+  .argument('[query]', 'Show sessions in the project matching this name or identity key')
+  .option('-n, --limit <n>', 'Max sessions to show (with a query)', '20')
   .option('--json', 'Output as JSON')
-  .action((opts: { json?: boolean }) => {
+  .action((query: string | undefined, opts: { limit: string; json?: boolean }) => {
     const db = getDB(true)
     const groups = listProjectGroups(db)
 
+    if (!query) {
+      listGroups(groups, opts.json === true)
+      return
+    }
+
+    const resolved = resolveProjectQuery(groups, query)
+    if (resolved.kind === 'none') {
+      console.error(`No project matching: ${query}`)
+      process.exit(1)
+    }
+    if (resolved.kind === 'ambiguous') {
+      console.error(`Multiple projects match "${query}":`)
+      for (const g of resolved.groups) {
+        console.error(`  ${g.displayName}  (${g.identityKey})`)
+      }
+      console.error('Refine the query, or pass a full identity key.')
+      process.exit(1)
+    }
+
+    const group = resolved.group
+    const sessions = listSessionsByIdentity(db, group.identityKey, {
+      limit: parseInt(opts.limit, 10),
+    }).sessions
+
     if (opts.json) {
-      console.log(JSON.stringify(groups, null, 2))
+      console.log(JSON.stringify(sessions, null, 2))
       return
     }
-
-    if (groups.length === 0) {
-      console.log('No projects found. Run `spool sync` to index sessions.')
+    if (sessions.length === 0) {
+      console.log(`No sessions in ${group.displayName}.`)
       return
     }
-
-    for (const g of groups) {
-      const count = String(g.sessionCount).padStart(4)
-      const date = (g.lastSessionAt ? formatDate(g.lastSessionAt) : '—').padEnd(10)
-      const sources = g.sources.join(',').padEnd(14)
-      const name = g.displayName.slice(0, 50)
-      console.log(`${count}  ${date}  ${sources}  ${name}`)
+    console.log(`${group.displayName}  ·  ${group.identityKey}`)
+    for (const s of sessions) {
+      printSession(s)
     }
   })
+
+function listGroups(groups: ProjectGroup[], json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(groups, null, 2))
+    return
+  }
+  if (groups.length === 0) {
+    console.log('No projects found. Run `spool sync` to index sessions.')
+    return
+  }
+  for (const g of groups) {
+    const count = String(g.sessionCount).padStart(4)
+    const date = (g.lastSessionAt ? formatDate(g.lastSessionAt) : '—').padEnd(10)
+    const sources = g.sources.join(',').padEnd(14)
+    const name = g.displayName.slice(0, 50)
+    console.log(`${count}  ${date}  ${sources}  ${name}`)
+  }
+}

--- a/packages/cli/src/commands/projects.ts
+++ b/packages/cli/src/commands/projects.ts
@@ -1,0 +1,29 @@
+import { Command } from 'commander'
+import { getDB, listProjectGroups } from '@spool-lab/core'
+import { formatDate } from '../format.js'
+
+export const projectsCommand = new Command('projects')
+  .description('List your projects, grouped across sources')
+  .option('--json', 'Output as JSON')
+  .action((opts: { json?: boolean }) => {
+    const db = getDB(true)
+    const groups = listProjectGroups(db)
+
+    if (opts.json) {
+      console.log(JSON.stringify(groups, null, 2))
+      return
+    }
+
+    if (groups.length === 0) {
+      console.log('No projects found. Run `spool sync` to index sessions.')
+      return
+    }
+
+    for (const g of groups) {
+      const count = String(g.sessionCount).padStart(4)
+      const date = (g.lastSessionAt ? formatDate(g.lastSessionAt) : '—').padEnd(10)
+      const sources = g.sources.join(',').padEnd(14)
+      const name = g.displayName.slice(0, 50)
+      console.log(`${count}  ${date}  ${sources}  ${name}`)
+    }
+  })

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ import { listCommand } from './commands/list.js'
 import { statusCommand } from './commands/status.js'
 import { showCommand } from './commands/show.js'
 import { pinCommand, unpinCommand, pinnedCommand } from './commands/pin.js'
+import { projectsCommand } from './commands/projects.js'
 import { doctorCommand } from './commands/doctor.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -26,6 +27,7 @@ program.addCommand(showCommand)
 program.addCommand(pinCommand)
 program.addCommand(unpinCommand)
 program.addCommand(pinnedCommand)
+program.addCommand(projectsCommand)
 program.addCommand(doctorCommand)
 
 program.parse()


### PR DESCRIPTION
## What
Adds `spool projects [--json]` — lists indexed projects, grouped across sources, the same way the desktop app's library groups them. Each row shows session count, last activity, sources, and display name; `--json` emits the raw `ProjectGroup` records.

## Why
The CLI could only filter sessions by a project path substring (`list -p`); there was no way to see the project groups themselves, even though core and the app already had that view.

## How it connects
Read-only, backed by core's `listProjectGroups` over the shared `project_groups_v` view — the same call the app's main process uses (`window.spool.listProjectGroups`) — so grouping stays consistent between CLI and app with no extra logic.

## Test plan
- New tests cover the grouped listing (count + sources), `--json` shape, and the empty state.
- Full CLI suite green (42 tests).

Stacked on #313.