### PR TITLE
fix(db): dedupe (session_id, msg_uuid) and add UNIQUE INDEX (schema v14)

### DIFF
--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -14,7 +14,7 @@ export const DB_PATH = join(SPOOL_DIR, 'spool.db')
  * Latest schema version the running build knows how to migrate to.
  * Bump in lockstep with the last `db.pragma('user_version = N')` in runMigrations.
  */
-export const LATEST_SCHEMA_VERSION = 13
+export const LATEST_SCHEMA_VERSION = 14
 
 let _db: Database.Database | null = null
 let _wasNewDb = false
@@ -596,6 +596,94 @@ export function runMigrations(db: Database.Database): void {
     })()
   }
 
+  if (version < 14) {
+    // v14: dedupe (session_id, msg_uuid) and add a partial UNIQUE index.
+    //
+    // Why: append-only sync needs INSERT OR IGNORE on (session_id,
+    // msg_uuid) as the dedupe key. Today there is no UNIQUE constraint
+    // and the claude source emits some records twice (tool-use shadow
+    // entries — identical content, same uuid, different seq), which the
+    // pre-fix DELETE+INSERT sync silently re-doubled on every re-sync.
+    // Audit on a real archive showed 118 such pairs (all content-
+    // identical, 94 empty tool-only + 24 with text, 0 mixed). Cascade-
+    // delete on findings makes the dedupe loss-free: the redundant
+    // finding rows pointed at the redundant message rows, both go.
+    //
+    // After dropping the redundant rows we recompute the denormalised
+    // counts on the affected sessions so the Library badge and the
+    // Security risk numbers don't show a half-cent of drift until the
+    // next sync touches them.
+    db.transaction(() => {
+      const affected = db.prepare(
+        `SELECT DISTINCT session_id FROM messages
+          WHERE msg_uuid IS NOT NULL
+          GROUP BY session_id, msg_uuid HAVING COUNT(*) > 1`,
+      ).all() as Array<{ session_id: number }>
+
+      db.prepare(
+        `DELETE FROM messages
+          WHERE msg_uuid IS NOT NULL
+            AND id NOT IN (
+              SELECT MIN(id) FROM messages
+               WHERE msg_uuid IS NOT NULL
+               GROUP BY session_id, msg_uuid
+            )`,
+      ).run()
+
+      const recountMsg = db.prepare(
+        `UPDATE sessions SET message_count = (
+            SELECT COUNT(*) FROM messages
+             WHERE session_id = sessions.id AND is_sidechain = 0
+          ) WHERE id = ?`,
+      )
+      // Inline scan-count recompute mirrors security/repo.ts'
+      // updateSessionCounts; the kind lists below must match
+      // @spool-lab/redact's INFO_SEVERITY_KINDS / HIGH_SEVERITY_KINDS
+      // at the time this migration was authored. They are inlined (not
+      // imported) so the schema-migration layer can stay free of a
+      // detection-vocabulary dependency — a redact-side rename must
+      // never break opening a legacy DB.
+      const recountScan = db.prepare(
+        `UPDATE sessions SET
+            scan_finding_count = (
+              SELECT COUNT(*) FROM findings
+               WHERE session_id = sessions.id AND state = 'active'
+                 AND kind NOT IN ('absolute-path','ip','internal-host')
+            ),
+            scan_high_count = (
+              SELECT COUNT(*) FROM findings
+               WHERE session_id = sessions.id AND state = 'active'
+                 AND kind IN (
+                   'private-key','ssh-key','cloud-cred-ini',
+                   'kubeconfig-token','netrc','connection-string',
+                   'url-creds','api-key','jwt','bearer',
+                   'basic-auth','env-var','generic-secret'
+                 )
+            ),
+            scan_purged_count = (
+              SELECT COUNT(*) FROM findings
+               WHERE session_id = sessions.id AND state = 'purged'
+            )
+          WHERE id = ?`,
+      )
+      for (const row of affected) {
+        recountMsg.run(row.session_id)
+        recountScan.run(row.session_id)
+      }
+
+      // Partial index: allow NULL msg_uuid for forward-compat even
+      // though no current parser ever emits NULL — we don't want the
+      // schema to lock that behaviour in.
+      db.exec(
+        `CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_session_uuid
+           ON messages(session_id, msg_uuid)
+         WHERE msg_uuid IS NOT NULL`,
+      )
+
+      db.pragma('user_version = 14')
+    })()
+  }
+
   rebuildFtsTableIfEmpty(db, 'messages', 'messages_fts_trigram')
   rebuildFtsTableIfEmpty(db, 'session_search', 'session_search_fts')
   rebuildFtsTableIfEmpty(db, 'session_search', 'session_search_fts_trigram')
