### PR TITLE
fix(core): parse OpenCode session model JSON instead of leaking raw blob

### DIFF
--- a/packages/core/src/parsers/opencode.test.ts
+++ b/packages/core/src/parsers/opencode.test.ts
@@ -78,7 +78,7 @@ describe('OpenCode parser', () => {
       makeOpenCodeSessionFilePath(dbPath, 'ses_abc123'),
     ])
     expect(getOpenCodeSessionIndexedMtime(makeOpenCodeSessionFilePath(dbPath, 'ses_abc123')))
-      .toBe('1779152404000::opencode-v2-sqlite-parent-subagents')
+      .toBe('1779152404000::opencode-v3-session-model-json')
   })
 
   it('folds OpenCode child sessions into the parent as sidechain messages', () => {
@@ -94,7 +94,7 @@ describe('OpenCode parser', () => {
       makeOpenCodeSessionFilePath(dbPath, 'ses_abc123'),
     ])
     expect(getOpenCodeSessionIndexedMtime(makeOpenCodeSessionFilePath(dbPath, 'ses_abc123')))
-      .toBe('1779152410000::opencode-v2-sqlite-parent-subagents')
+      .toBe('1779152410000::opencode-v3-session-model-json')
 
     const childPath = makeOpenCodeSessionFilePath(dbPath, 'ses_child_explore')
     expect(loadOpenCodeSession(childPath)).toEqual({ kind: 'filtered' })
@@ -231,6 +231,35 @@ describe('OpenCode parser', () => {
     expect(parseOpenCodeSession(missing)).toBeNull()
   })
 
+  it('derives the model from the session JSON, falling back for partial / non-JSON values', () => {
+    const cases: Array<{ id: string; rawModel: string; expected: string }> = [
+      { id: 'ses_model_full', rawModel: '{"id":"big-pickle","providerID":"opencode"}', expected: 'opencode/big-pickle' },
+      { id: 'ses_model_no_provider', rawModel: '{"id":"big-pickle"}', expected: 'big-pickle' },
+      { id: 'ses_model_malformed', rawModel: '{not json', expected: '{not json' },
+      { id: 'ses_model_plain', rawModel: 'opencode/gpt-5.4', expected: 'opencode/gpt-5.4' },
+    ]
+    const { db, dbPath } = createOpenCodeDb()
+    try {
+      const start = Date.UTC(2026, 4, 19, 1, 0, 6)
+      for (const c of cases) {
+        db.prepare(`
+          INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated, model, agent)
+          VALUES (?, 'proj_1', ?, '/work/api', ?, '1.0.0', ?, ?, ?, 'build')
+        `).run(c.id, c.id, c.id, start, start + 1000, c.rawModel)
+        insertTextMessage(db, { sessionId: c.id, messageId: `${c.id}_m`, role: 'user', text: 'hi', at: start + 500 })
+      }
+    } finally {
+      db.close()
+    }
+
+    for (const c of cases) {
+      const result = loadOpenCodeSession(makeOpenCodeSessionFilePath(dbPath, c.id))
+      expect(result.kind, c.id).toBe('parsed')
+      if (result.kind !== 'parsed') continue
+      expect(result.session.model, c.id).toBe(c.expected)
+    }
+  })
+
   it('maps WAL/SHM sidecar paths back to the main database file', () => {
     expect(normalizeOpenCodeWatchPath('/data/opencode/opencode.db-wal')).toBe('/data/opencode/opencode.db')
     expect(normalizeOpenCodeWatchPath('/data/opencode/opencode.db-shm')).toBe('/data/opencode/opencode.db')
@@ -298,7 +327,7 @@ function seedOpenCodeSession(db: Database.Database): void {
   `).run(start, start)
   db.prepare(`
     INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated, model, agent)
-    VALUES ('ses_abc123', 'proj_1', 'fix-auth-callback', '/work/api', 'Fix the auth callback', '1.0.0', ?, ?, 'opencode/gpt-5.4', 'build')
+    VALUES ('ses_abc123', 'proj_1', 'fix-auth-callback', '/work/api', 'Fix the auth callback', '1.0.0', ?, ?, '{"id":"gpt-5.4","providerID":"opencode","variant":"default"}', 'build')
   `).run(start, start + 4000)
 
   db.prepare(`

--- a/packages/core/src/parsers/opencode.ts
+++ b/packages/core/src/parsers/opencode.ts
@@ -3,7 +3,7 @@ import { basename, dirname, join } from 'node:path'
 import type { ParseSessionResult, ParsedMessage, ParsedSession } from '../types.js'
 import { stripSpoolSystemPrelude } from './spool-prelude.js'
 
-export const OPENCODE_INDEX_VERSION = 'opencode-v2-sqlite-parent-subagents'
+export const OPENCODE_INDEX_VERSION = 'opencode-v3-session-model-json'
 export const OPENCODE_DB_NAME = 'opencode.db'
 const OPENCODE_SESSION_SEPARATOR = '#session='
 const OPENCODE_SUBAGENT_PARENT_PREFIX = 'opencode-subagent:'
@@ -389,9 +389,21 @@ function modelFromMessage(message: OpenCodeMessageData): string {
   return modelId ?? ''
 }
 
+// OpenCode stores `session.model` as a serialized JSON object
+// (`{"id","providerID","variant"?}`), not a plain string — so trim alone would
+// leak raw JSON into the model field. Parse it into the same `provider/model`
+// shape modelFromMessage produces; fall back to the trimmed string for any
+// non-JSON or unparseable value.
 function normalizeModel(model: string | null): string {
   if (!model) return ''
-  return model.trim()
+  const trimmed = model.trim()
+  if (!trimmed.startsWith('{')) return trimmed
+  const parsed = parseJson<{ id?: string; modelID?: string; providerID?: string }>(trimmed)
+  if (!parsed) return trimmed
+  const providerId = parsed.providerID
+  const modelId = parsed.modelID ?? parsed.id
+  if (providerId && modelId) return `${providerId}/${modelId}`
+  return modelId ?? ''
 }
 
 function parseJson<T>(raw: string): T | null {


### PR DESCRIPTION
## What

OpenCode session rows displayed their model as a raw JSON blob — e.g. `{"id":"big-pickle","providerID":"opencode"}` — instead of a readable model id, unlike every other source (`claude-opus-4-7`, `gpt-5.4`, …).

## Why

Real `opencode.db` stores `session.model` as a serialized JSON object (`{"id","providerID","variant"?}`), not a plain string. `normalizeModel` only `.trim()`'d the column, so the JSON passed straight through to the indexed model field and into the session list UI. The existing test never caught it because its fixture seeded `session.model` as a plain string, which doesn't match the real schema.

## How it connects

- `normalizeModel` now parses the JSON safely (reusing the existing `parseJson` helper, so a malformed blob can't throw) and returns `providerID/id` — the same `provider/model` shape `modelFromMessage` already produces from message rows. Non-JSON / unparseable values fall back to the trimmed string.
- `OPENCODE_INDEX_VERSION` bumped to `opencode-v3-session-model-json` so sessions already indexed with the leaked value re-parse on next sync.

## Test plan

- Updated the main parser fixture to seed the realistic JSON shape, turning the existing assertion into a genuine regression test (fails on pre-fix code).
- Added a focused test covering full (`provider/id`), no-provider (`id` only), malformed-JSON (raw fallback), and plain-string cases.
- Updated the two indexed-mtime version assertions.
- `vitest` opencode suite 10/10; full core suite 345 pass / 1 skip; `tsc --noEmit` clean.
- Verified live: dev app re-indexed a real OpenCode session from the JSON blob to `opencode/big-pickle`; no `{`-prefixed model values remain DB-wide.

Note: OpenCode keeps a `provider/` prefix (`opencode/big-pickle`) where other sources show bare ids. Normalizing that for display (`compactModel`) is a separate, optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)