### PR TITLE
feat(security): make unknown PF labels observable in prod

### DIFF
--- a/packages/app/src/main/scan-worker-thread.ts
+++ b/packages/app/src/main/scan-worker-thread.ts
@@ -37,7 +37,7 @@ import {
 } from '@spool-lab/core'
 import { regexProvider, type RedactProvider, type SensitiveMatch } from '@spool-lab/redact'
 import { loadSecurityPreferences } from './securityPreferences.js'
-import { mapPfMatches, type PfRawMatch } from './security/class-mapping.js'
+import { mapPfMatches, setUnknownLabelSink, type PfRawMatch } from './security/class-mapping.js'
 import { detectWithRegex } from '@spool-lab/redact'
 import { PF_PROFILE_VERSION } from './security/model-paths.js'
 
@@ -107,6 +107,20 @@ void (async () => {
       ? { serviceName: 'spool-app-scan-worker', env: 'dev' }
       : { serviceName: 'spool-app-scan-worker', env: 'prod', logsDir: join(SPOOL_DIR, 'logs') },
   )
+
+  // Make unknown PF labels observable in prod, not just the dev
+  // console. A label that isn't in class-mapping's switch means a
+  // server-side model bump emitted a class before the mapping table
+  // was updated — those findings get dropped, and without this they
+  // vanish with zero diagnostic. Emit a span (label as attribute, no
+  // value) through the worker's own OTel runtime; the prod file
+  // exporter persists it to ~/.spool/logs. Fire-and-forget so the scan
+  // hot path never awaits the export.
+  setUnknownLabelSink((label) => {
+    void runEff(
+      Effect.void.pipe(Effect.withSpan('pf.unknown_label', { attributes: { label } })),
+    ).catch(() => {})
+  })
 
   // Main process already migrated the file before spawning this
   // thread; skipping here avoids a race with sync-worker (whose

--- a/packages/app/src/main/security/class-mapping.test.ts
+++ b/packages/app/src/main/security/class-mapping.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import type { SensitiveMatch } from '@spool-lab/redact'
-import { mapPfMatch, mapPfMatches, type PfRawMatch } from './class-mapping.js'
+import {
+  mapPfMatch,
+  mapPfMatches,
+  setUnknownLabelSink,
+  type PfRawMatch,
+} from './class-mapping.js'
 
 const regex = (kind: SensitiveMatch['kind'], start: number, end: number): SensitiveMatch => ({
   kind, value: '', start, end, confidence: 0.95, provider: 'regex',
@@ -99,8 +104,67 @@ describe('class mapping — suppression rules', () => {
   })
 
   it('unknown labels are dropped without throwing', () => {
-    const pf: PfRawMatch = { class: 'wat-is-this', value: 'x', start: 0, end: 1, score: 0.8 }
+    // score ≥ 0.85 so it clears the confidence floor and actually
+    // reaches the unknown-label branch in mapClass().
+    const pf: PfRawMatch = { class: 'wat-is-this', value: 'x', start: 0, end: 1, score: 0.99 }
     expect(mapPfMatch(pf, { regexMatches: [], fullText: 'x' })).toBeNull()
+  })
+})
+
+describe('class mapping — unknown-label observability', () => {
+  afterEach(() => {
+    // Restore the default no-op sink between cases.
+    setUnknownLabelSink(() => {})
+  })
+
+  it('invokes the sink with the unknown label (still drops the match)', () => {
+    const sink = vi.fn()
+    setUnknownLabelSink(sink)
+    const pf: PfRawMatch = { class: 'new_model_class', value: 'secret-ish', start: 0, end: 10, score: 0.99 }
+    expect(mapPfMatch(pf, { regexMatches: [], fullText: 'secret-ish' })).toBeNull()
+    expect(sink).toHaveBeenCalledTimes(1)
+    expect(sink).toHaveBeenCalledWith('new_model_class')
+  })
+
+  it('passes only the label, never the matched value', () => {
+    const sink = vi.fn()
+    setUnknownLabelSink(sink)
+    const pf: PfRawMatch = { class: 'mystery', value: 'sensitive-user-content', start: 0, end: 22, score: 0.9 }
+    mapPfMatch(pf, { regexMatches: [], fullText: 'sensitive-user-content' })
+    expect(sink).toHaveBeenCalledWith('mystery')
+    expect(sink.mock.calls[0]).not.toContain('sensitive-user-content')
+  })
+
+  it('does NOT fire for known or confidence-floored classes', () => {
+    const sink = vi.fn()
+    setUnknownLabelSink(sink)
+    // known class
+    mapPfMatch({ class: 'email', value: 'a@b.c', start: 0, end: 5, score: 0.99 }, { regexMatches: [], fullText: 'a@b.c' })
+    // unknown but below the 0.85 floor — dropped before mapClass()
+    mapPfMatch({ class: 'mystery', value: 'x', start: 0, end: 1, score: 0.5 }, { regexMatches: [], fullText: 'x' })
+    expect(sink).not.toHaveBeenCalled()
+  })
+
+  it('setUnknownLabelSink returns the previous sink for restoration', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const restoredToFirst = setUnknownLabelSink(first)
+    const prev = setUnknownLabelSink(second)
+    expect(prev).toBe(first)
+    void restoredToFirst
+  })
+
+  it('fires once per unknown match in a bulk map', () => {
+    const sink = vi.fn()
+    setUnknownLabelSink(sink)
+    const pf: PfRawMatch[] = [
+      { class: 'mystery_a', value: 'p', start: 0, end: 1, score: 0.99 },
+      { class: 'email', value: 'a@b.c', start: 2, end: 7, score: 0.99 },
+      { class: 'mystery_b', value: 'q', start: 8, end: 9, score: 0.99 },
+    ]
+    const out = mapPfMatches(pf, { regexMatches: [], fullText: 'p a@b.c q' })
+    expect(out.map((m) => m.kind)).toEqual(['email'])
+    expect(sink.mock.calls.map((c) => c[0])).toEqual(['mystery_a', 'mystery_b'])
   })
 })
 

