### PR TITLE
fix(redact): tighten internal-host and credit-card false positives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,10 +218,9 @@ jobs:
           pnpm -F @spool-lab/cli build
 
       # Publish in dependency order. Each step is idempotent: if the registry
-      # already has this version (re-run after a partial-fail, or redact's
-      # version was unchanged this release), we skip rather than error. We must
-      # still update redact whenever its source changes — the version bump is
-      # manual since redact tracks its own semver, independent of the app.
+      # already has this version (re-run after a partial-fail), we skip rather
+      # than error. redact is bumped in lockstep with core/cli by release.sh,
+      # so a fresh release always produces a new version per package.
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/packages/core/src/security/profile.ts
+++ b/packages/core/src/security/profile.ts
@@ -26,7 +26,12 @@
 //   2 — 2026-05-28: env-var detector now rejects values containing
 //       non-ASCII letters (CJK / Cyrillic / Hangul / Arabic / emoji
 //       are placeholder description text, never real env-var secrets).
-export const REDACT_DETECTOR_VERSION = 2
+//   3 — 2026-05-28: internal-host regex no longer case-insensitive
+//       (drops PascalCase `SqlParser.internal` style FPs); validator
+//       rejects trailing file-extensions (`runtime.prod.js`);
+//       credit-card regex rejects decimal fractional parts
+//       (`0.5227687358856201`). See issue #340.
+export const REDACT_DETECTOR_VERSION = 3
 
 export interface ProfileOpts {
   /** Regex detector revision. Bump in lockstep with rule changes. */

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/redact",
-  "version": "0.0.2",
+  "version": "0.5.0",
   "description": "Local, pure-TS sensitive-data detection for Spool sessions. Pattern + checksum + entropy pipeline today; pluggable provider boundary for future on-device ML (e.g. OpenAI Privacy Filter via transformers.js).",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/redact",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Local, pure-TS sensitive-data detection for Spool sessions. Pattern + checksum + entropy pipeline today; pluggable provider boundary for future on-device ML (e.g. OpenAI Privacy Filter via transformers.js).",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/redact/src/detectors.test.ts
+++ b/packages/redact/src/detectors.test.ts
@@ -39,6 +39,16 @@ describe('identity', () => {
   it('skips Luhn-invalid card-shaped digit runs', () => {
     expect(kindsOf('order 4111 1111 1111 1112')).not.toContain('credit-card')
   })
+  it('does not flag the fractional part of a decimal as a credit card (issue #340)', () => {
+    // `5227687358856201` happens to be 16 digits, start with 5
+    // (Mastercard prefix), and pass Luhn — but it's the fractional
+    // part of a `confidence` float, not a card number.
+    expect(kindsOf("[{'label': 'silence', 'confidence': 0.5227687358856201}]")).not.toContain('credit-card')
+    expect(kindsOf('score=0.5227687358856201 next')).not.toContain('credit-card')
+    // Sanity: a real-looking card right after a period (non-decimal
+    // context) is still caught.
+    expect(kindsOf('Card. 4111 1111 1111 1111')).toContain('credit-card')
+  })
   it('finds a US SSN, rejects reserved area 000/666/9xx', () => {
     expect(kindsOf('SSN 123-45-6789')).toContain('ssn')
     expect(kindsOf('666-45-6789 000-45-6789 900-45-6789')).not.toContain('ssn')
@@ -226,6 +236,20 @@ describe('location / infra', () => {
     expect(kindsOf('cat .env.local')).not.toContain('internal-host')
     expect(kindsOf('open next.config.local then env.dev.local')).not.toContain('internal-host')
     expect(kindsOf('see settings.local for prefs')).not.toContain('internal-host')
+  })
+  it('does not flag PascalCase property chains ending in `.internal` (issue #340)', () => {
+    // `SqlParser.internal` is a class/property access in code, not a
+    // hostname. The case-sensitive regex (no `/i` flag) rejects it.
+    expect(kindsOf('throw new SqlParser.internal.UnexpectedTokenError()')).not.toContain('internal-host')
+    expect(kindsOf('AppRouter.internal handles the redirect')).not.toContain('internal-host')
+  })
+  it('does not flag bundler output filenames like `*.prod.js` (issue #340)', () => {
+    // `app-page-turbo.runtime.prod.js` is a webpack/turbo build
+    // artifact. The loose `prod\.[a-z0-9]+` tail in the regex
+    // matches it; the file-extension validator drops it.
+    expect(kindsOf('chunk app-page-turbo.runtime.prod.js loaded')).not.toContain('internal-host')
+    expect(kindsOf('failed loading vendor.prod.css')).not.toContain('internal-host')
+    expect(kindsOf('see chunk.stg.json for the map')).not.toContain('internal-host')
   })
 })
 

--- a/packages/redact/src/detectors.ts
+++ b/packages/redact/src/detectors.ts
@@ -145,7 +145,10 @@ const GENERIC_SECRET_RX = /\b(?:api[_-]?key|secret|token|password|passwd|auth|ac
 
 // ── Identity ─────────────────────────────────────────────────────
 
-const CC_RX = /\b(?:4\d{3}|5[1-5]\d{2}|6(?:011|5\d{2})|3[47]\d{2}|3(?:0[0-5]|[68]\d)\d|(?:2131|1800|35\d{3}))[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{3,4}\b/g
+// Lookbehind `(?<!\d\.)` rejects the fractional part of a decimal
+// number — e.g. `confidence: 0.5227687358856201` happens to be 16
+// digits starting with 5 and Luhn-valid, but it's a float, not a card.
+const CC_RX = /(?<!\d\.)\b(?:4\d{3}|5[1-5]\d{2}|6(?:011|5\d{2})|3[47]\d{2}|3(?:0[0-5]|[68]\d)\d|(?:2131|1800|35\d{3}))[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{3,4}\b/g
 const SSN_RX = /\b(?!000|666|9\d{2})\d{3}-(?!00)\d{2}-(?!0000)\d{4}\b/g
 const EMAIL_RX = /\b[A-Za-z0-9](?:[A-Za-z0-9._+-]*[A-Za-z0-9])?@[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?\.[A-Za-z]{2,}\b/g
 const PHONE_RX = /(?:\+\d[\d .\-()]{7,16}\d|\(\d{2,4}\)[\d .\-]{6,14}\d)/g
@@ -186,7 +189,11 @@ const ABSOLUTE_PATH_RX = /(?:\/Users\/|\/home\/|\/var\/|\/etc\/|\/opt\/|[A-Z]:\\
 // false-positive rate from a real-world scan with `.local` enabled.
 // The remaining TLDs (`.internal`, `.corp`, `.lan`, `.intra`,
 // `.home`, `.prod.*`, `.stg.*`) are unambiguous internal-DNS markers.
-const INTERNAL_HOST_RX = /\b[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*\.(?:internal|corp|lan|intra|home|prod\.[a-z0-9]+|stg\.[a-z0-9]+)\b/gi
+//
+// Case-sensitive (no `/i`): real DNS labels are conventionally
+// lowercase. Dropping the `i` flag means PascalCase property chains
+// like `SqlParser.internal` no longer match.
+const INTERNAL_HOST_RX = /\b[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*\.(?:internal|corp|lan|intra|home|prod\.[a-z0-9]+|stg\.[a-z0-9]+)\b/g
 
 // ── Per-rule validators (false-positive filters) ─────────────────
 //
@@ -259,12 +266,29 @@ function ipLooksReal(value: string): boolean {
   return !isReservedIp(value)
 }
 
+// Common web/build asset extensions that the `prod\.[a-z0-9]+` and
+// `stg\.[a-z0-9]+` alternatives of INTERNAL_HOST_RX collide with —
+// e.g. `runtime.prod.js`, `vendor.prod.css`. Bundler output, not a
+// hostname.
+const HOST_TAIL_FILE_EXTS = new Set([
+  'js', 'ts', 'tsx', 'jsx', 'mjs', 'cjs',
+  'css', 'scss', 'sass', 'less',
+  'json', 'jsonc', 'yaml', 'yml',
+  'html', 'htm', 'xml',
+  'map', 'wasm', 'md', 'txt', 'log',
+  'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'ico',
+])
+
 /** internal-host: reject JS property chains the regex inadvertently
- *  matches (`process.env.HOME`, `import.meta.home`). */
+ *  matches (`process.env.HOME`, `import.meta.home`) and bundler
+ *  output filenames matched by the loose `prod.*` / `stg.*` tail
+ *  (`runtime.prod.js`, `chunk.stg.css`). */
 function internalHostLooksReal(value: string): boolean {
   if (/^process\.env\./i.test(value)) return false
   if (/^import\.meta\./i.test(value)) return false
   if (/^window\.location\./i.test(value)) return false
+  const lastDot = value.lastIndexOf('.')
+  if (lastDot >= 0 && HOST_TAIL_FILE_EXTS.has(value.slice(lastDot + 1).toLowerCase())) return false
   return true
 }
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 # APPLE_TEAM_ID). The workflow also publishes @spool-lab/core and
 # @spool-lab/cli to npm using NODE_AUTH_TOKEN (granular token,
 # scope=@spool-lab, read+write, "Bypass 2FA" enabled). @spool-lab/redact
-# is published only when its version on disk differs from the registry —
-# bump its package.json manually whenever redact source changes.
+# is published only when its version on disk differs from the registry,
+# and is bumped here in lockstep with the rest so versions stay aligned.
 # See .github/workflows/release.yml.
 #
 # Usage:
@@ -60,7 +60,7 @@ NEW_VERSION="$major.$minor.$patch"
 TAG="v$NEW_VERSION"
 green "Bumping to $NEW_VERSION"
 
-for f in package.json packages/app/package.json packages/core/package.json packages/cli/package.json packages/landing/package.json; do
+for f in package.json packages/app/package.json packages/core/package.json packages/cli/package.json packages/landing/package.json packages/redact/package.json; do
   if [[ -f "$f" ]]; then
     jq --arg v "$NEW_VERSION" '.version = $v' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
   fi


### PR DESCRIPTION
## Summary

Fixes #340 — two regex false positives in the Security Scan, plus a detector-version bump so existing scanned sessions auto-rescan and drop the stale findings on next launch.

- **`internal-host`** matched PascalCase property chains (`SqlParser.internal`) and bundler-output filenames (`app-page-turbo.runtime.prod.js`).
- **`credit-card`** matched `5227687358856201`, the fractional part of a `confidence: 0.5227687358856201` float that incidentally is 16 digits, Mastercard-prefixed, and Luhn-valid.

## What changed

`packages/redact/src/detectors.ts`:

1. **`INTERNAL_HOST_RX`**: dropped the `/i` flag. The `i` flag let `[a-z0-9]` swallow uppercase, so PascalCase prefixes were treated as DNS labels. Real DNS labels are conventionally lowercase, so case-sensitive matching is the right invariant. `SqlParser.internal` no longer matches.
2. **`internalHostLooksReal`**: added a tail-extension allowlist (`js / ts / tsx / jsx / mjs / cjs / css / scss / json / map / html / png / svg / …`). When the last segment of the matched value is a known web/build asset extension, drop it. Kills the `runtime.prod.js` / `vendor.prod.css` / `chunk.stg.json` class without dropping the legitimate `service.prod.<org>` / `host.stg.<org>` tier markers.
3. **`CC_RX`**: prepended `(?<!\d\.)` lookbehind. When the credit-card-shaped digit run is the fractional part of a decimal (`<digit>.<digits>`), reject. Preserves the rare-but-real case of a card number coming right after a `.` with no leading digit.

`packages/core/src/security/profile.ts`:

4. **`REDACT_DETECTOR_VERSION` 2 → 3**: cache nonce bump. Sessions stamped `regex@2` will fall out of `listSessionsNeedingScan` and get re-enqueued at next launch. `deleteRefreshableFindings` then wipes stale `active`/`dismissed` findings for the `regex` provider before the new scan writes its results — so existing false-positive `internal-host` and `credit-card` findings disappear automatically without user action. `purged` rows (user already nuked content) are preserved per the audit contract.

## Why this approach

- **Case-sensitive over allowlist**: a denylist of "code-looking" prefixes would be a moving target. Dropping `/i` is one mechanical invariant that maps to how DNS is actually written in the wild.
- **Tail-extension allowlist, not denylist**: the `prod.X` / `stg.X` regex alternatives are inherently ambiguous with `*.prod.js`-style filenames. Rather than weaken the regex further, the validator narrows the kill to known file extensions — additive, easy to extend.
- **Decimal lookbehind, not validator**: the validator only sees the matched substring; the decimal-context signal lives in the character before the match. A `(?<!\d\.)` lookbehind is the minimal way to encode it without plumbing context through.
- **Detector-version bump for cleanup**: the profile system is designed for exactly this — bump the version, all old stamps go stale, backfill loop rescans and the rescan path wipes the prior provider output before re-inserting. No migration script, no user-visible prompt, no manual rescan.

## Test plan

Regression specs added in `packages/redact/src/detectors.test.ts`, each referencing #340 in the spec name:

- [x] `SqlParser.internal` / `AppRouter.internal` not flagged as `internal-host`
- [x] `app-page-turbo.runtime.prod.js` / `vendor.prod.css` / `chunk.stg.json` not flagged as `internal-host`
- [x] `confidence: 0.5227687358856201` not flagged as `credit-card`
- [x] Sanity: `Card. 4111 1111 1111 1111` (period before card, no leading digit) still flagged
- [x] Existing positive cases still flagged: `api.eng.corp`, `db.prod.internal`, `card 4111 1111 1111 1111`
- [x] `pnpm -F @spool-lab/redact test` — 133/133
- [x] `pnpm -F @spool-lab/core test src/security` — 132/132 (`profile.test.ts` already pins via the `REDACT_DETECTOR_VERSION` constant; `repo.test.ts` `listSessionsNeedingScan` test already exercises the `regex@2` → `regex@3` stale-stamp path)
- [x] `pnpm -F @spool-lab/redact typecheck` clean
