### PR TITLE
fix: resolve CodeQL security-and-quality findings

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,10 @@ on:
       - "**/*.md"
       - "docs/**"
 
+# Tests only read the repo; upload-artifact needs no extra scope.
+permissions:
+  contents: read
+
 jobs:
   unit:
     strategy:

--- a/packages/app/e2e/helpers/demo-fixtures.ts
+++ b/packages/app/e2e/helpers/demo-fixtures.ts
@@ -228,7 +228,7 @@ export function buildDemoFixtures(
         String(date.getUTCMonth() + 1).padStart(2, '0'),
         String(date.getUTCDate()).padStart(2, '0'),
       )
-      const slug = `rollout-${session.iso.replace(/:/g, '-').replace('.000Z', 'Z').replace('T', 'T')}-${sessionId}.jsonl`
+      const slug = `rollout-${session.iso.replace(/:/g, '-').replace('.000Z', 'Z')}-${sessionId}.jsonl`
       const filePath = join(relDir, slug)
       writeText(filePath, makeCodexSession(sessionId, cwd, session.title, session.iso))
     })

--- a/packages/app/e2e/picker-browse-scope.spec.ts
+++ b/packages/app/e2e/picker-browse-scope.spec.ts
@@ -19,7 +19,7 @@ test.beforeAll(async () => {
       // Claude derives a project subdir from the cwd; mirror its convention
       // (replace `/` with `-`) so the synthesized sessions group into a
       // single browseable project.
-      const projectSlug = BIG_PROJECT_DIR.replace(/\//g, '-').replace(/^-/, '-')
+      const projectSlug = BIG_PROJECT_DIR.replace(/\//g, '-')
       const projectDir = join(claudeDir, projectSlug)
       mkdirSync(projectDir, { recursive: true })
       for (let i = 0; i < BIG_PROJECT_SESSION_COUNT; i++) {

--- a/packages/app/src/renderer/lib/snippet.test.ts
+++ b/packages/app/src/renderer/lib/snippet.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { snippetToStrongHtml } from './snippet.js'
+
+describe('snippetToStrongHtml', () => {
+  it('rewrites mark highlights to strong', () => {
+    expect(snippetToStrongHtml('a <mark>hit</mark> b')).toBe('a <strong>hit</strong> b')
+  })
+
+  it('escapes markup in the surrounding text so it renders inert', () => {
+    // An unclosed tag survives the parsers\' tag-stripping and reaches the
+    // FTS index; it must not become a live element when shown via innerHTML.
+    expect(snippetToStrongHtml('see <img src=x onerror=alert(1)')).toBe(
+      'see &lt;img src=x onerror=alert(1)',
+    )
+    expect(snippetToStrongHtml('<script>alert(1)</script>')).toBe(
+      '&lt;script&gt;alert(1)&lt;/script&gt;',
+    )
+  })
+
+  it('escapes inside and around highlights', () => {
+    expect(snippetToStrongHtml('<mark><b></mark> & "x"')).toBe(
+      '<strong>&lt;b&gt;</strong> &amp; &quot;x&quot;',
+    )
+  })
+
+  it('passes plain text through unchanged', () => {
+    expect(snippetToStrongHtml('just text')).toBe('just text')
+  })
+})

--- a/packages/app/src/renderer/lib/snippet.ts
+++ b/packages/app/src/renderer/lib/snippet.ts
@@ -1,7 +1,25 @@
 /** Rewrites `<mark>` tags from core's buildLikeSnippet to `<strong>`
  *  so renderer surfaces can style highlights via their own `<strong>`
  *  rules (accent color, font weight, etc.) without each surface
- *  carrying the same regex. */
+ *  carrying the same regex.
+ *
+ *  The snippet text comes straight from indexed session content and is
+ *  rendered via `dangerouslySetInnerHTML`, so everything except the
+ *  highlight markers we inject ourselves is HTML-escaped — a session
+ *  whose body contains markup is shown as inert text, never parsed. */
 export function snippetToStrongHtml(snippet: string): string {
-  return snippet.replace(/<mark>/g, '<strong>').replace(/<\/mark>/g, '</strong>')
+  return snippet
+    .split(/(<\/?mark>)/)
+    .map((part) =>
+      part === '<mark>' ? '<strong>' : part === '</mark>' ? '</strong>' : escapeHtml(part),
+    )
+    .join('')
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
 }

--- a/packages/core/src/parsers/spool-prelude.test.ts
+++ b/packages/core/src/parsers/spool-prelude.test.ts
@@ -38,4 +38,15 @@ q`
     const input = '<spool-system-prelude>a</spool-system-prelude>\n<spool-system-prelude>b</spool-system-prelude>\nq'
     expect(stripSpoolSystemPrelude(input)).toBe('q')
   })
+
+  it('leaves an unterminated marker intact', () => {
+    expect(stripSpoolSystemPrelude('<spool-system-prelude>no close tag')).toBe('<spool-system-prelude>no close tag')
+  })
+
+  it('stays fast on many unterminated open markers (no quadratic backtracking)', () => {
+    const hostile = '<spool-system-prelude>'.repeat(100_000)
+    const start = performance.now()
+    expect(stripSpoolSystemPrelude(hostile)).toBe(hostile)
+    expect(performance.now() - start).toBeLessThan(1000)
+  })
 })

--- a/packages/core/src/parsers/spool-prelude.ts
+++ b/packages/core/src/parsers/spool-prelude.ts
@@ -16,8 +16,17 @@ export function wrapSpoolSystemPrelude(systemBody: string, userQuery: string): s
   return `${SPOOL_SYSTEM_PRELUDE_OPEN}\n${systemBody}\n${SPOOL_SYSTEM_PRELUDE_CLOSE}\n\n${userQuery}`
 }
 
-const STRIP_RE = /<spool-system-prelude>[\s\S]*?<\/spool-system-prelude>/g
-
 export function stripSpoolSystemPrelude(text: string): string {
-  return text.replace(STRIP_RE, '').trim()
+  // indexOf scanning instead of a regex: the `<open>[\s\S]*?<close>` form
+  // backtracks quadratically when many unterminated open markers appear in
+  // hostile input. Each pass here is linear.
+  let result = text
+  let open = result.indexOf(SPOOL_SYSTEM_PRELUDE_OPEN)
+  while (open !== -1) {
+    const close = result.indexOf(SPOOL_SYSTEM_PRELUDE_CLOSE, open + SPOOL_SYSTEM_PRELUDE_OPEN.length)
+    if (close === -1) break // unterminated marker — leave the remainder intact
+    result = result.slice(0, open) + result.slice(close + SPOOL_SYSTEM_PRELUDE_CLOSE.length)
+    open = result.indexOf(SPOOL_SYSTEM_PRELUDE_OPEN)
+  }
+  return result.trim()
 }

--- a/packages/redact/src/mask.test.ts
+++ b/packages/redact/src/mask.test.ts
@@ -62,6 +62,15 @@ describe('maskValueByKind', () => {
     expect(maskValueByKind('api.eng.corp', 'internal-host')).toBe('[redacted].eng.corp')
     expect(maskValueByKind('db.prod.internal', 'internal-host')).toBe('[redacted].prod.internal')
   })
+  it('internal-host with no dot falls back to the generic mask', () => {
+    expect(maskValueByKind('localhost', 'internal-host')).toBe('[redacted internal host]')
+  })
+  it('internal-host stays fast on hostile input (no quadratic backtracking)', () => {
+    const hostile = `host${'.-'.repeat(50_000)}!`
+    const start = performance.now()
+    expect(maskValueByKind(hostile, 'internal-host')).toBe('[redacted internal host]')
+    expect(performance.now() - start).toBeLessThan(1000)
+  })
   it('synthetic kinds get a sensible default', () => {
     expect(maskValueByKind('Maya', 'synthetic:author')).toBe('[redacted name]')
     expect(maskValueByKind('custom-blob', 'synthetic:manual')).toBe('[redacted]')

--- a/packages/redact/src/mask.ts
+++ b/packages/redact/src/mask.ts
@@ -113,8 +113,15 @@ export function maskValueByKind(value: string, kind: SensitiveKind | string): st
       // four-octet pattern matters more than the digits.
       return value.includes(':') ? '[redacted IPv6]' : '[redacted IPv4]'
     case 'internal-host': {
-      const m = value.match(/\.([a-z0-9-]+(?:\.[a-z0-9-]+)*)$/i)
-      return m ? `[redacted].${m[1]}` : '[redacted internal host]'
+      // Keep the domain suffix (everything after the first dot) so readers
+      // see which network it was on. indexOf + a flat char-class test stays
+      // linear; the previous end-anchored nested-quantifier regex backtracked
+      // quadratically on hostile input like ".-.-.-.-".
+      const dot = value.indexOf('.')
+      const suffix = dot >= 0 ? value.slice(dot + 1) : ''
+      return suffix && /^[a-z0-9.-]+$/i.test(suffix)
+        ? `[redacted].${suffix}`
+        : '[redacted internal host]'
     }
     case 'absolute-path': {
       const m = value.match(/^(\/Users\/|\/home\/|\/var\/|\/etc\/|\/opt\/|[A-Z]:\\Users\\)/)

--- a/packages/share-kit/src/lib/parsers/source.test.ts
+++ b/packages/share-kit/src/lib/parsers/source.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { decodeEntities, stats } from './source.js'
+
+describe('decodeEntities', () => {
+  it('decodes the common entities', () => {
+    expect(decodeEntities('a&nbsp;b')).toBe('a b')
+    expect(decodeEntities('&lt;tag&gt;')).toBe('<tag>')
+    expect(decodeEntities('&quot;x&quot;')).toBe('"x"')
+    expect(decodeEntities('it&#39;s')).toBe("it's")
+    expect(decodeEntities('a &amp; b')).toBe('a & b')
+  })
+
+  it('decodes &amp; last so escaped entities survive one decode pass', () => {
+    // `&amp;lt;` is an escaped `&lt;` — it must decode to the literal `&lt;`,
+    // not be double-unescaped into `<`.
+    expect(decodeEntities('&amp;lt;')).toBe('&lt;')
+    expect(decodeEntities('&amp;amp;')).toBe('&amp;')
+  })
+})
+
+describe('stats', () => {
+  it('counts CJK / kana / hangul as individual characters', () => {
+    expect(stats([{ body: '你好世界' }]).wordCount).toBe(4)
+    expect(stats([{ body: 'こんにちは' }]).wordCount).toBe(5)
+    expect(stats([{ body: '안녕하세요' }]).wordCount).toBe(5)
+  })
+
+  it('counts latin runs as whitespace-delimited words', () => {
+    expect(stats([{ body: 'the quick brown fox' }]).wordCount).toBe(4)
+  })
+
+  it('mixes CJK chars and latin words', () => {
+    expect(stats([{ body: 'hello 世界' }]).wordCount).toBe(3)
+  })
+})

--- a/packages/share-kit/src/lib/parsers/source.ts
+++ b/packages/share-kit/src/lib/parsers/source.ts
@@ -46,12 +46,13 @@ export class ParseError extends Error {
 export function decodeEntities(s: string): string {
   return s
     .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&#x27;/g, "'")
+    // `&amp;` last so e.g. `&amp;lt;` decodes to the literal `&lt;`, not `<`.
+    .replace(/&amp;/g, '&')
 }
 
 /** Word + read-time stats. Detects CJK content and counts characters
@@ -59,8 +60,12 @@ export function decodeEntities(s: string): string {
  *  treats 整段中文 as one "word", which looks silly in the header. */
 export function stats(turns: { body: string }[]): { wordCount: number; readMin: number } {
   const joined = turns.map((t) => t.body).join(' ')
-  const cjk = (joined.match(/[　-鿿가-힯぀-ゟ゠-ヿ]/g) || []).length
-  const latinWords = (joined.replace(/[　-鿿가-힯぀-ゟ゠-ヿ]+/g, ' ').trim().split(/\s+/).filter(Boolean)).length
+  // U+3000–U+9FFF (CJK symbols/punctuation through unified ideographs) plus
+  // Hangul. The old class also listed the Hiragana/Katakana blocks, but those
+  // sit inside U+3000–U+9FFF — pure overlap, same matches, now dropped.
+  const cjkRe = /[　-鿿가-힯]/g
+  const cjk = (joined.match(cjkRe) || []).length
+  const latinWords = (joined.replace(cjkRe, ' ').trim().split(/\s+/).filter(Boolean)).length
   const wordCount = cjk + latinWords
   // Mixed content: weight CJK at 500 chars/min, Latin at 220 wpm
   const cjkMinutes = cjk / 500


### PR DESCRIPTION
Clears the open CodeQL code-scanning alerts. Each change is the high-confidence true positive; the lower-value/false-positive alerts (title tag-stripping, internal-only binary-name lookups) were left alone.

## Changes

- **redact (`mask.ts`)** — `internal-host` mask now extracts the domain suffix with `indexOf` + a flat character-class check. The previous end-anchored, nested-quantifier regex backtracked quadratically on input like `.-.-.-.-`. Output is unchanged for real hostnames.
- **core (`spool-prelude.ts`)** — `stripSpoolSystemPrelude` scans with `indexOf` instead of `/<open>[\s\S]*?<close>/g`, which backtracked quadratically when many unterminated open markers appeared. Behavior is identical for normal input; an unterminated marker is left intact.
- **app (`snippet.ts`)** — search-snippet text is HTML-escaped before `dangerouslySetInnerHTML`, so only the `<mark>` highlight markers we inject become elements and indexed session content renders as inert text.
- **share-kit (`source.ts`)** — `decodeEntities` now decodes `&amp;` last, so `&amp;lt;` resolves to the literal `&lt;` instead of being double-unescaped to `<`. The `stats` CJK character class drops the redundant Hiragana/Katakana sub-ranges (they sit inside `U+3000–U+9FFF`), removing the overlap warning with no change to what matches.
- **ci (`e2e.yml`)** — added a minimal top-level `permissions: contents: read` block.
- **e2e fixtures/spec** — removed two no-op identity `.replace()` calls.

## Tests

- Regression tests added for each logic change (snippet escaping, entity-decode order, CJK counting, internal-host masking + ReDoS timing guard, prelude stripping + ReDoS timing guard).
- Suites run green: redact (135), core (383), share-kit (43), app renderer unit incl. the new snippet test.