### PR TITLE
chore(skill): make launch-video feature-agnostic

### DIFF
--- a/.claude/skills/launch-video/SKILL.md
+++ b/.claude/skills/launch-video/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 argument-hint: "[version (e.g. v0.5.0)]"
 ---
 
-Build a release video for a Spool version. The output is a 1080p MP4 plus a poster JPG, intended for X / Twitter. Runtime scales with feature count: 20–40s, 3–8 feature beats + brand outro, optionally an "artifact" payoff scene before the outro for releases whose centrepiece is a tangible export (PDFs, share-files, etc).
+Build a release video for a Spool version. The output is a 1080p MP4 plus a poster JPG, intended for X / Twitter. Runtime scales with feature count: 20–40s, 3–8 feature beats + brand outro, optionally a stylised capstone scene before the outro for releases whose payoff is a tangible outcome the captured clips can't show on their own.
 
 ## Mental model
 
@@ -24,7 +24,7 @@ This is **not** a PPT: text panel and demo coexist continuously, with hard match
 
 Read these references before you start composing. They are not optional — each captures hard-won decisions from prior releases.
 
-- `references/composition.md` — the proven layout, dimensions, drop-shadow recipe, panel + annotation timing patterns, beat-sync approach, the panel-leads-spotlight rhythm rule, the optional artifact-fan payoff scene
+- `references/composition.md` — the proven layout, dimensions, drop-shadow recipe, panel + annotation timing patterns, beat-sync approach, the panel-leads-spotlight rhythm rule, the optional capstone scene
 - `references/capture.md` — how to record native macOS windows of the Electron app, helper functions to use, per-release seed authoring, the feature-flag-at-build-time gotcha
 - `references/cursor-overlay.md` — synthetic cursor that tracks Playwright mouse + visualises clicks. Solves "Playwright doesn't move the OS cursor and screencapture only films pixels"; required whenever a scene's whole point is a click
 - `references/spotlight.md` — SVG-mask focus technique; single-hole for one target, dual-hole for cause-effect (preview always bright + active control bright); the payoff pattern (collapse secondary to redirect the eye)
@@ -68,11 +68,12 @@ Read these references before you start composing. They are not optional — each
 ## Hard rules
 
 - **Synthetic cursor is allowed but must track real input.** A floating GSAP cursor that arrives at random places looks uncanny — that rule from prior releases stands. What's *not* uncanny is the cursor-overlay technique in `references/cursor-overlay.md`: a DOM cursor injected into the page that follows Playwright's actual `mouse.move()` and pulses on `mousedown`. If a scene's whole point is a click, draw the cursor. Don't draw a cursor for scenes where nothing's being clicked.
-- **Chain state across clips. Don't reset between recordings.** If clip 3 ends with the editor in `Timeline / Bone / Walnut`, clip 4 starts there. Pre-clip state resets (clicking different templates / papers between recordings) cause a visible "flash" at the clipCut boundary even though both clips show editor pixels. If the export beat needs a specific final look, get to it *inside* the recording (the user sees the click) or land it earlier in the chain so it's the natural state by the export beat.
+- **Chain state across clips. Don't reset between recordings.** If clip N ends with the UI in some configuration, clip N+1 starts there. Pre-clip state resets (clicking around to clean up between recordings) cause a visible "flash" at the clipCut boundary even though both clips show valid app pixels. If a later beat needs a specific look, get to it *inside* an earlier recording (the user sees the click) or design the demo flow so the natural state at each beat is already what you want.
 - **First frame must be the full hero state.** Brand mark + panel 1 + UI window all visible at `t=0`, not faded in. Twitter's auto-thumbnail grabs this frame.
 - **Annotations and spotlights live inside `.window`**, not on the outer canvas. They must move with the camera transform.
+- **Spotlight coords must be verified by overlay on the rendered frame.** Eyeballing them off a grid on a raw `.mov` is consistently 5–15% off. See `pitfalls.md` on the drawbox verification loop.
 - **No decorative chrome.** No vignette, callsign, progress bar, or trailer-style overlay flashes. The UI is the protagonist.
