### PR TITLE
feat(security): purge a leaked value everywhere in one action

### DIFF
--- a/packages/app/e2e/security-blast-radius.spec.ts
+++ b/packages/app/e2e/security-blast-radius.spec.ts
@@ -87,3 +87,36 @@ test('credential finding shows cross-session blast radius; PII does not', async 
   await expect(radius.locator('[data-testid="blast-radius-row"]')).toHaveCount(1)
   await expect(radius.locator('[data-testid="blast-radius-row"] [data-testid="source-dot"]')).toHaveCount(1)
 })
+
+test('purge everywhere scrubs every copy and collapses the radius', async () => {
+  const { window } = ctx
+  await window.locator('[data-testid="sidebar-security"]').click()
+  await expect(window.locator('[data-testid="security-page"]')).toBeVisible()
+
+  const apiRow = window.locator('[data-testid="finding-row-wrap"]').filter({
+    has: window.locator('[data-testid="finding-row"][data-kind="api-key"]'),
+  }).first()
+  const radius = apiRow.locator('[data-testid="blast-radius"]')
+  await expect(radius).toBeVisible({ timeout: 10_000 })
+  // Expand idempotently — the BlastRadius component is not remounted
+  // between tests in this file, so its `expanded` state can already be
+  // true from the previous test. Toggle only if currently collapsed,
+  // then wait for the list rather than assuming the click expanded it.
+  const toggle = radius.locator('[data-testid="blast-radius-toggle"]')
+  if ((await toggle.getAttribute('aria-expanded')) !== 'true') await toggle.click()
+  await expect(radius.locator('[data-testid="blast-radius-list"]')).toBeVisible()
+
+  // The "Purge everywhere" CTA opens the bulk confirm dialog.
+  await radius.locator('[data-testid="purge-everywhere"]').click()
+  const dialog = window.locator('[data-testid="purge-confirm"]')
+  await expect(dialog).toBeVisible()
+  await dialog.locator('[data-testid="purge-confirm-button"]').click()
+
+  // After purge: no api-key finding anywhere shows a blast radius (the
+  // value is masked across both sessions → 0 active occurrences). This
+  // is the UI proof that purge-everywhere reached every copy. FTS
+  // re-sync is asserted deterministically in the core purge unit test
+  // (purge.test.ts → 'keeps messages_fts in sync'), so it's not
+  // re-checked through the flakier search path here.
+  await expect(window.locator('[data-testid="blast-radius"]')).toHaveCount(0, { timeout: 10_000 })
+})

--- a/packages/app/src/main/ipc/security.test.ts
+++ b/packages/app/src/main/ipc/security.test.ts
@@ -334,6 +334,32 @@ describe('registerSecurityIpc', () => {
       expect(results).toHaveLength(1)
     })
 
