### PR TITLE
fix(app): annotate showAvatar to break TS7022 circular inference

### DIFF
--- a/packages/app/src/renderer/components/MessageList.tsx
+++ b/packages/app/src/renderer/components/MessageList.tsx
@@ -125,7 +125,7 @@ function buildRows(messages: Message[], label: DividerLabel): Row[] {
         messages: visibleSidechainMessages(group),
       }
     } else {
-      const showAvatar =
+      const showAvatar: boolean =
         !prevMsg || prevMsg.role !== msg.role || prevMsg.role === 'system'
       row = { kind: 'msg', msg, showAvatar }
     }


### PR DESCRIPTION
## What
`buildRows` in `MessageList.tsx` declared `showAvatar` with no type. Under the app's `tsconfig.json`, TypeScript flags it `TS7022` — "implicitly has type 'any' because it is referenced directly or indirectly in its own initializer" — from a circular control-flow inference through the `Row` union (`row = { kind: 'msg', msg, showAvatar }`). Pinning `showAvatar: boolean` (the type `Row`'s `msg` variant already requires) breaks the cycle.

## Why
The error has been latent since #265. It never gated anything because the app build runs esbuild via electron-vite (no type-check) and CI's `e2e.yml` has only `unit` (vitest) + `e2e` (playwright) jobs — no `tsc` step. So `pnpm -C packages/app exec tsc --noEmit` reported it but nothing enforced it. This clears the one outstanding type error so the app package type-checks clean.

## How it connects
Pure type annotation on one local; no runtime/behaviour change. The value is identical (`!prevMsg || prevMsg.role !== msg.role || prevMsg.role === 'system'`).

## Test plan
- `pnpm -C packages/app exec tsc --noEmit -p tsconfig.json` — **was** 1 error (MessageList:128), **now** clean (exit 0), whole app package included.
- Adjacent suites unaffected (no behaviour change); `unit` + `e2e` continue to pass.

> Coverage note: this class of error can't be guarded by a runtime test, and the repo currently runs no `tsc` job in CI, so nothing automatically prevents recurrence. Out of scope here; a separate change could add a typecheck gate (the app package now type-checks clean, so such a gate would pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)