--- a/packages/app/src/main/security/class-mapping.ts
+++ b/packages/app/src/main/security/class-mapping.ts
@@ -43,6 +43,25 @@ export interface PfRawMatch {
   score: number
 }
 
+/** Sink invoked once per unknown PF label so the drop is observable in
+ *  prod (not just the dev console). The label is passed deliberately
+ *  WITHOUT the matched value — the model swap we're diagnosing is a
+ *  class-name regression, and the value is user content we don't want
+ *  in logs. The call site (scan-worker / pf-provider) wires this to the
+ *  OTel pipeline; default is a no-op so the module stays side-effect
+ *  free for unit tests and any caller that doesn't opt in. */
+export type UnknownLabelSink = (label: string) => void
+
+let unknownLabelSink: UnknownLabelSink = () => {}
+
+/** Install the observability sink for unknown PF labels. Returns the
+ *  previous sink so tests can restore it. */
+export function setUnknownLabelSink(sink: UnknownLabelSink): UnknownLabelSink {
+  const prev = unknownLabelSink
+  unknownLabelSink = sink
+  return prev
+}
+
 export interface MappingContext {
   /** Matches already produced by the regex provider for the same
    *  text. Used by url/secret rules — pf only emits when regex also
@@ -138,8 +157,12 @@ function mapClass(pf: PfRawMatch, ctx: MappingContext): SensitiveKind | null {
       return null
 
     default:
-      // Unknown label — log once in dev, drop in prod. Only fires on
-      // model swaps that forgot to update this switch.
+      // Unknown label — drop, but make it observable. Only fires on
+      // model swaps that emit a class before this switch is updated;
+      // in prod those findings vanish silently otherwise, so route the
+      // label through the observability sink (see UnknownLabelSink) and
+      // keep the dev console.warn for local feedback.
+      unknownLabelSink(pf.class)
       if (process.env['NODE_ENV'] !== 'production') {
         console.warn('[pf class-mapping] unknown label:', pf.class)
       }


### PR DESCRIPTION
## What
When the PF model emits a class not in the mapping table, the label is now recorded as a span attribute through the existing OTel pipeline (`pf.unknown_label`), in addition to the existing dev-only `console.warn`. The match is still dropped; only the label (never the matched value) is emitted.

## Why
Unknown labels were dropped silently in production (`console.warn` was gated to non-prod). A server-side model update that emits a new class before the mapping table is updated would lose findings invisibly, with zero diagnostic. The prod file span exporter persists attributes (not events), so the label is attached as an attribute to guarantee visibility.

## How it connects
The mapping function stays pure/side-effect-free via an injectable `UnknownLabelSink`; the scan worker wires the default sink to its own OTel runtime (fire-and-forget, so the scan hot path never awaits export).

## Test plan
- New cases (mocked sink): sink invoked with label / match still dropped; only the label passed; not fired for known classes or confidence-floored matches; fires once per unknown match in bulk.
- Fixed a pre-existing test that used a below-floor score and never reached the unknown branch.
- Verified red on pre-fix code, green after. `src/main/security/` suite 59 passed.