### PR TITLE
fix(security): refetch SessionCard findings on EVT_FINDINGS_CHANGED

### DIFF
--- a/packages/app/e2e/security-session-card-refresh.spec.ts
+++ b/packages/app/e2e/security-session-card-refresh.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect, type Page } from '@playwright/test'
+import { launchApp, waitForSync, type AppContext } from './helpers/launch'
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Regression: SessionCard inside SecurityPage must refetch its
+// findings list when EVT_FINDINGS_CHANGED arrives for this session
+// (background rescan after a profile version bump, a programmatic
+// dismiss, an allowlist toggle, …). Pre-fix the card mounted, loaded
+// its findings once, and never resubscribed — the parent SecurityPage
+// refreshed its session-level aggregates but the card's `findings`
+// state stayed pinned to the initial fetch until the user navigated
+// away and back.
+//
+// security-mute-refresh.spec.ts covers the parent-page refresh path;
+// this file is specifically about the card's inner row list.
+
+const FAKE_AKIA = 'AKIA' + 'V3QFKW72ZDLNP4XR'
+const SID = 'card-refresh-session'
+
+let ctx: AppContext
+
+test.beforeAll(async () => {
+  ctx = await launchApp({
+    extraFixtures: ({ claudeDir }) => {
+      // Two findings, different kinds, so dismissing one leaves the
+      // session present on the page (with the other finding still
+      // active). If both findings shared a kind the parent's
+      // listSessionsWithFindings filter could unmount the card and
+      // confound the test.
+      const file = join(claudeDir, 'test-project', 'card-refresh.jsonl')
+      writeFileSync(file, [
+        JSON.stringify({
+          type: 'user',
+          sessionId: SID,
+          cwd: '/tmp/test-project',
+          uuid: 'cr-1',
+          timestamp: '2026-05-22T10:00:00Z',
+          message: { role: 'user', content: `rotate ${FAKE_AKIA} and email dev@fly.io` },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          uuid: 'cr-2',
+          timestamp: '2026-05-22T10:00:05Z',
+          message: { role: 'assistant', model: 'claude-sonnet-4', content: 'ok' },
+        }),
+      ].join('\n'))
+    },
+  })
+})
+
+test.afterAll(async () => { await ctx?.cleanup() })
+
+async function waitForWorkerIdle(window: Page): Promise<void> {
+  await window.waitForFunction(async () => {
+    const api = (globalThis as { spool?: { security?: { getScanStatus: () => Promise<{ queued: number; scanning: number | null; backfillRemaining: number }> } } }).spool
+    if (!api?.security) return false
+    const s = await api.security.getScanStatus()
+    return s.queued === 0 && s.scanning === null && s.backfillRemaining === 0
+  }, { timeout: 30_000, polling: 250 })
+}
+
+test('SessionCard refetches findings when EVT_FINDINGS_CHANGED arrives for this session', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+  await waitForWorkerIdle(window)
+
+  await window.locator('[data-testid="sidebar-security"]').click()
+  await expect(window.locator('[data-testid="security-page"]')).toBeVisible()
+
+  const card = window.locator(`[data-testid="security-session-row"][data-session-uuid="${SID}"]`)
+  await expect(card).toBeVisible({ timeout: 10_000 })
+
+  // Baseline: card should render both findings (api-key + email).
+  const rows = card.locator('[data-testid="finding-row"]')
+  await expect(rows).toHaveCount(2)
+
+  // Dismiss the email via IPC. This publishes EVT_FINDINGS_CHANGED
+  // with `{ sessionId }`. The card's new subscription is the only
+  // thing that turns the IPC event into a reload — without it the
+  // row stays put forever.
+  await window.evaluate(async (sid: string) => {
+    const api = (globalThis as { spool: {
+      security: {
+        listFindings: (f: { sessionId?: number; state?: string; limit?: number }) => Promise<Array<{ id: number; kind: string }>>
+        dismissFinding: (id: number, scope: 'session' | 'global') => Promise<void>
+      }
+      listSessions: () => Promise<{ sessions: Array<{ id: number; sessionUuid: string }> }>
+    } }).spool
+    const page = await api.listSessions()
+    const sessionId = page.sessions.find((s) => s.sessionUuid === sid)?.id
+    if (sessionId === undefined) throw new Error(`session ${sid} not synced`)
+    const findings = await api.security.listFindings({ sessionId, state: 'active', limit: 10 })
+    const email = findings.find((f) => f.kind === 'email')
+    if (!email) throw new Error('expected an active email finding')
+    await api.security.dismissFinding(email.id, 'session')
+  }, SID)
+
+  // Without any navigation: row count drops from 2 to 1 within the
+  // subscribe debounce window (300ms) plus refetch latency. Pre-fix
+  // this never resolves and the test times out.
+  await expect(rows).toHaveCount(1, { timeout: 5_000 })
+})

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -1210,6 +1210,35 @@ function SessionCard({
 
   useEffect(() => { void load() }, [load])
 
+  // Refetch findings when this session is rescanned (manual click,
+  // post-sync auto-rescan, REDACT_DETECTOR_VERSION bump, …). Without
+  // this, the card shows stale findings until the user navigates
+  // away and back. The parent SecurityPage refetches its session
+  // list on the same event but doesn't propagate into mounted cards.
+  //
+  // Stability: keep the subscription pinned to session.id alone so
+  // filter / pagination changes don't re-subscribe. `load` is held
+  // in a ref so the handler always invokes the latest one without
+  // appearing in the effect's deps.
+  //
+  // Debounce 300ms (same as ProjectView / SecurityPage / SessionDetail)
+  // so a backfill burst publishing N session-rescanned events
+  // collapses to one refetch instead of N.
+  const loadRef = useRef(load)
+  loadRef.current = load
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const off = securityApi.onChange((c) => {
+      if (c.sessionId !== session.id) return
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => { timer = null; void loadRef.current() }, 300)
+    })
+    return () => {
+      if (timer) clearTimeout(timer)
+      off()
+    }
+  }, [session.id])
+
   // Reset pagination to first page when the active kind filter
   // changes — keeps Load-more counts aligned with the new result set.
   const activeKindsKey = activeKinds.join('|')


