### PR TITLE
fix(security): collapse bulk purge into a single transaction (#344)

### DIFF
--- a/packages/core/src/security/purge.test.ts
+++ b/packages/core/src/security/purge.test.ts
@@ -205,6 +205,70 @@ describe('purgeFindings bulk', () => {
     expect(after.content_text.endsWith(' tail')).toBe(true)
   })
 
+  // Regression for issue #344 — a bulk purge of ~17 k absolute-path
+  // findings froze the renderer for ~60 s because each finding paid
+  // its own BEGIN/COMMIT (and its own `updateSessionCounts`, and its
+  // own publish event). The fix collapses the batch into a single
+  // transaction and coalesces publish events to one per session. We
+  // assert the coalescing here — the timing improvement is a
+  // by-product of the same change and harder to assert reliably on
+  // an in-memory DB without fsync.
+  it('emits one publish event per touched session, not per finding (issue #344)', async () => {
+    const SESSIONS = 5
+    const FINDINGS_PER_SESSION = 50
+    // Extra sessions beyond session 1 already created by setupDb.
+    for (let i = 2; i <= SESSIONS; i++) {
+      db.prepare(
+        `INSERT INTO sessions (id, project_id, source_id, session_uuid, file_path, title, started_at, ended_at)
+         VALUES (?, 1, 1, ?, ?, ?, '2026-01-01', '2026-01-01')`,
+      ).run(i, `s-${i}`, `/p/s-${i}`, `Session ${i}`)
+    }
+    const raw = '/Users/someone/secrets'
+    let nextMessageId = 100
+    for (let s = 1; s <= SESSIONS; s++) {
+      for (let f = 0; f < FINDINGS_PER_SESSION; f++) {
+        const messageId = nextMessageId++
+        const content = `path-${f}: ${raw}`
+        db.prepare(
+          `INSERT INTO messages (id, session_id, source_id, role, content_text, timestamp, seq)
+           VALUES (?, ?, 1, 'user', ?, '2026-01-01', ?)`,
+        ).run(messageId, s, content, f)
+        const start = content.indexOf(raw)
+        insertFindings(db, [{
+          sessionId: s, messageId, kind: 'absolute-path',
+          valueHash: `h-${s}-${f}`, confidence: 0.9, provider: 'regex',
+          startOffset: start, endOffset: start + raw.length, state: 'active',
+        }])
+      }
+    }
+
+    const events: Array<{ type: string; sessionId: number; findingId?: number }> = []
+    const ids = (db.prepare('SELECT id FROM findings').all() as Array<{ id: number }>).map(r => r.id)
+    expect(ids.length).toBe(SESSIONS * FINDINGS_PER_SESSION)
+
+    const results = await Effect.runPromise(
+      purgeFindings(ids, {
+        db,
+        publish: (c) => Effect.sync(() => {
+          events.push(c as { type: string; sessionId: number; findingId?: number })
+        }),
+      }),
+    )
+
+    expect(results).toHaveLength(SESSIONS * FINDINGS_PER_SESSION)
+    // Exactly one event per affected session — the load-bearing
+    // coalescing assertion for issue #344.
+    expect(events).toHaveLength(SESSIONS)
+    expect(events.every(e => e.type === 'state-changed')).toBe(true)
+    expect(new Set(events.map(e => e.sessionId))).toEqual(new Set([1, 2, 3, 4, 5]))
+
+    // Every message body now contains the mask, no raw path survives.
+    const surviving = db.prepare(
+      "SELECT COUNT(*) AS n FROM messages WHERE content_text LIKE ?",
+    ).get(`%${raw}%`) as { n: number }
+    expect(surviving.n).toBe(0)
+  })
+
   describe('orderForBulkPurge', () => {
     it('returns ids grouped by message, descending start_offset within a message', () => {
       insertMessage(db, 30, 'msg A')

--- a/packages/core/src/security/purge.ts
+++ b/packages/core/src/security/purge.ts
@@ -97,44 +97,75 @@ export function purgeFinding(
   )
 }
 
-/** Bulk purge across many findings. Caller passes an arbitrary
- *  ordering; we re-sort to the only correct order:
+/** Bulk purge across many findings.
  *
- *    1. Group by `message_id`
- *    2. Within each group, apply in **descending** `start_offset` so
- *       earlier offsets stay valid as the string shifts.
+ *  Ordering: caller passes an arbitrary order; we re-sort to the only
+ *  correct order — group by `message_id`, then within each group
+ *  apply in **descending** `start_offset` so earlier offsets stay
+ *  valid as the string shifts. Without this two findings inside the
+ *  same message at offsets [10..20] and [40..60] would corrupt:
+ *  purging [10..20] first shifts everything after by `mask.length -
+ *  10`, and the second slice now points at the wrong bytes.
  *
- *  Without this re-sort, two findings inside the same message at
- *  offsets [10..20] and [40..60] would corrupt: purging [10..20]
- *  first shifts everything after offset 20 by `mask.length - 10`,
- *  and the second slice [40..60] now points at the wrong bytes
- *  (often leaking part of the second secret into the mask, or
- *  losing it entirely). */
+ *  Performance: the whole bulk runs in ONE sqlite transaction with
+ *  one `content_text` SELECT/UPDATE per affected message and ONE
+ *  `updateSessionCounts` per affected session. The earlier
+ *  per-finding loop paid a fsync per finding (~3–5 ms on macOS) and
+ *  rebuilt session counts N times; on archives with ~17 k absolute-
+ *  path findings concentrated in a handful of sessions that
+ *  serialised into ~60 s of main-process work and froze the app
+ *  (issue #344). */
 export function purgeFindings(
   findingIds: readonly number[],
   deps: PurgeDeps,
 ): Effect.Effect<PurgeResult[], PurgeError> {
   return Effect.gen(function* () {
-    // Resolve offsets/message ids up front so we can deterministically
-    // order. The Effect.try preserves db-failure → PurgeError mapping.
-    const ordered = yield* Effect.try({
-      try: () => orderForBulkPurge(deps.db, findingIds),
+    if (findingIds.length === 0) {
+      return [] as PurgeResult[]
+    }
+
+    // Resolve every row up front so the transaction body never has
+    // to fan back out into per-finding SELECTs. The Map keys also
+    // dedupe accidental duplicate ids cheaply.
+    const rows = yield* Effect.try({
+      try: () => loadFindingsForBulkPurge(deps.db, findingIds),
       catch: (cause) => new PurgeError({ findingId: -1, reason: 'db-failed', cause }),
     })
 
-    const out: PurgeResult[] = []
-    for (const id of ordered) {
-      const result = yield* purgeFinding(id, deps).pipe(
-        Effect.catchTag('PurgeError', (err) =>
-          err.reason === 'already-purged'
-            ? Effect.succeed(null)
-            : Effect.fail(err),
-        ),
-      )
-      if (result) out.push(result)
+    // Mirror single-purge pre-checks so callers passing a stale or
+    // orphan id get the same `PurgeError` they'd see one at a time.
+    // Done BEFORE opening the transaction so a bad id never leaves a
+    // half-purged batch behind — the old loop committed each finding
+    // separately and could abort partway through.
+    for (const id of new Set(findingIds)) {
+      const row = rows.get(id)
+      if (!row) {
+        return yield* Effect.fail(new PurgeError({ findingId: id, reason: 'not-found' }))
+      }
+      if (row.state === 'active' && row.message_id === null) {
+        return yield* Effect.fail(new PurgeError({ findingId: id, reason: 'message-missing' }))
+      }
     }
-    yield* Effect.annotateCurrentSpan('purged', out.length)
-    return out
+
+    const { results, sessionIds } = yield* Effect.try({
+      try: () => applyBulkPurgeTxn(deps.db, rows),
+      catch: (cause) => new PurgeError({ findingId: -1, reason: 'db-failed', cause }),
+    })
+
+    // One coalesced event per touched session — the renderer's
+    // 300 ms debounce in SecurityPage / BlastRadius / SessionDetail
+    // would have collapsed N per-finding events into a single refetch
+    // anyway, so emitting one up front skips N-1 IPC hops.
+    for (const sessionId of sessionIds) {
+      yield* deps.publish({
+        type: 'state-changed',
+        sessionId,
+        state: 'purged',
+      })
+    }
+
+    yield* Effect.annotateCurrentSpan('purged', results.length)
+    return results
   }).pipe(
     Effect.withSpan('security.purge.bulk', { attributes: { requested: findingIds.length } }),
   )
@@ -223,6 +254,122 @@ export function orderForBulkPurge(
     for (const r of byMessage.get(key)!) out.push(r.id)
   }
   return out
+}
+
+function loadFindingsForBulkPurge(
+  db: Database.Database,
+  findingIds: readonly number[],
+): Map<number, FindingForPurge> {
+  const out = new Map<number, FindingForPurge>()
+  if (findingIds.length === 0) return out
+  // Chunk the IN-list — sqlite caps host parameters at 999 by
+  // default and a single rescan can hand us tens of thousands of ids.
+  const CHUNK = 500
+  for (let i = 0; i < findingIds.length; i += CHUNK) {
+    const slice = findingIds.slice(i, i + CHUNK)
+    const placeholders = slice.map(() => '?').join(',')
+    const rows = db.prepare(
+      `SELECT id, session_id, message_id, kind, start_offset, end_offset, state
+         FROM findings WHERE id IN (${placeholders})`,
+    ).all(...slice) as FindingForPurge[]
+    for (const r of rows) out.set(r.id, r)
+  }
+  return out
+}
+
+function applyBulkPurgeTxn(
+  db: Database.Database,
+  rows: Map<number, FindingForPurge>,
+): { results: PurgeResult[]; sessionIds: number[] } {
+  // Only `active` rows do work; `purged` rows are silently skipped to
+  // preserve the prior idempotent-on-replay semantics ("re-clicking
+  // Purge after a partial failure must not error"). Orphan rows have
+  // already been screened by the caller's pre-checks.
+  const active: FindingForPurge[] = []
+  for (const row of rows.values()) {
+    if (row.state === 'active' && row.message_id !== null) active.push(row)
+  }
+
+  // Group by message so each message body is rewritten exactly once.
+  const byMessage = new Map<number, FindingForPurge[]>()
+  for (const row of active) {
+    const key = row.message_id as number
+    let bucket = byMessage.get(key)
+    if (!bucket) { bucket = []; byMessage.set(key, bucket) }
+    bucket.push(row)
+  }
+  // Descending offset within each message — earlier offsets stay
+  // valid as the suffix shifts.
+  for (const bucket of byMessage.values()) {
+    bucket.sort((a, b) => b.start_offset - a.start_offset)
+  }
+
+  const purgedAt = new Date().toISOString()
+  const results: PurgeResult[] = []
+  const sessionIdsSeen = new Set<number>()
+  const sessionIds: number[] = []
+  const sessionsToRecount = new Set<number>()
+
+  const selectMessage = db.prepare(
+    'SELECT content_text FROM messages WHERE id = ?',
+  )
+  const updateMessage = db.prepare(
+    'UPDATE messages SET content_text = ? WHERE id = ?',
+  )
+  const updateFinding = db.prepare(
+    `UPDATE findings
+        SET state = 'purged', state_changed_at = ?
+      WHERE id = ?`,
+  )
+
+  // One transaction wraps the whole batch: a single fsync at COMMIT
+  // instead of one per finding. This is the load-bearing change for
+  // issue #344 — 17 k findings went from ~60 s to a few hundred ms.
+  db.transaction(() => {
+    for (const [messageId, bucket] of byMessage) {
+      const msg = selectMessage.get(messageId) as { content_text: string } | undefined
+      if (!msg) {
+        // The session-rescan / cascade-delete window is narrow but
+        // possible; treat a missing message like the single-purge
+        // path's "disappeared between read and purge" — throw inside
+        // the transaction so sqlite rolls everything back.
+        throw new Error(`Message ${messageId} disappeared between read and purge`)
+      }
+
+      let text = msg.content_text
+      for (const finding of bucket) {
+        const original = text.slice(finding.start_offset, finding.end_offset)
+        const mask = maskValueByKind(original, finding.kind as SensitiveKind)
+        text =
+          text.slice(0, finding.start_offset) +
+          mask +
+          text.slice(finding.end_offset)
+        updateFinding.run(purgedAt, finding.id)
+        results.push({
+          findingId: finding.id,
+          sessionId: finding.session_id,
+          maskUsed: mask,
+          purgedAt,
+        })
+        if (!sessionIdsSeen.has(finding.session_id)) {
+          sessionIdsSeen.add(finding.session_id)
+          sessionIds.push(finding.session_id)
+        }
+        sessionsToRecount.add(finding.session_id)
+      }
+      updateMessage.run(text, messageId)
+    }
+
+    // Recompute denormalised counts once per affected session — the
+    // earlier per-finding loop called this N times for sessions that
+    // had a large fan-in, which on its own ran two SELECTs +
+    // an UPDATE per call.
+    for (const sessionId of sessionsToRecount) {
+      updateSessionCounts(db, sessionId)
+    }
+  })()
+
+  return { results, sessionIds }
 }
 
 function applyPurgeTxn(

--- a/packages/core/src/security/types.ts
+++ b/packages/core/src/security/types.ts
@@ -116,7 +116,12 @@ export interface DismissScope {
  *  as no-ops (forward-compat). */
 export type FindingsChange =
   | { type: 'inserted'; sessionId: number }
-  | { type: 'state-changed'; sessionId: number; findingId: number; state: FindingState }
+  // `findingId` is omitted for bulk events that coalesce many
+  // findings into one per-session notification (bulk dismiss, bulk
+  // purge). All consumers filter by `sessionId` and re-fetch, so the
+  // omission is harmless and avoids fanning out N IPC messages for
+  // an action that touches K << N sessions.
+  | { type: 'state-changed'; sessionId: number; findingId?: number; state: FindingState }
   | { type: 'session-rescanned'; sessionId: number }
 
 /** Snapshot of the scan worker's transient state. The DB stores


### PR DESCRIPTION
## What

Bulk-purging thousands of security findings froze the app for ~60s. This rewrites `purgeFindings` to do the whole batch in one sqlite transaction with per-message and per-session batching.

Closes #344.

## Why

The reported repro was 17,218 absolute-path findings purged across one bulk action, blocking the renderer for 59.2s (the exact span the user pasted from the logs). Reading the code, the per-finding loop in `purgeFindings`:

- ran each finding through its own `BEGIN/COMMIT` (one fsync per finding — ~3–5 ms on macOS),
- called `updateSessionCounts` (two aggregate SELECTs + an UPDATE) once per finding even when the same session was touched thousands of times,
- and emitted one `state-changed` IPC event per finding.

For an archive where one session contributes thousands of findings of the same kind this serialises into the observed minute-long main-process stall. Single-finding purge is unchanged (it is already ~5 ms and the dialog-driven UX expects a per-finding result).

## How

`purgeFindings` is rewritten to:

- Load every target row in one `IN`-list query, chunked at 500 to stay under sqlite's 999-host-parameter cap.
- Pre-validate `not-found` / orphan (`message_id IS NULL`) rows **before** opening the transaction, so a stale id can no longer half-commit a batch (the prior loop would commit the early findings then bail out partway).
- Wrap the entire batch in one `db.transaction(...)` — one fsync at COMMIT instead of N.
- Group by `message_id` and rewrite each message body exactly once with all findings applied in **descending** `start_offset` order (the same offset-drift safety the prior code relied on, now also de-duplicated across reads).
- Recompute `updateSessionCounts` once per distinct affected session.
- Emit one coalesced `state-changed` event per touched session. All renderer consumers (`SecurityPage`, `BlastRadius`, `SessionDetail`, `ProjectView`) already debounce these and filter by `sessionId`; bulk dismiss has been sending events in this shape at runtime since #234.

`FindingsChange.state-changed.findingId` is made optional to match what the bulk dismiss path was already sending at runtime; a comment documents the bulk-coalescing contract.

`purgeEverywhere` benefits automatically because it delegates to `purgeFindings`.

### How it connects

- The Security Scan feature ([memory: Security Scan feature](https://github.com/paperboytm/spool/issues/344)) is the only surface that produces destructive actions across many findings at once. Issue #344 is the first real-world dataset where the per-finding cost compounded into a UX bug.
- `purgeFindings` is exposed via the `security:purge-findings` IPC channel and consumed by both the in-page bulk action and `BlastRadius`'s "purge across all sessions" path.
- The renderer's existing 300 ms debounce on `securityApi.onChange` would have collapsed N per-finding events into one refetch anyway; coalescing at the source just avoids the N-1 wasted IPC hops.

## Verification

- `pnpm vitest run src/security` in `packages/core` — 133/133 green (8 files).
- `pnpm vitest run src/main/ipc/security.test.ts` in `packages/app` — 29/29 green.
- New regression test: 5 sessions × 50 findings → exactly 5 publish events (not 250), no raw value survives in any message body.
- Manual dev run on a real archive: 8,185 absolute-path findings across 197 sessions purged in 1.41s; UI stays responsive; DB inspection confirms `state='purged'` on all 8,185, message bodies contain the per-kind mask, `messages_fts` no longer matches the raw value, and `scan_purged_count` aggregates correctly per session.

## Notes / non-goals

- Single-finding `purgeFinding` is unchanged.
- Atomicity of bulk purge becomes all-or-nothing on error (previously it would half-commit then fail). This is the safer semantic for retry, but it is a behavior change worth flagging.
- A separate follow-up should consider moving DB-heavy security mutations off the main process onto the existing `scan-worker` thread, so even a sub-second purge does not cost a frame on the renderer.
- Purge still does not survive a subsequent source-file re-sync (the cascade-delete + re-insert path overwrites `content_text` from source). That is a pre-existing design gap separate from this fix and will be tracked in its own issue.