### PR TITLE
fix(security): keep rescan icon glued to the scanned-time stamp

### DIFF
--- a/packages/app/e2e/security-scan-meta-stability.spec.ts
+++ b/packages/app/e2e/security-scan-meta-stability.spec.ts
@@ -86,7 +86,16 @@ test('Meta row keeps the timestamp and holds the rescan button still during a sc
 
   // Precondition: the boot backfill has set a "scanned X ago" stamp.
   await expect(scanState).toBeVisible()
-  const restingX = (await rescanBtn.boundingBox())!.x
+
+  // Regression (meta-rescan-adjacency): the ↻ button sits immediately to
+  // the right of the "scanned X ago" stamp ("last scanned · refresh"),
+  // not flung to the row's far edge. A stats span that grew to `flex-1`
+  // once ate the full row width and shoved ↻ against the right margin.
+  const stampBox = (await scanState.boundingBox())!
+  const btnBoxResting = (await rescanBtn.boundingBox())!
+  expect(btnBoxResting.x - (stampBox.x + stampBox.width)).toBeLessThan(24)
+
+  const restingX = btnBoxResting.x
 
   await rescanBtn.click()
 

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -521,7 +521,13 @@ function SecurityPageInner({ onOpenSession, onShareSession, onOpenSettings }: Pr
          *  Ignored entry lines up with the cards' right-edge controls
          *  instead of overhanging them. */}
         <div className="max-w-[720px] pr-3 flex items-center gap-3">
-        <span className="min-w-0 flex-1 truncate font-mono text-[11px] leading-5 text-warm-faint dark:text-dark-muted tabular-nums">
+        {/* Left group owns the flex-1 width so the stats truncate without
+         *  wrapping, while the ↻ button stays glued to the right of the
+         *  "scanned X ago" stamp (reads as "last scanned · refresh").
+         *  Only the Ignored entry, as the outer flex-none sibling, floats
+         *  to the list's right edge. */}
+        <div className="min-w-0 flex-1 flex items-center gap-2">
+        <span className="min-w-0 truncate font-mono text-[11px] leading-5 text-warm-faint dark:text-dark-muted tabular-nums">
           {t('security.summary', { findings: visibleActive, defaultValue: '{{findings}} risk' })}
           {infoCount > 0 && (
             <span className="opacity-70">
@@ -606,6 +612,7 @@ function SecurityPageInner({ onOpenSession, onShareSession, onOpenSettings }: Pr
             aria-hidden
           />
         </button>
+        </div>
         {ignoredCount > 0 && (
           <button
             type="button"


### PR DESCRIPTION
## What
On the Security page meta row, the ↻ rescan button had drifted to the row's far right (next to the Ignored entry), leaving a large gap after the "scanned X ago" stamp. This restores it to sit immediately after the stamp — reading as "last scanned · refresh" — with only the Ignored entry floating to the list's right edge.

## Why
#322 deliberately paired ↻ with the stamp (the code comment still says so). #324's meta-row truncate fix then gave the stats `<span>` `flex-1` to stop it wrapping when long — but `flex-1` made the span consume the full row width, shoving ↻ against the right margin. The intent and the rendered layout diverged; this is a visual regression, not a redesign.

## How
Wrap `[stats + ↻]` in a `flex-1 min-w-0` left group (stats back to `min-w-0 truncate`, ↻ `flex-none`); Ignored stays an outer `flex-none` sibling, so it still aligns to the list's right edge. Keeps the no-wrap/truncate behaviour #324 wanted **and** the stamp↔refresh adjacency #322 wanted.

## Test plan
- Extends `security-scan-meta-stability.spec.ts` with an adjacency assertion: ↻'s left edge is within 24px of the stamp's right edge (under the regression it was hundreds of px away). The existing during-scan stability assertions are unchanged.
- App package typechecks clean; meta-stability spec's other assertions still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)