### PR TITLE
fix(app): keep session scrolling responsive

### DIFF
--- a/packages/app/e2e/session-detail.spec.ts
+++ b/packages/app/e2e/session-detail.spec.ts
@@ -209,3 +209,85 @@ test('custom session scrollbar thumb follows pointer while dragging long session
   const after = await scroller.evaluate((el) => el.scrollTop)
   expect(after).toBeGreaterThan(before.scrollTop)
 })
+
+test('clicking the scrollbar track jumps the message list to that position', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  await window.locator('[data-testid="sidebar-project-row"]').first().click()
+  await window
+    .locator(`[data-testid="session-row"][data-session-uuid="${LARGE_SESSION_UUID}"]`)
+    .click()
+  await expect(window.locator('[data-testid="session-detail"]')).toBeVisible({ timeout: 10000 })
+
+  const scroller = window.locator('[data-testid="message-list-scroll"]')
+  const track = window.locator('[data-testid="message-scrollbar-track"]')
+  await expect
+    .poll(
+      async () => scroller.evaluate((el) => el.scrollHeight - el.clientHeight),
+      { timeout: 3000 },
+    )
+    .toBeGreaterThan(0)
+  await expect(track).toBeVisible()
+
+  const before = await scroller.evaluate((el) => el.scrollTop)
+
+  const trackBox = await track.boundingBox()
+  if (!trackBox) throw new Error('missing scrollbar track box')
+
+  await window.mouse.click(
+    trackBox.x + trackBox.width / 2,
+    trackBox.y + trackBox.height * 0.75,
+  )
+
+  await expect
+    .poll(async () => scroller.evaluate((el) => el.scrollTop), { timeout: 3000 })
+    .toBeGreaterThan(before + 200)
+})
+
+test('dragging the scrollbar thumb to the bottom reaches the actual list end', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  await window.locator('[data-testid="sidebar-project-row"]').first().click()
+  await window
+    .locator(`[data-testid="session-row"][data-session-uuid="${LARGE_SESSION_UUID}"]`)
+    .click()
+  await expect(window.locator('[data-testid="session-detail"]')).toBeVisible({ timeout: 10000 })
+
+  const scroller = window.locator('[data-testid="message-list-scroll"]')
+  const thumb = window.locator('[data-testid="message-scrollbar-thumb"]')
+  await expect
+    .poll(
+      async () => scroller.evaluate((el) => el.scrollHeight - el.clientHeight),
+      { timeout: 3000 },
+    )
+    .toBeGreaterThan(0)
+  await expect(thumb).toBeVisible()
+
+  const thumbBox = await thumb.boundingBox()
+  if (!thumbBox) throw new Error('missing scrollbar thumb box')
+  const trackBox = await window.locator('[data-testid="message-scrollbar-track"]').boundingBox()
+  if (!trackBox) throw new Error('missing scrollbar track box')
+
+  const startX = thumbBox.x + thumbBox.width / 2
+  const startY = thumbBox.y + thumbBox.height / 2
+  const bottomY = trackBox.y + trackBox.height - 2
+
+  await window.mouse.move(startX, startY)
+  await window.mouse.down()
+  await window.mouse.move(startX, bottomY, { steps: 30 })
+  await window.mouse.up()
+
+  // The bug being regressed: pixel-ratio scrollTop math couldn't reach the
+  // true bottom because Virtuoso's scrollHeight estimate (1500 × 64) is
+  // smaller than the real measured total once markdown rows expand. With
+  // scrollToIndex(rowCount - 1), the scroller must land at the true max.
+  await expect
+    .poll(
+      async () =>
+        scroller.evaluate((el) => el.scrollHeight - el.clientHeight - el.scrollTop),
+      { timeout: 5000 },
+    )
+    .toBeLessThan(16)
+})

--- a/packages/app/e2e/session-detail.spec.ts
+++ b/packages/app/e2e/session-detail.spec.ts
@@ -155,3 +155,57 @@ test('handles 1500-message session: virtualization + deep find', async () => {
   })
   await expect(window.locator('[data-testid="session-find-active-match"]')).toHaveCount(1)
 })