-- **No "pull back to neutral" before the outro.** End the last feature beat on its focus, then hard-cut/fade to the Spool lockup (or to the artifact-fan scene if the release earns it).
+- **No "pull back to neutral" before the outro.** End the last feature beat on its focus, then hard-cut/fade to the Spool lockup (or to the capstone scene if the release earns one).
 
 ## Files this skill touches
 

--- a/.claude/skills/launch-video/references/capture.md
+++ b/.claude/skills/launch-video/references/capture.md
@@ -45,7 +45,7 @@ const PROJECTS: ProjectSeed[] = [
 **Rules for seed data:**
 
 - English-only titles
-- **Must not reference real user sessions** — invent plausible titles thematically relevant to the release (e.g. for a share-feature release, titles about "share flow review", "share rate limiting", etc).
+- **Must not reference real user sessions** — invent plausible titles thematically relevant to the release (e.g. for a security release, sessions describing the kind of work where the leaked secret might plausibly have been pasted into the chat).
 - 10–15 projects total feels right in the sidebar.
 - One project's `total` should be high (≥ 70) to demo the count badge.
 - Mix `source` between `claude` and `codex` so the badges look varied.
@@ -78,7 +78,7 @@ test('record release clips', async () => {
 
   await recordNativeWindow(ctx.app, path.join(OUT_DIR, '01-home.mov'), 4.0, async () => {
     await ctx.window.waitForTimeout(500)         // settle so the cursor is in the first filmed frame
-    await cursorClick(ctx.window, '[data-testid="sidebar-shares"]', {
+    await cursorClick(ctx.window, '[data-testid="<feature-gated-element>"]', {
       preClickPause: 260, postClickPause: 280,
     })
     // ... drive the rest of the scene
@@ -99,11 +99,13 @@ pnpm --filter @spool/app exec playwright test e2e/release-capture.spec.ts \
 
 `--global-timeout` is required for relaxed-pacing releases — Playwright's config default is 300s and a 7-beat spec with relaxed `postClickPause` values can easily exceed that. `--retries=0` because a flaky capture (Electron failing to focus, screencapture permission glitch) on first run can spawn a second Electron whose window overlaps the first — the capture then records the wrong app state. Better to fail loudly and re-run by hand than auto-retry and ship wrong frames.
 
-If the feature being demoed is behind a build-time flag (e.g. `VITE_FEATURE_SHARE`), build the app with the flag *before* running the spec — `import.meta.env.VITE_FEATURE_<NAME>` is inlined at build time:
+If the feature being demoed is behind a build-time flag (e.g. `VITE_FEATURE_<NAME>`), build the app with the flag *before* running the spec — `import.meta.env.VITE_FEATURE_<NAME>` is inlined at build time:
 
 ```bash
-VITE_FEATURE_SHARE=1 pnpm --filter @spool/app run build:electron
+VITE_FEATURE_<NAME>=1 pnpm --filter @spool/app run build:electron
 ```
+
+If the feature is also gated by a runtime opt-in stored in `agents.json` (e.g. a Labs toggle), seed it via `launchDemoApp(..., { agentsConfig: { <flag>: true } })` so the main process reads it at boot.
 
 ## Capture-time constants
 
@@ -121,4 +123,4 @@ VITE_FEATURE_SHARE=1 pnpm --filter @spool/app run build:electron
 - **First-frame black pixels in the output `.mov`.** `screencapture -V` has ~21ms latency before the first frame lands. Padded out at composition time via `tpad` (see `poster.md`).
 - **Timing slips between perform() and screencapture.** `recordNativeWindow` starts the recording, then runs `perform()`. There's a ~500ms lead-in where you can `waitForTimeout` to settle before the first action.
 - **Captures show test-suite fixtures instead of demo seed.** Symptom: clip 1 records the wrong Electron window's content (e.g. test-project fixtures with XYLOPHONE_CANARY data). Cause: a previous test left an Electron process running and Playwright auto-retried after a flake, spawning a second Electron whose Quartz window-id won the `nativeWindowInfo()` match. Fix: `pkill -9 -f Electron` before the spec, and run with `--retries=0` so flakes don't silently double up.
-- **Build-time feature flag not applied.** Symptom: test fails to find a feature-gated selector (e.g. `[data-testid="sidebar-shares"]`) even though the smoke test passes for unrelated selectors. Cause: built the app without `VITE_FEATURE_<NAME>=1`. Vite inlines `import.meta.env.VITE_FEATURE_<NAME>` at build time, not runtime, so setting the env var when running playwright is too late. Rebuild with the flag.
+- **Build-time feature flag not applied.** Symptom: test fails to find a feature-gated selector (e.g. `[data-testid="<feature-gated-element>"]`) even though the smoke test passes for unrelated selectors. Cause: built the app without `VITE_FEATURE_<NAME>=1`. Vite inlines `import.meta.env.VITE_FEATURE_<NAME>` at build time, not runtime, so setting the env var when running playwright is too late. Rebuild with the flag.

--- a/.claude/skills/launch-video/references/composition.md
+++ b/.claude/skills/launch-video/references/composition.md
@@ -29,12 +29,13 @@ The proven HyperFrames composition layout. Copy from `videos/launch-template/ind
 
 Camera = `transform-origin + scale` on the `.window`. The annotation rectangles inherit the same transform because they live inside `.window`.
 
-| Scene | Pattern |
+| Intent | Pattern |
 |---|---|
 | First-screen / overview | No zoom (`scale: 1`) |
-| Sidebar collapse / expand | Light zoom (`scale: 1.12–1.18`) with origin near sidebar centre (`8%, 50%`) |
-| Pinned-section emergence | Tight zoom (`scale: 1.25–1.35`) with origin on top-left sidebar (`12%, 17%`) |
-| Updater banner | Tight zoom (`scale: 1.28–1.5`) with origin on bottom-left sidebar (`10%, 85–95%`) |
+| Highlight a sidebar region | Light zoom (`scale: 1.12–1.18`) with origin near the region's centre |
+| Punch into a small element (badge, banner) | Tight zoom (`scale: 1.25–1.5`) with origin over the element |
+
+Many releases ship with `scale: 1` throughout and rely on the spotlight mask (`spotlight.md`) for focus. Reach for a camera punch only when you want the underlying UI itself to physically grow into frame — not as a substitute for spotlight focus.
 
 Avoid:
 
@@ -66,7 +67,7 @@ Symmetry matters — `left: 0.5%, width: 22%` will look unbalanced (touches side
 
 ## Annotation timing
 
-Fade the annotation in **after** the feature is fully visible in the clip, not when the clip starts. For example, if the `PINNED · N sessions` strip finishes populating at clip-time `2.5s`, the annotation should fade in at timeline `clip-start + 2.5s + 0.1s`. Earlier = empty rectangle on screen.
+Fade the annotation in **after** the target region is fully populated in the clip, not when the clip starts. For example, if a strip finishes populating at clip-time `2.5s`, the annotation should fade in at timeline `clip-start + 2.5s + 0.1s`. Earlier = empty rectangle on screen.
 
 Fade out **with the scene**, not after. When the panel exits and the camera transitions, the annotation goes with them.
 
@@ -129,30 +130,17 @@ Quality floor by tempo factor:
 
 Always append a 0.6–0.8s `afade=t=out` tail so the music decays into the lockup instead of stopping flat.
 
-## Artifact fan (optional capstone scene)
+## Optional capstone scene
 
-For releases whose centrepiece produces a tangible export (PDFs, share files, etc), an optional scene *between* the final feature beat and the brand outro: four document cards materialise centre-stage as a stylised fan, each pairing a paper × template combo with a format tag.
+Some releases earn an extra scene *between* the final feature beat and the brand outro — a stylised after-shot that shows the *outcome* of what the feature does (e.g. tangible exports fanned out as document cards, a list collapsing to "all clean", a generated artefact landing in a destination). Build it in pure HTML/CSS layered above `.window` so no extra captures are needed.
 
-Why it works:
-
-- The Export scene shows the *mechanism* (open a dropdown, see 4 formats). The artifact scene shows the *outcome* (here are 4 documents leaving the editor). Together they close the "tune → publish" arc.
-- Cards are pure CSS — no new captures, no fake browsers, no fake Twitter / Slack screenshots. The documents themselves are the demo.
-
-Composition:
-
-- 4 cards, 220×300px each, arranged in a subtle fan: rotations roughly -10° / -3° / +3° / +10°, slight Y arc (corner cards drop ~30px below middle cards)
-- Each card has: paper background colour (mirrors `share-kit`'s `PaperDef`), header with `Spool.` mark + template name, body in template-faithful style, bottom-left format tag (mono uppercase), bottom-right meta line (page count, image dimensions, file type)
-- Body styles are stylised per template: chat bubbles for Chat, threaded posts with avatars for Forum, vertical rail with markers for Timeline, monospace `# heading > quote` source view for Markdown (the MD card deliberately shows source code, not rendered output — that's what an .md file actually is, and the visual contrast against the other three keeps the formats distinct)
-- Stagger in 0.10–0.15s apart over ~0.55s each, hold 0.7–1.5s, fade out
-- Total scene: 3–4s including transitions
-
-Skip this scene if the release isn't export-focused — it adds runtime and would feel forced for, say, a sidebar polish release. Earned only when the export itself is the headline.
+Only earn this scene when the outcome is the headline. For releases whose payoff already lives inside the final feature clip (a count collapsing, a list emptying, a toggle settling), cut straight from that beat to the lockup — adding a capstone there forces redundancy and bloats runtime. The decision is per-release, not a default.
 
 ## Panel + annotation animations
 
 Already encoded in the template as `panelIn()`, `panelOut()`, `zoomTo()`, `clipFade()` GSAP helpers. Don't rewrite them per release; just call them with new timing values.
 
-The `clipCut(outSel, inSel, at)` helper that swaps videos should use the v0.5.0 timings — incoming clip opacity 1 at `at - 0.20`, outgoing opacity 0 at `at + 0.10` — so the renderer has time to decode the incoming clip's first frame before the outgoing one disappears. A tighter overlap can produce a one-frame dark gap that reads as a flash. See `pitfalls.md` #11.
+The `clipCut(outSel, inSel, at)` helper that swaps videos should bring the incoming clip's opacity to 1 at `at - 0.20` and drop the outgoing clip's opacity to 0 at `at + 0.10` — the 0.30s overlap gives the renderer time to decode the incoming clip's first frame before the outgoing one disappears. A tighter overlap can produce a one-frame dark gap that reads as a flash. See `pitfalls.md` on clip-boundary gaps.
 
 Word-by-word stagger on `panel-headline` is the one place where motion is *allowed* to be slightly playful — keeps the text from feeling like a static slide.
 

--- a/.claude/skills/launch-video/references/cursor-overlay.md
+++ b/.claude/skills/launch-video/references/cursor-overlay.md
@@ -11,10 +11,10 @@ Two facts about the capture pipeline:
 
 So a scene like "click the + button, watch the picker open" reads as "the picker just appeared on its own" — no agency, no cause. The viewer doesn't see the click happen.
 
-Prior releases (v0.4.11 era) solved this by deleting the cursor entirely and using amber annotations to call out the *result* of the action ("the new pinned section appeared"). That works for changes that are visible at scale, but it falls apart when:
+An earlier approach deleted the cursor entirely and used amber annotations to call out the *result* of the action. That works for changes that are visible at scale, but it falls apart when:
 
-- The same UI region keeps appearing with different contents (Templates list cycling)
-- The click is on a tiny target (a + button, a tab)
+- The same UI region keeps appearing with different contents (a list cycling through options)
+- The click is on a tiny target (a + button, a tab, a row affordance that fades in on hover)
 - There are multiple consecutive clicks the viewer needs to follow
 
 The cursor-overlay technique fixes this. The trick is that the cursor must track real input — a cursor that floats by itself looks more uncanny than no cursor at all.
@@ -53,11 +53,11 @@ await cursorPark(ctx.window, 120, 360) // off to the side before clip 1 starts r
 
 await recordNativeWindow(ctx.app, OUT_DIR + '/01-foo.mov', 5.2, async () => {
   await ctx.window.waitForTimeout(550)
-  await cursorClick(ctx.window, '[data-testid="sidebar-shares"]', {
+  await cursorClick(ctx.window, '[data-testid="<your-target>"]', {
     preClickPause: 260,
     postClickPause: 280,
   })
-  await cursorPark(ctx.window, 700, 480, 22) // park on grid card, NOT on next clip's target
+  await cursorPark(ctx.window, 700, 480, 22) // park on real content, NOT on next clip's target
   await ctx.window.waitForTimeout(2600)
 })
 ```

--- a/.claude/skills/launch-video/references/pitfalls.md
+++ b/.claude/skills/launch-video/references/pitfalls.md
@@ -74,15 +74,15 @@ The video has ~6–8 strong beats from the BGM. Don't try to land every scene cu
 
 ## 10. Real screen recordings, not mock UIs
 
-Early v0.4.11 attempts (livecut v1–v6) used a hand-built HTML mockup of the Spool UI inside the composition. It iterated for hours and still looked uncanny — wrong row heights, wrong icons, wrong rhythm.
+Early attempts at hand-built HTML mockups of the Spool UI inside the composition iterate for hours and still look uncanny — wrong row heights, wrong icons, wrong rhythm.
 
 **Lesson:** always record the real Electron app. The capture pipeline exists for a reason. Don't try to recreate the UI in HTML, ever.
 
-(Exception: an *artifact* scene — a stylised post-demo card showing what the export "looks like" — is fine because the cards are explicitly not the app UI; they're documents. See `composition.md` § Artifact fan.)
+(Exception: a stylised post-demo capstone card — a document or artefact summary that's *explicitly not the app UI* — is fine because the viewer reads it as a separate object, not a fake UI. See `composition.md` § Optional capstone scene.)
 
 ## 11. Clip-boundary gap (the silent full-screen flash)
 
-The most insidious bug from v0.5.0. Two adjacent video clips, both showing visually identical editor states at the boundary, *should* swap invisibly. But on rendered output we'd see a single frame of near-black at the exact cut, reading as a full-screen flash.
+Two adjacent video clips, both showing visually identical UI states at the boundary, *should* swap invisibly. But on rendered output you can see a single frame of near-black at the exact cut, reading as a full-screen flash.
 
 **Root cause:** clip A's `data-duration` ended before clip B's `data-start` began. Even by 0.13s. During that gap, neither video element was "playing" — clip A had ended (browsers show a frozen last frame, but the HyperFrames renderer may release the buffer), clip B wasn't seekable yet. The result was a frame the renderer composed against an empty video element.
 
@@ -93,6 +93,8 @@ prev_clip.data_start + prev_clip.data_duration ≥ next_clip.data_start + 0.10
 ```
 
 In English: the previous clip must still be playing when the next clip starts to take over. Aim for ≥ 0.20s overlap. Tighten the next clip's `data-start` earlier rather than extending the previous clip's `data-duration` past the end of the actual `.mov` file (a video element past its natural end may render unpredictably).
+
+Also bring the incoming clip's opacity up 0.20s **before** the boundary (`clipCut` already does this), so the renderer has time to decode the first frame before the outgoing clip disappears.
 
 **Bonus fix in the `clipCut` helper:** bring the incoming clip's opacity up *before* the boundary, not at it:
 
@@ -107,17 +109,15 @@ This gives the renderer time to decode the incoming clip's first frame before th
 
 ## 12. Pre-clip state resets cause a flash at the cut
 
-Between recording clip 3 and clip 4 in v0.5.0 we tried to "reset" the editor to a clean baseline (clicking different template / paper / typeface / colorway). When the composition cut from clip 3's end-state to clip 4's start-state, the editor visibly jumped from `Timeline / Bone / Walnut` to `Chat / Snow / Amber`. The viewer's brain registered it as a glitch even though both states were technically valid.
+If you "reset" the demo's UI state between recordings (clicking different options to clean up for the next clip's start), the composition cuts from clip N's end-state to clip N+1's start-state and the UI visibly jumps. The viewer's brain registers it as a glitch even though both states were technically valid.
 
 **Why:** the reset clicks happened *outside* the recordings, so the viewer never saw the cause. A state change with no cause reads as a bug.
 
 **Do instead, in order of preference:**
 
 1. **Chain state.** Clip A ends with whatever state, clip B starts there. No reset between recordings. Design the demo flow so the natural state at each beat is what you want.
-2. **Reset *inside* a recording.** If you must change state mid-demo (e.g. to get back to Chat for the export beat), do it via visible cursor clicks during a recorded clip — the viewer sees the user making the choice.
+2. **Reset *inside* a recording.** If you must change state mid-demo to land a later beat on the right configuration, do it via visible cursor clicks during a recorded clip — the viewer sees the user making the choice.
 3. **Never** reset between clips and hope the panel transition will mask it. It won't.
-
-For the v0.5.0 export beat, the fix was to cycle Chat → Timeline → Chat *inside* clip 3, so by the time clips 4–7 ran, the editor was already on Chat and stayed there.
 
 ## 13. Cognitive budget per scene
 
@@ -126,9 +126,7 @@ A 5-second scene shows the viewer two channels in parallel: a panel headline + s
 - **One action + a full panel read** — cursor moves, one click, result settles. Viewer reads kicker + 2-line headline + 2-line sub.
 - **Up to 2 actions + a partial panel read** — cursor moves, click, settle ~1s, click again, settle. Viewer reads kicker + headline; the sub gets skimmed.
 
-**You cannot fit 3 actions in 5s with a panel.** The viewer's eyes can't track three template clicks on the right while reading a paragraph on the left. The third action might as well not exist.
-
-v0.5.0's original scene 3 cycled Chat → Letter → Forum → Timeline (3 clicks). The viewer absorbed the first and last; Letter and Forum slipped by uncounted. We trimmed it to Chat → Timeline → Chat (2 clicks across a longer beat) and the scene immediately read better.
+**You cannot fit 3 actions in 5s with a panel.** The viewer's eyes can't track three sequential clicks on the right while reading a paragraph on the left. The third action might as well not exist — middle-of-the-sequence clicks slip by uncounted while the eye snaps between text and UI.
 
 **Rule:** ≤ 2 clicks per scene if the panel has a sub. If you absolutely need to demo more variations, give it its own scene with a shorter panel.
 
@@ -139,9 +137,23 @@ Synchronising `panelIn()` and `spotlightSnap()` at the same instant means the vi
 **Do:** fire `panelIn(...)` first, then `spotlightSnap(...)` 0.3–0.4s later, then the click another 0.3–0.5s after that. The viewer reads the headline → finds where to look → sees the action.
 
 ```js
-panelIn("#panel4", 14.85);                          // 0.00s: text anchors
-spotlightSnap(F.editorPreview, 15.25, F.paperRow);  // 0.40s: highlight arrives
-// clip 04's paper-bone click happens at ~16.16     // ~1.30s: action lands
+panelIn("#panelN", T);                              // 0.00s: text anchors
+spotlightSnap(F.primaryRegion, T + 0.40, F.controlPanel); // 0.40s: highlight arrives
+// click in the captured clip lands around T + 1.30s        // ~1.30s: action lands
 ```
 
 This is the single most impactful timing rule for readability. Without it the video reads as "everything happening at once and I can't follow." With it the video has a natural rhythm.
+
+## 15. Spotlight coords must be verified on the rendered frame, not eyeballed off a grid
+
+Measuring focus rectangles by reading gridlines on a raw `.mov` frame is unreliable: the frame's content position can differ from the composition's display state (e.g. the captured clip is in an unfiltered state while the composition plays it after a filter has been applied, shifting rows down). Eyeballed coords come out 5–15% too high or low and read as "the spotlight isn't framing anything specific."
+
+**Do this closed loop before re-rendering:**
+
+1. Set your `F.region` coords.
+2. Compute the hole's canvas rect: `x_canvas = 700 + 10·x`, `y_canvas = 197 + 6.85·y`, `w_canvas = 10·w`, `h_canvas = 6.85·h` (window at canvas 700,197 sized 1000×685; viewBox 0–100).
+3. Overlay that rect on the existing rendered frame with `ffmpeg -ss <t> -i final.mp4 -frames:v 1 -vf "drawbox=x=…:y=…:w=…:h=…:color=lime:t=3" check.png`.
+4. Open `check.png`. If the bright box doesn't tightly frame its target, adjust coords and re-draw — content position is independent of the spotlight, so you don't need to re-render to iterate.
+5. Re-render only after every region's box visibly frames its target.
+
+The dim opacity also matters: against a dark UI, `fill-opacity=0.70` reads as nearly no dim, washing out the focus. `0.80` gives noticeable but not aggressive contrast.

--- a/.claude/skills/launch-video/references/spotlight.md
+++ b/.claude/skills/launch-video/references/spotlight.md
@@ -63,13 +63,13 @@ function spotlightSnap(primary, at, secondary) {
 }
 ```
 
-Define your focus rectangles once near the top of the script, in `% of .window`:
+Define your focus rectangles once near the top of the script, in `% of .window`. Name them after what they frame in the captured UI (a sidebar row, a card, a control), measured per release:
 
 ```js
 const F = {
-  sidebarShares: { x: 0.6,  y: 10.0, w: 20,   h: 3.4 },
-  templates:     { x: 71.5, y: 11,   w: 26.5, h: 41 },
-  editorPreview: { x: 1,    y: 1,    w: 68,   h: 98 },
+  sidebarTarget:  { x: 0.6,  y: 10.0, w: 20,   h: 3.4 },
+  primaryRegion:  { x: 1,    y: 1,    w: 68,   h: 98 },
+  controlPanel:   { x: 71.5, y: 11,   w: 26.5, h: 41 },
   // ...
 };
 ```
@@ -77,10 +77,10 @@ const F = {
 Then in scene code:
 
 ```js
-spotlightOn(F.sidebarShares, 0.45);          // single, dim everything else
-spotlightSnap(F.draftsGrid, 1.55);            // retarget, still on
-spotlightSnap(F.editorPreview, 10.15, F.templates); // dual: preview + control
-spotlightSnap(F.editorPreview, 30.15);        // collapse secondary, single again
+spotlightOn(F.sidebarTarget, 0.45);                       // single, dim everything else
+spotlightSnap(F.primaryRegion, 1.55);                     // retarget, still on
+spotlightSnap(F.primaryRegion, 10.15, F.controlPanel);    // dual: preview + control
+spotlightSnap(F.primaryRegion, 30.15);                    // collapse secondary, single again
 spotlightOff(34.50);
 ```
 
@@ -95,30 +95,30 @@ A snap, paired with a click happening 100–200ms later, reads as "the eye is al
 **Single** — for scenes where one region matters at a time:
 
 - Sidebar click target
-- Drafts grid contents
+- A list or grid of items
 - A dropdown opening
 
 **Dual** — for cause-and-effect scenes where two regions need to be readable at the same time:
 
-- "User clicks Letter template, preview reflows" → primary = preview, secondary = template list
-- "User toggles Privacy bulk, masked pills update" → primary = preview, secondary = privacy summary
-- "User clicks Bone paper, preview restyles" → primary = preview, secondary = paper row
+- User clicks a control on the right; a preview on the left reflows → primary = preview, secondary = control
+- User toggles a setting; an indicator updates → primary = indicator, secondary = setting
+- User picks an option from a list; the staged document restyles → primary = document, secondary = option list
 
-The convention: **primary = preview / result**, **secondary = control / cause**. The secondary retargets per click; the primary stays fixed on the preview throughout the scene.
+The convention: **primary = result / outcome**, **secondary = control / cause**. The secondary retargets per click; the primary stays fixed on the outcome throughout the scene.
 
 ## The payoff pattern
 
-When the cause-and-effect has played its loop, collapse the secondary to `NULL_HOLE`. With the right side suddenly dim, the viewer's eye has only the preview to look at — and that's exactly when the preview's change is the payoff.
+When the cause-and-effect has played its loop, collapse the secondary to `NULL_HOLE`. With one side suddenly dim, the viewer's eye has only the outcome to look at — and that's exactly when the outcome's change is the payoff.
 
 ```js
-// Scene 6 (Privacy): preview + privacy panel both bright, user toggles masks.
-spotlightSnap(F.editorPreview, 25.65, F.privacyPanel);
-// After the re-mask click, kill the secondary.
-// Now the preview's redacted pills are the only thing lit.
-spotlightSnap(F.editorPreview, 29.65);
+// Dual: outcome + control both bright while the user toggles.
+spotlightSnap(F.primaryRegion, 25.65, F.controlPanel);
+// After the final click, kill the secondary.
+// Only the outcome stays lit — its state change reads as the answer.
+spotlightSnap(F.primaryRegion, 29.65);
 ```
 
-This is a deliberate 0.5–1.0s moment of "look here, this is the answer." Particularly useful for features whose payoff is subtle (mask states, gap markers, accent shifts) and could get lost in a busy dual-spotlight frame.
+This is a deliberate 0.5–1.0s moment of "look here, this is the answer." Particularly useful for features whose payoff is subtle (a count collapsing, a state flip, a value vanishing) and would get lost in a busy dual-spotlight frame.
 
 ## Measuring hole coordinates
 
@@ -132,17 +132,17 @@ Same workflow as amber rectangles, but with one advantage: spotlight is forgivin
 
 ## clipCut interaction
 
-`spotlightSnap` doesn't change which clip is visible — it just moves the holes. When a scene changes underlying clips (clip 3 → clip 4 etc.), the spotlight coords usually don't need to change since the layout is the same (right-panel controls in the same place, preview in the same place). Retarget only when the *active control* changes — Templates list → Paper row → Typeface row, etc.
+`spotlightSnap` doesn't change which clip is visible — it just moves the holes. When a scene changes underlying clips, the spotlight coords usually don't need to change if the layout is the same (controls in the same place, outcome in the same place). Retarget only when the *active control* changes from one row/element to another.
 
 Order of operations at scene boundaries:
 
 ```js
 // Panel anchors first (0.4s lead — see composition.md on panel-leads-spotlight)
-panelIn("#panel4", 14.85);
+panelIn("#panelN", 14.85);
 // Clip swaps next
-clipCut("#clip-templates", "#clip-style", 14.65);
+clipCut("#clip-prev", "#clip-next", 14.65);
 // Spotlight retargets last
-spotlightSnap(F.editorPreview, 15.25, F.paperRow);
+spotlightSnap(F.primaryRegion, 15.25, F.controlPanel);
 ```
 
 ## Common pitfalls


### PR DESCRIPTION
## What

Strips share/export-specific content from the `launch-video` skill so it reads as "how to make **any** Spool release video" rather than "how the v0.4.11/v0.5.0 share video was made."

## Why

Producing the v0.5.0 **Security** launch video (PR #333) surfaced that the skill had drifted feature-specific:

- `composition.md` had an entire "Artifact fan (optional capstone scene)" section keyed to share's PDF/PNG/Markdown/.spool exports — irrelevant for a security release whose payoff is a vanishing risk count.
- `spotlight.md`'s example F regions were all share-editor specifics (`editorPreview`, `templates`, `paperRow`, `typefaceRow`, `colorwayRow`, `privacyPanel`, `dropdown`) — copied straight from the share video's composition.
- `pitfalls.md` items #11–#13 debriefed the share video's specific scenes (Chat → Letter → Forum → Timeline cycling, "Timeline / Bone / Walnut" state, "the v0.5.0 export beat") instead of generalising the lessons.
- `capture.md` used `VITE_FEATURE_SHARE=1` as the example build flag.
- `cursor-overlay.md` referenced `[data-testid="sidebar-shares"]` and v0.4.11-era amber-only conventions.
- `SKILL.md` mentioned "artifact-fan scene", "Timeline / Bone / Walnut" state-chaining example.

Concrete case studies belong in per-release memory and per-release `videos/spool-vX.Y.Z/README.md`, not in the canonical methodology.

## How it connects

- Replaces share-specific F examples with generic names (`primaryRegion`, `controlPanel`, `sidebarTarget`, etc.)
- Replaces the Artifact-fan section with a short "optional capstone scene" note (the *principle*, not the share implementation)
- Rewrites pitfall debriefs to keep the *lesson* and drop the scene-specific bodies
- **Adds new pitfall #15** documenting the drawbox-on-rendered-frame verification loop for spotlight coords — the most painful learning from the v0.5.0 security video, which would have saved several iterations
- Notes the `agentsConfig` runtime opt-in pattern in `capture.md` (the helper option added in PR #333)

No content was removed wholesale where the underlying lesson was generally applicable; only the share-specific *bodies* were rewritten.

## Test plan

Docs-only change. Verified by `grep -rn -iE 'VITE_FEATURE_SHARE|paperRow|editorPreview|sidebar-shares|drafts grid|pinned section|artifact[- ]fan|bone|walnut' .claude/skills/launch-video/` → empty.