### PR TITLE
feat(security): default-on via agents.json seed + unbreak worker chunk

### DIFF
--- a/packages/app/src/main/acp.test.ts
+++ b/packages/app/src/main/acp.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { AcpManager } from './acp.js'
+import { AcpManager, applySecurityEnabledSeed } from './acp.js'
 
 describe('AcpManager builtin agents', () => {
   it('includes Gemini CLI as a native ACP agent', () => {
@@ -11,5 +11,41 @@ describe('AcpManager builtin agents', () => {
       bin: 'gemini',
       acpMode: 'native',
     })
+  })
+})
+
+describe('applySecurityEnabledSeed', () => {
+  it('seeds true when there is no agents.json yet', () => {
+    expect(applySecurityEnabledSeed(null)).toEqual({
+      changed: true,
+      config: { securityEnabled: true },
+    })
+  })
+
+  it('seeds true when the field is absent', () => {
+    expect(applySecurityEnabledSeed({ defaultAgent: 'claude' })).toEqual({
+      changed: true,
+      config: { defaultAgent: 'claude', securityEnabled: true },
+    })
+  })
+
+  it('preserves an explicit opt-out', () => {
+    expect(applySecurityEnabledSeed({ securityEnabled: false })).toEqual({
+      changed: false,
+      config: { securityEnabled: false },
+    })
+  })
+
+  it('is a no-op when already true', () => {
+    expect(applySecurityEnabledSeed({ securityEnabled: true })).toEqual({
+      changed: false,
+      config: { securityEnabled: true },
+    })
+  })
+
+  it('does not mutate the input object', () => {
+    const input = { defaultAgent: 'codex' }
+    applySecurityEnabledSeed(input)
+    expect(input).toEqual({ defaultAgent: 'codex' })
   })
 })

--- a/packages/app/src/main/acp.ts
+++ b/packages/app/src/main/acp.ts
@@ -219,6 +219,29 @@ function saveAgentsConfig(config: AgentsConfig): void {
   writeFileSync(AGENTS_CONFIG_PATH, JSON.stringify(config, null, 2), 'utf8')
 }
 
