### PR TITLE
fix(security): roll back optimistic prefs cache on IPC failure

### DIFF
--- a/packages/app/src/renderer/api/securityPrefsCache.test.ts
+++ b/packages/app/src/renderer/api/securityPrefsCache.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { SecurityPreferences } from '../../preload/index.js'
+
+const setPrefs = vi.fn()
+
+vi.mock('./security.js', () => ({
+  securityApi: {
+    setPrefs: (patch: Partial<SecurityPreferences>) => setPrefs(patch),
+    getPrefs: vi.fn(),
+    onPrefsChanged: vi.fn(),
+  },
+}))
+
+import {
+  patchSecurityPrefs,
+  __resetSecurityPrefsCacheForTest,
+  __pushAuthoritativePrefsForTest,
+  __readCacheForTest as readCache,
+  __subscribeForTest as subscribe,
+} from './securityPrefsCache.js'
+
+const base: SecurityPreferences = {
+  kindAllowlist: [],
+  infoDefaultVisible: false,
+  rescanAfterSync: 'auto',
+  securityPageValuesBlurred: false,
+  findingsStripValuesBlurred: false,
+  pfEnabled: false,
+  pfCalloutDismissed: false,
+  pfActivationPending: false,
+}
+
+describe('patchSecurityPrefs optimistic update', () => {
+  beforeEach(() => {
+    setPrefs.mockReset()
+    __resetSecurityPrefsCacheForTest(base)
+  })
+
+  it('persists the optimistic value on IPC success', async () => {
+    setPrefs.mockResolvedValueOnce(undefined)
+    await patchSecurityPrefs({ pfEnabled: true })
+    expect(setPrefs).toHaveBeenCalledWith({ pfEnabled: true })
+    expect(readCache()).toMatchObject({ pfEnabled: true })
+  })
+
+  it('reverts the cache and notifies subscribers on IPC rejection', async () => {
+    let notifications = 0
+    const unsub = subscribe(() => { notifications += 1 })
+    setPrefs.mockRejectedValueOnce(new Error('ipc down'))
+    await patchSecurityPrefs({ pfEnabled: true })
+    // optimistic apply (1) + rollback (1) = 2 emits
+    expect(notifications).toBe(2)
+    expect(readCache()).toMatchObject({ pfEnabled: false })
+    unsub()
+  })
+
+  it('does not clobber a newer authoritative value that landed during the in-flight IPC', async () => {
+    let rejectIpc: (e: unknown) => void = () => {}
+    setPrefs.mockImplementationOnce(
+      () => new Promise((_res, rej) => { rejectIpc = rej }),
+    )
+    const p = patchSecurityPrefs({ pfEnabled: true })
+    // Authoritative broadcast lands while setPrefs is still pending.
+    __pushAuthoritativePrefsForTest({ ...base, pfEnabled: true, rescanAfterSync: 'manual' })
+    // Now the IPC rejects — the stale snapshot must NOT overwrite the newer truth.
+    rejectIpc(new Error('ipc down'))
+    await p
+    expect(readCache()).toMatchObject({ pfEnabled: true, rescanAfterSync: 'manual' })
+  })
+
+  it('cold cache: persists without optimistic write or rollback', async () => {
+    __resetSecurityPrefsCacheForTest(null)
+    setPrefs.mockRejectedValueOnce(new Error('ipc down'))
+    await patchSecurityPrefs({ pfEnabled: true })
+    expect(setPrefs).toHaveBeenCalledWith({ pfEnabled: true })
+    expect(readCache()).toBeNull()
+  })
+})

--- a/packages/app/src/renderer/api/securityPrefsCache.ts
+++ b/packages/app/src/renderer/api/securityPrefsCache.ts
@@ -25,6 +25,19 @@ let cached: SecurityPreferences | null = null
 let inflight: Promise<SecurityPreferences | null> | null = null
 const subscribers = new Set<() => void>()
 
