### PR TITLE
feat(sync): switch syncer to append-only so user-side state survives re-sync

### DIFF
--- a/packages/core/src/db/queries.test.ts
+++ b/packages/core/src/db/queries.test.ts
@@ -203,7 +203,15 @@ describe('insertSpoolAuthoredSession', () => {
     expect(row.title).toBe('real query')
     expect(row.title_source).toBe('spool')
     expect(row.file_path).toBe('/Users/x/.claude/projects/-Users-x--spool-agent-search-sessions/ask-uuid-3.jsonl')
-    expect(row.message_count).toBe(5)
+    // upsertSession deliberately no longer touches message_count —
+    // the syncer recomputes it from the actual DB row count after
+    // insertMessages so the count tracks INSERT-OR-IGNORE-deduped
+    // truth (claude tool-use shadows would otherwise re-inflate it
+    // back to pre-v14 levels on every sync).
+    // insertSpoolAuthoredSession seeded message_count = 0; the
+    // upsertSession opts above pass 5, but the row should still
+    // read 0 since the count is now owned by recomputeMessageCount.
+    expect(row.message_count).toBe(0)
   })
 })
 

--- a/packages/core/src/db/queries.ts
+++ b/packages/core/src/db/queries.ts
@@ -107,6 +107,21 @@ export function getAllSessionMtimes(db: Database.Database): Map<string, string> 
   return new Map(rows.map(r => [r.file_path, r.raw_file_mtime]))
 }
 
+/** Sync mode for {@link upsertSession}.
+ *
+ *  - `rewrite`: today's behaviour. When the session already exists,
+ *    DELETE all its messages so the caller's {@link insertMessages}
+ *    can fully repopulate from the parsed source. Used for first
+ *    syncs, source-rewrite recoveries, and the explicit "Refresh from
+ *    source" action.
+ *  - `append`: skip the DELETE. The caller's {@link insertMessages}
+ *    will INSERT OR IGNORE against the partial UNIQUE index on
+ *    (session_id, msg_uuid), so existing rows survive and any
+ *    user-side state attached to them (Security Scan purge/dismiss,
+ *    star, etc.) persists across the re-sync — the root-cause fix for
+ *    "purge gets undone by re-sync". */
+export type UpsertSessionMode = 'rewrite' | 'append'
+
 export function upsertSession(
   db: Database.Database,
   opts: {
@@ -123,6 +138,7 @@ export function upsertSession(
     model: string
     rawFileMtime: string
   },
+  mode: UpsertSessionMode = 'rewrite',
 ): number {
   const existing = db
     .prepare('SELECT id, file_path FROM sessions WHERE session_uuid = ?')
@@ -143,19 +159,28 @@ export function upsertSession(
         + `${existing.file_path} → ${opts.filePath}`,
       )
     }
-    db.prepare('DELETE FROM messages WHERE session_id = ?').run(existing.id)
+    if (mode === 'rewrite') {
+      db.prepare('DELETE FROM messages WHERE session_id = ?').run(existing.id)
+    }
     // file_path is updated too: Spool-authored sessions start with a sentinel
     // ('spool:pending:<uuid>') and get rebound to the real source path here on
     // first sync. For normal sessions this is a no-op (same path).
+    //
+    // `message_count` is intentionally NOT updated here — the syncer
+    // recomputes it from the actual DB row count after insertMessages
+    // returns, which is the only count consistent with INSERT OR
+    // IGNORE-driven dedupe (claude tool-use shadow records would
+    // otherwise inflate the parser-derived value back to pre-v14
+    // levels on every sync).
     db.prepare(`
       UPDATE sessions SET
         title = CASE WHEN title_source = 'derived' THEN ? ELSE title END,
         file_path = ?,
-        started_at = ?, ended_at = ?, message_count = ?,
+        started_at = ?, ended_at = ?,
         has_tool_use = ?, cwd = ?, model = ?, raw_file_mtime = ?
       WHERE id = ?
     `).run(
-      opts.title, opts.filePath, opts.startedAt, opts.endedAt, opts.messageCount,
+      opts.title, opts.filePath, opts.startedAt, opts.endedAt,
       opts.hasToolUse ? 1 : 0, opts.cwd, opts.model, opts.rawFileMtime,
       existing.id,
     )
@@ -201,6 +226,16 @@ export function upsertSessionSearch(
   )
 }
 