+
+test('custom session scrollbar thumb follows pointer while dragging long sessions', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  await window.locator('[data-testid="sidebar-project-row"]').first().click()
+  await window
+    .locator(`[data-testid="session-row"][data-session-uuid="${LARGE_SESSION_UUID}"]`)
+    .click()
+  await expect(window.locator('[data-testid="session-detail"]')).toBeVisible({ timeout: 10000 })
+
+  const scroller = window.locator('[data-testid="message-list-scroll"]')
+  const thumb = window.locator('[data-testid="message-scrollbar-thumb"]')
+  await expect
+    .poll(
+      async () => scroller.evaluate((el) => el.scrollHeight - el.clientHeight),
+      { timeout: 3000 },
+    )
+    .toBeGreaterThan(0)
+  await expect(thumb).toBeVisible()
+
+  const before = await scroller.evaluate((el) => ({
+    scrollTop: el.scrollTop,
+    maxScrollTop: el.scrollHeight - el.clientHeight,
+  }))
+  expect(before.maxScrollTop).toBeGreaterThan(0)
+
+  const thumbBox = await thumb.boundingBox()
+  if (!thumbBox) throw new Error('missing scrollbar thumb box')
+  const trackBox = await window.locator('[data-testid="message-scrollbar-track"]').boundingBox()
+  if (!trackBox) throw new Error('missing scrollbar track box')
+
+  const startX = thumbBox.x + thumbBox.width / 2
+  const startY = thumbBox.y + thumbBox.height / 2
+  const targetY = Math.min(trackBox.y + trackBox.height - thumbBox.height / 2 - 8, startY + 120)
+
+  await window.mouse.move(startX, startY)
+  await window.mouse.down()
+  await window.mouse.move(startX, targetY, { steps: 12 })
+
+  await expect
+    .poll(async () => {
+      const draggingThumbBox = await thumb.boundingBox()
+      if (!draggingThumbBox) return Number.POSITIVE_INFINITY
+      const draggingThumbCenter = draggingThumbBox.y + draggingThumbBox.height / 2
+      return Math.abs(draggingThumbCenter - targetY)
+    })
+    .toBeLessThan(16)
+
+  await window.mouse.up()
+
+  const after = await scroller.evaluate((el) => el.scrollTop)
+  expect(after).toBeGreaterThan(before.scrollTop)
+})

--- a/packages/app/src/renderer/components/MessageList.tsx
+++ b/packages/app/src/renderer/components/MessageList.tsx
@@ -1,7 +1,7 @@
-import { forwardRef, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ChevronDown, ChevronRight } from 'lucide-react'
-import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
+import { Virtuoso, type Components, type ScrollSeekConfiguration, type ScrollSeekPlaceholderProps, type VirtuosoHandle } from 'react-virtuoso'
 import type { Message } from '@spool-lab/core'
 import MessageBubble, { type FindRange } from './MessageBubble.js'
 
@@ -32,6 +32,15 @@ type Row =
   | { kind: 'msg'; msg: Message; showAvatar: boolean }
   | { kind: 'sidechain'; key: string; label: string; timestamp: string; messages: Message[] }
   | { kind: 'divider'; key: string; isoDay: string; label: string }
+
+const scrollSeekConfiguration: ScrollSeekConfiguration = {
+  enter: (velocity) => Math.abs(velocity) > 600,
+  exit: (velocity) => Math.abs(velocity) < 120,
+}
+
+const virtuosoComponents: Components<Row> = {
+  ScrollSeekPlaceholder: MessageScrollSeekPlaceholder,
+}
 
 /** Stable per-local-day key used for divider grouping + dedup. */
 function localDayKey(iso: string): string {
@@ -167,6 +176,25 @@ function formatRowTime(iso: string, locale: string | undefined): string {
   }
 }
 