+// Monotonic version, bumped on every authoritative cache write
+// (prime resolve + EVT_PREFS_CHANGED). An optimistic patch records
+// the version it produced; if that version is no longer current when
+// the IPC rejects, a newer authoritative value has landed in between
+// and we must NOT clobber it by rolling back to a now-stale snapshot.
+let cacheVersion = 0
+
+function setCache(next: SecurityPreferences | null): void {
+  cached = next
+  cacheVersion += 1
+  emit()
+}
+
 function emit(): void {
   for (const fn of subscribers) {
     try { fn() } catch (err) { console.error('[securityPrefsCache] subscriber threw:', err) }
@@ -55,12 +68,29 @@ export function useCachedSecurityPrefs(): SecurityPreferences | null {
  *  main-process EVT_PREFS_CHANGED reply still lands in the cache,
  *  but by then the user already sees the new state. */
 export async function patchSecurityPrefs(patch: Partial<SecurityPreferences>): Promise<void> {
-  if (cached) {
-    cached = { ...cached, ...patch }
-    emit()
+  // Cold cache: nothing to optimistically update or roll back. Just
+  // persist; the EVT_PREFS_CHANGED broadcast primes the cache.
+  if (!cached) {
+    try { await securityApi.setPrefs(patch) }
+    catch (err) { console.error('[securityPrefsCache] setPrefs failed:', err) }
+    return
   }
-  try { await securityApi.setPrefs(patch) }
-  catch (err) { console.error('[securityPrefsCache] setPrefs failed:', err) }
+
+  const snapshot = cached
+  setCache({ ...cached, ...patch })
+  const optimisticVersion = cacheVersion
+  try {
+    await securityApi.setPrefs(patch)
+  } catch (err) {
+    console.error('[securityPrefsCache] setPrefs failed, rolling back:', err)
+    // Only revert if no authoritative write landed while the IPC was
+    // in flight. If `cacheVersion` moved past our optimistic write, a
+    // prime resolve or EVT_PREFS_CHANGED already replaced the cache
+    // with a newer truth — rolling back to `snapshot` would clobber it.
+    if (cacheVersion === optimisticVersion) {
+      setCache(snapshot)
+    }
+  }
 }
 
 /** Idempotent prefetch. Call once at app boot (from an App-level
@@ -72,9 +102,8 @@ export async function primeSecurityPrefsCache(): Promise<SecurityPreferences | n
   if (inflight) return inflight
   inflight = securityApi.getPrefs()
     .then((p) => {
-      cached = p
       inflight = null
-      emit()
+      setCache(p)
       return p
     })
     .catch(() => {
@@ -106,7 +135,31 @@ function ensureUpstreamSubscription(): void {
   if (typeof window === 'undefined' || !window.spool?.security?.onPrefsChanged) return
   subscriptionAttached = true
   securityApi.onPrefsChanged((next) => {
-    cached = next
-    emit()
+    setCache(next)
   })
+}
+
+/** Test-only. Reset all module-level state between cases and
+ *  optionally seed an initial authoritative cache value. */
+export function __resetSecurityPrefsCacheForTest(seed: SecurityPreferences | null = null): void {
+  cached = seed
+  inflight = null
+  cacheVersion = 0
+  subscribers.clear()
+  subscriptionAttached = false
+}
+
+/** Test-only. Simulate an authoritative EVT_PREFS_CHANGED landing. */
+export function __pushAuthoritativePrefsForTest(next: SecurityPreferences | null): void {
+  setCache(next)
+}
+
+/** Test-only. Read the current cache snapshot. */
+export function __readCacheForTest(): SecurityPreferences | null {
+  return cached
+}
+
+/** Test-only. Subscribe to cache-change notifications. */
+export function __subscribeForTest(fn: () => void): () => void {
+  return subscribe(fn)
 }


### PR DESCRIPTION
## What
`patchSecurityPrefs` now snapshots the prior cache value, applies the change optimistically, and **rolls back + re-notifies subscribers if the `setPrefs` IPC rejects** — guarded by a monotonic cache version so a newer authoritative update can't be clobbered by a stale rollback.

## Why
The optimistic write had no rollback. A failed IPC left the renderer showing the toggled (wrong) state until the next `EVT_PREFS_CHANGED` re-synced it, with no error surfaced — a security pref silently appearing on/off when the write actually failed.

## How it connects
Backs the Settings → Security toggles (blur prefs, PF enable, muted kinds). Keeps the cache honest at its boundary.

## Test plan
- New `securityPrefsCache.test.ts`: optimistic-apply-persists-on-success; revert-and-notify-on-rejection; in-flight authoritative-update race (no clobber); cold-cache no-rollback.
- Verified red on pre-fix code (rejection test: cache kept stale value), green after.
- Renderer api + featureFlags adjacent suites green; full app vitest 289 passed.

## Note
The error is not re-thrown to callers (both call sites are fire-and-forget). The cache-honesty contract is met; surfacing a toast is a separate caller-side change.