@@ -641,6 +729,10 @@ function ensureSchemaSanity(db: Database.Database): void {
   ensureCol('sessions', 'title', 'TEXT')
   ensureCol('sessions', 'title_source', `TEXT NOT NULL DEFAULT 'derived'`)
   ensureCol('sessions', 'message_count', 'INTEGER NOT NULL DEFAULT 0')
+  // v14 (and forward) reads messages.msg_uuid; legacy DBs predating
+  // its introduction (some test fixtures, very old installs) won't have
+  // the column. ALTER ADD is a no-op when present.
+  ensureCol('messages', 'msg_uuid', 'TEXT')
 }
 
 /**

--- a/packages/core/src/db/migration-v12.test.ts
+++ b/packages/core/src/db/migration-v12.test.ts
@@ -18,8 +18,8 @@ function seedProjectAndSession(db: Database.Database, sessionUuid: string): numb
 }
 
 describe('migration v12 — security scan schema', () => {
-  it('LATEST_SCHEMA_VERSION is 13', () => {
-    expect(LATEST_SCHEMA_VERSION).toBe(13)
+  it('LATEST_SCHEMA_VERSION is 14', () => {
+    expect(LATEST_SCHEMA_VERSION).toBe(14)
   })
 
   it('adds 5 scan_* columns to sessions (profile / completed_at / finding_count / high_count / purged_count)', () => {

--- a/packages/core/src/db/migration-v14.test.ts
+++ b/packages/core/src/db/migration-v14.test.ts
@@ -1,0 +1,174 @@
+// Migration v14 covers two things:
+//  1. Dedupe pre-existing (session_id, msg_uuid) duplicates that the
+//     pre-append-only sync used to silently re-insert from the source.
+//  2. Add a partial UNIQUE INDEX so future syncs can use INSERT OR
+//     IGNORE as the dedupe primitive.
+//
+// The audit that motivated this (issue #344 follow-up) found 118 such
+// pairs in a real archive, all content-identical, ~5% of them carrying
+// findings. The dedupe path therefore has to cascade-clean findings
+// and re-derive the denormalised counts on the touched sessions.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { runMigrations } from './db.js'
+
+function seedV13(): Database.Database {
+  const db = new Database(':memory:')
+  runMigrations(db)
+  // Roll the user_version back so we can seed pre-v14 state (the
+  // index doesn't exist yet, so duplicate inserts are accepted).
+  db.pragma('user_version = 13')
+  // Drop the v14 index if a future bump re-creates one with the
+  // same name — keeps the seed self-contained.
+  db.exec('DROP INDEX IF EXISTS idx_messages_session_uuid')
+  db.prepare(
+    `INSERT INTO projects (id, source_id, slug, display_path, display_name)
+     VALUES (1, 1, 'p', '/p', 'p')`,
+  ).run()
+  db.prepare(
+    `INSERT INTO sessions (id, project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count)
+     VALUES (1, 1, 1, 's-1', '/p/s-1', 'S1', '2026-01-01', '2026-01-01', 0)`,
+  ).run()
+  return db
+}
+
+function insertMsg(db: Database.Database, opts: {
+  id: number; sessionId: number; uuid: string | null;
+  role?: string; content?: string; seq: number; sidechain?: boolean;
+}): void {
+  db.prepare(
+    `INSERT INTO messages (id, session_id, source_id, msg_uuid, role, content_text, timestamp, is_sidechain, seq)
+     VALUES (?, ?, 1, ?, ?, ?, '2026-01-01', ?, ?)`,
+  ).run(
+    opts.id, opts.sessionId, opts.uuid, opts.role ?? 'assistant',
+    opts.content ?? '', opts.sidechain ? 1 : 0, opts.seq,
+  )
+}
+
+function bumpToV14(db: Database.Database): void {
+  // Re-invoke the public migration runner; it will see user_version=13
+  // and apply the v14 step we just authored.
+  runMigrations(db)
+}
+
+describe('migration v14: dedupe + UNIQUE INDEX(session_id, msg_uuid)', () => {
+  let db: Database.Database
+  beforeEach(() => { db = seedV13() })
+
+  it('collapses identical-content dupes to the lowest id and bumps user_version', () => {
+    insertMsg(db, { id: 10, sessionId: 1, uuid: 'a', content: 'hello', seq: 0 })
+    insertMsg(db, { id: 11, sessionId: 1, uuid: 'a', content: 'hello', seq: 1 })
+    insertMsg(db, { id: 12, sessionId: 1, uuid: 'b', content: 'world', seq: 2 })
+
+    bumpToV14(db)
+
+    const rows = db.prepare('SELECT id, msg_uuid FROM messages ORDER BY id').all() as Array<{ id: number; msg_uuid: string }>
+    expect(rows).toEqual([
+      { id: 10, msg_uuid: 'a' },
+      { id: 12, msg_uuid: 'b' },
+    ])
+    expect((db.pragma('user_version') as Array<{ user_version: number }>)[0]!.user_version).toBe(14)
+  })
+
+  it('cascade-deletes findings on dropped duplicate rows', () => {
+    insertMsg(db, { id: 20, sessionId: 1, uuid: 'k', content: 'leak', seq: 0 })
+    insertMsg(db, { id: 21, sessionId: 1, uuid: 'k', content: 'leak', seq: 5 })
+    // findings on BOTH copies — the redundant copy carries a redundant
+    // detection from the pre-dedupe scanner pass. After migration only
+    // the kept copy's finding should remain.
+    db.prepare(
+      `INSERT INTO findings (id, session_id, message_id, kind, value_hash, confidence, provider, start_offset, end_offset, state)
+       VALUES (100, 1, 20, 'api-key', 'h', 0.9, 'regex', 0, 4, 'active'),
+              (101, 1, 21, 'api-key', 'h', 0.9, 'regex', 0, 4, 'active')`,
+    ).run()
+
+    bumpToV14(db)
+
+    const findings = db.prepare('SELECT id, message_id FROM findings ORDER BY id').all() as Array<{ id: number; message_id: number }>
+    expect(findings).toEqual([{ id: 100, message_id: 20 }])
+  })
+
+  it('recomputes session.message_count after dedupe (non-sidechain only)', () => {
+    insertMsg(db, { id: 30, sessionId: 1, uuid: 'x', seq: 0 })
+    insertMsg(db, { id: 31, sessionId: 1, uuid: 'x', seq: 1 }) // dupe → drops
+    insertMsg(db, { id: 32, sessionId: 1, uuid: 'y', seq: 2 })
+    insertMsg(db, { id: 33, sessionId: 1, uuid: 'z', seq: 3, sidechain: true })
+    db.prepare('UPDATE sessions SET message_count = ? WHERE id = 1').run(3) // pre-dedupe inflated
+
+    bumpToV14(db)
+
+    const row = db.prepare('SELECT message_count FROM sessions WHERE id = 1').get() as { message_count: number }
+    // 2 non-sidechain after dedupe (x kept once, y), z is sidechain.
+    expect(row.message_count).toBe(2)
+  })
+
+  it('recomputes scan counts using the redact severity sets', () => {
+    insertMsg(db, { id: 40, sessionId: 1, uuid: 'x', seq: 0 })
+    insertMsg(db, { id: 41, sessionId: 1, uuid: 'x', seq: 1 }) // dupe → drops
+    // Survivor-row findings: one HIGH (api-key), one LOW (email),
+    // one INFO (absolute-path), one purged. After recompute:
+    //   scan_finding_count = 2 (HIGH + LOW; INFO excluded)
+    //   scan_high_count    = 1 (api-key)
+    //   scan_purged_count  = 1
+    db.prepare(
+      `INSERT INTO findings (session_id, message_id, kind, value_hash, confidence, provider, start_offset, end_offset, state)
+       VALUES (1, 40, 'api-key',       'h1', 0.9, 'regex', 0, 1, 'active'),
+              (1, 40, 'email',         'h2', 0.9, 'regex', 1, 2, 'active'),
+              (1, 40, 'absolute-path', 'h3', 0.9, 'regex', 2, 3, 'active'),
+              (1, 40, 'api-key',       'h4', 0.9, 'regex', 3, 4, 'purged')`,
+    ).run()
+    // Pre-dedupe inflated counts.
+    db.prepare(
+      `UPDATE sessions SET scan_finding_count = 99, scan_high_count = 99, scan_purged_count = 99 WHERE id = 1`,
+    ).run()
+
+    bumpToV14(db)
+
+    const row = db.prepare(
+      'SELECT scan_finding_count, scan_high_count, scan_purged_count FROM sessions WHERE id = 1',
+    ).get() as { scan_finding_count: number; scan_high_count: number; scan_purged_count: number }
+    expect(row).toEqual({ scan_finding_count: 2, scan_high_count: 1, scan_purged_count: 1 })
+  })
+
+  it('adds a partial UNIQUE index that rejects future duplicates', () => {
+    bumpToV14(db)
+    insertMsg(db, { id: 50, sessionId: 1, uuid: 'p', seq: 0 })
+    expect(() => insertMsg(db, { id: 51, sessionId: 1, uuid: 'p', seq: 1 }))
+      .toThrow(/UNIQUE constraint/)
+  })
+
+  it('allows multiple NULL msg_uuid rows in the same session (partial index)', () => {
+    bumpToV14(db)
+    // No current parser emits NULL, but the schema doesn't forbid it
+    // — the partial index must mirror that and stay out of NULL rows.
+    insertMsg(db, { id: 60, sessionId: 1, uuid: null, seq: 0 })
+    expect(() => insertMsg(db, { id: 61, sessionId: 1, uuid: null, seq: 1 }))
+      .not.toThrow()
+  })
+
+  it('leaves messages_fts in sync after cascade DELETE', () => {
+    insertMsg(db, { id: 70, sessionId: 1, uuid: 'q', content: 'searchable-token', seq: 0 })
+    insertMsg(db, { id: 71, sessionId: 1, uuid: 'q', content: 'searchable-token', seq: 1 })
+
+    bumpToV14(db)
+
+    // FTS should hit exactly once (one surviving row), not twice.
+    const hits = db.prepare(
+      'SELECT COUNT(*) AS n FROM messages_fts WHERE messages_fts MATCH ?',
+    ).get('"searchable-token"') as { n: number }
+    expect(hits.n).toBe(1)
+  })
+
+  it('is idempotent — re-running migrations does not re-dedupe or re-throw', () => {
+    insertMsg(db, { id: 80, sessionId: 1, uuid: 'r', seq: 0 })
+    insertMsg(db, { id: 81, sessionId: 1, uuid: 'r', seq: 1 })
+    bumpToV14(db)
+    expect((db.pragma('user_version') as Array<{ user_version: number }>)[0]!.user_version).toBe(14)
+
+    // Second pass — no-op.
+    runMigrations(db)
+    const count = db.prepare('SELECT COUNT(*) AS c FROM messages WHERE msg_uuid = ?').get('r') as { c: number }
+    expect(count.c).toBe(1)
+  })
+})


### PR DESCRIPTION
## What

Schema migration v14: dedupe pre-existing `(session_id, msg_uuid)` duplicates in `messages`, recompute the denormalised counts on affected sessions, then add a partial `UNIQUE INDEX(session_id, msg_uuid) WHERE msg_uuid IS NOT NULL`.

No behaviour change to sync today. This is the schema groundwork the next PR needs in order to switch the syncer over to `INSERT OR IGNORE` as the dedupe primitive.

## Why

Today's syncer uses DELETE+INSERT on every re-sync of a session file. Combined with the absence of any uniqueness constraint on `(session_id, msg_uuid)`, that pattern silently re-doubled some claude source records on each pass: `claude-code` writes tool-use shadow entries (same uuid, same content, different seq) twice in the jsonl, and there was nothing in the schema to reject them.

An audit on a populated archive found:
- **118 duplicate `(session_id, msg_uuid)` pairs** across 197 sessions
- All 118 are **byte-identical within their pair** (94 empty tool-only + 24 with text; zero pairs with distinct content)
- The scanner had detected secret findings on **both** copies, so the same logical occurrence shows up twice on the Security page in ~0.5% of cases

This is the foundational fix for the broader follow-up to #344: making Security Scan purge / dismiss state survive a re-sync of the same source file. That work depends on the syncer being able to use `INSERT OR IGNORE` on `(session_id, msg_uuid)` as the new dedupe primitive — which in turn requires the unique index this PR adds.

## How

The new v14 step runs in one transaction:

1. **Detect affected sessions** (`SELECT DISTINCT session_id ... HAVING COUNT(*) > 1`) so we know which counts need refreshing after the delete.
2. **Drop the redundant rows** (`DELETE ... WHERE id NOT IN (SELECT MIN(id) ... GROUP BY session_id, msg_uuid)`). FK cascade clears the redundant `findings` rows; the existing `messages_fts` AFTER DELETE trigger removes the redundant FTS rows.
3. **Recompute** `message_count` (non-sidechain rows) and `scan_finding_count` / `scan_high_count` / `scan_purged_count` for each affected session so the Library badge and Risk panel reflect the deduped truth immediately, instead of drifting until the next sync touches them.
4. **Add the partial UNIQUE INDEX** `idx_messages_session_uuid ON messages(session_id, msg_uuid) WHERE msg_uuid IS NOT NULL`. The `WHERE` clause keeps the schema honest with the parser contract (always non-null in practice) without forbidding a future malformed-source escape hatch.

Two small adjacent edits to keep this safe:
- `ensureSchemaSanity` gains `ensureCol('messages', 'msg_uuid', 'TEXT')` — the v4 `migration-backup` test fixture seeds a minimal `messages` table without that column, and without the backfill the v14 step crashes on legacy DBs that pre-date `msg_uuid`.
- The INFO / HIGH severity kind lists in the recount SQL are inlined (not imported from `@spool-lab/redact`) so the schema-migration layer stays free of a detection-vocabulary dependency — a redact-side rename must never break opening a legacy DB.

### How it connects

- This is PR 1 of a planned series. PR 2 will switch the syncer's `insertMessages` to `INSERT OR IGNORE` on this index, gated by a cheap `classifySync()` that detects source truncation/rewrite (first-uuid mismatch or shrunk row count) and falls back to today's DELETE+INSERT.
- Append-only sync is the architecturally correct semantic given that source jsonl files (claude/codex/gemini/opencode) are themselves append-only event logs. It also incidentally fixes the over-counting bug surfaced here.
- The pre-existing v13 subagent filter has nothing to do with this — that filter lives in `source-paths.ts` at the discovery level, so subagent files never reach the syncer regardless.

## Verification

- New migration test file `packages/core/src/db/migration-v14.test.ts` — 8 tests covering: lowest-id collapse, finding cascade-delete, `message_count` recompute, scan-count recompute against the redact severity sets, partial-index rejects future dupes, allows multiple NULL `msg_uuid`, FTS coherence after cascade, idempotency.
- `pnpm vitest run` in `packages/core` — 372 passed, 1 skipped, 0 failed.
- Migration smoke-test on a real `~/.spool-dev` archive: `user_version` 13 → 14, 118 dupe pairs collapsed to 0, 60216 → 60106 message rows, 8261 → 8259 finding rows, all sample session counts match the recompute-from-truth, `messages_fts` row count == `messages` row count, `INSERT ... ON CONFLICT(session_id, msg_uuid) DO NOTHING` on an existing pair returns 0 changes.

## Notes / non-goals

- Sync behaviour unchanged in this PR. The DELETE+INSERT pattern stays exactly as it is today.
- No public type changes; no IPC surface changes.
- One-time backup of pre-migration DB was taken locally for the smoke-test; the migration is atomic so a transactional failure rolls back automatically and `backupBeforeDestructive` is not necessary here.
- ML / regex / allowlist semantics are untouched.