### PR TITLE
chore(release): set VITE_FEATURE_SECURITY=1 in mac + linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,12 @@ jobs:
           npx electron-vite build
           npx electron-builder --mac --arm64 --publish never
         env:
+          # Compile Security Scan into the bundle. Without this, every
+          # Security surface is tree-shaken out of the prod build —
+          # `securityBuildCapable()` returns false, the worker never
+          # boots, and the default-on agents.json seed is a no-op
+          # because the resolver short-circuits.
+          VITE_FEATURE_SECURITY: '1'
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -80,6 +86,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build app (AppImage + tar.gz)
+        env:
+          # See the mac build comment — VITE_FEATURE_SECURITY=1 is what
+          # compiles the Security surface into the bundle.
+          VITE_FEATURE_SECURITY: '1'
         run: |
           pnpm -F @spool/app build:deps
           cd packages/app


### PR DESCRIPTION
## Summary

Compile Security Scan into the release bundle so v0.5.0 actually ships the feature. Without this env var, `securityBuildCapable()` returns false in the prod build → every guarded surface is dead-code-eliminated by Vite/terser → the default-on agents.json seed from #331 is a no-op because the resolver short-circuits at build-capable=false.

Set on both the mac arm64 and linux jobs. `VITE_FEATURE_SHARE` stays unset — Share is still pre-release and gated behind Labs in dev only.

## Test plan

- [x] Diff confirmed against the existing e2e build command (`packages/app/package.json` `test:e2e` already passes `VITE_FEATURE_SECURITY=1 electron-vite build`); using the same env at release time gives parity between what CI exercises and what users download.
- [ ] After merge, cut v0.5.0 via `scripts/release.sh --minor` and verify the installed binary boots the scan worker + seeds agents.json on first launch.