+/** Insert message rows, skipping any that collide with the partial
+ *  UNIQUE index on (session_id, msg_uuid). Returns the count of rows
+ *  actually inserted — callers use this to decide whether anything
+ *  changed (NULL scan_profile, fire onSessionChanged) or to skip
+ *  downstream work when re-sync was a no-op.
+ *
+ *  The ON CONFLICT clause must restate the same `WHERE msg_uuid IS
+ *  NOT NULL` predicate as the index it targets; SQLite requires the
+ *  predicates to match before it considers a partial index for
+ *  conflict resolution. */
 export function insertMessages(
   db: Database.Database,
   sessionId: number,
@@ -215,21 +250,67 @@ export function insertMessages(
     toolNames: string[]
     seq: number
   }>,
-): void {
+): number {
   const stmt = db.prepare(`
     INSERT INTO messages
       (session_id, source_id, msg_uuid, parent_uuid, role,
        content_text, timestamp, is_sidechain, tool_names, seq)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(session_id, msg_uuid) WHERE msg_uuid IS NOT NULL DO NOTHING
   `)
 
+  let inserted = 0
   for (const m of messages) {
-    stmt.run(
+    const info = stmt.run(
       sessionId, sourceId, m.uuid, m.parentUuid, m.role,
       m.contentText, m.timestamp, m.isSidechain ? 1 : 0,
       JSON.stringify(m.toolNames), m.seq,
     )
+    if (info.changes > 0) inserted++
   }
+  return inserted
+}
+
+/** Lightweight snapshot used by the syncer's `classifySync` heuristic
+ *  to decide between append and rewrite paths — just the row count
+ *  and the leading uuid in seq order. We deliberately do NOT pull
+ *  `content_text` here: comparing parsed-vs-stored content would
+ *  trigger rewrite whenever Security Scan has already replaced the
+ *  raw value with its mask, undoing the purge on every re-sync. Only
+ *  msg_uuid-bearing rows participate in the dedupe index, so NULL-uuid
+ *  rows are excluded. */
+export function getMessageSnapshot(
+  db: Database.Database,
+  sessionId: number,
+): { firstUuid: string | null; total: number } {
+  const total = (db.prepare(
+    `SELECT COUNT(*) AS c FROM messages
+      WHERE session_id = ? AND msg_uuid IS NOT NULL`,
+  ).get(sessionId) as { c: number }).c
+  const first = db.prepare(
+    `SELECT msg_uuid FROM messages
+      WHERE session_id = ? AND msg_uuid IS NOT NULL
+      ORDER BY seq, id LIMIT 1`,
+  ).get(sessionId) as { msg_uuid: string } | undefined
+  return { firstUuid: first?.msg_uuid ?? null, total }
+}
+
+/** Refresh `sessions.message_count` for a single session from the
+ *  actual non-sidechain row count. Called after every sync's INSERT
+ *  block so the denormalised count tracks the deduped truth — the
+ *  parser's `parsed.messages.length` would re-introduce the v14-fixed
+ *  inflation for source formats (claude) that emit some records
+ *  twice. */
+export function recomputeMessageCount(
+  db: Database.Database,
+  sessionId: number,
+): void {
+  db.prepare(
+    `UPDATE sessions SET message_count = (
+        SELECT COUNT(*) FROM messages
+         WHERE session_id = sessions.id AND is_sidechain = 0
+      ) WHERE id = ?`,
+  ).run(sessionId)
 }
 
 export const SESSION_SELECT = `

--- a/packages/core/src/db/queries.ts
+++ b/packages/core/src/db/queries.ts
@@ -273,26 +273,38 @@ export function insertMessages(
 
 /** Lightweight snapshot used by the syncer's `classifySync` heuristic
  *  to decide between append and rewrite paths — just the row count
- *  and the leading uuid in seq order. We deliberately do NOT pull
- *  `content_text` here: comparing parsed-vs-stored content would
- *  trigger rewrite whenever Security Scan has already replaced the
- *  raw value with its mask, undoing the purge on every re-sync. Only
- *  msg_uuid-bearing rows participate in the dedupe index, so NULL-uuid
- *  rows are excluded. */
+ *  and the leading uuid in seq order, joined off `session_uuid` so the
+ *  caller doesn't pay a second `SELECT id FROM sessions` round-trip
+ *  (upsertSession does that lookup anyway right after).
+ *
+ *  We deliberately do NOT pull `content_text` here: comparing parsed-
+ *  vs-stored content would trigger rewrite whenever Security Scan has
+ *  already replaced the raw value with its mask, undoing the purge on
+ *  every re-sync. Only msg_uuid-bearing rows participate in the dedupe
+ *  index, so NULL-uuid rows are excluded.
+ *
+ *  Returns `total === 0, firstUuid === null` both for "session row
+ *  doesn't exist yet" and "session exists with no msg_uuid-bearing
+ *  rows" — classifySync treats both as `rewrite` so the two-state
+ *  collapse is intentional, not a lost signal. */
 export function getMessageSnapshot(
   db: Database.Database,
-  sessionId: number,
+  sessionUuid: string,
 ): { firstUuid: string | null; total: number } {
-  const total = (db.prepare(
-    `SELECT COUNT(*) AS c FROM messages
-      WHERE session_id = ? AND msg_uuid IS NOT NULL`,
-  ).get(sessionId) as { c: number }).c
-  const first = db.prepare(
-    `SELECT msg_uuid FROM messages
-      WHERE session_id = ? AND msg_uuid IS NOT NULL
-      ORDER BY seq, id LIMIT 1`,
-  ).get(sessionId) as { msg_uuid: string } | undefined
-  return { firstUuid: first?.msg_uuid ?? null, total }
+  // Single window-function query: pulls total and leading uuid in one
+  // index scan over (session_id, msg_uuid). `LIMIT 1` returns the
+  // smallest-seq row; `COUNT(*) OVER ()` annotates it with the total
+  // across the windowed partition (no GROUP BY needed since the
+  // WHERE already scopes to one session).
+  const row = db.prepare(
+    `SELECT m.msg_uuid AS msg_uuid, COUNT(*) OVER () AS total
+       FROM messages m
+       JOIN sessions s ON s.id = m.session_id
+      WHERE s.session_uuid = ? AND m.msg_uuid IS NOT NULL
+      ORDER BY m.seq, m.id LIMIT 1`,
+  ).get(sessionUuid) as { msg_uuid: string; total: number } | undefined
+  if (!row) return { firstUuid: null, total: 0 }
+  return { firstUuid: row.msg_uuid, total: row.total }
 }
 
 /** Refresh `sessions.message_count` for a single session from the

--- a/packages/core/src/sync/syncer.test.ts
+++ b/packages/core/src/sync/syncer.test.ts
@@ -416,6 +416,89 @@ describe('Syncer', () => {
   //   4. A shrunk parse result is a strong rewrite signal — source
   //      file truncation must replay through the safe path.
 
+  it('append-only sync keeps Security Scan masks in session_search_fts after a content-changing re-sync (no raw leak)', async () => {
+    // Regression for the gap the post-PR code review surfaced:
+    // upsertSessionSearch used to read from parsed.messages (the raw
+    // jsonl), so on every re-sync the session-level FTS index
+    // re-acquired the raw secret even though messages_fts was
+    // correctly masked. The fix routes session_search through
+    // messages.content_text — what's already in the DB after purge —
+    // so the "search across sessions" surface no longer leaks purged
+    // values for active sessions whose source files keep growing.
+    const baseDir = makeTempDir('spool-syncer-session-search-mask-')
+    const claudeDir = join(baseDir, 'claude', 'projects', 'test-project')
+    const spoolDataDir = join(baseDir, 'spool-data')
+    mkdirSync(claudeDir, { recursive: true })
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDataDir)
+
+    const filePath = join(claudeDir, 'session-search-mask.jsonl')
+    const userRecord = (uuid: string, ts: string, content: string) => JSON.stringify({
+      type: 'user',
+      sessionId: 'session-search-mask-session',
+      cwd: '/tmp/test-project',
+      uuid,
+      timestamp: ts,
+      message: { role: 'user', content },
+    })
+    // Two messages so the parser derives the title from the FIRST
+    // user message (a benign greeting) and the secret lives in a
+    // later message — this isolates the user_text/assistant_text leak
+    // the PR introduces from the title-derivation leak (pre-existing
+    // and out of scope here; the parser slices the first 120 chars of
+    // the first user message into sessions.title and that path has
+    // its own redaction story).
+    const SECRET = 'AKIAIOSFODNN7EXAMPLE'
+    writeFileSync(filePath, [
+      userRecord('m0', '2026-05-01T00:00:00Z', 'hello, please review my repo'),
+      userRecord('m1', '2026-05-01T00:01:00Z', `here is the credential: ${SECRET} thanks`),
+    ].join('\n'))
+
+    const { getDB, Syncer } = await loadCoreModules()
+    const db = getDB()
+    openDbs.push(db)
+    expect(new Syncer(db).syncFile(filePath, 'claude')).toBe('added')
+
+    const sessionId = (db.prepare(
+      "SELECT id FROM sessions WHERE session_uuid = 'session-search-mask-session'"
+    ).get() as { id: number }).id
+    const messageId = (db.prepare(
+      "SELECT id FROM messages WHERE session_id = ? AND msg_uuid = 'm1'"
+    ).get(sessionId) as { id: number }).id
+
+    // Simulate Security Scan purge of the m1 finding: mask
+    // content_text in place. The source jsonl still has the raw
+    // value — that's the threat model.
+    db.prepare(
+      `UPDATE messages SET content_text = 'here is the credential: [redacted: AWS key] thanks' WHERE id = ?`,
+    ).run(messageId)
+
+    // A real append at the source (claude session keeps growing).
+    writeFileSync(filePath, [
+      userRecord('m0', '2026-05-01T00:00:00Z', 'hello, please review my repo'),
+      userRecord('m1', '2026-05-01T00:01:00Z', `here is the credential: ${SECRET} thanks`),
+      userRecord('m2', '2026-05-01T00:02:00Z', 'a follow-up'),
+    ].join('\n'))
+    touchFile(filePath)
+    expect(new Syncer(db).syncFile(filePath, 'claude')).toBe('updated')
+
+    // session_search.user_text must reflect what the DB holds (mask),
+    // not what parsed.messages saw (raw).
+    const search = db.prepare(
+      'SELECT user_text FROM session_search WHERE session_id = ?'
+    ).get(sessionId) as { user_text: string }
+    expect(search.user_text.includes(SECRET)).toBe(false)
+    expect(search.user_text.includes('[redacted: AWS key]')).toBe(true)
+
+    // And a column-restricted FTS search against user_text must not
+    // surface the raw value (assistant_text and title leaks would be
+    // separate paths — title derivation is the parser's job, not
+    // this PR's surface).
+    const ftsHits = db.prepare(
+      'SELECT COUNT(*) AS n FROM session_search_fts WHERE session_search_fts MATCH ?'
+    ).get(`user_text:"${SECRET}"`) as { n: number }
+    expect(ftsHits.n).toBe(0)
+  })
+
   it('append-only sync preserves Security Scan purge state across a no-op re-sync (issue #344 follow-up)', async () => {
     const baseDir = makeTempDir('spool-syncer-purge-survives-')
     const claudeDir = join(baseDir, 'claude', 'projects', 'test-project')

--- a/packages/core/src/sync/syncer.test.ts
+++ b/packages/core/src/sync/syncer.test.ts
@@ -214,7 +214,14 @@ describe('Syncer', () => {
     expect(sessionCount.n).toBe(2)
   })
 
-  it('Security Scan cascade: a message-mutating sync clears scan_profile and fires onSessionChanged', async () => {
+  it('Security Scan cascade: appending a new message clears scan_profile and fires onSessionChanged', async () => {
+    // This used to assert that ANY mtime touch + content change
+    // clears scan_profile, on the assumption that the syncer always
+    // does DELETE+INSERT. Under append-only sync that contract
+    // changes: the cascade fires only when at least one new row is
+    // actually inserted (new uuid). Re-syncing the same-uuid file
+    // with edited content is now an explicit "use Refresh from
+    // source" case, covered above by the no-auto-rewrite test.
     const baseDir = makeTempDir('spool-syncer-scan-cascade-')
     const claudeDir = join(baseDir, 'claude', 'projects', 'test-project')
     const spoolDataDir = join(baseDir, 'spool-data')
@@ -223,34 +230,32 @@ describe('Syncer', () => {
     vi.stubEnv('SPOOL_DATA_DIR', spoolDataDir)
 
     const filePath = join(claudeDir, 'cascade.jsonl')
-    const writeJsonl = (suffix: string) =>
-      writeFileSync(filePath, [
-        JSON.stringify({
-          type: 'user',
-          sessionId: 'cascade-session-1',
-          cwd: '/tmp/test-project',
-          uuid: 'u1',
-          timestamp: '2026-05-01T00:00:00Z',
-          message: { role: 'user', content: `hello ${suffix}` },
-        }),
-      ].join('\n'))
-    writeJsonl('first')
+    const record = (uuid: string, content: string) => JSON.stringify({
+      type: 'user',
+      sessionId: 'cascade-session-1',
+      cwd: '/tmp/test-project',
+      uuid,
+      timestamp: `2026-05-01T00:0${uuid.slice(-1)}:00Z`,
+      message: { role: 'user', content },
+    })
+    writeFileSync(filePath, record('u1', 'hello first'))
 
     const { getDB, Syncer } = await loadCoreModules()
     const db = getDB()
     openDbs.push(db)
 
-    // First sync — session inserted with default scan_profile = NULL.
-    let firstSyncer = new Syncer(db)
-    expect(firstSyncer.syncFile(filePath, 'claude')).toBe('added')
+    expect(new Syncer(db).syncFile(filePath, 'claude')).toBe('added')
 
     // Pretend the scan worker has finished a scan, so scan_profile is set.
     db.prepare("UPDATE sessions SET scan_profile = 'regex@3' WHERE session_uuid = ?")
       .run('cascade-session-1')
 
-    // Mutate the source file's mtime so syncFile re-processes.
-    touchFile(filePath)
-    writeJsonl('second-with-new-content')
+    // Append a brand-new message — this is the path that should
+    // invalidate scan_profile and notify subscribers.
+    writeFileSync(filePath, [
+      record('u1', 'hello first'),
+      record('u2', 'hello — new turn'),
+    ].join('\n'))
     touchFile(filePath)
 
     const changed: number[] = []
@@ -389,6 +394,279 @@ describe('Syncer', () => {
     expect(db.prepare('SELECT 1 FROM sessions WHERE file_path = ?').get(staleChildPath)).toBeTruthy()
     expect(syncer.syncFile(dbPath, 'opencode')).toBe('updated')
     expect(db.prepare('SELECT 1 FROM sessions WHERE file_path = ?').get(staleChildPath)).toBeUndefined()
+  })
+
+  // ─── Append-only sync (schema v14 follow-up) ────────────────────────
+  //
+  // The four tests below pin down the contract for the new
+  // INSERT-OR-IGNORE sync path:
+  //
+  //   1. Re-syncing a file whose content has not changed must NOT
+  //      invalidate the user-side state (Security Scan purge in
+  //      particular). This is the load-bearing fix that originally
+  //      motivated the redesign — issue #344's follow-up question
+  //      "does purge survive re-sync?".
+  //   2. Appending genuinely-new messages must take the fast path
+  //      (no DELETE+INSERT) but still trigger the Security Scan
+  //      cascade so the new content gets scanned.
+  //   3. An in-place edit of an already-stored message must be
+  //      detected and fall back to the rewrite path; otherwise
+  //      INSERT OR IGNORE silently drops the new content and the
+  //      DB ends up stale.
+  //   4. A shrunk parse result is a strong rewrite signal — source
+  //      file truncation must replay through the safe path.
+
+  it('append-only sync preserves Security Scan purge state across a no-op re-sync (issue #344 follow-up)', async () => {
+    const baseDir = makeTempDir('spool-syncer-purge-survives-')
+    const claudeDir = join(baseDir, 'claude', 'projects', 'test-project')
+    const spoolDataDir = join(baseDir, 'spool-data')
+    mkdirSync(claudeDir, { recursive: true })
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDataDir)
+
+    const filePath = join(claudeDir, 'purge-survives.jsonl')
+    writeFileSync(filePath, JSON.stringify({
+      type: 'user',
+      sessionId: 'purge-survives-session',
+      cwd: '/tmp/test-project',
+      uuid: 'm1',
+      timestamp: '2026-05-01T00:00:00Z',
+      message: { role: 'user', content: 'leaked: AKIAIOSFODNN7EXAMPLE here' },
+    }))
+
+    const { getDB, Syncer } = await loadCoreModules()
+    const db = getDB()
+    openDbs.push(db)
+
+    expect(new Syncer(db).syncFile(filePath, 'claude')).toBe('added')
+
+    // Simulate a Security Scan run: a finding lands in the DB and the
+    // user purges it. content_text gets the mask, the finding flips
+    // to state='purged', scan_profile is filled.
+    const sessionId = (db.prepare(
+      "SELECT id FROM sessions WHERE session_uuid = 'purge-survives-session'"
+    ).get() as { id: number }).id
+    const messageId = (db.prepare(
+      'SELECT id FROM messages WHERE session_id = ? ORDER BY id LIMIT 1'
+    ).get(sessionId) as { id: number }).id
+    db.prepare(
+      `INSERT INTO findings (session_id, message_id, kind, value_hash, confidence, provider, start_offset, end_offset, state, state_changed_at)
+       VALUES (?, ?, 'api-key', 'h-aws', 0.95, 'regex', 8, 28, 'purged', datetime('now'))`,
+    ).run(sessionId, messageId)
+    db.prepare(
+      `UPDATE messages SET content_text = 'leaked: [redacted: AWS key] here' WHERE id = ?`,
+    ).run(messageId)
+    db.prepare(
+      `UPDATE sessions SET scan_profile = 'regex@3', scan_purged_count = 1 WHERE id = ?`,
+    ).run(sessionId)
+
+    // Touch the source file's mtime without changing its content —
+    // this is exactly the pattern the old DELETE+INSERT path used to
+    // weaponise into a purge-undo.
+    touchFile(filePath)
+    const changedIds: number[] = []
+    const reSyncer = new Syncer(db, undefined, (id) => { changedIds.push(id) })
+    reSyncer.syncFile(filePath, 'claude')
+
+    // Purge state must still be there.
+    const finding = db.prepare(
+      'SELECT state FROM findings WHERE session_id = ?'
+    ).get(sessionId) as { state: string } | undefined
+    expect(finding?.state).toBe('purged')
+
+    // Masked content must still be there.
+    const msg = db.prepare(
+      'SELECT content_text FROM messages WHERE id = ?'
+    ).get(messageId) as { content_text: string } | undefined
+    expect(msg?.content_text).toBe('leaked: [redacted: AWS key] here')
+
+    // scan_profile must NOT have been cleared — nothing changed, so
+    // the scan worker should not be asked to redo the session.
+    const sess = db.prepare(
+      'SELECT scan_profile FROM sessions WHERE id = ?'
+    ).get(sessionId) as { scan_profile: string | null }
+    expect(sess.scan_profile).toBe('regex@3')
+
+    // onSessionChanged must not have fired for the no-op re-sync.
+    expect(changedIds).toEqual([])
+  })
+
+  it('append-only sync inserts newly-appended messages without DELETEing the existing tail and still cascades scan_profile', async () => {
+    const baseDir = makeTempDir('spool-syncer-append-grows-')
+    const claudeDir = join(baseDir, 'claude', 'projects', 'test-project')
+    const spoolDataDir = join(baseDir, 'spool-data')
+    mkdirSync(claudeDir, { recursive: true })
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDataDir)
+
+    const filePath = join(claudeDir, 'append-grows.jsonl')
+    const userRecord = (uuid: string, ts: string, content: string) => JSON.stringify({
+      type: 'user',
+      sessionId: 'append-grows-session',
+      cwd: '/tmp/test-project',
+      uuid,
+      timestamp: ts,
+      message: { role: 'user', content },
+    })
+    writeFileSync(filePath, [
+      userRecord('m1', '2026-05-01T00:00:00Z', 'first message'),
+      userRecord('m2', '2026-05-01T00:01:00Z', 'second message'),
+    ].join('\n'))
+
+    const { getDB, Syncer } = await loadCoreModules()
+    const db = getDB()
+    openDbs.push(db)
+
+    expect(new Syncer(db).syncFile(filePath, 'claude')).toBe('added')
+    const sessionId = (db.prepare(
+      "SELECT id FROM sessions WHERE session_uuid = 'append-grows-session'"
+    ).get() as { id: number }).id
+
+    // Stand in for "scan worker has finished": set scan_profile so
+    // the cascade is observable. Also park a finding row that should
+    // survive (it's tied to m1 by message_id, which append-only sync
+    // must not DELETE).
+    const m1Id = (db.prepare(
+      "SELECT id FROM messages WHERE session_id = ? AND msg_uuid = 'm1'"
+    ).get(sessionId) as { id: number }).id
+    db.prepare("UPDATE sessions SET scan_profile = 'regex@3' WHERE id = ?").run(sessionId)
+    db.prepare(
+      `INSERT INTO findings (session_id, message_id, kind, value_hash, confidence, provider, start_offset, end_offset, state)
+       VALUES (?, ?, 'email', 'h1', 0.9, 'regex', 0, 5, 'active')`,
+    ).run(sessionId, m1Id)
+
+    // Append a third message at the source.
+    writeFileSync(filePath, [
+      userRecord('m1', '2026-05-01T00:00:00Z', 'first message'),
+      userRecord('m2', '2026-05-01T00:01:00Z', 'second message'),
+      userRecord('m3', '2026-05-01T00:02:00Z', 'third — brand new'),
+    ].join('\n'))
+    touchFile(filePath)
+
+    const changedIds: number[] = []
+    const reSyncer = new Syncer(db, undefined, (id) => { changedIds.push(id) })
+    expect(reSyncer.syncFile(filePath, 'claude')).toBe('updated')
+
+    // m1 row id stable → finding still pointing at the right row.
+    const m1RowAfter = db.prepare(
+      "SELECT id FROM messages WHERE session_id = ? AND msg_uuid = 'm1'"
+    ).get(sessionId) as { id: number }
+    expect(m1RowAfter.id).toBe(m1Id)
+
+    // The pre-existing finding survives the re-sync.
+    const finding = db.prepare(
+      'SELECT message_id, state FROM findings WHERE session_id = ?'
+    ).get(sessionId) as { message_id: number; state: string }
+    expect(finding).toEqual({ message_id: m1Id, state: 'active' })
+
+    // m3 actually landed.
+    const newCount = (db.prepare(
+      'SELECT COUNT(*) AS c FROM messages WHERE session_id = ?'
+    ).get(sessionId) as { c: number }).c
+    expect(newCount).toBe(3)
+
+    // Cascade DID fire — new content arrived.
+    const sess = db.prepare(
+      'SELECT scan_profile FROM sessions WHERE id = ?'
+    ).get(sessionId) as { scan_profile: string | null }
+    expect(sess.scan_profile).toBeNull()
+    expect(changedIds).toEqual([sessionId])
+  })
+
+  it('does NOT auto-rewrite content on a same-uuid in-place source edit (deliberate; PR3 force-resync covers this)', async () => {
+    // This pins the deliberate trade-off behind the append-only
+    // design. Source files for every supported provider are
+    // append-only event logs at the tool contract level; in-place
+    // edits of an existing uuid only happen when a user manually
+    // mutates the jsonl on disk. We could content-compare in
+    // classifySync to catch that, but doing so would also trigger
+    // rewrite whenever Security Scan has replaced the raw value with
+    // its mask — undoing the purge on the next re-sync, which is the
+    // exact regression that motivated this work. The explicit
+    // "Refresh from source" action (PR 3) is the right UX for the
+    // rare manual-edit case.
+    const baseDir = makeTempDir('spool-syncer-no-auto-rewrite-')
+    const claudeDir = join(baseDir, 'claude', 'projects', 'test-project')
+    const spoolDataDir = join(baseDir, 'spool-data')
+    mkdirSync(claudeDir, { recursive: true })
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDataDir)
+
+    const filePath = join(claudeDir, 'manual-edit.jsonl')
+    const record = (text: string) => JSON.stringify({
+      type: 'user',
+      sessionId: 'manual-edit-session',
+      cwd: '/tmp/test-project',
+      uuid: 'u1',
+      timestamp: '2026-05-01T00:00:00Z',
+      message: { role: 'user', content: text },
+    })
+    writeFileSync(filePath, record('original content'))
+    const { getDB, Syncer } = await loadCoreModules()
+    const db = getDB()
+    openDbs.push(db)
+    expect(new Syncer(db).syncFile(filePath, 'claude')).toBe('added')
+
+    // Source rewrites the same uuid with different content.
+    writeFileSync(filePath, record('rewritten content'))
+    touchFile(filePath)
+    const changedIds: number[] = []
+    const reSyncer = new Syncer(db, undefined, (id) => { changedIds.push(id) })
+    reSyncer.syncFile(filePath, 'claude')
+
+    // DB intentionally keeps the original content — INSERT OR IGNORE
+    // saw the existing uuid and skipped the new row.
+    const msg = db.prepare(
+      "SELECT content_text FROM messages WHERE msg_uuid = 'u1'"
+    ).get() as { content_text: string }
+    expect(msg.content_text).toBe('original content')
+
+    // And no cascade fired — append path with 0 inserted is a no-op.
+    expect(changedIds).toEqual([])
+  })
+
+  it('falls back to rewrite when the source file shrinks below the stored row count', async () => {
+    const baseDir = makeTempDir('spool-syncer-rewrite-on-shrink-')
+    const claudeDir = join(baseDir, 'claude', 'projects', 'test-project')
+    const spoolDataDir = join(baseDir, 'spool-data')
+    mkdirSync(claudeDir, { recursive: true })
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDataDir)
+
+    const filePath = join(claudeDir, 'rewrite-on-shrink.jsonl')
+    const userRecord = (uuid: string, content: string) => JSON.stringify({
+      type: 'user',
+      sessionId: 'rewrite-on-shrink-session',
+      cwd: '/tmp/test-project',
+      uuid,
+      timestamp: `2026-05-01T00:0${uuid.slice(-1)}:00Z`,
+      message: { role: 'user', content },
+    })
+    writeFileSync(filePath, [
+      userRecord('m1', 'first'),
+      userRecord('m2', 'second'),
+      userRecord('m3', 'third'),
+    ].join('\n'))
+
+    const { getDB, Syncer } = await loadCoreModules()
+    const db = getDB()
+    openDbs.push(db)
+    expect(new Syncer(db).syncFile(filePath, 'claude')).toBe('added')
+
+    const sessionId = (db.prepare(
+      "SELECT id FROM sessions WHERE session_uuid = 'rewrite-on-shrink-session'"
+    ).get() as { id: number }).id
+    expect((db.prepare(
+      'SELECT COUNT(*) AS c FROM messages WHERE session_id = ?'
+    ).get(sessionId) as { c: number }).c).toBe(3)
+
+    // Source loses its tail.
+    writeFileSync(filePath, userRecord('m1', 'first'))
+    touchFile(filePath)
+    expect(new Syncer(db).syncFile(filePath, 'claude')).toBe('updated')
+
+    // Stale m2/m3 are gone (rewrite path ran DELETE+INSERT) and m1
+    // remains.
+    const after = db.prepare(
+      'SELECT msg_uuid FROM messages WHERE session_id = ? ORDER BY msg_uuid'
+    ).all(sessionId) as Array<{ msg_uuid: string }>
+    expect(after.map(r => r.msg_uuid)).toEqual(['m1'])
   })
 })
 

--- a/packages/core/src/sync/syncer.ts
+++ b/packages/core/src/sync/syncer.ts
@@ -24,6 +24,9 @@ import {
   upsertSession,
   upsertSessionSearch,
   insertMessages,
+  getMessageSnapshot,
+  recomputeMessageCount,
+  type UpsertSessionMode,
 } from '../db/queries.js'
 import type { ParsedMessage, SyncResult } from '../types.js'
 import { computeIdentity } from '../projects/identity.js'
@@ -148,6 +151,62 @@ export class Syncer {
     return { added, updated, errors }
   }
 
+  /** Decide whether a re-sync of `sessionUuid` against `parsed` is a
+   *  pure append (existing rows untouched, new uuids inserted) or
+   *  needs the safer DELETE+INSERT rewrite path.
+   *
+   *  Rewrite signals (any of):
+   *    - Session row doesn't exist yet → trivially a first-sync,
+   *      collapsed into `rewrite` because the code paths are
+   *      identical when there's nothing to preserve.
+   *    - Session row exists but has no msg_uuid-bearing message rows
+   *      (orphan / corrupt state) → safest to repopulate from scratch.
+   *    - Parser returned no messages but DB has some — almost certainly
+   *      a parse failure mid-flight; rewrite would wipe data the
+   *      source no longer has, which is the user's intent.
+   *    - Parser returned fewer messages than DB has — source was
+   *      truncated or rewritten from its head; uuids beyond the new
+   *      tail are stale and must be re-derived.
+   *    - The first stored uuid no longer matches the parser's first
+   *      uuid → leading prefix shifted; preserved tail uuids could
+   *      now point at semantically-different records.
+   *
+   *  Anything else is `append`.
+   *
+   *  Note: we deliberately do NOT auto-detect in-place edits of an
+   *  existing message uuid (same uuid, different content_text on the
+   *  source side). Two reasons:
+   *
+   *    1. Source files for every supported provider (claude / codex /
+   *       gemini / opencode) are append-only event logs at the tool
+   *       contract level. Real in-place edits only happen when a user
+   *       manually edits the jsonl on disk — rare, deliberate, and
+   *       best handled by an explicit "Refresh from source" action.
+   *    2. After a Security Scan purge, `messages.content_text` is the
+   *       mask but the source still has the raw value. A naive
+   *       content-compare would see the difference and trigger
+   *       rewrite, which would cascade-delete the finding and let the
+   *       raw value re-enter the DB — exactly the regression that
+   *       motivated this work. The purge protection requires that we
+   *       NOT chase content drift on uuid-matched messages. */
+  private classifySync(
+    sessionUuid: string,
+    parsed: ParsedMessage[],
+  ): UpsertSessionMode {
+    const session = this.db
+      .prepare('SELECT id FROM sessions WHERE session_uuid = ?')
+      .get(sessionUuid) as { id: number } | undefined
+    if (!session) return 'rewrite'
+
+    const snapshot = getMessageSnapshot(this.db, session.id)
+    if (snapshot.total === 0) return 'rewrite'
+    if (parsed.length === 0) return 'rewrite'
+    if (parsed.length < snapshot.total) return 'rewrite'
+    if (parsed[0]!.uuid !== snapshot.firstUuid) return 'rewrite'
+
+    return 'append'
+  }
+
   private applyCodexTitles(): void {
     if (this.codexTitleIndex.size === 0) return
     const stmt = this.db.prepare(
@@ -216,7 +275,15 @@ export class Syncer {
       const isNew = existingMtime === null
       const hasToolUse = parsed.messages.some(m => m.toolNames.length > 0)
 
+      // Classify the sync before we touch anything. The result decides
+      // whether existing message rows survive (`append`) or get
+      // DELETE-cascaded by upsertSession (`rewrite`). The
+      // `first-sync` case is just `rewrite` semantically — there is
+      // nothing to preserve.
+      const mode = this.classifySync(parsed.sessionUuid, parsed.messages)
+
       let committedSessionId: number | null = null
+      let insertedCount = 0
       this.db.transaction(() => {
         const sessionId = upsertSession(this.db, {
           projectId,
@@ -231,9 +298,11 @@ export class Syncer {
           cwd: parsed.cwd,
           model: parsed.model,
           rawFileMtime: mtime,
-        })
+        }, mode)
 
-        insertMessages(this.db, sessionId, sourceId, parsed.messages)
+        insertedCount = insertMessages(this.db, sessionId, sourceId, parsed.messages)
+        recomputeMessageCount(this.db, sessionId)
+
         upsertSessionSearch(this.db, {
           sessionId,
           title: parsed.title,
@@ -241,13 +310,21 @@ export class Syncer {
           assistantText: buildSessionSearchText(parsed.messages, 'assistant'),
         })
 
-        // Security Scan cascade: messages.content_text changed, so any
-        // existing findings now have stale offsets. Drop scan_profile
-        // inside the same transaction so a crash between here and the
-        // worker re-enqueue still leaves the session in "needs scan".
-        this.db.prepare(
-          `UPDATE sessions SET scan_profile = NULL, scan_completed_at = NULL WHERE id = ?`,
-        ).run(sessionId)
+        // Security Scan cascade: only fire when message content
+        // actually changed for this session. In `rewrite` mode that
+        // is always the case (the DELETE invalidated every finding's
+        // offsets); in `append` mode it depends on whether the
+        // INSERT OR IGNORE pass actually added rows. Skipping the
+        // cascade on no-op re-syncs is the load-bearing UX win — it
+        // lets the user-side state attached to existing rows
+        // (purge / dismiss / star) survive when the source file is
+        // re-touched without new content, instead of being
+        // invalidated by a redundant re-scan.
+        if (mode === 'rewrite' || insertedCount > 0) {
+          this.db.prepare(
+            `UPDATE sessions SET scan_profile = NULL, scan_completed_at = NULL WHERE id = ?`,
+          ).run(sessionId)
+        }
 
         this.db.prepare(`
           INSERT INTO sync_log (source_id, file_path, status)
@@ -256,7 +333,11 @@ export class Syncer {
         committedSessionId = sessionId
       })()
 
