### PR TITLE
perf(security): batch scan-worker enqueue burst into one status publish

### DIFF
--- a/packages/core/src/security/worker.test.ts
+++ b/packages/core/src/security/worker.test.ts
@@ -326,6 +326,63 @@ describe('ScanWorker', () => {
     })
   })
 
+  // Regression: the per-session loop in rescanAll / backfill used to
+  // call `updateStatus` for every offer, fanning out into N IPC
+  // events to the renderer (and N React renders) for a burst of N
+  // sessions. The same "1000 events for 1000 items" shape as the
+  // original bulk-purge bug in #346 — except for status events
+  // instead of finding events. The fix is to mutate the Ref per
+  // session but publish only once at the end of the burst, so a
+  // 1000-session rescan fans out into ~1 enqueue-phase event for the
+  // renderer rather than 1000.
+  it('rescanAll fans out into O(K) status events, not O(N), during the enqueue burst', async () => {
+    const N = 10
+    const multiDb = setupDb(N)
+    await withWorker(multiDb, async (worker) => {
+      const collectFiber = Effect.runFork(
+        Stream.takeUntil(worker.statusChanges, (s) =>
+          s.queued === 0 && s.scanning === null && s.backfillRemaining === 0,
+        ).pipe(Stream.runCollect),
+      )
+      await new Promise<void>((r) => setTimeout(r, 20))
+      await Effect.runPromise(worker.rescanAll())
+      await Effect.runPromise(waitForIdle(worker))
+      const collected = Chunk.toReadonlyArray(
+        await Effect.runPromise(Fiber.join(collectFiber)),
+      )
+
+      // Per-burst event budget:
+      //   - 1 up-front updateStatus (sets backfillRemaining +
+      //     manualBurstInFlight via {@link rescanAll})
+      //   - 1 post-loop publishStatus (folds N per-session publishes
+      //     into one — the load-bearing change being asserted here)
+      //   - SCAN_LIFECYCLE_PUBLISHES (= 2) per scanOne, namely
+      //       start: queued--, scanning=id
+      //       end:   scanning=null, backfillRemaining--
+      //     The constant is captured at the top of the test so a
+      //     future change to scanOne (e.g. an intermediate progress
+      //     event) is a one-line bump here, not a budget mystery for
+      //     the next reader.
+      //
+      // Old per-item-publish loop produced N + SCAN_LIFECYCLE_PUBLISHES*N
+      // + 2 events for the same burst — roughly 32 at N=10. The new
+      // bound is 2 + SCAN_LIFECYCLE_PUBLISHES*N ≈ 22, leaving the +3
+      // slack for Effect's scheduler interleaving.
+      const SCAN_LIFECYCLE_PUBLISHES = 2
+      const eventBudget = 2 + SCAN_LIFECYCLE_PUBLISHES * N + 3
+      expect(collected.length).toBeLessThanOrEqual(eventBudget)
+
+      // Burst correctness still holds — the per-item loop's effect on
+      // backfillTotal must be the high-water mark.
+      expect(Math.max(...collected.map(s => s.backfillTotal))).toBe(N)
+      // …and the burst drains all the way back to idle.
+      const last = collected[collected.length - 1]!
+      expect(last.backfillRemaining).toBe(0)
+      expect(last.queued).toBe(0)
+      expect(last.scanning).toBeNull()
+    })
+  })
+
   it('backfill() default does NOT raise manualBurstInFlight', async () => {
     const multiDb = setupDb(3)
     await withWorker(multiDb, async (worker) => {

--- a/packages/core/src/security/worker.ts
+++ b/packages/core/src/security/worker.ts
@@ -101,9 +101,11 @@ export function makeScanWorker(
 
     const publish = (c: FindingsChange) => PubSub.publish(events, c).pipe(Effect.asVoid)
 
-    // Update statusRef AND publish the new snapshot so subscribers get
-    // a push event for every mutation. One helper at the seam avoids
-    // forgetting to publish from a future Ref.update site.
+    // Mutate statusRef in place WITHOUT publishing — used as the
+    // building block for `updateStatus` (which publishes after
+    // mutating) and for the bulk-enqueue path in rescanAll / backfill
+    // (which mutates per session but publishes only once at the end of
+    // the burst).
     //
     // `backfillTotal` is derived here so individual mutation sites
     // (enqueue / rescanAll / backfill / scanOne) don't have to
@@ -114,7 +116,7 @@ export function makeScanWorker(
     // navigation: a user who switches tabs mid-burst and comes back
     // gets the true original total via `getStatus`, not the
     // remaining-at-remount-time approximation.
-    const updateStatus = (f: (s: ScanStatus) => ScanStatus) =>
+    const mutateStatus = (f: (s: ScanStatus) => ScanStatus) =>
       Ref.update(statusRef, (prev) => {
         const after = f(prev)
         // High-water mark of *backfillRemaining alone*. Including the
@@ -141,11 +143,27 @@ export function makeScanWorker(
         // sees a stale truth across burst boundaries.
         const manualBurstInFlight = fullyIdle ? false : after.manualBurstInFlight
         return { ...after, backfillTotal, manualBurstInFlight }
-      }).pipe(
-        Effect.zipRight(Ref.get(statusRef)),
-        Effect.flatMap((s) => PubSub.publish(statusEvents, s)),
-        Effect.asVoid,
-      )
+      })
+
+    /** Publish the current statusRef snapshot to the statusChanges
+     *  PubSub. Subscribers (the main-process forwarder fiber that
+     *  pushes to the renderer) wake up once per call. */
+    const publishStatus = Ref.get(statusRef).pipe(
+      Effect.flatMap((s) => PubSub.publish(statusEvents, s)),
+      Effect.asVoid,
+    )
+
+    /** Mutate statusRef AND publish the new snapshot so subscribers
+     *  get a push event for every mutation. The single-session
+     *  `enqueue` (and every scanOne lifecycle step) uses this; bulk
+     *  enqueue paths use `mutateStatus` + a single `publishStatus`
+     *  at the end of the burst instead, so a 1000-session rescanAll
+     *  fans out into one IPC event for the renderer rather than
+     *  one-per-session (and one React render rather than one per
+     *  session — the original purge-bulk problem in a different
+     *  shape). */
+    const updateStatus = (f: (s: ScanStatus) => ScanStatus) =>
+      mutateStatus(f).pipe(Effect.zipRight(publishStatus))
 
     // Burst-reset variant for backfill() (and any future caller that
     // means "start a fresh burst, discard whatever the previous one
@@ -240,6 +258,18 @@ export function makeScanWorker(
         yield* updateStatus((s) => ({ ...s, queued: s.queued + 1 }))
       })
 
+    /** Queue + mutate without publishing. Used by rescanAll / backfill
+     *  to fold N sessions worth of status mutations into a single
+     *  publish at the end of the burst. Each `Queue.offer` runs as a
+     *  separate Effect step, so the drain fiber can pull and process
+     *  items concurrently — `mutateStatus` ensures the per-item
+     *  increment is atomic with the Ref state the drain reads. */
+    const enqueueSilent = (sessionId: number) =>
+      Effect.gen(function* () {
+        yield* Queue.offer(queue, sessionId)
+        yield* mutateStatus((s) => ({ ...s, queued: s.queued + 1 }))
+      })
+
     const rescanAll = () =>
       Effect.gen(function* () {
         // SELECT and UPDATE share one transaction so a concurrent sync
@@ -268,8 +298,13 @@ export function makeScanWorker(
           manualBurstInFlight: true,
         }))
         for (const r of all) {
-          yield* enqueue(r.id)
+          yield* enqueueSilent(r.id)
         }
+        // Single publish at the end of the burst — collapses N IPC
+        // hops to the renderer into one (the previous per-item path
+        // hit the same "1000 React renders for a 1000-session
+        // archive" shape the bulk purge had before #346).
+        if (all.length > 0) yield* publishStatus
         yield* Effect.annotateCurrentSpan('enqueued', all.length)
         return all.length
       }).pipe(Effect.withSpan('security.worker.rescan_all'))
@@ -297,8 +332,11 @@ export function makeScanWorker(
           manualBurstInFlight: opts?.userInitiated === true,
         }))
         for (const id of stale) {
-          yield* enqueue(id)
+          yield* enqueueSilent(id)
         }