+    it('PURGE_EVERYWHERE scrubs the value across sessions + returns touched sessions', async () => {
+      // Same value (one hash) in two sessions.
+      fixture.db.prepare(
+        `INSERT INTO sessions (id, project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count)
+         VALUES (2, 1, 1, 's-2', '/p/s-2', 'Session 2', '2026-01-02', '2026-01-02', 1)`,
+      ).run()
+      fixture.db.prepare(
+        `INSERT INTO messages (id, session_id, source_id, role, content_text, timestamp, seq)
+         VALUES (20, 2, 1, 'user', 'dup AKIAIOSFODNN7EXAMPLE', '2026-01-02', 0)`,
+      ).run()
+      insertFindings(fixture.db, [
+        { sessionId: 1, messageId: 10, kind: 'api-key', valueHash: 'shared', confidence: 0.95, provider: 'regex', startOffset: 5, endOffset: 25, state: 'active' },
+        { sessionId: 2, messageId: 20, kind: 'api-key', valueHash: 'shared', confidence: 0.95, provider: 'regex', startOffset: 4, endOffset: 24, state: 'active' },
+      ])
+      const out = await invoke<{ count: number; sessionIds: number[] }>(
+        SECURITY_IPC_CHANNELS.PURGE_EVERYWHERE,
+        { kind: 'api-key', valueHash: 'shared' },
+      )
+      expect(out.count).toBe(2)
+      expect([...out.sessionIds].sort()).toEqual([1, 2])
+      for (const id of [10, 20]) {
+        const msg = fixture.db.prepare('SELECT content_text FROM messages WHERE id = ?').get(id) as { content_text: string }
+        expect(msg.content_text.includes('AKIAIOSFODNN7EXAMPLE')).toBe(false)
+      }
+    })
+
     it('RESCAN_ALL delegates to worker.rescanAll and wraps as { count }', async () => {
       const result = await invoke<{ count: number }>(SECURITY_IPC_CHANNELS.RESCAN_ALL)
       expect(result.count).toBe(1)

--- a/packages/app/src/main/ipc/security.ts
+++ b/packages/app/src/main/ipc/security.ts
@@ -23,6 +23,7 @@ import {
   undismissFinding,
   purgeFinding,
   purgeFindings,
+  purgeEverywhere,
   listAllowlistEntries,
   countAllowlistEntries,
   removeAllowlistSession,
@@ -68,6 +69,7 @@ export const SECURITY_IPC_CHANNELS = {
   UNDISMISS_FINDING:           'security:undismiss-finding',
   PURGE_FINDING:               'security:purge-finding',
   PURGE_FINDINGS:              'security:purge-findings',
+  PURGE_EVERYWHERE:            'security:purge-everywhere',
   RESCAN_ALL:                  'security:rescan-all',
   RESCAN_SESSION:              'security:rescan-session',
 
@@ -268,6 +270,19 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): () => void {
     const results = await runPromise(purgeFindings(findingIds, { db, publish: publish as never })) as PurgeResult[]
     return results
   })
+  ipcMain.handle(
+    SECURITY_IPC_CHANNELS.PURGE_EVERYWHERE,
+    async (_e, args: { kind: SensitiveKind; valueHash: string }) => {
+      const publish = (change: unknown) =>
+        Effect.sync(() => {
+          getMainWindow()?.webContents.send(SECURITY_IPC_CHANNELS.EVT_FINDINGS_CHANGED, change)
+        })
+      const out = await runPromise(
+        purgeEverywhere(args.kind, args.valueHash, { db, publish: publish as never }),
+      ) as { results: PurgeResult[]; sessionIds: number[] }
+      return { count: out.results.length, sessionIds: out.sessionIds }
+    },
+  )
   ipcMain.handle(SECURITY_IPC_CHANNELS.RESCAN_ALL, () =>
     runPromise(worker.rescanAll()).then((count) => ({ count })),
   )

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -286,6 +286,8 @@ const api = {
       ipcRenderer.invoke('security:purge-finding', findingId),
     purgeFindings: (findingIds: number[]): Promise<Array<{ findingId: number; sessionId: number; maskUsed: string; purgedAt: string }>> =>
       ipcRenderer.invoke('security:purge-findings', findingIds),
+    purgeEverywhere: (kind: SensitiveKind, valueHash: string): Promise<{ count: number; sessionIds: number[] }> =>
+      ipcRenderer.invoke('security:purge-everywhere', { kind, valueHash }),
     rescanAll: (): Promise<{ count: number }> =>
       ipcRenderer.invoke('security:rescan-all'),
     rescanSession: (sessionId: number): Promise<{ ok: boolean }> =>

--- a/packages/app/src/renderer/api/security.ts
+++ b/packages/app/src/renderer/api/security.ts
@@ -65,6 +65,8 @@ export const securityApi = {
     window.spool.security.purgeFinding(findingId),
   purgeFindings: (findingIds: number[]) =>
     window.spool.security.purgeFindings(findingIds),
+  purgeEverywhere: (kind: SensitiveKind, valueHash: string) =>
+    window.spool.security.purgeEverywhere(kind, valueHash),
   rescanAll: () => window.spool.security.rescanAll(),
   rescanSession: (sessionId: number) => window.spool.security.rescanSession(sessionId),
 

--- a/packages/app/src/renderer/components/security/BlastRadius.tsx
+++ b/packages/app/src/renderer/components/security/BlastRadius.tsx
@@ -10,10 +10,11 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronRight } from 'lucide-react'
+import { ChevronRight, Eraser } from 'lucide-react'
 import { securityApi, type OccurrenceBySession } from '../../api/security.js'
 import { getSessionSourceColor } from '../../../shared/sessionSources.js'
-import type { SensitiveKind } from '@spool-lab/redact'
+import { HIGH_SEVERITY_KINDS, type SensitiveKind } from '@spool-lab/redact'
+import PurgeConfirmDialog from './PurgeConfirmDialog.js'
 
 interface Props {
   kind: SensitiveKind
@@ -31,6 +32,7 @@ export default function BlastRadius({ kind, valueHash, currentSessionId, onLoade
   const { t } = useTranslation()
   const [rows, setRows] = useState<OccurrenceBySession[] | null>(null)
   const [expanded, setExpanded] = useState(false)
+  const [purgePending, setPurgePending] = useState(false)
 
   const load = useCallback(async () => {
     try {
@@ -65,6 +67,20 @@ export default function BlastRadius({ kind, valueHash, currentSessionId, onLoade
     ? rows
     : rows.filter(r => r.sessionId !== currentSessionId)
   const otherCount = others.length
+  // "Purge everywhere" scrubs every copy across ALL sessions (including
+  // the one being viewed), so its count spans the whole archive — not
+  // just the other sessions surfaced in the headline.
+  const totalCopies = rows.reduce((sum, r) => sum + r.count, 0)
+  const isCredential = HIGH_SEVERITY_KINDS.has(kind)
+
+  async function purgeEverywhere() {
+    try { await securityApi.purgeEverywhere(kind, valueHash) }
+    catch { /* surfaces via onChange → refetch shrinks the radius */ }
+    await load()
+  }
+
+  // Nothing meaningful to show: the value lives only in the current
+  // session (or nowhere). The in-session ×N badge already covers that.
   if (otherCount <= 0) return null
   // Projects among those OTHER sessions — only surfaced when it spans
   // more than one, so we never print the awkward "across 1 project".
@@ -128,8 +144,39 @@ export default function BlastRadius({ kind, valueHash, currentSessionId, onLoade
               )}
             </li>
           ))}
+          {/* Close the loop: after rotating at the source, scrub every
+           *  copy from Spool's surfaces in one transaction. The bulk
+           *  PurgeConfirmDialog makes clear the originals in ~/.claude
+           *  are untouched. Credentials only — the same tier that gets
+           *  the radius. */}
+          {isCredential && (
+            <li>
+              <button
+                type="button"
+                data-testid="purge-everywhere"
+                onClick={() => setPurgePending(true)}
+                className="inline-flex items-center gap-1.5 h-5 -ml-0.5 rounded font-sans text-[11px] text-warm-muted dark:text-dark-muted hover:text-accent dark:hover:text-accent-dark transition-colors"
+              >
+                <Eraser size={12} strokeWidth={1.7} aria-hidden />
+                {t('security.purge_everywhere_cta', {
+                  count: totalCopies,
+                  defaultValue_one: 'Purge everywhere · {{count}} copy',
+                  defaultValue_other: 'Purge everywhere · {{count}} copies',
+                })}
+              </button>
+            </li>
+          )}
         </ul>
       )}
+      <PurgeConfirmDialog
+        open={purgePending}
+        count={totalCopies}
+        kind={kind}
+        bulk
+        hasCredential={isCredential}
+        onConfirm={() => { setPurgePending(false); void purgeEverywhere() }}
+        onCancel={() => setPurgePending(false)}
+      />
     </div>
   )
 }

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -399,6 +399,8 @@
     "blast_radius_sessions_other": "Auch in {{count}} weiteren Sitzungen",
     "blast_radius_projects_one": "{{count}} Projekt",
     "blast_radius_projects_other": "{{count}} Projekte",
+    "purge_everywhere_cta_one": "Überall entfernen · {{count}} Kopie",
+    "purge_everywhere_cta_other": "Überall entfernen · {{count}} Kopien",
     "purge_unknown_value": "der erkannte Wert",
     "purge_bulk_pattern_one": "{{count}} Wert im aktiven Set",
     "purge_bulk_pattern_other": "{{count}} Werte im aktiven Set",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -399,6 +399,8 @@
     "blast_radius_sessions_other": "Also in {{count}} other sessions",
     "blast_radius_projects_one": "{{count}} project",
     "blast_radius_projects_other": "{{count}} projects",
+    "purge_everywhere_cta_one": "Purge everywhere · {{count}} copy",
+    "purge_everywhere_cta_other": "Purge everywhere · {{count}} copies",
     "purge_unknown_value": "the matched value",
     "purge_bulk_pattern_one": "{{count}} value across the active set",
     "purge_bulk_pattern_other": "{{count}} values across the active set",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -399,6 +399,8 @@
     "blast_radius_sessions_other": "Également dans {{count}} autres sessions",
     "blast_radius_projects_one": "{{count}} projet",
     "blast_radius_projects_other": "{{count}} projets",
+    "purge_everywhere_cta_one": "Purger partout · {{count}} copie",
+    "purge_everywhere_cta_other": "Purger partout · {{count}} copies",
     "purge_unknown_value": "la valeur détectée",
     "purge_bulk_pattern_one": "{{count}} valeur dans l'ensemble actif",
     "purge_bulk_pattern_other": "{{count}} valeurs dans l'ensemble actif",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -374,6 +374,7 @@
     "rotate_at_vendor": "{{vendor}} でローテーション",
     "blast_radius_sessions_other": "他の {{count}} 件のセッションにも存在",
     "blast_radius_projects_other": "{{count}} 個のプロジェクト",
+    "purge_everywhere_cta_other": "すべて削除 · {{count}} 件",
     "purge_unknown_value": "一致した値",
     "purge_bulk_pattern_other": "現在の集合内の {{count}} 個の値",
     "purge_bulk_samples_label": "書き換えられる値のサンプル",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -374,6 +374,7 @@
     "rotate_at_vendor": "{{vendor}}에서 교체",
     "blast_radius_sessions_other": "다른 세션 {{count}}개에도 있음",
     "blast_radius_projects_other": "프로젝트 {{count}}개",
+    "purge_everywhere_cta_other": "모든 곳에서 제거 · {{count}}개",
     "purge_unknown_value": "일치한 값",
     "purge_bulk_pattern_other": "활성 세트의 {{count}}개 값",
     "purge_bulk_samples_label": "다시 작성될 값 샘플",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -374,6 +374,7 @@
     "rotate_at_vendor": "在 {{vendor}} 轮换",
     "blast_radius_sessions_other": "另外 {{count}} 个会话中也有",
     "blast_radius_projects_other": "{{count}} 个项目",
+    "purge_everywhere_cta_other": "全部清除 · {{count}} 处",
     "purge_unknown_value": "匹配到的值",
     "purge_bulk_pattern_other": "在当前集合中 {{count}} 个值",
     "purge_bulk_samples_label": "将被改写的值示例",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -374,6 +374,7 @@
     "rotate_at_vendor": "在 {{vendor}} 輪換",
     "blast_radius_sessions_other": "另外 {{count}} 個工作階段中也有",
     "blast_radius_projects_other": "{{count}} 個專案",
+    "purge_everywhere_cta_other": "全部清除 · {{count}} 處",
     "purge_unknown_value": "匹配到的值",
     "purge_bulk_pattern_other": "在目前集合中 {{count}} 個值",
     "purge_bulk_samples_label": "將被改寫的值範例",

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -61,7 +61,7 @@ export type {
 export { scanSession, ScanError } from './scan.js'
 export type { ScanResult, ScanSessionDeps } from './scan.js'
 
-export { purgeFinding, purgeFindings, orderForBulkPurge, PurgeError } from './purge.js'
+export { purgeFinding, purgeFindings, purgeEverywhere, orderForBulkPurge, PurgeError } from './purge.js'
 export type { PurgeResult, PurgeDeps } from './purge.js'
 
 export { makeScanWorker, waitForIdle } from './worker.js'

--- a/packages/core/src/security/purge.test.ts
+++ b/packages/core/src/security/purge.test.ts
@@ -3,7 +3,8 @@ import { Effect } from 'effect'
 import Database from 'better-sqlite3'
 import { runMigrations } from '../db/db.js'
 import { insertFindings, listFindings, updateSessionCounts } from './repo.js'
-import { purgeFinding, purgeFindings, orderForBulkPurge, PurgeError } from './purge.js'
+import { purgeFinding, purgeFindings, purgeEverywhere, orderForBulkPurge, PurgeError } from './purge.js'
+import { occurrencesByValueHash } from './repo.js'
 
 function setupDb(): Database.Database {
   const db = new Database(':memory:')
@@ -225,5 +226,110 @@ describe('purgeFindings bulk', () => {
     it('returns [] for empty input', () => {
       expect(orderForBulkPurge(db, [])).toEqual([])
     })
+  })
+})
+
+describe('purgeEverywhere', () => {
+  function setupMultiSession(): Database.Database {
+    const db = new Database(':memory:')
+    runMigrations(db)
+    db.prepare(
+      `INSERT INTO projects (id, source_id, slug, display_path, display_name)
+       VALUES (1, 1, 'a', '/a', 'a'), (2, 1, 'b', '/b', 'b')`,
+    ).run()
+    db.prepare(
+      `INSERT INTO sessions (id, project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count)
+       VALUES (1, 1, 1, 's-1', '/a/s-1', 'S1', '2026-01-01', '2026-01-01', 1),
+              (2, 1, 1, 's-2', '/a/s-2', 'S2', '2026-01-02', '2026-01-02', 1),
+              (3, 2, 1, 's-3', '/b/s-3', 'S3', '2026-01-03', '2026-01-03', 1)`,
+    ).run()
+    return db
+  }
+
+  const RAW = 'ghp_' + 'abcdefghijklmnopqrstuvwxyz0123456789'
+  const HASH = 'gh-shared'
+
+  let db: Database.Database
+  beforeEach(() => {
+    db = setupMultiSession()
+    // Same key in session 1 (×2 in one message), session 2 (×1), and
+    // session 3 (×1, other project). Plus an unrelated key in session 1
+    // that must survive.
+    insertMessage(db, 10, `first ${RAW} then ${RAW} done`)
+    insertMessage(db, 20, `only ${RAW} here`)
+    insertMessage(db, 30, `${RAW} alone`)
+    const idx10a = `first ${RAW} then ${RAW} done`.indexOf(RAW)
+    const idx10b = `first ${RAW} then ${RAW} done`.lastIndexOf(RAW)
+    insertFindings(db, [
+      { sessionId: 1, messageId: 10, kind: 'api-key', valueHash: HASH, confidence: 0.95, provider: 'regex', startOffset: idx10a, endOffset: idx10a + RAW.length, state: 'active' },
+      { sessionId: 1, messageId: 10, kind: 'api-key', valueHash: HASH, confidence: 0.95, provider: 'regex', startOffset: idx10b, endOffset: idx10b + RAW.length, state: 'active' },
+      { sessionId: 2, messageId: 20, kind: 'api-key', valueHash: HASH, confidence: 0.95, provider: 'regex', startOffset: `only ${RAW} here`.indexOf(RAW), endOffset: `only ${RAW} here`.indexOf(RAW) + RAW.length, state: 'active' },
+      { sessionId: 3, messageId: 30, kind: 'api-key', valueHash: HASH, confidence: 0.95, provider: 'regex', startOffset: 0, endOffset: RAW.length, state: 'active' },
+    ])
+    updateSessionCounts(db, 1); updateSessionCounts(db, 2); updateSessionCounts(db, 3)
+  })
+
+  function findById(db: Database.Database) {
+    return (sessionId: number) => listFindings(db, { sessionId, state: 'any' })
+  }
+
+  it('masks every occurrence of the value across all sessions', async () => {
+    const out = await Effect.runPromise(purgeEverywhere('api-key', HASH, deps(db)))
+    expect(out.results).toHaveLength(4) // 2 + 1 + 1
+    for (const id of [10, 20, 30]) {
+      const msg = db.prepare('SELECT content_text FROM messages WHERE id = ?').get(id) as { content_text: string }
+      expect(msg.content_text.includes(RAW)).toBe(false)
+      expect(msg.content_text.includes('[redacted: GitHub key]')).toBe(true)
+    }
+  })
+
+  it('returns the distinct touched session ids', async () => {
+    const out = await Effect.runPromise(purgeEverywhere('api-key', HASH, deps(db)))
+    expect([...out.sessionIds].sort()).toEqual([1, 2, 3])
+  })
+
+  it('flips all matching findings to purged and zeroes the blast radius', async () => {
+    expect(occurrencesByValueHash(db, 'api-key', HASH)).toHaveLength(3)
+    await Effect.runPromise(purgeEverywhere('api-key', HASH, deps(db)))
+    const all = findById(db)
+    for (const sid of [1, 2, 3]) {
+      expect(all(sid).every(f => f.state === 'purged')).toBe(true)
+    }
+    // No active occurrences remain anywhere → blast radius is empty.
+    expect(occurrencesByValueHash(db, 'api-key', HASH)).toHaveLength(0)
+  })
+
+  it('keeps messages_fts in sync so search no longer surfaces the value', async () => {
+    const before = db.prepare(
+      'SELECT COUNT(*) AS n FROM messages_fts WHERE messages_fts MATCH ?',
+    ).get(`"${RAW}"`) as { n: number }
+    expect(before.n).toBe(3) // one per message containing the key
+    await Effect.runPromise(purgeEverywhere('api-key', HASH, deps(db)))
+    const after = db.prepare(
+      'SELECT COUNT(*) AS n FROM messages_fts WHERE messages_fts MATCH ?',
+    ).get(`"${RAW}"`) as { n: number }
+    expect(after.n).toBe(0)
+  })
+
+  it('does not touch a different value sharing the same kind', async () => {
+    const OTHER = 'ghp_' + 'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ'
+    insertMessage(db, 40, `unrelated ${OTHER}`)
+    db.prepare(
+      `INSERT INTO sessions (id, project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count)
+       VALUES (4, 1, 1, 's-4', '/a/s-4', 'S4', '2026-01-04', '2026-01-04', 1)`,
+    ).run()
+    db.prepare('UPDATE messages SET session_id = 4 WHERE id = 40').run()
+    insertFindings(db, [
+      { sessionId: 4, messageId: 40, kind: 'api-key', valueHash: 'gh-other', confidence: 0.95, provider: 'regex', startOffset: `unrelated `.length, endOffset: `unrelated `.length + OTHER.length, state: 'active' },
+    ])
+    await Effect.runPromise(purgeEverywhere('api-key', HASH, deps(db)))
+    const msg = db.prepare('SELECT content_text FROM messages WHERE id = 40').get() as { content_text: string }
+    expect(msg.content_text.includes(OTHER)).toBe(true) // untouched
+  })
+
+  it('is a no-op (empty results) when nothing matches', async () => {
+    const out = await Effect.runPromise(purgeEverywhere('api-key', 'no-such-hash', deps(db)))
+    expect(out.results).toEqual([])
+    expect(out.sessionIds).toEqual([])
   })
 })

--- a/packages/core/src/security/purge.ts
+++ b/packages/core/src/security/purge.ts
@@ -140,6 +140,46 @@ export function purgeFindings(
   )
 }
 
+/** Purge EVERY active occurrence of one leaked value — the
+ *  `(kind, value_hash)` pair — across all sessions in the archive, in a
+ *  single logical operation. The natural follow-through to "I've rotated
+ *  this key at the source → now scrub every copy from Spool's surfaces".
+ *
+ *  Delegates to {@link purgeFindings}, which re-orders the collected ids
+ *  via {@link orderForBulkPurge} so per-message offsets stay valid. The
+ *  original `~/.claude` session files are NOT touched — this masks only
+ *  Spool's stored copies (DB + FTS), closing the search / AI / browse
+ *  exposure.
+ *
+ *  Returns the purge results plus the distinct session ids touched, in
+ *  first-seen order, so the IPC layer can emit one change event per
+ *  session. */
+export function purgeEverywhere(
+  kind: SensitiveKind,
+  valueHash: string,
+  deps: PurgeDeps,
+): Effect.Effect<{ results: PurgeResult[]; sessionIds: number[] }, PurgeError> {
+  return Effect.gen(function* () {
+    const ids = yield* Effect.try({
+      try: () =>
+        (deps.db.prepare(
+          `SELECT id FROM findings
+            WHERE kind = ? AND value_hash = ? AND state = 'active'`,
+        ).all(kind, valueHash) as Array<{ id: number }>).map(r => r.id),
+      catch: (cause) => new PurgeError({ findingId: -1, reason: 'db-failed', cause }),
+    })
+    const results = yield* purgeFindings(ids, deps)
+    const seen = new Set<number>()
+    const sessionIds: number[] = []
+    for (const r of results) {
+      if (!seen.has(r.sessionId)) { seen.add(r.sessionId); sessionIds.push(r.sessionId) }
+    }
+    return { results, sessionIds }
+  }).pipe(
+    Effect.withSpan('security.purge.everywhere', { attributes: { kind } }),
+  )
+}
+
 /** Produce a purge order that's safe against offset drift. Findings
  *  with `message_id IS NULL` (orphan rows that the schema permits but
  *  should never happen in practice) fall to the end so they don't


### PR DESCRIPTION
## What
The expanded blast-radius list gains a quiet **"Purge everywhere · N copies"** action that scrubs every copy of the leaked value across all sessions in a single transaction, behind a bulk confirm dialog. `N` is the total occurrence count across the whole archive (including the session being viewed).

## Why
Once you've rotated the key at its source, the cleanup follow-through is removing every Spool copy so it can't leak back through search / AI / browse. Doing that finding-by-finding is tedious and easy to leave half-done; this closes the remediation loop in one click.

## How it connects
- Builds directly on the blast-radius layer: same credential tier, same expanded list, reusing `occurrencesByValueHash` for the count.
- New `purgeEverywhere` core fn + IPC + renderer api; the bulk `PurgeConfirmDialog` makes explicit that only Spool's own DB copies are masked — the originals in `~/.claude` are untouched.
- The radius auto-shrinks/collapses afterward via the existing `onChange` refetch, which is the UI proof every copy was reached.
- Styled as a quiet text action (muted → accent on hover) to match the Dismiss / per-finding Purge vocabulary.

## Test plan
- Unit (`purge.test.ts`): purge-everywhere masks all occurrences across sessions, keeps `messages_fts` in sync, is idempotent.
- e2e: "Purge everywhere" opens the bulk dialog, confirm scrubs both sessions, and every blast radius for that value disappears.
- Core security suite green (132 tests); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)