-      if (committedSessionId !== null && this.onSessionChanged) {
+      if (
+        committedSessionId !== null
+        && this.onSessionChanged
+        && (mode === 'rewrite' || insertedCount > 0)
+      ) {
         try { this.onSessionChanged(committedSessionId) } catch { /* swallow callback errors */ }
       }
       return isNew ? 'added' : 'updated'

--- a/packages/core/src/sync/syncer.ts
+++ b/packages/core/src/sync/syncer.ts
@@ -193,18 +193,28 @@ export class Syncer {
     sessionUuid: string,
     parsed: ParsedMessage[],
   ): UpsertSessionMode {
-    const session = this.db
-      .prepare('SELECT id FROM sessions WHERE session_uuid = ?')
-      .get(sessionUuid) as { id: number } | undefined
-    if (!session) return 'rewrite'
-
-    const snapshot = getMessageSnapshot(this.db, session.id)
+    // One join'd query — covers "session row missing", "session row
+    // exists with no messages", and the leading-uuid / total-row
+    // signals all at once. See getMessageSnapshot for the rationale.
+    const snapshot = getMessageSnapshot(this.db, sessionUuid)
     if (snapshot.total === 0) return 'rewrite'
     if (parsed.length === 0) return 'rewrite'
     if (parsed.length < snapshot.total) return 'rewrite'
     if (parsed[0]!.uuid !== snapshot.firstUuid) return 'rewrite'
-
     return 'append'
+  }
+
+  /** True if the title we'd write differs from what's currently stored
+   *  for this session. Lets the syncer skip the session_search rebuild
+   *  on no-op mtime touches without losing title-only updates (e.g.
+   *  codex's auto-titling pass via applyCodexTitles, or a claude
+   *  custom-title record landing while everything else stays the
+   *  same). */
+  private titleDiffersFromStored(sessionId: number, nextTitle: string): boolean {
+    const row = this.db
+      .prepare('SELECT title FROM sessions WHERE id = ?')
+      .get(sessionId) as { title: string | null } | undefined
+    return (row?.title ?? '') !== nextTitle
   }
 
   private applyCodexTitles(): void {
@@ -301,26 +311,47 @@ export class Syncer {
         }, mode)
 
         insertedCount = insertMessages(this.db, sessionId, sourceId, parsed.messages)
-        recomputeMessageCount(this.db, sessionId)
 
-        upsertSessionSearch(this.db, {
-          sessionId,
-          title: parsed.title,
-          userText: buildSessionSearchText(parsed.messages, 'user'),
-          assistantText: buildSessionSearchText(parsed.messages, 'assistant'),
-        })
+        // True only when something we wrote could matter to downstream
+        // consumers — a rewrite always counts (DELETE invalidated
+        // every finding's offsets), an append counts only when at
+        // least one row landed.
+        const contentChanged = mode === 'rewrite' || insertedCount > 0
 
-        // Security Scan cascade: only fire when message content
-        // actually changed for this session. In `rewrite` mode that
-        // is always the case (the DELETE invalidated every finding's
-        // offsets); in `append` mode it depends on whether the
-        // INSERT OR IGNORE pass actually added rows. Skipping the
-        // cascade on no-op re-syncs is the load-bearing UX win — it
-        // lets the user-side state attached to existing rows
-        // (purge / dismiss / star) survive when the source file is
-        // re-touched without new content, instead of being
-        // invalidated by a redundant re-scan.
-        if (mode === 'rewrite' || insertedCount > 0) {
+        if (contentChanged) {
+          // Keep `sessions.message_count` honest with the deduped DB
+          // truth (claude tool-use shadow records would inflate the
+          // parser-derived value back to pre-v14 levels). Gated on
+          // contentChanged so no-op syncs don't pay the UPDATE.
+          recomputeMessageCount(this.db, sessionId)
+        }
+
+        // Session-level search index. **Read content from the DB,
+        // not from `parsed.messages`** — Security Scan purge masks
+        // `messages.content_text` but never touches the source jsonl.
+        // Building search text from the parser output would re-index
+        // the raw secret in session_search_fts on every re-sync of an
+        // active session, leaking the purged value back into the
+        // "search across sessions" surface. Reading from DB instead
+        // makes session_search_fts a faithful projection of what
+        // messages_fts already protects. Skip on no-op re-syncs of an
+        // unchanged title — nothing to refresh.
+        const titleChanged = this.titleDiffersFromStored(sessionId, parsed.title)
+        if (contentChanged || titleChanged) {
+          upsertSessionSearch(this.db, {
+            sessionId,
+            title: parsed.title,
+            userText: buildSessionSearchTextFromDb(this.db, sessionId, 'user'),
+            assistantText: buildSessionSearchTextFromDb(this.db, sessionId, 'assistant'),
+          })
+        }
+
+        // Security Scan cascade — invalidate scan_profile so the
+        // worker re-enqueues this session. Same gate as content
+        // change above; idle mtime touches stay no-ops, which is the
+        // load-bearing UX win that lets purge / dismiss / star
+        // survive across re-sync of an unchanged source file.
+        if (contentChanged) {
           this.db.prepare(
             `UPDATE sessions SET scan_profile = NULL, scan_completed_at = NULL WHERE id = ?`,
           ).run(sessionId)
@@ -333,11 +364,8 @@ export class Syncer {
         committedSessionId = sessionId
       })()
 
-      if (
-        committedSessionId !== null
-        && this.onSessionChanged
-        && (mode === 'rewrite' || insertedCount > 0)
-      ) {
+      const contentChanged = mode === 'rewrite' || insertedCount > 0
+      if (committedSessionId !== null && this.onSessionChanged && contentChanged) {
         try { this.onSessionChanged(committedSessionId) } catch { /* swallow callback errors */ }
       }
       return isNew ? 'added' : 'updated'
@@ -525,10 +553,24 @@ function loadCodexSessionIndex(): Map<string, string> {
   return titles
 }
 
-function buildSessionSearchText(messages: ParsedMessage[], role: 'user' | 'assistant'): string {
-  return messages
-    .filter(message => !message.isSidechain && message.role === role)
-    .map(message => message.contentText.trim())
+/** Build the per-role text that backs `session_search_fts`, reading
+ *  from `messages.content_text` so that Security Scan purge masks are
+ *  honoured. The legacy `buildSessionSearchText(parsed.messages, …)`
+ *  shape pulled directly from the parser output (i.e. from the source
+ *  jsonl which still contains the raw secret), which leaked purged
+ *  values back into the session-level FTS on every re-sync. */
+function buildSessionSearchTextFromDb(
+  db: Database.Database,
+  sessionId: number,
+  role: 'user' | 'assistant',
+): string {
+  const rows = db.prepare(
+    `SELECT content_text FROM messages
+      WHERE session_id = ? AND is_sidechain = 0 AND role = ?
+      ORDER BY seq, id`,
+  ).all(sessionId, role) as Array<{ content_text: string }>
+  return rows
+    .map(r => r.content_text.trim())
     .filter(Boolean)
     .join('\n')
 }


### PR DESCRIPTION
## What

Stop wiping `messages` rows on every re-sync. The syncer now classifies each `syncFile` call as either `append` (preserve existing rows, INSERT OR IGNORE new ones on the v14 index) or `rewrite` (today's DELETE+INSERT path, kept as the safe fallback). This is the root-cause fix for the issue surfaced in #344's follow-up: **purge / dismiss / allowlist state used to be cascade-deleted by re-sync; now it persists naturally as long as the source's append-only contract holds.**

## Why

The old `upsertSession` did `DELETE FROM messages WHERE session_id = ?` for any existing session, then `insertMessages` replayed the entire parse output. The FK cascade on `findings.message_id` cleared every Security Scan finding for that session — including ones the user had explicitly purged — and the next scan re-detected the raw secret and put it back on the page. Same shape for dismiss, allowlist hits, and any future user-attached message state.

Source files for every supported provider (claude / codex / gemini / opencode) are append-only event logs at the tool contract level. The DELETE+INSERT pattern was a simplification that contradicted the actual data model. v14 (#347) added the dedupe primitive — partial `UNIQUE INDEX (session_id, msg_uuid) WHERE msg_uuid IS NOT NULL` — that this PR now uses as the new sync primitive.

Audit-derived constraints driving the design:
- Claude jsonl emits some records twice (tool-use shadow entries: same uuid, identical content, different seq). With INSERT OR IGNORE on the v14 index those collapse automatically; the parser-derived `message_count` would otherwise re-inflate to pre-v14 levels on every sync.
- Codex / gemini synthetic uuids are stable across re-parses of unchanged source. OpenCode uses sqlite PKs.
- After a purge, `messages.content_text` is the mask but the source still has the raw — meaning **any content-compare in `classifySync` would trigger rewrite, undoing the very purge this PR exists to protect**.

## How

### Classification (`classifySync`)

Rewrite signals (any one is enough):
- Session row doesn't exist yet — first sync.
- Session row exists with no msg_uuid-bearing message rows (orphan / corruption recovery).
- Parser returned no messages but DB has some (parse-failure recovery).
- Parser produced fewer rows than DB has (source truncated / rewritten from its head).
- Stored first uuid (by `seq, id`) no longer matches parser's first uuid (leading prefix shifted).

Anything else → `append`.

Deliberately NOT a signal: a same-uuid in-place content edit. A content-compare would trip on every purged message and re-spread the raw value back into the DB. The (rare) genuine manual-edit case is the job of an explicit "Refresh from source" action (PR 3 in the planned series).

### Adjacent changes

- `upsertSession(db, opts, mode)` — new `mode` parameter (`'rewrite' | 'append'`, default `'rewrite'` preserves all existing callers including tests). `'append'` skips the `DELETE FROM messages WHERE session_id = ?`. The function also stops touching `message_count` — owned by the new `recomputeMessageCount` instead so the count tracks INSERT-OR-IGNORE-deduped truth.
- `insertMessages` — switched from plain INSERT to `ON CONFLICT(session_id, msg_uuid) WHERE msg_uuid IS NOT NULL DO NOTHING`, returns the number of rows actually inserted.
- `recomputeMessageCount(db, sessionId)` — `SELECT COUNT(*) FROM messages WHERE session_id = ? AND is_sidechain = 0`, written into `sessions.message_count`. One UPDATE per sync.
- `getMessageSnapshot(db, sessionId)` — cheap classifier read (`total` + `firstUuid`). Deliberately does not load `content_text`.
- The Security Scan cascade — `UPDATE sessions SET scan_profile = NULL, scan_completed_at = NULL` and `onSessionChanged(sessionId)` — now fires only in `rewrite` mode OR when at least one row was actually inserted. No-op re-syncs (file mtime touched but no new content) become true no-ops.

### How it connects

- PR 1 (#347) provided the partial UNIQUE INDEX this PR's `ON CONFLICT` clause targets. The migration also dedup'd 118 pre-existing duplicate pairs that the old DELETE+INSERT had been silently inflating on every sync.
- PR 3 will add the explicit "Refresh from source" UI / IPC entry point so the manual-edit recovery case has a real escape hatch.
- The Security Scan worker observes the cascade via `onSessionChanged` (queue invalidation). Skipping the cascade on no-op syncs translates directly into "purge state persists across mtime touches of unchanged source files" without any worker-side change.

## Verification

- `pnpm vitest run` in `packages/core` — 376 passed, 1 skipped, 0 failed. The existing "scan cascade on message-mutating sync" test is rewritten to assert the new contract (cascade fires on row INSERT, not on same-uuid content drift); four new tests pin the contract: purge survives mtime touch, true append cascades and preserves prior findings, in-place edit is deliberately not auto-detected, source shrink falls back to rewrite.
- Empirical end-to-end on a real dev archive (~60k messages, 8.2k findings, 197 sessions with prior purges):
  - Snapshot session 5 (22 purged findings, `scan_profile = 'regex@3'`).
  - `touch` its source jsonl mtime, wait for the watcher.
  - `sync_log` records a status=ok entry — the re-sync ran.
  - All 22 purged findings still present, `scan_purged_count` still 22, `scan_profile` still `'regex@3'`. Under the old DELETE+INSERT this would have been wiped to zero.
  - An actively-written session (claude session 278) takes the append path: `messageCount` ticks from 335 → 340 across a few minutes, scan worker re-runs only when a brand-new message lands, no message rows are ever deleted.

## Notes / non-goals

- IPC, renderer, and Security Scan code are untouched.
- One-time content edits to an existing msg_uuid (manual jsonl mutation) are not auto-detected. PR 3 will add the explicit "Refresh from source" action; users hitting that case rebuild the session deliberately.
- ML / regex / allowlist semantics unchanged.
- No backfill / migration required — schema is at v14 already.