+        // Single publish at the end of the burst (see rescanAll for
+        // the rationale — same fan-out shape).
+        if (stale.length > 0) yield* publishStatus
         yield* Effect.annotateCurrentSpan('enqueued', stale.length)
         yield* Effect.annotateCurrentSpan('userInitiated', opts?.userInitiated === true)
         return stale.length


### PR DESCRIPTION
## What

Collapse the per-session status publishes inside `rescanAll` and `backfill` into a single publish at the end of the burst. The drain-side per-`scanOne` publishes are unchanged.

## Why

The scan worker's `rescanAll` and `backfill` loops called `enqueue(sessionId)` per session, which fanned out into N IPC events to the renderer (one per `updateStatus`) for a burst of N sessions. Each event hit the main process's PubSub forwarder, was sent to the renderer over IPC, and triggered a `setScanStatus` call → re-render.

Same "1000 React renders for a 1000-item burst" shape as the original bulk-purge bug fixed in #346, but on the status-event path instead of the finding-event path. On a real archive it surfaces as scrollbar judder + meter twitching on SecurityPage right after clicking Rescan all on a large set.

Discovery: the audit I ran after the #346/#347/#348/#349 series finished — "are there other surfaces with the same anti-pattern?" `rescanAll` / `backfill` were the only ones with high user-visible impact still pending. `cleanupStaleOpenCodeSessions` has the same structural shape but only fires on the rare case of OpenCode session deletion.