### PR DESCRIPTION
## Summary

The `SessionCard` inside `SecurityPage` loaded its findings list once on mount and then never resubscribed. The parent `SecurityPage` already refetched its session-level aggregates on `EVT_FINDINGS_CHANGED`, but the card's own `findings` state stayed pinned to the initial fetch — so a background rescan, a programmatic dismiss / purge, or the `REDACT_DETECTOR_VERSION` 1→2 backfill that ships in #334 left stale rows visible until the user navigated away and back.

## Why this surface, not the shared filter

`SessionDetail` (per-session detail page) and `ProjectView` (library row badge) already subscribe to `securityApi.onChange` with the same pattern. `SecurityPage` itself subscribes, but only refetches the session list, not the rows inside each mounted card. Closing the gap means the card behaves like its siblings instead of as an outlier.

## React best practices applied

- **Stable subscription**: `useEffect` deps are `[session.id]` only. `load` is held in a ref so changes to `activeKinds` / `findingsPageCount` don't tear down + recreate the subscription. Matches the `refreshRef` pattern already used a few lines below for `onScanStatus`.
- **Cheap event filter**: handler bails on `c.sessionId !== session.id` before doing any work — single integer compare, so events for other sessions cost ~nothing even with many cards mounted.
- **Debounce 300ms**: matches the established constant in `SecurityPage` / `ProjectView` / `SessionDetail`. A backfill burst publishing one event per scanned session collapses to a single refetch.
- **Cleanup**: clears the timer + unsubscribes on unmount.

## Test plan

- [x] `packages/app/e2e/security-session-card-refresh.spec.ts` — new regression. Renders a card with two findings of different kinds (api-key + email so the parent's `listSessionsWithFindings` keeps the session present after partial dismiss), dismisses the email via IPC, asserts the row count drops to 1 within 5s without navigation. Pre-fix this times out because the card never observes the dismiss.
- [x] All 24 security e2e specs pass locally on this branch: `npx playwright test --config packages/app/e2e/playwright.config.ts security` → 24/24 in 27.5s
- [x] `pnpm -F @spool/app exec tsc --noEmit` — clean
