### PR TITLE
release: v0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spool",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/app",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "productName": "Spool",
   "main": "./out/main/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/cli",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": false,
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/core",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/landing",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/redact",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Local, pure-TS sensitive-data detection for Spool sessions. Pattern + checksum + entropy pipeline today; pluggable provider boundary for future on-device ML (e.g. OpenAI Privacy Filter via transformers.js).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## What

Patch release rolling up the merged work since v0.5.1:

| PR | Summary |
|---|---|
| #346 | Collapse bulk purge into a single transaction — closes #344 (60s freeze) |
| #347 | Schema v14: dedupe `(session_id, msg_uuid)` + UNIQUE INDEX |
| #348 | Switch syncer to append-only — purge / dismiss state now survives re-sync |
| #349 | "Refresh from source" — explicit per-session rebuild action |
| #350 | Batch scan-worker enqueue burst into one status publish |
| #351 | Smooth the scan-end visual transition (unified `ScanStatusBanner`) |
| #352 | Move purge / dismiss / undismiss SQL onto a worker thread + late-attach plumbing |

## Why

Cuts a patch version so the bulk-purge UX fix from #344 actually reaches users — the 60s → main-thread-responsive arc only matters in real installs. Same release also picks up the append-only sync semantic that makes Security Scan state durable across the natural "re-sync the session after a new turn" lifecycle.

No schema or IPC contract changes beyond what already landed in v0.5.1's migration v13 → v0.5.2's migration v14. Schema migration is idempotent and runs once on first launch.

## Verification

Each underlying PR's CI was green at merge; this release branch only bumps `version` in 6 `package.json` files. No code changes ride along.