### PR TITLE
polish(security): group meta-row actions + let the page fill width

### DIFF
--- a/packages/app/e2e/security-ignored-entry.spec.ts
+++ b/packages/app/e2e/security-ignored-entry.spec.ts
@@ -69,7 +69,8 @@ test('Security page surfaces an Ignored entry that opens the manage modal', asyn
   // rescan needed.
   const entry = window.locator('[data-testid="security-ignored-open"]')
   await expect(entry).toBeVisible({ timeout: 15_000 })
-  await expect(entry).toContainText(/Ignored/)
+  // Icon-only button — the label lives in the tooltip / aria-label.
+  await expect(entry).toHaveAttribute('aria-label', /Ignored/)
 
   // Clicking opens the shared manage modal.
   await entry.click()

--- a/packages/app/e2e/security-scan-meta-stability.spec.ts
+++ b/packages/app/e2e/security-scan-meta-stability.spec.ts
@@ -87,15 +87,7 @@ test('Meta row keeps the timestamp and holds the rescan button still during a sc
   // Precondition: the boot backfill has set a "scanned X ago" stamp.
   await expect(scanState).toBeVisible()
 
-  // Regression (meta-rescan-adjacency): the ↻ button sits immediately to
-  // the right of the "scanned X ago" stamp ("last scanned · refresh"),
-  // not flung to the row's far edge. A stats span that grew to `flex-1`
-  // once ate the full row width and shoved ↻ against the right margin.
-  const stampBox = (await scanState.boundingBox())!
-  const btnBoxResting = (await rescanBtn.boundingBox())!
-  expect(btnBoxResting.x - (stampBox.x + stampBox.width)).toBeLessThan(24)
-
-  const restingX = btnBoxResting.x
+  const restingX = (await rescanBtn.boundingBox())!.x
 
   await rescanBtn.click()
 

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -520,14 +520,8 @@ function SecurityPageInner({ onOpenSession, onShareSession, onOpenSettings }: Pr
          *  scroll area's stable 8px gutter below) so the right-aligned
          *  Ignored entry lines up with the cards' right-edge controls
          *  instead of overhanging them. */}
-        <div className="max-w-[720px] pr-3 flex items-center gap-3">
-        {/* Left group owns the flex-1 width so the stats truncate without
-         *  wrapping, while the ↻ button stays glued to the right of the
-         *  "scanned X ago" stamp (reads as "last scanned · refresh").
-         *  Only the Ignored entry, as the outer flex-none sibling, floats
-         *  to the list's right edge. */}
-        <div className="min-w-0 flex-1 flex items-center gap-2">
-        <span className="min-w-0 truncate font-mono text-[11px] leading-5 text-warm-faint dark:text-dark-muted tabular-nums">
+        <div className="pr-3 flex items-center gap-3">
+        <span className="min-w-0 flex-1 truncate font-mono text-[11px] leading-5 text-warm-faint dark:text-dark-muted tabular-nums">
           {t('security.summary', { findings: visibleActive, defaultValue: '{{findings}} risk' })}
           {infoCount > 0 && (
             <span className="opacity-70">
@@ -589,9 +583,10 @@ function SecurityPageInner({ onOpenSession, onShareSession, onOpenSettings }: Pr
             </>
           )}
         </span>
-        {/* Rescan stays paired with the "scanned X ago" stamp (reads as
-         *  "last scanned · refresh"); only the Ignored entry floats to
-         *  the far right, aligned to the list's right edge. */}
+        {/* Both actions sit together at the row's right edge, icon-only
+         *  with tooltips for a uniform look — the stats span's flex-1
+         *  pushes the group over. */}
+        <div className="flex-none flex items-center gap-1">
         <button
           type="button"
           data-testid="security-rescan-all"
@@ -612,7 +607,6 @@ function SecurityPageInner({ onOpenSession, onShareSession, onOpenSettings }: Pr
             aria-hidden
           />
         </button>
-        </div>
         {ignoredCount > 0 && (
           <button
             type="button"
@@ -620,19 +614,17 @@ function SecurityPageInner({ onOpenSession, onShareSession, onOpenSettings }: Pr
             onClick={() => setIgnoredOpen(true)}
             title={t('security.ignored_manage', { defaultValue: 'Ignored items' })}
             aria-label={t('security.ignored_manage', { defaultValue: 'Ignored items' })}
-            className="flex-none inline-flex items-center gap-1.5 h-5 px-1.5 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75"
+            className="flex-none inline-flex items-center justify-center w-5 h-5 rounded text-warm-faint dark:text-dark-muted hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:text-warm-text dark:hover:text-dark-text transition-colors duration-75"
           >
             <CircleSlash size={13} strokeWidth={1.75} aria-hidden />
-            <span className="font-mono text-[11px]">
-              {t('security.ignored_label', { defaultValue: 'Ignored' })}
-            </span>
           </button>
         )}
+        </div>
         </div>
       </div>
 
       <div className="flex-1 min-h-0 overflow-y-auto px-6 pb-6 [scrollbar-gutter:stable]">
-        <div className="max-w-[720px]">
+        <div>
           {/* ScanBanner + ScanResultBanner sit OUTSIDE the empty /
            *  findings / loading branch below so a manual rescan that
            *  finishes with zero findings still surfaces the "Scan


### PR DESCRIPTION
## What
Two small alignment fixes on the Security page:

1. **Meta-row actions grouped right.** The Rescan ↻ button moves to the right edge next to the Ignored entry, and the Ignored entry loses its "Ignored" text label — both are now icon-only with tooltips, forming a uniform action cluster on the right. The stats span's `flex-1` pushes the cluster over.
2. **Page fills width.** Drops the `max-w-[720px]` cap on the meta row + findings list so Security fills the content width like every other main surface (Shares / Projects / Library), removing the empty right gutter when the sidebar is collapsed.

## Why
- The meta row had two visually different action affordances (an icon-only ↻ on the left paired with the timestamp, and a text+icon "Ignored" pill on the right). Grouping both as icon-only on the right reads as one consistent control set.
- Security was the only main page constrained to 720px; siblings fill the width, so a collapsed sidebar left an unintentional-looking gap. Long finding values / session titles also get more room before truncating.

## How it connects
- `SecurityPage.tsx`: removes the left-group wrapper (rescan now a sibling in a right-aligned `flex gap-1` cluster), makes the Ignored button icon-only (`w-5 h-5`, keeps `title` + `aria-label`), and removes the two `max-w-[720px]` caps (meta row + scroll content). The scanner-unavailable card and empty-state copy keep their own readable caps.
- Supersedes the rescan-adjacent-to-timestamp layout from #327 — the timestamp↔refresh adjacency is replaced by the grouped-right cluster.

## Test plan
- `security-scan-meta-stability`: drops the now-moot rescan↔timestamp adjacency assertion; keeps the during-scan "rescan button doesn't shift" assertion (still holds — it's right-anchored).
- `security-ignored-entry`: asserts the icon button's `aria-label` (was: visible "Ignored" text).
- `security-blast-radius` green — full-width didn't disturb the finding rows.
- app typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)