+/** Pure: if the config has no explicit `securityEnabled`, seed it to `true`.
+ *  Returns the (possibly-mutated) config and whether the caller should
+ *  persist. An explicit `false` is preserved — users who opted out stay
+ *  opted out across upgrades. */
+export function applySecurityEnabledSeed(
+  input: AgentsConfig | null,
+): { changed: boolean; config: AgentsConfig } {
+  const config: AgentsConfig = input ? { ...input } : {}
+  if (config.securityEnabled === undefined) {
+    config.securityEnabled = true
+    return { changed: true, config }
+  }
+  return { changed: false, config }
+}
+
+/** Side-effectful boot hook: seed `securityEnabled: true` into agents.json
+ *  on first launch of a security-capable build, so the feature is on by
+ *  default without conflating "no opinion" with "ON" inside the resolver. */
+export function seedSecurityEnabledDefault(): void {
+  const { changed, config } = applySecurityEnabledSeed(loadAgentsConfig())
+  if (changed) saveAgentsConfig(config)
+}
+
 /** Merge builtin + custom agent configs */
 function getEffectiveConfigs(): Record<string, AgentConfig> {
   const userConfig = loadAgentsConfig()

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -52,7 +52,7 @@ import type {
   ShareDraftRow, UpsertShareDraftInput,
 } from '@spool-lab/core'
 import { setupTray } from './tray.js'
-import { AcpManager } from './acp.js'
+import { AcpManager, seedSecurityEnabledDefault } from './acp.js'
 import { setupAutoUpdater, downloadUpdate, quitAndInstall } from './updater.js'
 import { openTerminal } from './terminal.js'
 import { getSessionResumeCommand } from '../shared/resumeCommand.js'
@@ -582,6 +582,13 @@ app.whenReady().then(async () => {
 
   db = getDB()
   acpManager = new AcpManager()
+
+  // Default-on for security-capable builds: write `securityEnabled: true`
+  // into agents.json the first time we see a config without an explicit
+  // choice. Keeps the resolver semantics clean — `undefined` still means
+  // "no opinion" — while making the GA default explicit on disk. Users
+  // who opt out via Labs persist as `false` and are not re-seeded.
+  if (securityBuildCapable()) seedSecurityEnabledDefault()
 
   syncer = new Syncer(db, undefined, (sessionId) => {
     // Sync mutated this session's messages; existing findings now have

--- a/packages/app/src/main/scan-worker-thread.ts
+++ b/packages/app/src/main/scan-worker-thread.ts
@@ -39,7 +39,11 @@ import { regexProvider, type RedactProvider, type SensitiveMatch } from '@spool-
 import { loadSecurityPreferences } from './securityPreferences.js'
 import { mapPfMatches, setUnknownLabelSink, type PfRawMatch } from './security/class-mapping.js'
 import { detectWithRegex } from '@spool-lab/redact'
-import { PF_PROFILE_VERSION } from './security/model-paths.js'
+// Import directly from pf-version (no `electron` import). Going through
+// model-paths.ts pulls `import { app } from 'electron'` into a shared
+// Rollup chunk and crashes the worker at load with
+// "Cannot find module 'electron'".
+import { PF_PROFILE_VERSION } from './security/pf-version.js'
 
 if (!parentPort) {
   throw new Error('scan-worker-thread.ts is only meant to run as a worker_thread child')

--- a/packages/app/src/main/security/model-manifest.ts
+++ b/packages/app/src/main/security/model-manifest.ts
@@ -17,7 +17,7 @@
 //   2. regenerate the per-file sha256s against the new commit
 //   3. update class-mapping.ts if the label set changed
 
-import { PF_HF_REPO } from './model-paths.js'
+import { PF_HF_REPO } from './pf-version.js'
 
 export interface ManifestFile {
   /** Relative path inside the model directory + the path the file is

--- a/packages/app/src/main/security/model-paths.ts
+++ b/packages/app/src/main/security/model-paths.ts
@@ -1,20 +1,16 @@
-// Filesystem paths + version constants for the Privacy Filter ONNX
-// model bundle. Centralised so download / load / unload code agrees
-// and the directory shows up in one place in Settings.
+// Filesystem paths for the Privacy Filter ONNX model bundle. Centralised
+// so download / load / unload code agrees and the directory shows up in
+// one place in Settings.
+//
+// Pure version + repo constants live in pf-version.ts so worker threads
+// can read them without dragging this file's `electron` import into the
+// worker chunk.
 
 import { app } from 'electron'
 import { join } from 'node:path'
+import { PF_MODEL_ID } from './pf-version.js'
 
-/** Directory name under userData/models/. Bumped any time the model
- *  changes — the scan profile string keys off PF_PROFILE_VERSION so
- *  a model swap forces a full rescan. */
-export const PF_MODEL_ID = 'openai-privacy-filter-q4'
-export const PF_MODEL_VERSION = '1.5b-q4'
-/** HuggingFace repository — pinned to a specific commit at download
- *  time. transformers.js loads the model files via the pf-model://
- *  protocol against the local copy; this URL is only used by the
- *  downloader, never by the inference renderer. */
-export const PF_HF_REPO = 'openai/privacy-filter'
+export { PF_MODEL_ID, PF_MODEL_VERSION, PF_HF_REPO, PF_PROFILE_VERSION } from './pf-version.js'
 
 /** Parent directory for all model bundles. transformers.js fetches
  *  files at `${env.localModelPath}/${modelId}/${file}`, so the
@@ -31,14 +27,3 @@ export function pfModelDir(): string {
 export function pfManifestPath(): string {
   return join(pfModelDir(), 'manifest.json')
 }
-
-/** Profile segment produced when PF is enabled. Used by
- *  `currentProfileString({ pfEnabled: true, pfVersion: ... })`.
- *  Tracked independently of PF_MODEL_VERSION so tuning the
- *  class-mapping (precision/recall tradeoffs, suppressed classes)
- *  can force a backfill rescan without re-downloading weights.
- *  Bump suffix when scan-result shape would meaningfully differ:
- *    r1 — initial release (all 8 classes considered)
- *    r2 — 2026-05-21: restricted to email/phone/dob/secret-boost;
- *         person/address/url/account dropped due to OOD precision */
-export const PF_PROFILE_VERSION = `${PF_MODEL_VERSION}.r2`

--- a/packages/app/src/main/security/pf-version.ts
+++ b/packages/app/src/main/security/pf-version.ts
@@ -1,0 +1,31 @@
+// Pure version + repo constants for the Privacy Filter ONNX model.
+//
+// This file is split out from model-paths.ts so worker threads can read
+// `PF_PROFILE_VERSION` without dragging in `import { app } from 'electron'`
+// transitively. Worker threads cannot `require('electron')`, and when both
+// main and worker import from the same source module Rollup chunks the
+// constants together with the electron import — booting the worker fails
+// with "Cannot find module 'electron'". Keep this file electron-free.
+
+/** Directory name under userData/models/. Bumped any time the model
+ *  changes — the scan profile string keys off PF_PROFILE_VERSION so
+ *  a model swap forces a full rescan. */
+export const PF_MODEL_ID = 'openai-privacy-filter-q4'
+export const PF_MODEL_VERSION = '1.5b-q4'
+
+/** HuggingFace repository — pinned to a specific commit at download
+ *  time. transformers.js loads the model files via the pf-model://
+ *  protocol against the local copy; this URL is only used by the
+ *  downloader, never by the inference renderer. */
+export const PF_HF_REPO = 'openai/privacy-filter'
+
+/** Profile segment produced when PF is enabled. Used by
+ *  `currentProfileString({ pfEnabled: true, pfVersion: ... })`.
+ *  Tracked independently of PF_MODEL_VERSION so tuning the
+ *  class-mapping (precision/recall tradeoffs, suppressed classes)
+ *  can force a backfill rescan without re-downloading weights.
+ *  Bump suffix when scan-result shape would meaningfully differ:
+ *    r1 — initial release (all 8 classes considered)
+ *    r2 — 2026-05-21: restricted to email/phone/dob/secret-boost;
+ *         person/address/url/account dropped due to OOD precision */
+export const PF_PROFILE_VERSION = `${PF_MODEL_VERSION}.r2`


### PR DESCRIPTION
## Summary

- Make Security Scan on by default in security-capable production builds. On first boot, if `agents.json` has no explicit `securityEnabled` field, the main process seeds it to `true`. Users who opt out via Labs persist as `false` and are never re-seeded.
- Fix a worker-thread boot crash that every security-capable prod build will hit: `model-paths.ts` has a top-level `import { app } from 'electron'`, and Rollup chunks its pure constants together with that import. The scan worker can't `require('electron')`, so the chunk fails to load and the renderer surfaces "Scanner unavailable". Splitting the pure constants into `pf-version.ts` keeps the shared chunk electron-free.

## Why

- Seed-on-disk keeps the resolver semantics clean: `undefined` still means "no opinion" and falls back to DEV, but in a prod build the value on disk is always explicit. Users see Security in the sidebar without having to discover the Labs toggle, and an explicit opt-out is preserved across upgrades.
- The chunk split is the prerequisite for any security-capable prod build to function at all. Today nobody hits it because no CI build sets `VITE_FEATURE_SECURITY=1`; once we flip that env in `release.yml`, every release would crash without this fix.

## How it connects

- The resolver in `featureFlags.ts` / `securityRuntimeEnabled` is untouched. The default-on behaviour comes from `applySecurityEnabledSeed` writing the explicit `true` before the boot path reads the config.
- `pf-version.ts` is a leaf module (no imports). `model-paths.ts` keeps its function exports and re-exports the same four constant names so no other consumer needs to change.

## Test plan

- [x] `pnpm -F @spool/app test` — 334 passed, including 5 new `applySecurityEnabledSeed` cases (null / absent / explicit-false preserved / true noop / input not mutated)
- [x] `pnpm -F @spool/app exec tsc --noEmit` — clean
- [x] Local prod-style install with `VITE_FEATURE_SECURITY=1`: `agents.json` gets `securityEnabled: true` appended on first boot; other fields preserved
- [x] Worker boot verified on the installed binary: `scan worker thread booted; threadId = 2` / `booted — worker + IPC ready, backfilling`; stderr clean
- [x] `grep require\(["']electron["']\)` across rebuilt chunks loaded by `scan-worker-thread.js` returns nothing
- [ ] No release env flip in this PR — `release.yml` will set `VITE_FEATURE_SECURITY=1` in a follow-up once we sign off on the rest of the polish