+function MessageScrollSeekPlaceholder({ height, type }: ScrollSeekPlaceholderProps) {
+  if (type === 'group') return null
+  return (
+    <div
+      className="px-6 py-2"
+      style={{ height }}
+      aria-hidden
+    >
+      <div className="flex items-start gap-2">
+        <div className="flex-none w-5 h-5 rounded-full mt-0.5 bg-warm-surface2 dark:bg-dark-surface2" />
+        <div className="flex-1 min-w-0 space-y-2 pt-1">
+          <div className="h-3 w-3/4 rounded bg-warm-surface2 dark:bg-dark-surface2" />
+          <div className="h-3 w-1/2 rounded bg-warm-surface2 dark:bg-dark-surface2" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
 const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
   { messages, isDark, showFindBar, messageFindRanges, activeMatchIndex, onActiveMatchRef, targetMessageId, showTargetHighlight },
   ref,
@@ -174,6 +202,14 @@ const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
   const { t, i18n } = useTranslation()
   const virtuosoRef = useRef<VirtuosoHandle | null>(null)
   const [expandedSidechains, setExpandedSidechains] = useState<Set<string>>(() => new Set())
+  const [virtuosoScroller, setVirtuosoScroller] = useState<HTMLElement | null>(null)
+  const [scrollbarSyncNonce, setScrollbarSyncNonce] = useState(0)
+  const bindVirtuosoScroller = useCallback((ref: HTMLElement | Window | null) => {
+    setVirtuosoScroller(ref instanceof HTMLElement ? ref : null)
+  }, [])
+  const requestScrollbarSync = useCallback(() => {
+    setScrollbarSyncNonce((value) => value + 1)
+  }, [])
 
   const dividerLabel = useMemo(
     () => makeDividerLabel(t('session.divider_today'), t('session.divider_yesterday'), i18n.language),
@@ -224,130 +260,255 @@ const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
     )
   }
 
-  return (
-    <Virtuoso
-      ref={virtuosoRef}
-      data={rows}
-      computeItemKey={(_index, row) => row.kind === 'msg' ? `m-${row.msg.id}` : row.key}
-      defaultItemHeight={64}
-      {...(initialIndex ? { initialTopMostItemIndex: initialIndex } : {})}
-      increaseViewportBy={400}
-      data-testid="message-list-scroll"
-      className="flex-1 [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]"
-      itemContent={(index, row) => {
-        if (row.kind === 'divider') {
-          return (
-            <div
-              data-index={index}
-              data-testid="day-divider"
-              data-day={row.isoDay}
-              className="px-6 pt-5 pb-2 flex items-center gap-3 select-none"
-            >
-              <span className="flex-1 h-px bg-warm-border dark:bg-dark-border" />
-              <span className="text-[10px] font-semibold tracking-[0.08em] uppercase text-warm-faint dark:text-dark-muted">
-                {row.label}
-              </span>
-              <span className="flex-1 h-px bg-warm-border dark:bg-dark-border" />
-            </div>
-          )
-        }
-        if (row.kind === 'sidechain') {
-          const rowHasFindMatch = showFindBar && hasFindMatch(row.messages, messageFindRanges)
-          const rowHasTarget = targetMessageId != null && row.messages.some(message => message.id === targetMessageId)
-          const expanded = expandedSidechains.has(row.key) || rowHasFindMatch || rowHasTarget
-          const rowTime = formatRowTime(row.timestamp, i18n.language)
+  const renderRowContent = (index: number, row: Row) => {
+    if (row.kind === 'divider') {
+      return (
+        <div
+          data-index={index}
+          data-testid="day-divider"
+          data-day={row.isoDay}
+          className="px-6 pt-5 pb-2 flex items-center gap-3 select-none"
+        >
+          <span className="flex-1 h-px bg-warm-border dark:bg-dark-border" />
+          <span className="text-[10px] font-semibold tracking-[0.08em] uppercase text-warm-faint dark:text-dark-muted">
+            {row.label}
+          </span>
+          <span className="flex-1 h-px bg-warm-border dark:bg-dark-border" />
+        </div>
+      )
+    }
+    if (row.kind === 'sidechain') {
+      const rowHasFindMatch = showFindBar && hasFindMatch(row.messages, messageFindRanges)
+      const rowHasTarget = targetMessageId != null && row.messages.some(message => message.id === targetMessageId)
+      const expanded = expandedSidechains.has(row.key) || rowHasFindMatch || rowHasTarget
+      const rowTime = formatRowTime(row.timestamp, i18n.language)
 
-          return (
-            <div data-index={index} className="px-6 py-2">
-              <button
-                type="button"
-                onClick={() => {
-                  setExpandedSidechains((current) => {
-                    const next = new Set(current)
-                    if (next.has(row.key)) next.delete(row.key)
-                    else next.add(row.key)
-                    return next
-                  })
-                }}
-                className="w-full min-w-0 flex items-center gap-2 rounded-md border border-warm-border dark:border-dark-border bg-warm-surface/70 dark:bg-dark-surface/70 px-3 py-2 text-left hover:bg-warm-surface2 dark:hover:bg-dark-surface2 transition-colors"
-              >
-                {expanded ? (
-                  <ChevronDown size={14} strokeWidth={1.8} className="flex-none text-warm-faint dark:text-dark-muted" aria-hidden />
-                ) : (
-                  <ChevronRight size={14} strokeWidth={1.8} className="flex-none text-warm-faint dark:text-dark-muted" aria-hidden />
-                )}
-                <span className="flex-1 min-w-0 truncate text-xs font-medium text-warm-muted dark:text-dark-muted">
-                  {row.label}
-                </span>
-                <span className="flex-none text-[10px] font-mono text-warm-faint dark:text-dark-muted">
-                  {t('session.messages_other', { count: row.messages.length })}
-                  {rowTime ? ` · ${rowTime}` : ''}
-                </span>
-              </button>
-
-              {expanded && (
-                <div className="mt-2 ml-2 border-l border-warm-border dark:border-dark-border">
-                  {row.messages.map((message, messageIndex) => {
-                    const matchState = showFindBar ? messageFindRanges.get(message.id) : undefined
-                    const containsActive = matchState != null
-                      && activeMatchIndex >= matchState.offset
-                      && activeMatchIndex < matchState.offset + matchState.ranges.length
-                    const isTarget = message.id === targetMessageId
-
-                    return (
-                      <div
-                        key={message.id}
-                        {...(isTarget ? { 'data-testid': 'target-message' } : {})}
-                        {...(isTarget && showTargetHighlight ? { 'data-highlighted': '1' } : {})}
-                        className={`transition-colors duration-700 ${
-                          isTarget && showTargetHighlight ? 'bg-accent/10 dark:bg-accent-dark/10' : ''
-                        }`}
-                      >
-                        <MessageBubble
-                          message={message}
-                          isDark={isDark}
-                          showAvatar={shouldShowAvatarInGroup(row.messages, messageIndex)}
-                          {...(matchState ? { findRanges: matchState.ranges, matchIndexOffset: matchState.offset } : {})}
-                          activeMatchIndex={containsActive ? activeMatchIndex : -1}
-                          {...(containsActive ? { onActiveMatchRef } : {})}
-                        />
-                      </div>
-                    )
-                  })}
-                </div>
-              )}
-            </div>
-          )
-        }
-        const msg = row.msg
-        const matchState = showFindBar ? messageFindRanges.get(msg.id) : undefined
-        const containsActive = matchState != null
-          && activeMatchIndex >= matchState.offset
-          && activeMatchIndex < matchState.offset + matchState.ranges.length
-        const isTarget = msg.id === targetMessageId
-
-        return (
-          <div
-            data-index={index}
-            {...(isTarget ? { 'data-testid': 'target-message' } : {})}
-            {...(isTarget && showTargetHighlight ? { 'data-highlighted': '1' } : {})}
-            className={`transition-colors duration-700 ${
-              isTarget && showTargetHighlight ? 'bg-accent/10 dark:bg-accent-dark/10' : ''
-            }`}
+      return (
+        <div data-index={index} className="px-6 py-2">
+          <button
+            type="button"
+            onClick={() => {
+              setExpandedSidechains((current) => {
+                const next = new Set(current)
+                if (next.has(row.key)) next.delete(row.key)
+                else next.add(row.key)
+                return next
+              })
+            }}
+            className="w-full min-w-0 flex items-center gap-2 rounded-md border border-warm-border dark:border-dark-border bg-warm-surface/70 dark:bg-dark-surface/70 px-3 py-2 text-left hover:bg-warm-surface2 dark:hover:bg-dark-surface2 transition-colors"
           >
-            <MessageBubble
-              message={msg}
-              isDark={isDark}
-              showAvatar={row.showAvatar}
-              {...(matchState ? { findRanges: matchState.ranges, matchIndexOffset: matchState.offset } : {})}
-              activeMatchIndex={containsActive ? activeMatchIndex : -1}
-              {...(containsActive ? { onActiveMatchRef } : {})}
-            />
-          </div>
-        )
-      }}
-    />
+            {expanded ? (
+              <ChevronDown size={14} strokeWidth={1.8} className="flex-none text-warm-faint dark:text-dark-muted" aria-hidden />
+            ) : (
+              <ChevronRight size={14} strokeWidth={1.8} className="flex-none text-warm-faint dark:text-dark-muted" aria-hidden />
+            )}
+            <span className="flex-1 min-w-0 truncate text-xs font-medium text-warm-muted dark:text-dark-muted">
+              {row.label}
+            </span>
+            <span className="flex-none text-[10px] font-mono text-warm-faint dark:text-dark-muted">
+              {t('session.messages_other', { count: row.messages.length })}
+              {rowTime ? ` · ${rowTime}` : ''}
+            </span>
+          </button>
+
+          {expanded && (
+            <div className="mt-2 ml-2 border-l border-warm-border dark:border-dark-border">
+              {row.messages.map((message, messageIndex) => {
+                const matchState = showFindBar ? messageFindRanges.get(message.id) : undefined
+                const containsActive = matchState != null
+                  && activeMatchIndex >= matchState.offset
+                  && activeMatchIndex < matchState.offset + matchState.ranges.length
+                const isTarget = message.id === targetMessageId
+
+                return (
+                  <div
+                    key={message.id}
+                    data-message-id={message.id}
+                    {...(isTarget ? { 'data-testid': 'target-message' } : {})}
+                    {...(isTarget && showTargetHighlight ? { 'data-highlighted': '1' } : {})}
+                    className={`transition-colors duration-700 ${
+                      isTarget && showTargetHighlight ? 'bg-accent/10 dark:bg-accent-dark/10' : ''
+                    }`}
+                  >
+                    <MessageBubble
+                      message={message}
+                      isDark={isDark}
+                      showAvatar={shouldShowAvatarInGroup(row.messages, messageIndex)}
+                      {...(matchState ? { findRanges: matchState.ranges, matchIndexOffset: matchState.offset } : {})}
+                      activeMatchIndex={containsActive ? activeMatchIndex : -1}
+                      {...(containsActive ? { onActiveMatchRef } : {})}
+                    />
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )
+    }
+    const msg = row.msg
+    const matchState = showFindBar ? messageFindRanges.get(msg.id) : undefined
+    const containsActive = matchState != null
+      && activeMatchIndex >= matchState.offset
+      && activeMatchIndex < matchState.offset + matchState.ranges.length
+    const isTarget = msg.id === targetMessageId
+
+    return (
+      <div
+        data-index={index}
+        data-message-id={msg.id}
+        {...(isTarget ? { 'data-testid': 'target-message' } : {})}
+        {...(isTarget && showTargetHighlight ? { 'data-highlighted': '1' } : {})}
+        className={`transition-colors duration-700 ${
+          isTarget && showTargetHighlight ? 'bg-accent/10 dark:bg-accent-dark/10' : ''
+        }`}
+      >
+        <MessageBubble
+          message={msg}
+          isDark={isDark}
+          showAvatar={row.showAvatar}
+          {...(matchState ? { findRanges: matchState.ranges, matchIndexOffset: matchState.offset } : {})}
+          activeMatchIndex={containsActive ? activeMatchIndex : -1}
+          {...(containsActive ? { onActiveMatchRef } : {})}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative flex-1 min-h-0">
+      <Virtuoso
+        ref={virtuosoRef}
+        scrollerRef={bindVirtuosoScroller}
+        data={rows}
+        computeItemKey={(_index, row) => row.kind === 'msg' ? `m-${row.msg.id}` : row.key}
+        defaultItemHeight={64}
+        {...(initialIndex ? { initialTopMostItemIndex: initialIndex } : {})}
+        increaseViewportBy={400}
+        scrollSeekConfiguration={scrollSeekConfiguration}
+        totalListHeightChanged={requestScrollbarSync}
+        components={virtuosoComponents}
+        data-testid="message-list-scroll"
+        className="h-full scrollbar-none [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]"
+        itemContent={renderRowContent}
+      />
+      <MessageScrollbar scroller={virtuosoScroller} syncNonce={scrollbarSyncNonce} />
+    </div>
   )
 })
 
 export default MessageList
+
+function MessageScrollbar({ scroller, syncNonce }: { scroller: HTMLElement | null; syncNonce: number }) {
+  const trackRef = useRef<HTMLDivElement | null>(null)
+  const draggingRef = useRef(false)
+  const [metrics, setMetrics] = useState({
+    clientHeight: 0,
+    scrollHeight: 0,
+    scrollTop: 0,
+  })
+  const [dragThumbTop, setDragThumbTop] = useState<number | null>(null)
+
+  const syncMetrics = useCallback(() => {
+    if (!scroller || draggingRef.current) return
+    const next = {
+      clientHeight: scroller.clientHeight,
+      scrollHeight: scroller.scrollHeight,
+      scrollTop: scroller.scrollTop,
+    }
+    setMetrics((prev) => {
+      if (
+        prev.clientHeight === next.clientHeight &&
+        prev.scrollHeight === next.scrollHeight &&
+        prev.scrollTop === next.scrollTop
+      ) {
+        return prev
+      }
+      return next
+    })
+  }, [scroller])
+
+  useEffect(() => {
+    if (!scroller) return
+    syncMetrics()
+    scroller.addEventListener('scroll', syncMetrics, { passive: true })
+
+    const observer = new ResizeObserver(() => syncMetrics())
+    observer.observe(scroller)
+    const content = scroller.querySelector('[data-virtuoso-scroller] > *') ?? scroller.firstElementChild
+    if (content instanceof Element) observer.observe(content)
+
+    return () => {
+      scroller.removeEventListener('scroll', syncMetrics)
+      observer.disconnect()
+    }
+  }, [scroller, syncMetrics])
+
+  useEffect(() => {
+    syncMetrics()
+  }, [syncMetrics, syncNonce])
+
+  if (!scroller || metrics.scrollHeight <= metrics.clientHeight || metrics.clientHeight === 0) {
+    return null
+  }
+
+  const trackInset = 4
+  const trackHeight = Math.max(0, metrics.clientHeight - trackInset * 2)
+  const thumbHeight = Math.max(24, Math.round((metrics.clientHeight / metrics.scrollHeight) * trackHeight))
+  const maxThumbTop = Math.max(0, trackHeight - thumbHeight)
+  const maxScrollTop = Math.max(1, metrics.scrollHeight - metrics.clientHeight)
+  const syncedThumbTop = Math.round((metrics.scrollTop / maxScrollTop) * maxThumbTop)
+  const thumbTop = dragThumbTop ?? syncedThumbTop
+
+  const scrollToThumbTop = (top: number) => {
+    const nextTop = Math.max(0, Math.min(maxThumbTop, top))
+    setDragThumbTop(nextTop)
+    scroller.scrollTop = maxThumbTop === 0 ? 0 : (nextTop / maxThumbTop) * maxScrollTop
+  }
+
+  return (
+    <div
+      ref={trackRef}
+      data-testid="message-scrollbar-track"
+      className="absolute right-0 top-1 bottom-1 w-3 z-10"
+      aria-hidden
+      onPointerDown={(event) => {
+        if (event.target !== event.currentTarget) return
+        const rect = event.currentTarget.getBoundingClientRect()
+        scrollToThumbTop(event.clientY - rect.top - thumbHeight / 2)
+      }}
+    >
+      <div
+        data-testid="message-scrollbar-thumb"
+        className="absolute right-0.5 w-2 rounded-full bg-[var(--spool-scrollbar-thumb)] hover:bg-[var(--spool-scrollbar-thumb-hover)]"
+        style={{ height: thumbHeight, transform: `translateY(${thumbTop}px)` }}
+        onPointerDown={(event) => {
+          event.preventDefault()
+          event.currentTarget.setPointerCapture(event.pointerId)
+          draggingRef.current = true
+          const trackRect = trackRef.current?.getBoundingClientRect()
+          const grabOffset = trackRect ? event.clientY - trackRect.top - thumbTop : 0
+
+          const handlePointerMove = (moveEvent: PointerEvent) => {
+            const rect = trackRef.current?.getBoundingClientRect()
+            if (!rect) return
+            scrollToThumbTop(moveEvent.clientY - rect.top - grabOffset)
+          }
+
+          const handlePointerUp = () => {
+            draggingRef.current = false
+            setDragThumbTop(null)
+            syncMetrics()
+            window.removeEventListener('pointermove', handlePointerMove)
+            window.removeEventListener('pointerup', handlePointerUp)
+            window.removeEventListener('pointercancel', handlePointerUp)
+          }
+
+          window.addEventListener('pointermove', handlePointerMove)
+          window.addEventListener('pointerup', handlePointerUp)
+          window.addEventListener('pointercancel', handlePointerUp)
+        }}
+      />
+    </div>
+  )
+}

--- a/packages/app/src/renderer/components/MessageList.tsx
+++ b/packages/app/src/renderer/components/MessageList.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ChevronDown, ChevronRight } from 'lucide-react'
-import { Virtuoso, type Components, type ScrollSeekConfiguration, type ScrollSeekPlaceholderProps, type VirtuosoHandle } from 'react-virtuoso'
+import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
 import type { Message } from '@spool-lab/core'
 import MessageBubble, { type FindRange } from './MessageBubble.js'
 
@@ -32,15 +32,6 @@ type Row =
   | { kind: 'msg'; msg: Message; showAvatar: boolean }
   | { kind: 'sidechain'; key: string; label: string; timestamp: string; messages: Message[] }
   | { kind: 'divider'; key: string; isoDay: string; label: string }
-
-const scrollSeekConfiguration: ScrollSeekConfiguration = {
-  enter: (velocity) => Math.abs(velocity) > 600,
-  exit: (velocity) => Math.abs(velocity) < 120,
-}
-
-const virtuosoComponents: Components<Row> = {
-  ScrollSeekPlaceholder: MessageScrollSeekPlaceholder,
-}
 
 /** Stable per-local-day key used for divider grouping + dedup. */
 function localDayKey(iso: string): string {
@@ -134,7 +125,7 @@ function buildRows(messages: Message[], label: DividerLabel): Row[] {
         messages: visibleSidechainMessages(group),
       }
     } else {
-      const showAvatar =
+      const showAvatar: boolean =
         !prevMsg || prevMsg.role !== msg.role || prevMsg.role === 'system'
       row = { kind: 'msg', msg, showAvatar }
     }
@@ -174,25 +165,6 @@ function formatRowTime(iso: string, locale: string | undefined): string {
   } catch {
     return ''
   }
-}
-
-function MessageScrollSeekPlaceholder({ height, type }: ScrollSeekPlaceholderProps) {
-  if (type === 'group') return null
-  return (
-    <div
-      className="px-6 py-2"
-      style={{ height }}
-      aria-hidden
-    >
-      <div className="flex items-start gap-2">
-        <div className="flex-none w-5 h-5 rounded-full mt-0.5 bg-warm-surface2 dark:bg-dark-surface2" />
-        <div className="flex-1 min-w-0 space-y-2 pt-1">
-          <div className="h-3 w-3/4 rounded bg-warm-surface2 dark:bg-dark-surface2" />
-          <div className="h-3 w-1/2 rounded bg-warm-surface2 dark:bg-dark-surface2" />
-        </div>
-      </div>
-    </div>
-  )
 }
 
 const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
@@ -251,6 +223,19 @@ const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
       virtuosoRef.current?.scrollIntoView({ index: idx, align: 'center', behavior: 'auto' })
     },
   }), [idToRowIndex])
+
+  // Custom scrollbar maps thumb position → row index → Virtuoso scrollToIndex.
+  // We can't use scrollTop directly because Virtuoso estimates scrollHeight
+  // from defaultItemHeight; real rows (markdown bubbles) are usually taller,
+  // so a pixel-ratio map can't reach the actual top/bottom until rows measure.
+  const rowCount = rows.length
+  const scrollToRatio = useCallback((ratio: number) => {
+    const handle = virtuosoRef.current
+    if (!handle || rowCount === 0) return
+    const clamped = Math.max(0, Math.min(1, ratio))
+    const index = Math.round(clamped * (rowCount - 1))
+    handle.scrollToIndex({ index, align: 'start', behavior: 'auto' })
+  }, [rowCount])
 
   if (messages.length === 0) {
     return (
@@ -385,29 +370,49 @@ const MessageList = forwardRef<MessageListHandle, Props>(function MessageList(
         defaultItemHeight={64}
         {...(initialIndex ? { initialTopMostItemIndex: initialIndex } : {})}
         increaseViewportBy={400}
-        scrollSeekConfiguration={scrollSeekConfiguration}
         totalListHeightChanged={requestScrollbarSync}
-        components={virtuosoComponents}
         data-testid="message-list-scroll"
         className="h-full scrollbar-none [mask-image:linear-gradient(to_bottom,black_calc(100%_-_24px),transparent)]"
         itemContent={renderRowContent}
       />
-      <MessageScrollbar scroller={virtuosoScroller} syncNonce={scrollbarSyncNonce} />
+      <MessageScrollbar
+        scroller={virtuosoScroller}
+        syncNonce={scrollbarSyncNonce}
+        scrollToRatio={scrollToRatio}
+      />
     </div>
   )
 })
 
 export default MessageList
 
-function MessageScrollbar({ scroller, syncNonce }: { scroller: HTMLElement | null; syncNonce: number }) {
+function MessageScrollbar({
+  scroller,
+  syncNonce,
+  scrollToRatio,
+}: {
+  scroller: HTMLElement | null
+  syncNonce: number
+  scrollToRatio: (ratio: number) => void
+}) {
   const trackRef = useRef<HTMLDivElement | null>(null)
   const draggingRef = useRef(false)
+  const activeDragRef = useRef<{ move: (event: PointerEvent) => void; up: () => void } | null>(null)
   const [metrics, setMetrics] = useState({
     clientHeight: 0,
     scrollHeight: 0,
     scrollTop: 0,
   })
   const [dragThumbTop, setDragThumbTop] = useState<number | null>(null)
+
+  useEffect(() => () => {
+    const active = activeDragRef.current
+    if (!active) return
+    window.removeEventListener('pointermove', active.move)
+    window.removeEventListener('pointerup', active.up)
+    window.removeEventListener('pointercancel', active.up)
+    activeDragRef.current = null
+  }, [])
 
   const syncMetrics = useCallback(() => {
     if (!scroller || draggingRef.current) return
@@ -435,8 +440,8 @@ function MessageScrollbar({ scroller, syncNonce }: { scroller: HTMLElement | nul
 
     const observer = new ResizeObserver(() => syncMetrics())
     observer.observe(scroller)
-    const content = scroller.querySelector('[data-virtuoso-scroller] > *') ?? scroller.firstElementChild
-    if (content instanceof Element) observer.observe(content)
+    const content = scroller.firstElementChild
+    if (content) observer.observe(content)
 
     return () => {
       scroller.removeEventListener('scroll', syncMetrics)
@@ -463,7 +468,7 @@ function MessageScrollbar({ scroller, syncNonce }: { scroller: HTMLElement | nul
   const scrollToThumbTop = (top: number) => {
     const nextTop = Math.max(0, Math.min(maxThumbTop, top))
     setDragThumbTop(nextTop)
-    scroller.scrollTop = maxThumbTop === 0 ? 0 : (nextTop / maxThumbTop) * maxScrollTop
+    scrollToRatio(maxThumbTop === 0 ? 0 : nextTop / maxThumbTop)
   }
 
   return (
@@ -502,8 +507,10 @@ function MessageScrollbar({ scroller, syncNonce }: { scroller: HTMLElement | nul
             window.removeEventListener('pointermove', handlePointerMove)
             window.removeEventListener('pointerup', handlePointerUp)
             window.removeEventListener('pointercancel', handlePointerUp)
+            activeDragRef.current = null
           }
 
+          activeDragRef.current = { move: handlePointerMove, up: handlePointerUp }
           window.addEventListener('pointermove', handlePointerMove)
           window.addEventListener('pointerup', handlePointerUp)
           window.addEventListener('pointercancel', handlePointerUp)


### PR DESCRIPTION
On long session detail views, the custom scrollbar thumb could drift out of sync with the mouse while dragging, making the list feel broken and hard to navigate. This change keeps the thumb position tied to the pointer during drag operations, syncs it back to the virtualized message scroller after interaction, and uses lightweight scroll-seek placeholders so large sessions remain responsive while scrolling. It also adds e2e coverage for dragging the session scrollbar in a 1500-message session.