### PR TITLE
fix(security): derive last-scanned time from global MAX, not the findings page

### DIFF
--- a/packages/app/e2e/security-empty-state-copy.spec.ts
+++ b/packages/app/e2e/security-empty-state-copy.spec.ts
@@ -1,23 +1,34 @@
 import { test, expect } from '@playwright/test'
 import { launchApp, waitForSync, type AppContext } from './helpers/launch'
 
-// Regression for the EmptyState copy split: when no scan has ever
-// completed (fresh archive, `lastScan === null`), the empty state must
-// say "Scan hasn't run yet." instead of the post-scan "Nothing to
-// review." copy. Pre-fix both branches showed the same string and the
-// user couldn't tell whether their archive was clean or unscanned.
+// EmptyState copy split: the empty Security page must distinguish a
+// completed scan that found nothing ("Nothing to review.",
+// data-scan-state="clean") from a scan that never ran
+// ("Scan hasn't run yet.", data-scan-state="never").
+//
+// The discriminator is `lastScanCompletedAt`: it is the global
+// MAX(scan_completed_at) across all sessions, NOT derived from the
+// (filtered, paginated) findings list. A scanned-clean session has a
+// completion timestamp but zero findings; deriving "last scanned" from
+// the findings list would see an empty list and mislabel "clean" as
+// "never". This test guards that: launchApp's base fixtures contain no
+// sensitive values, so they sync, scan, and complete with zero findings
+// → scan_completed_at is set → the empty state reads "clean".
+//
+// Coverage note: the "never" branch (lastScanCompletedAt === null) is
+// not exercised here. A genuine never-scanned state needs an archive
+// where no session has ever completed a scan, which the base fixtures
+// can't represent (they always scan on boot) and which is otherwise a
+// brief, timing-dependent transient — not a stable e2e target. The
+// branch is trivial renderer logic (`lastScan === null ? 'never' :
+// 'clean'`) covered by reading the component.
 
 let ctx: AppContext
 
-test.beforeAll(async () => {
-  // No extraFixtures → fresh archive → zero sessions → no scan ever
-  // completed → `lastScanCompletedAt` stays null.
-  ctx = await launchApp()
-})
-
+test.beforeAll(async () => { ctx = await launchApp() })
 test.afterAll(async () => { await ctx?.cleanup() })
 
