### PR TITLE
release: v0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spool",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/app",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "productName": "Spool",
   "main": "./out/main/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/landing",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/redact",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Local, pure-TS sensitive-data detection for Spool sessions. Pattern + checksum + entropy pipeline today; pluggable provider boundary for future on-device ML (e.g. OpenAI Privacy Filter via transformers.js).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch release for the regex-detector false-positive fix in #341 (closes #340).

## What ships

- `internal-host` no longer flags PascalCase identifiers (`SqlParser.internal`) or bundler-output filenames (`runtime.prod.js`).
- `credit-card` no longer flags the fractional part of decimals (`0.5227687358856201`).
- `REDACT_DETECTOR_VERSION` bumped 2 → 3: existing scanned sessions get re-enqueued at next launch, stale findings auto-cleaned by the rescan path. No user action required.
- `@spool-lab/redact` now version-locked to the app (0.5.1) and bumped together with core/cli by `release.sh`.