### PR TITLE
feat(sync): "Refresh from source" — explicit per-session rebuild action

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -867,6 +867,49 @@ ipcMain.handle('spool:sync-now', () => {
   return runSyncWorker()
 })
 
+/**
+ * Explicit "Refresh from source" — rebuilds a single session by
+ * bypassing the watcher's mtime-skip and the syncer's classifySync
+ * heuristic. This is the escape hatch for the rare cases append-only
+ * sync deliberately can't auto-detect:
+ *
+ *   - The user manually edited the jsonl on disk (rare but real).
+ *   - A provider updated an existing message in-place without
+ *     bumping mtime in a way the watcher noticed.
+ *   - The session's DB rows have drifted from the source for any
+ *     other reason and the user wants to start over from source.
+ *
+ * Cost the user is accepting by triggering this: every finding row
+ * tied to the session's messages is cascade-deleted by the DELETE
+ * FROM messages step. Active findings are re-detected on the next
+ * scan; allowlist entries survive (different table, not cascaded);
+ * but per-finding state the user set explicitly — `state = 'purged'`
+ * is the one that hurts — is gone. The renderer warns about this
+ * before calling.
+ */
+ipcMain.handle('spool:force-resync-session', (_e, { sessionUuid }: { sessionUuid: string }) => {
+  if (!syncer) return { ok: false as const, error: 'syncer-not-ready' }
+  const row = db
+    .prepare('SELECT file_path, source_id FROM sessions WHERE session_uuid = ?')
+    .get(sessionUuid) as { file_path: string; source_id: number } | undefined
+  if (!row) return { ok: false as const, error: 'session-not-found' }
+  const sourceRow = db
+    .prepare('SELECT name FROM sources WHERE id = ?')
+    .get(row.source_id) as { name: SessionSource } | undefined
+  if (!sourceRow) return { ok: false as const, error: 'source-not-found' }
+  try {
+    const result = syncer.syncFile(
+      row.file_path, sourceRow.name, undefined, undefined,
+      { forceMode: 'rewrite' },
+    )
+    if (result === 'error') return { ok: false as const, error: 'sync-error' }
+    return { ok: true as const, result }
+  } catch (err) {
+    console.error('[spool:force-resync-session]', err)
+    return { ok: false as const, error: String(err) }
+  }
+})
+
 ipcMain.handle('spool:resume-cli', (_e, { sessionUuid, source, cwd }: { sessionUuid: string; source: string; cwd?: string }) => {
   try {
     const command = getSessionResumeCommand(source, sessionUuid)

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -147,6 +147,12 @@ const api = {
   syncNow: (): Promise<SyncResult> =>
     ipcRenderer.invoke('spool:sync-now'),
 
+  forceResyncSession: (sessionUuid: string): Promise<
+    { ok: true; result: 'added' | 'updated' | 'skipped' }
+    | { ok: false; error: string }
+  > =>
+    ipcRenderer.invoke('spool:force-resync-session', { sessionUuid }),
+
   resumeCLI: (sessionUuid: string, source: string, cwd?: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('spool:resume-cli', { sessionUuid, source, cwd }),
 

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { SquareTerminal, SquarePen, MoreHorizontal, Copy, ShieldAlert, Check } from 'lucide-react'
+import { toast } from 'sonner'
+import { SquareTerminal, SquarePen, MoreHorizontal, Copy, ShieldAlert, Check, RotateCcw } from 'lucide-react'
 import type { Session, Message } from '@spool-lab/core'
 import { type FindRange } from './MessageBubble.js'
 import MessageList, { type MessageListHandle } from './MessageList.js'
 import SessionFindBar from './SessionFindBar.js'
 import FindingsStrip from './security/FindingsStrip.js'
+import RefreshFromSourceDialog from './session/RefreshFromSourceDialog.js'
 import { useSecurityEnabled } from '../featureFlags.js'
 import { securityApi } from '../api/security.js'
 import PinButton from './PinButton.js'
@@ -40,6 +42,8 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
   useEffect(() => { setStripOpen(false) }, [sessionUuid])
   const [resuming, setResuming] = useState(false)
   const [commandCopied, setCommandCopied] = useState(false)
+  const [refreshDialogOpen, setRefreshDialogOpen] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
   const [showFindBar, setShowFindBar] = useState(false)
   const [showTargetHighlight, setShowTargetHighlight] = useState(false)
   const [findFocusNonce, setFindFocusNonce] = useState(0)
@@ -265,6 +269,34 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
     setTimeout(() => setResuming(false), 1000)
   }
 
+  async function handleRefreshFromSource() {
+    if (!session || refreshing) return
+    setRefreshing(true)
+    try {
+      const out = await window.spool.forceResyncSession(session.sessionUuid)
+      if (out.ok) {
+        // Reload the session + messages so the rebuilt transcript
+        // and the cleared scan_* counts surface immediately. Without
+        // this the refresh succeeds in the DB but the user keeps
+        // looking at the pre-refresh transcript, which is the exact
+        // confusion this action exists to dispel.
+        const reloaded = await window.spool.getSession(session.sessionUuid)
+        if (reloaded) {
+          setSession(reloaded.session)
+          setMessages(reloaded.messages)
+        }
+        toast.success(t('session.refreshSuccess'))
+        setRefreshDialogOpen(false)
+      } else {
+        toast.error(t('session.refreshError', { error: out.error }))
+      }
+    } catch (err) {
+      toast.error(t('session.refreshError', { error: String(err) }))
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
   const resumeCommandAvailable = Boolean(session && getSessionResumeCommand(session.source, session.sessionUuid))
 
   return (
@@ -367,6 +399,11 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
                 icon: <Copy size={14} strokeWidth={1.6} aria-hidden />,
                 onSelect: () => { void handleCopyCommand() },
               }] : []),
+              {
+                label: t('session.refreshFromSource'),
+                icon: <RotateCcw size={14} strokeWidth={1.6} aria-hidden />,
+                onSelect: () => { setRefreshDialogOpen(true) },
+              },
             ]}
           />
         </div>
@@ -386,6 +423,13 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
       />
 
       <FindingsStrip session={session} open={stripOpen} onClose={() => setStripOpen(false)} />
+
+      <RefreshFromSourceDialog
+        open={refreshDialogOpen}
+        busy={refreshing}
+        onConfirm={() => { void handleRefreshFromSource() }}
+        onCancel={() => { if (!refreshing) setRefreshDialogOpen(false) }}
+      />
 
       {/* Messages */}
       <MessageList

--- a/packages/app/src/renderer/components/session/RefreshFromSourceDialog.tsx
+++ b/packages/app/src/renderer/components/session/RefreshFromSourceDialog.tsx
@@ -1,0 +1,107 @@
+// Confirms the "Refresh from source" action — rebuilds a single
+// session's messages from its source jsonl, bypassing the append-only
+// sync's classifySync gate. Surfaces the gravity (purged content
+// reappears as raw, scanner re-runs) in the visual hierarchy the user
+// will actually read: pretitle for the action, title for the
+// question, one short lead paragraph, the load-bearing security
+// caveat in a tinted callout box that earns its own attention, and
+// the reassuring dismiss-survives footnote underneath. Mirrors
+// PurgeConfirmDialog's outer shape (modal + Esc / click-outside
+// cancel) so the two destructive flows feel uniform.
+
+import { RotateCcw, ShieldAlert } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useHotkeys } from '../../hooks/useHotkeys.js'
+
+interface Props {
+  open: boolean
+  busy: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export default function RefreshFromSourceDialog({ open, busy, onConfirm, onCancel }: Props) {
+  const { t } = useTranslation()
+  const cancelRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (open) cancelRef.current?.focus()
+  }, [open])
+  useHotkeys({ Escape: onCancel }, { active: open && !busy, modal: true })
+
+  if (!open) return null
+
+  return (
+    <div
+      data-testid="refresh-from-source-confirm"
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-warm-text/30 dark:bg-black/40"
+      onClick={(e) => { if (!busy && e.target === e.currentTarget) onCancel() }}
+    >
+      <div
+        className="font-sans bg-warm-bg dark:bg-dark-bg rounded-[10px] w-[460px] max-w-[90vw] overflow-hidden border border-warm-border dark:border-dark-border"
+        style={{ boxShadow: '0 18px 48px rgba(28,28,24,0.18), 0 2px 6px rgba(28,28,24,0.08)' }}
+      >
+        <div className="px-6 pt-5 pb-4">
+          <div className="flex items-center gap-1.5 text-[12px] font-medium text-accent dark:text-accent-dark">
+            <RotateCcw size={13} strokeWidth={1.7} aria-hidden />
+            <span>{t('session.refreshPretitle')}</span>
+          </div>
+          <h2 className="mt-2 text-[16px] leading-[22px] font-semibold tracking-[-0.005em] text-warm-text dark:text-dark-text">
+            {t('session.refreshConfirmTitle')}
+          </h2>
+
+          <p className="mt-3 text-[13px] leading-[19px] text-warm-muted dark:text-dark-muted">
+            {t('session.refreshConfirmLead')}
+          </p>
+
+          <div
+            className="mt-4 flex items-start gap-2 rounded-lg border border-accent/30 dark:border-accent-dark/35 bg-accent/[0.06] dark:bg-accent-dark/[0.10] p-3"
+            role="note"
+          >
+            <ShieldAlert
+              size={15}
+              strokeWidth={1.7}
+              aria-hidden
+              className="flex-none mt-0.5 text-accent dark:text-accent-dark"
+            />
+            <div className="flex-1 min-w-0 text-[12.5px] leading-[18px] text-warm-text dark:text-dark-text">
+              <div className="font-medium">{t('session.refreshConfirmWarnTitle')}</div>
+              <div className="mt-1 text-warm-muted dark:text-dark-muted">
+                {t('session.refreshConfirmWarnBody')}
+              </div>
+            </div>
+          </div>
+
+          <p className="mt-3 text-[12px] leading-[18px] text-warm-faint dark:text-dark-muted">
+            {t('session.refreshConfirmDismissNote')}
+          </p>
+        </div>
+
+        <div className="flex justify-end gap-2 px-6 pb-5 pt-3">
+          <button
+            ref={cancelRef}
+            type="button"
+            disabled={busy}
+            onClick={onCancel}
+            className="inline-flex items-center h-7 px-2.5 rounded-md bg-warm-surface dark:bg-dark-surface border border-warm-border dark:border-dark-border text-[12px] font-medium text-warm-text dark:text-dark-text hover:bg-warm-surface2 dark:hover:bg-dark-surface2 hover:border-warm-border2 dark:hover:border-dark-border2 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            data-testid="refresh-from-source-commit"
+            onClick={onConfirm}
+            className="inline-flex items-center gap-1.5 h-7 px-3 rounded-md bg-accent dark:bg-accent-dark border border-accent dark:border-accent-dark text-[12px] font-medium text-white hover:bg-accent/90 dark:hover:bg-accent-dark/90 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            <RotateCcw size={12} strokeWidth={1.7} aria-hidden />
+            {t('session.refreshConfirmAction')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -122,7 +122,17 @@
     "msgs_one": "{{count}} Nachr.",
     "msgs_other": "{{count}} Nachr.",
     "divider_today": "Heute",
-    "divider_yesterday": "Gestern"
+    "divider_yesterday": "Gestern",
+    "refreshFromSource": "Aus Quelle aktualisieren",
+    "refreshPretitle": "Aus Quelle neu aufbauen",
+    "refreshConfirmTitle": "Diese Sitzung aus der Quelle aktualisieren?",
+    "refreshConfirmLead": "Spool baut die Nachrichten dieser Sitzung direkt aus der ursprünglichen Transkriptdatei neu auf.",
+    "refreshConfirmWarnTitle": "Gelöschte Inhalte kommen als Klartext zurück.",
+    "refreshConfirmWarnBody": "Jeder Wert, den du in dieser Sitzung gelöscht hast, kehrt mit der Bestätigung sofort in Spools Suchindex und in den KI-Kontext zurück — bis der nächste Scan ihn erneut findet und du ihn erneut löschst.",
+    "refreshConfirmDismissNote": "Ignorierte Funde bleiben ignoriert.",
+    "refreshConfirmAction": "Aktualisieren",
+    "refreshSuccess": "Sitzung aus Quelle aktualisiert",
+    "refreshError": "Aktualisierung fehlgeschlagen: {{error}}"
   },
   "library": {
     "greeting": "Willkommen zurück",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -122,7 +122,17 @@
     "msgs_one": "{{count}} msg",
     "msgs_other": "{{count}} msgs",
     "divider_today": "Today",
-    "divider_yesterday": "Yesterday"
+    "divider_yesterday": "Yesterday",
+    "refreshFromSource": "Refresh from source",
+    "refreshPretitle": "Rebuild from source",
+    "refreshConfirmTitle": "Refresh this session from source?",
+    "refreshConfirmLead": "Spool will rebuild this session's messages directly from the original transcript file.",
+    "refreshConfirmWarnTitle": "Purged content comes back as raw.",
+    "refreshConfirmWarnBody": "Any value you've purged in this session returns to Spool's search index and to the AI context the moment you confirm, until the next scan re-detects it and you purge again.",
+    "refreshConfirmDismissNote": "Dismissed findings stay dismissed.",
+    "refreshConfirmAction": "Refresh",
+    "refreshSuccess": "Session refreshed from source",
+    "refreshError": "Couldn't refresh: {{error}}"
   },
   "library": {
     "greeting": "Welcome back",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -122,7 +122,17 @@
     "msgs_one": "{{count}} msg",
     "msgs_other": "{{count}} msgs",
     "divider_today": "Aujourd'hui",
-    "divider_yesterday": "Hier"
+    "divider_yesterday": "Hier",
+    "refreshFromSource": "Actualiser depuis la source",
+    "refreshPretitle": "Reconstruire depuis la source",
+    "refreshConfirmTitle": "Actualiser cette session depuis la source ?",
+    "refreshConfirmLead": "Spool va reconstruire les messages de cette session directement depuis le fichier de transcription original.",
+    "refreshConfirmWarnTitle": "Le contenu purgé revient en clair.",
+    "refreshConfirmWarnBody": "Toute valeur que tu as purgée dans cette session revient dans l'index de recherche de Spool et dans le contexte IA dès que tu confirmes, jusqu'à ce que le prochain scan la redétecte et que tu la purges à nouveau.",
+    "refreshConfirmDismissNote": "Les détections ignorées restent ignorées.",
+    "refreshConfirmAction": "Actualiser",
+    "refreshSuccess": "Session actualisée depuis la source",
+    "refreshError": "Impossible d'actualiser : {{error}}"
   },
   "library": {
     "greeting": "Bon retour",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -118,7 +118,17 @@
     "scrollToBottom": "末尾までスクロール",
     "msgs_other": "{{count}} 件",
     "divider_today": "今日",
-    "divider_yesterday": "昨日"
+    "divider_yesterday": "昨日",
+    "refreshFromSource": "ソースから再同期",
+    "refreshPretitle": "ソースから再構築",
+    "refreshConfirmTitle": "このセッションをソースから再同期しますか？",
+    "refreshConfirmLead": "Spool は元のトランスクリプトファイルからこのセッションのメッセージを再構築します。",
+    "refreshConfirmWarnTitle": "完全削除した内容が原文に戻ります。",
+    "refreshConfirmWarnBody": "このセッションで完全削除した値は、確認した瞬間に Spool の検索インデックスと AI コンテキストに戻ります。次のスキャンで再検出され、再度完全削除するまでです。",
+    "refreshConfirmDismissNote": "無視した検出は無視のままです。",
+    "refreshConfirmAction": "再同期",
+    "refreshSuccess": "セッションをソースから再同期しました",
+    "refreshError": "再同期に失敗しました：{{error}}"
   },
   "library": {
     "greeting": "おかえりなさい",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -118,7 +118,17 @@
     "scrollToBottom": "맨 아래로 스크롤",
     "msgs_other": "{{count}}개",
     "divider_today": "오늘",
-    "divider_yesterday": "어제"
+    "divider_yesterday": "어제",
+    "refreshFromSource": "원본에서 다시 동기화",
+    "refreshPretitle": "원본에서 다시 빌드",
+    "refreshConfirmTitle": "이 세션을 원본에서 다시 동기화할까요?",
+    "refreshConfirmLead": "Spool 이 원본 트랜스크립트 파일에서 이 세션의 메시지를 다시 빌드합니다.",
+    "refreshConfirmWarnTitle": "완전 삭제한 내용이 원문으로 돌아옵니다.",
+    "refreshConfirmWarnBody": "이 세션에서 완전 삭제한 값은 확인하는 순간 Spool 의 검색 인덱스와 AI 컨텍스트로 돌아옵니다. 다음 스캔에서 다시 감지되고 다시 완전 삭제할 때까지 그렇습니다.",
+    "refreshConfirmDismissNote": "무시한 발견은 무시 상태로 유지됩니다.",
+    "refreshConfirmAction": "다시 동기화",
+    "refreshSuccess": "세션을 원본에서 다시 동기화했습니다",
+    "refreshError": "다시 동기화 실패: {{error}}"
   },
   "library": {
     "greeting": "환영합니다",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -118,7 +118,17 @@
     "scrollToBottom": "滚到底部",
     "msgs_other": "{{count}} 条",
     "divider_today": "今天",
-    "divider_yesterday": "昨天"
+    "divider_yesterday": "昨天",
+    "refreshFromSource": "从源文件重新同步",
+    "refreshPretitle": "从源文件重建",
+    "refreshConfirmTitle": "从源文件重新同步这个会话？",
+    "refreshConfirmLead": "Spool 会用原始的记录文件重建这个会话的消息。",
+    "refreshConfirmWarnTitle": "清除过的内容会回到原始形态。",
+    "refreshConfirmWarnBody": "你在这个会话里清除过的值，确认后会立刻回到 Spool 的搜索索引和 AI 上下文里，直到下次扫描重新发现它、并由你再次清除。",
+    "refreshConfirmDismissNote": "已忽略的发现会保持忽略状态。",
+    "refreshConfirmAction": "重新同步",
+    "refreshSuccess": "会话已从源文件重新同步",
+    "refreshError": "重新同步失败：{{error}}"
   },
   "library": {
     "greeting": "欢迎回来",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -118,7 +118,17 @@
     "scrollToBottom": "捲到底部",
     "msgs_other": "{{count}} 則",
     "divider_today": "今天",
-    "divider_yesterday": "昨天"
+    "divider_yesterday": "昨天",
+    "refreshFromSource": "從原始檔重新同步",
+    "refreshPretitle": "從原始檔重建",
+    "refreshConfirmTitle": "從原始檔重新同步這個會話？",
+    "refreshConfirmLead": "Spool 會用原始的記錄檔重建這個會話的訊息。",
+    "refreshConfirmWarnTitle": "清除過的內容會回到原始形態。",
+    "refreshConfirmWarnBody": "你在這個會話裡清除過的值，確認後會立刻回到 Spool 的搜尋索引和 AI 上下文裡，直到下次掃描重新發現它、並由你再次清除。",
+    "refreshConfirmDismissNote": "已忽略的發現會保持忽略狀態。",
+    "refreshConfirmAction": "重新同步",
+    "refreshSuccess": "會話已從原始檔重新同步",
+    "refreshError": "重新同步失敗：{{error}}"
   },
   "library": {
     "greeting": "歡迎回來",

--- a/packages/core/src/parsers/codex.ts
+++ b/packages/core/src/parsers/codex.ts
@@ -36,7 +36,16 @@ export function loadCodexSession(filePath: string): ParseSessionResult {
   let isInternalAssessmentSession = false
 
   // Extract UUID from filename: rollout-2026-03-23T17-13-24-{uuid}.jsonl
-  const fileMatch = basename(filePath).match(/rollout-.+-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/)
+  //
+  // The previous `.+-` form was flagged by CodeQL as polynomial-ReDoS
+  // (js/polynomial-redos): an attacker-controlled filename like
+  // `rollout-rollout-rollout-...` could blow up regex backtracking on
+  // the ambiguity between `.+` and `-`. The fixed shape spells out
+  // codex's literal timestamp grammar (\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2})
+  // which has no overlap with the trailing UUID-`-`-separator, so the
+  // engine matches in O(n) with no backtracking. Codex hasn't changed
+  // its rollout filename format since the parser was written.
+  const fileMatch = basename(filePath).match(/^rollout-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/)
   if (fileMatch?.[1]) sessionUuid = fileMatch[1]
 
   for (const line of readNonEmptyLines(filePath)) {

--- a/packages/core/src/sync/syncer.test.ts
+++ b/packages/core/src/sync/syncer.test.ts
@@ -705,6 +705,154 @@ describe('Syncer', () => {
     expect(changedIds).toEqual([])
   })
 
+  it('forceMode rewrite bypasses both the mtime-skip and classifySync gates (Refresh from source)', async () => {
+    // The "Refresh from source" user action runs against a session
+    // whose source file hasn't moved (mtime unchanged) and whose
+    // uuid/length signals say "no append needed". Both gates would
+    // normally short-circuit. Force=rewrite must go through the
+    // DELETE+INSERT path anyway — that's the whole point of the
+    // escape hatch.
+    const baseDir = makeTempDir('spool-syncer-force-rewrite-')
+    const claudeDir = join(baseDir, 'claude', 'projects', 'test-project')
+    const spoolDataDir = join(baseDir, 'spool-data')
+    mkdirSync(claudeDir, { recursive: true })
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDataDir)
+
+    const filePath = join(claudeDir, 'force-rewrite.jsonl')
+    const record = (uuid: string, ts: string, content: string) => JSON.stringify({
+      type: 'user',
+      sessionId: 'force-rewrite-session',
+      cwd: '/tmp/test-project',
+      uuid,
+      timestamp: ts,
+      message: { role: 'user', content },
+    })
+    writeFileSync(filePath, record('m1', '2026-05-01T00:00:00Z', 'original'))
+
+    const { getDB, Syncer } = await loadCoreModules()
+    const db = getDB()
+    openDbs.push(db)
+    expect(new Syncer(db).syncFile(filePath, 'claude')).toBe('added')
+
+    const sessionId = (db.prepare(
+      "SELECT id FROM sessions WHERE session_uuid = 'force-rewrite-session'"
+    ).get() as { id: number }).id
+    const m1Id = (db.prepare(
+      "SELECT id FROM messages WHERE session_id = ?"
+    ).get(sessionId) as { id: number }).id
+
+    // Park scan state + a finding to verify the rewrite cascade
+    // actually fires (in append mode with insertedCount=0 it would
+    // be silently preserved — that's what makes Refresh meaningful).
+    db.prepare("UPDATE sessions SET scan_profile = 'regex@3' WHERE id = ?").run(sessionId)
+    db.prepare(
+      `INSERT INTO findings (session_id, message_id, kind, value_hash, confidence, provider, start_offset, end_offset, state, state_changed_at)
+       VALUES (?, ?, 'api-key', 'h', 0.9, 'regex', 0, 1, 'purged', datetime('now'))`,
+    ).run(sessionId, m1Id)
+
+    // Standard re-sync — mtime hasn't moved, classify would say
+    // append. Confirm that's what would happen WITHOUT the force.
+    const baselineChanged: number[] = []
+    expect(
+      new Syncer(db, undefined, (id) => { baselineChanged.push(id) })
+        .syncFile(filePath, 'claude'),
+    ).toBe('skipped')
+    expect(baselineChanged).toEqual([])
+    expect((db.prepare(
+      "SELECT scan_profile FROM sessions WHERE id = ?"
+    ).get(sessionId) as { scan_profile: string | null }).scan_profile).toBe('regex@3')
+
+    // Force=rewrite must skip the mtime gate AND run the rewrite
+    // path. mtime is identical, classify would say append.
+    const forced: number[] = []
+    const forceResult = new Syncer(db, undefined, (id) => { forced.push(id) })
+      .syncFile(filePath, 'claude', undefined, undefined, { forceMode: 'rewrite' })
+    expect(forceResult).toBe('updated')
+    expect(forced).toEqual([sessionId])
+
+    // Rewrite ran → previous message rows were DELETEd, so the
+    // finding pointing at the old message_id was cascade-cleared.
+    // (SQLite reuses INTEGER PRIMARY KEY rowids on DELETE+INSERT in
+    // a single transaction, so the new message id may match the
+    // old; the cascade is the meaningful proof, not the rowid.)
+    const cleared = db.prepare(
+      'SELECT COUNT(*) AS c FROM findings WHERE session_id = ?'
+    ).get(sessionId) as { c: number }
+    expect(cleared.c).toBe(0)
+
+    // scan_profile must be NULLed so the worker re-scans.
+    expect((db.prepare(
+      "SELECT scan_profile FROM sessions WHERE id = ?"
+    ).get(sessionId) as { scan_profile: string | null }).scan_profile).toBeNull()
+  })
+
+  it('forceMode does not silently delete a session when its source parse returns filtered', async () => {
+    // Regression for the self-review finding on PR 3 (force-resync
+    // UI): the non-force code path treats a `filtered` parse result
+    // as "this session should be removed from the index" and calls
+    // deleteSessionByFilePath. Under force, the user pressed
+    // "Refresh from source" because they want their session back,
+    // not because they want it deleted — so the destructive
+    // branch must be skipped. Gemini is the cheapest source to
+    // construct a filtered result for: a record with `kind:
+    // 'subagent'` triggers the parser's `{ kind: 'filtered' }`
+    // return at gemini.ts:36.
+    const baseDir = makeTempDir('spool-syncer-force-filtered-')
+    const geminiCliHome = join(baseDir, 'gemini-home')
+    const chatsDir = join(geminiCliHome, '.gemini', 'tmp', 'workspace', 'chats')
+    const historyDir = join(geminiCliHome, '.gemini', 'history', 'workspace')
+    const spoolDataDir = join(baseDir, 'spool-data')
+    mkdirSync(chatsDir, { recursive: true })
+    mkdirSync(historyDir, { recursive: true })
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDataDir)
+    vi.stubEnv('HOME', geminiCliHome)
+
+    // First sync — a normal gemini session lands in the DB.
+    const filePath = join(chatsDir, 'session-1.json')
+    writeFileSync(filePath, JSON.stringify({
+      sessionId: 'force-filtered-session',
+      startTime: '2026-05-01T00:00:00Z',
+      lastUpdated: '2026-05-01T00:00:00Z',
+      messages: [
+        { id: 'm1', type: 'user', timestamp: '2026-05-01T00:00:00Z', content: 'hi' },
+      ],
+    }))
+
+    const { getDB, Syncer } = await loadCoreModules()
+    const db = getDB()
+    openDbs.push(db)
+    expect(new Syncer(db).syncFile(filePath, 'gemini')).toBe('added')
+    const sessionId = (db.prepare(
+      "SELECT id FROM sessions WHERE session_uuid = 'force-filtered-session'"
+    ).get() as { id: number }).id
+
+    // Now mutate the source so the parser returns kind: 'filtered'
+    // (gemini does this when record.kind === 'subagent'). Without
+    // force, the destructive cleanup runs.
+    writeFileSync(filePath, JSON.stringify({
+      sessionId: 'force-filtered-session',
+      kind: 'subagent',
+      startTime: '2026-05-01T00:00:00Z',
+      lastUpdated: '2026-05-01T00:01:00Z',
+      messages: [
+        { id: 'm1', type: 'user', timestamp: '2026-05-01T00:00:00Z', content: 'hi' },
+      ],
+    }))
+    touchFile(filePath)
+
+    // Force=rewrite must NOT delete the session — that would be the
+    // exact regression the self-review caught. The action should
+    // be a no-op for unreachable sources and return 'skipped'.
+    const force = new Syncer(db).syncFile(
+      filePath, 'gemini', undefined, undefined, { forceMode: 'rewrite' },
+    )
+    expect(force).toBe('skipped')
+    const stillThere = db.prepare(
+      'SELECT COUNT(*) AS c FROM sessions WHERE id = ?'
+    ).get(sessionId) as { c: number }
+    expect(stillThere.c).toBe(1)
+  })
+
   it('falls back to rewrite when the source file shrinks below the stored row count', async () => {
     const baseDir = makeTempDir('spool-syncer-rewrite-on-shrink-')
     const claudeDir = join(baseDir, 'claude', 'projects', 'test-project')

--- a/packages/core/src/sync/syncer.ts
+++ b/packages/core/src/sync/syncer.ts
@@ -47,6 +47,19 @@ export type SyncEventCallback = (event: SyncProgressEvent) => void
  *  Receives the sessions.id, NOT the session_uuid. */
 export type SessionChangedCallback = (sessionId: number) => void
 
+/** Per-call overrides for {@link Syncer.syncFile}. The watcher and
+ *  `syncAll` never pass these — they go through the standard
+ *  mtime-skip + classifySync path. The "Refresh from source" user
+ *  action sets `forceMode: 'rewrite'` to bypass both gates so a
+ *  session that looks identical at the uuid/length surface gets
+ *  rebuilt from the source jsonl anyway. */
+export interface SyncFileOptions {
+  /** Bypass classifySync and mtime-skip. Used by the explicit
+   *  "Refresh from source" IPC action; not set by the watcher or
+   *  syncAll. */
+  forceMode?: 'rewrite'
+}
+
 export class Syncer {
   private db: Database.Database
   private onProgress: SyncEventCallback | undefined
@@ -230,17 +243,31 @@ export class Syncer {
     })()
   }
 
-  syncFile(filePath: string, source: SessionSource, knownMtimes?: Map<string, string>, precomputedMtime?: string): 'added' | 'updated' | 'skipped' | 'error' {
+  syncFile(
+    filePath: string,
+    source: SessionSource,
+    knownMtimes?: Map<string, string>,
+    precomputedMtime?: string,
+    options?: SyncFileOptions,
+  ): 'added' | 'updated' | 'skipped' | 'error' {
+    const force = options?.forceMode
     try {
       if (source === 'opencode' && isOpenCodeDatabaseFile(filePath)) {
-        return this.syncOpenCodeDatabase(filePath, knownMtimes)
+        return this.syncOpenCodeDatabase(filePath, knownMtimes, options)
       }
 
       const mtime = precomputedMtime ?? getIndexedMtime(filePath, source)
       const existingMtime = knownMtimes
         ? (knownMtimes.get(filePath) ?? null)
         : getSessionMtime(this.db, filePath)
-      if (existingMtime === mtime) return 'skipped'
+      // mtime-skip is the watcher's hot-path optimization. The
+      // explicit "Refresh from source" action bypasses it on
+      // purpose — the user is asking for a re-sync precisely
+      // because they suspect the DB drifted from the source even
+      // though the mtime didn't move (e.g. manual jsonl edit, or
+      // the in-place updates some providers do without bumping
+      // mtime on the spool side).
+      if (!force && existingMtime === mtime) return 'skipped'
 
       const parseResult = source === 'claude'
         ? loadClaudeSession(filePath)
@@ -251,7 +278,15 @@ export class Syncer {
             : loadOpenCodeSession(filePath)
 
       if (parseResult.kind !== 'parsed') {
-        if (parseResult.kind === 'filtered' && existingMtime !== null) {
+        // The "filtered" path normally removes a session whose source
+        // is no longer indexable (e.g. claude subagent jsonl that
+        // moved under a /subagents/ subdir). Skip that destructive
+        // step in force mode: the user pressed "Refresh from source"
+        // expecting their session to come back, not to be deleted —
+        // and a refresh that lands on a filtered source is almost
+        // certainly something the user wants to know about rather
+        // than have happen silently.
+        if (parseResult.kind === 'filtered' && existingMtime !== null && !force) {
           this.db.prepare(`
             INSERT INTO sync_log (source_id, file_path, status, message)
             VALUES (?, ?, 'ok', ?)
@@ -290,7 +325,10 @@ export class Syncer {
       // DELETE-cascaded by upsertSession (`rewrite`). The
       // `first-sync` case is just `rewrite` semantically — there is
       // nothing to preserve.
-      const mode = this.classifySync(parsed.sessionUuid, parsed.messages)
+      // Explicit force overrides classification — the user has
+      // accepted that any per-message user-side state (Security Scan
+      // purge, dismiss) on this session will be rebuilt from source.
+      const mode: UpsertSessionMode = force ?? this.classifySync(parsed.sessionUuid, parsed.messages)
 
       let committedSessionId: number | null = null
       let insertedCount = 0
@@ -385,7 +423,7 @@ export class Syncer {
     }
   }
 
-  private syncOpenCodeDatabase(dbPath: string, knownMtimes?: Map<string, string>): 'added' | 'updated' | 'skipped' | 'error' {
+  private syncOpenCodeDatabase(dbPath: string, knownMtimes?: Map<string, string>, options?: SyncFileOptions): 'added' | 'updated' | 'skipped' | 'error' {
     let changed = false
     let hadError = false
 
@@ -408,7 +446,7 @@ export class Syncer {
     }
 
     for (const sessionPath of sessionPaths) {
-      const result = this.syncFile(sessionPath, 'opencode', knownMtimes)
+      const result = this.syncFile(sessionPath, 'opencode', knownMtimes, undefined, options)
       if (result === 'added' || result === 'updated') changed = true
       else if (result === 'error') hadError = true
     }


### PR DESCRIPTION
## What

Adds an explicit "Refresh from source" user action that rebuilds a single session by bypassing the append-only sync's mtime-skip and `classifySync` gates. Surfaced in `SessionDetail`'s existing overflow menu as a third action alongside Copy ID / Copy resume command.

## Why

PR #348 (append-only sync) deliberately stops auto-detecting two cases:

- A user manually edits the jsonl on disk (rare but real).
- A provider updates an existing message in-place without changing the part of mtime the watcher relies on.

The trade-off was correct (auto-content-compare would also trip on every purge-masked message and re-spread the raw value) — but it left no escape hatch for users who genuinely know their DB has drifted from source. This PR is that hatch.

It also rounds out the planned 3-PR series started by #346 (collapse bulk purge into a single transaction) and continued by #347 (dedupe + UNIQUE INDEX) and #348 (append-only sync).

## How

**Core syncer** (`packages/core/src/sync/syncer.ts`)
- New `SyncFileOptions { forceMode?: 'rewrite' }` type.
- `syncFile(...)` takes it as a 5th optional positional. When set, the mtime-skip early-return and `classifySync` dispatch are both bypassed — the rewrite path runs unconditionally.
- `syncOpenCodeDatabase` forwards `options` down so Refresh on an OpenCode session actually rewrites.
- Pre-fix self-review found a destructive bug: the existing "filtered parse" branch (claude subagent files etc.) was running its `deleteSessionByFilePath` step regardless of force, meaning a user pressing Refresh on a session whose parse now returns `filtered` would have silently lost the entire row plus cascaded findings. The branch now requires `!force`.

**IPC** (`packages/app/src/main/index.ts`)
- New `spool:force-resync-session` channel takes a `sessionUuid`, looks up `file_path` + `source_id`, calls `syncer.syncFile(..., { forceMode: 'rewrite' })`.
- Returns a tagged `{ ok: true, result } | { ok: false, error }` shape so the renderer branches cleanly.

**Preload** (`packages/app/src/preload/index.ts`)
- Standard `forceResyncSession(sessionUuid)` wrapper.

**UI** (`packages/app/src/renderer/components/SessionDetail.tsx` + `.../session/RefreshFromSourceDialog.tsx`)
- One surface: SessionDetail's existing `MoreHorizontal` overflow menu gains the action. Same place users already reach for Copy ID / Copy resume command.
- Modal mirrors PurgeConfirmDialog's outer shape (Esc / click-outside cancel, ref-managed focus, busy lockout).
- Body restructured per the post-flat-design self-review:
  - Eyebrow pretitle in accent
  - Tightened title
  - One-line lead paragraph
  - Tinted-amber callout box for the load-bearing risk ("Purged content comes back as raw") with `ShieldAlert` icon
  - Reassuring "Dismissed findings stay dismissed" footnote
- On confirm: IPC call, on success reload via `getSession` so the rebuilt transcript surfaces immediately. Pre-fix self-review caught the stale-render bug — the success toast fired but the message list kept showing pre-refresh content because the existing `useEffect` only re-runs when `sessionUuid` changes.

**i18n** (`en.json`, `zh-CN.json`, `zh-TW.json`)
- 9 new `session.refresh*` keys.
- Chinese variants audited against the codebase translation convention: `purge → 清除`, `dismiss → 忽略`, `session → 会话`, `jsonl → 原始记录文件`; `Spool` / `AI` stay English (matches the existing `Agent 搜索` precedent).
- `de` / `fr` / `ja` / `ko` fall through to `en` via `fallbackLng: 'en'`; full localisation belongs to a separate i18n sweep.

### How it connects

- Completes the 4-PR series #346 / #347 / #348 / this one. The post-PR-348 review explicitly named "force-resync UI" as the planned answer to the same-uuid in-place edit case; this is that answer.
- Existing scan-worker plumbing already invalidates `scan_profile` and re-enqueues on the cascade — no scanner-side change needed. The force path goes through the same rewrite branch as a genuine source-rewrite, so all the cascades that were correct there are correct here too.
- IPC handler runs in the main process against the long-lived `syncer` instance. SQLite WAL serialises concurrent writers (sync worker, scan worker), so a Refresh that lands while a background sync is in flight queues cleanly instead of corrupting.

## Verification

- **Tests** (`packages/core/src/sync/syncer.test.ts`): 380 core tests green (378 prior + 2 new).
  - "forceMode rewrite bypasses both the mtime-skip and classifySync gates (Refresh from source)" — asserts the cascade fires, finding rows cascade-clear, and `onSessionChanged` is called even when the mtime hasn't moved and uuid/length signals say "append."
  - "forceMode does not silently delete a session when its source parse returns filtered" — regression for the self-review finding; verified to fail on the pre-fix code (the filtered branch ran regardless of force) and pass with the guard in place.
- App typecheck clean.
- Manual: clicked Refresh from source on a real claude session in dev. Dialog opens, confirmation triggers the rewrite, message list reloads, success toast fires. Cancel / click-outside / Escape all cancel cleanly.

## Notes / non-goals

- No global "Refresh all sessions" surface — that would be a destructive batch action and isn't the user need this PR addresses.
- No keyboard shortcut for the action — it's intentionally a deliberate, gated invocation.
- i18n fallback for `de` / `fr` / `ja` / `ko` is English; a follow-up sweep can translate.