-test('Empty Security page distinguishes never-scanned from scanned-clean', async () => {
+test('Empty Security page reads "clean" after a scan completes with no findings', async () => {
   const { window } = ctx
   await waitForSync(window)
 
@@ -26,10 +37,6 @@ test('Empty Security page distinguishes never-scanned from scanned-clean', async
 
   const title = window.locator('[data-testid="security-empty-title"]')
   await expect(title).toBeVisible()
-  await expect(title).toHaveAttribute('data-scan-state', 'never')
-  await expect(title).toHaveText(/Scan hasn't run yet\./)
-
-  // P5: the trimmed info footnote is only shown when info-severity
-  // categories exist, which they don't on a fresh archive — so we can't
-  // assert it here. That copy is covered by snapshot/visual review.
+  await expect(title).toHaveAttribute('data-scan-state', 'clean')
+  await expect(title).toHaveText(/Nothing to review\./)
 })

--- a/packages/app/src/main/ipc/security.test.ts
+++ b/packages/app/src/main/ipc/security.test.ts
@@ -18,6 +18,7 @@ import {
   runMigrations,
   insertFindings,
   updateSessionCounts,
+  setSessionScanProfile,
   listFindings,
   type ScanWorker,
   type ScanStatus,
@@ -212,6 +213,14 @@ describe('registerSecurityIpc', () => {
         SECURITY_IPC_CHANNELS.RISK_BY_CATEGORY,
       )
       expect(rows[0]).toMatchObject({ kind: 'api-key', severity: 'high', count: 1, sessions: 1 })
+    })
+
+    it('LAST_SCAN_COMPLETED_AT returns null before any scan, then the MAX', async () => {
+      const before = await invoke<string | null>(SECURITY_IPC_CHANNELS.LAST_SCAN_COMPLETED_AT)
+      expect(before).toBeNull()
+      setSessionScanProfile(fixture.db, 1, 'regex@4', '2026-02-01T00:00:00Z')
+      const after = await invoke<string | null>(SECURITY_IPC_CHANNELS.LAST_SCAN_COMPLETED_AT)
+      expect(after).toBe('2026-02-01T00:00:00Z')
     })
 
     it('GET_FINDING_VALUE reads the live message text', async () => {

--- a/packages/app/src/main/ipc/security.ts
+++ b/packages/app/src/main/ipc/security.ts
@@ -14,6 +14,7 @@ import {
   listSessionsWithFindingsPage,
   countSessionsWithFindings,
   riskByCategory,
+  lastScanCompletedAt,
   getFindingValue,
   getFindingValues,
   dismissFinding,
@@ -52,6 +53,7 @@ export const SECURITY_IPC_CHANNELS = {
   LIST_SESSIONS_WITH_FINDINGS_PAGE: 'security:list-sessions-with-findings-page',
   COUNT_SESSIONS_WITH_FINDINGS: 'security:count-sessions-with-findings',
   RISK_BY_CATEGORY:            'security:risk-by-category',
+  LAST_SCAN_COMPLETED_AT:      'security:last-scan-completed-at',
   GET_FINDING_VALUE:           'security:get-finding-value',
   GET_FINDING_VALUES:          'security:get-finding-values',
   GET_SCAN_STATUS:             'security:get-scan-status',
@@ -189,6 +191,9 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
   )
   ipcMain.handle(SECURITY_IPC_CHANNELS.RISK_BY_CATEGORY, () =>
     riskByCategory(db),
+  )
+  ipcMain.handle(SECURITY_IPC_CHANNELS.LAST_SCAN_COMPLETED_AT, () =>
+    lastScanCompletedAt(db),
   )
   ipcMain.handle(SECURITY_IPC_CHANNELS.GET_FINDING_VALUE, (_e, findingId: number) =>
     getFindingValue(db, findingId),

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -266,6 +266,8 @@ const api = {
       ipcRenderer.invoke('security:count-sessions-with-findings', filter),
     riskByCategory: (): Promise<RiskByCategoryRow[]> =>
       ipcRenderer.invoke('security:risk-by-category'),
+    lastScanCompletedAt: (): Promise<string | null> =>
+      ipcRenderer.invoke('security:last-scan-completed-at'),
     getFindingValue: (findingId: number): Promise<string | null> =>
       ipcRenderer.invoke('security:get-finding-value', findingId),
     getFindingValues: (ids: number[]): Promise<Record<number, string | null>> =>

--- a/packages/app/src/renderer/api/security.ts
+++ b/packages/app/src/renderer/api/security.ts
@@ -41,6 +41,8 @@ export const securityApi = {
     window.spool.security.countSessionsWithFindings(filter),
   riskByCategory: (): Promise<RiskByCategoryRow[]> =>
     window.spool.security.riskByCategory(),
+  lastScanCompletedAt: (): Promise<string | null> =>
+    window.spool.security.lastScanCompletedAt(),
   getFindingValue: (findingId: number): Promise<string | null> =>
     window.spool.security.getFindingValue(findingId),
   getFindingValues: (ids: number[]): Promise<Record<number, string | null>> =>

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -192,7 +192,7 @@ function SecurityPageInner({ onOpenSession, onShareSession, onOpenSettings }: Pr
 
   const refresh = useCallback(async () => {
     try {
-      const [r, sPage, sTotal, st] = await Promise.all([
+      const [r, sPage, sTotal, st, lastScan] = await Promise.all([
         securityApi.riskByCategory(),
         securityApi.listSessionsWithFindingsPage({
           ...filter,
@@ -200,21 +200,18 @@ function SecurityPageInner({ onOpenSession, onShareSession, onOpenSettings }: Pr
         }),
         securityApi.countSessionsWithFindings(filter),
         securityApi.getScanStatus(),
+        securityApi.lastScanCompletedAt(),
       ])
       setRisk(r)
       setSessions(sPage.rows as Sess[])
       setSessionsHasMore(sPage.hasMore)
       setSessionsTotal(sTotal)
       setScanStatus(st)
-      // Pick the most recent scan_completed_at across the session set
-      // we just fetched. Cheap because s is already in-memory.
-      const completedAts = (sPage.rows as Sess[])
-        .map(x => x.scanCompletedAt)
-        .filter((x): x is string => Boolean(x))
-      if (completedAts.length > 0) {
-        completedAts.sort()
-        setLastScanCompletedAt(completedAts[completedAts.length - 1] ?? null)
-      }
+      // True most-recent scan completion across ALL sessions — not the
+      // filtered/paginated findings page. A session scanned + cleaned
+      // (now 0 active findings) drops off that list, so deriving from
+      // it could read older than the real last scan.
+      setLastScanCompletedAt(lastScan)
       setLoading(false)
       setError(null)
       // Return fresh risk so callers (e.g. the manual-rescan ACK

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -32,6 +32,7 @@ export {
   listSessionsWithFindingsPage,
   countSessionsWithFindings,
   riskByCategory,
+  lastScanCompletedAt,
   getFindingValue,
   getFindingValues,
   getAllowlists,

--- a/packages/core/src/security/repo.test.ts
+++ b/packages/core/src/security/repo.test.ts
@@ -15,6 +15,7 @@ import {
   listSessionsWithFindingsPage,
   countSessionsWithFindings,
   riskByCategory,
+  lastScanCompletedAt,
   getFindingValue,
   getAllowlists,
   isAllowlisted,
@@ -398,6 +399,36 @@ describe('repo: scan_profile lifecycle', () => {
     setSessionScanProfile(db, 1, 'regex@2', '2026-01-10')
     setSessionScanProfile(db, 2, 'regex@3', '2026-01-11')
     expect(listSessionsNeedingScan(db, 'regex@3')).toEqual([1])
+  })
+})
+
+describe('repo: lastScanCompletedAt', () => {
+  let db: Database.Database
+  beforeEach(() => { db = setupDb() })
+
+  it('returns null when nothing has been scanned', () => {
+    expect(lastScanCompletedAt(db)).toBeNull()
+  })
+
+  it('returns the MAX scan_completed_at across all sessions', () => {
+    setSessionScanProfile(db, 1, 'regex@3', '2026-01-10T00:00:00Z')
+    setSessionScanProfile(db, 2, 'regex@3', '2026-01-12T00:00:00Z')
+    expect(lastScanCompletedAt(db)).toBe('2026-01-12T00:00:00Z')
+  })
+
+  it('counts a scanned-then-cleaned session (no active findings) — the regression case', () => {
+    // Session 1: older scan, still has an active finding (would be the
+    // only contributor to a findings-list-derived timestamp).
+    setSessionScanProfile(db, 1, 'regex@3', '2026-01-10T00:00:00Z')
+    insertFindings(db, [
+      { sessionId: 1, messageId: 10, kind: 'api-key', valueHash: 'h1', confidence: 0.95, provider: 'regex', startOffset: 14, endOffset: 34, state: 'active' },
+    ])
+    // Session 2: newer scan, came back clean (zero findings) so it
+    // drops off listSessionsWithFindings entirely.
+    setSessionScanProfile(db, 2, 'regex@3', '2026-01-15T00:00:00Z')
+    // The page-derived value would be session 1's old time; the true
+    // last scan is session 2's.
+    expect(lastScanCompletedAt(db)).toBe('2026-01-15T00:00:00Z')
   })
 })
 

--- a/packages/core/src/security/repo.ts
+++ b/packages/core/src/security/repo.ts
@@ -517,6 +517,22 @@ export function riskByCategory(db: Database.Database): RiskByCategoryRow[] {
   }))
 }
 
+/** The most recent `scan_completed_at` across ALL sessions, regardless
+ *  of whether they currently have active findings. Drives the Security
+ *  page's "scanned X ago" label. Deriving it from the filtered,
+ *  paginated findings list undercounts: a session scanned + cleaned
+ *  (no active findings) drops off that list and stops contributing, so
+ *  the label could read older than the true last scan. Returns null
+ *  when nothing has been scanned yet. */
+export function lastScanCompletedAt(db: Database.Database): string | null {
+  const row = db.prepare(
+    `SELECT MAX(scan_completed_at) AS last
+       FROM sessions
+      WHERE scan_completed_at IS NOT NULL`,
+  ).get() as { last: string | null }
+  return row.last
+}
+
 /** Read the live raw value for one finding. Used by the UI's review
  *  panel and the Purge confirm dialog. Returns null when the finding
  *  no longer points at a valid message (race against session


### PR DESCRIPTION
## What
The "scanned X ago" timestamp now comes from a dedicated query — `MAX(scan_completed_at)` across all sessions — exposed via IPC, instead of being derived from the filtered, paginated findings list.

## Why
The old derivation took the max `scan_completed_at` over only the sessions currently shown (filtered + paginated by active findings). A session that was just scanned and cleaned drops off that list and stops contributing, so the displayed time could read older than the true last scan.

## How it connects
`ScanStatus` is in-memory worker *progress* state and tracks no completion timestamp; the persisted truth is `sessions.scan_completed_at`. Added `lastScanCompletedAt(db)` in core, wired through IPC → preload → renderer api, consumed in `SecurityPage`'s existing refresh. No UI/copy change.

## Test plan
- New core `repo.test.ts` case: older-scanned session with an active finding vs newer-scanned cleaned session — asserts the newer time wins. Verified red against a query that mimicked the old active-findings-only derivation, green after.
- New IPC test for `LAST_SCAN_COMPLETED_AT`. Core security suite 111 passed; app IPC security 25 passed.

---
**CI fix (e2e):** `security-empty-state-copy` asserted `data-scan-state='never'` for a `launchApp()` base-fixture archive. That archive scans clean (zero findings), so the correct state is `clean` — the prior 'never' only passed because the old derivation read the empty findings list and returned null, the exact conflation this PR fixes. Updated the assertion to `clean`/"Nothing to review.".

**Coverage note:** the `never` branch (`lastScanCompletedAt === null`) is not e2e-covered — a genuine never-scanned state isn't a stable e2e target (base fixtures always scan on boot; otherwise it's a brief transient). It's trivial renderer logic (`lastScan === null ? 'never' : 'clean'`).