## How

Split the previously-unified `updateStatus` into three pieces:

- `mutateStatus(f)` — `Ref.update` only, no publish. Still derives `backfillTotal` and `manualBurstInFlight` so callers don't have to remember to bump them.
- `publishStatus` — `Ref.get` + `PubSub.publish` current snapshot.
- `updateStatus(f)` — `mutateStatus + publishStatus`. Every existing call site keeps its semantics unchanged.

Add `enqueueSilent` = `Queue.offer + mutateStatus`. `rescanAll` and `backfill` use it in place of `enqueue` inside their for-loops. After the loop emits N silent mutations, a single `publishStatus` at the end collapses what was previously N IPC events into one. The drain fiber still publishes per `scanOne` lifecycle step (start: `queued--`, `scanning=id`; end: `scanning=null`, `backfillRemaining--`), so the renderer's per-session progress signal is unchanged.

The single-session `enqueue` (called from `spool:rescan-session` IPC when the syncer's `onSessionChanged` callback fires) is unchanged — fires one publish per call, no need to silence it.

### What's preserved
- `backfillTotal` high-water still equals burst size, set on the up-front `updateStatus` before the silent loop runs.
- `manualBurstInFlight` still flips on at the up-front `updateStatus`; the `fullyIdle` override at full drain still flips it off.
- `waitForIdle` reads `getStatus` (`Ref.get`), not the stream, so it doesn't care which mutations were silent.

### How it connects
- Same shape as #346's per-finding-transaction → per-batch-transaction collapse. Different domain (status events instead of DB transactions), same anti-pattern, same fix shape.
- Scan worker's queue/drain semantics are documented in [memory: Scan worker burst semantics] — this PR doesn't touch `resetBurst`'s `Queue.takeAll` path or the sticky-max `backfillTotal` invariant.

## Verification

- `packages/core/src/security/worker.test.ts` — 17 tests pass (16 prior + 1 new regression).
- New test: `rescanAll fans out into O(K) status events, not O(N), during the enqueue burst`. Asserts `collected.length <= 2 + SCAN_LIFECYCLE_PUBLISHES * N + 3`. Verified to **fail** on the pre-fix code (per-item publishes overflowed the budget) and **pass** on the new code. The scan-lifecycle constant is named so a future PR that adds a mid-scan progress event has a one-line bump rather than a budget mystery.
- Full core suite: 381/381 (380 prior + 1 new).

## Notes / non-goals

- The 0-session edge case for `rescanAll` / `backfill({userInitiated:true})` — where `mutateStatus`'s `fullyIdle` override clears `manualBurstInFlight` before the renderer can observe it — is **pre-existing** (the same flow happens in the old per-item-publish code) and not addressed here. Tracked for separate UX follow-up.
- `dismissFindings` was inspected in the same audit and is already structurally correct (single `db.transaction`, per-session count recompute outside the loop). Minor SQL-batch optimization opportunity left for a follow-up if anyone observes lag at the 10k+ findings tier.
- `cleanupStaleOpenCodeSessions` has the same per-item-transaction anti-pattern but only fires on rare OpenCode session-deletion events. Will fold into a follow-up PR if it ever surfaces.