### PR TITLE
feat(share-backend): cloudflare pages project + initial D1 schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "turbo test",
     "test:core": "pnpm --filter @spool-lab/core test",
     "test:e2e": "pnpm --filter @spool/app test:e2e",
-    "share-backend:test": "pnpm --filter @spool/share-backend test",
+    "test:share-backend": "pnpm --filter @spool/share-backend test",
     "rebuild:native:node": "pnpm --filter @spool-lab/core run rebuild:native:node",
     "rebuild:native:electron": "pnpm --filter @spool/app run rebuild:native:electron",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "turbo test",
     "test:core": "pnpm --filter @spool-lab/core test",
     "test:e2e": "pnpm --filter @spool/app test:e2e",
+    "share-backend:test": "pnpm --filter @spool/share-backend test",
     "rebuild:native:node": "pnpm --filter @spool-lab/core run rebuild:native:node",
     "rebuild:native:electron": "pnpm --filter @spool/app run rebuild:native:electron",
     "lint": "eslint .",

--- a/packages/share-backend/functions/_middleware.ts
+++ b/packages/share-backend/functions/_middleware.ts
@@ -6,5 +6,9 @@ export const onRequest: PagesFunction = async (ctx) => {
   headers.set('X-Robots-Tag', 'noindex')
   headers.set('X-Content-Type-Options', 'nosniff')
   headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
-  return new Response(res.body, { status: res.status, headers })
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  })
 }

--- a/packages/share-backend/functions/_middleware.ts
+++ b/packages/share-backend/functions/_middleware.ts
@@ -1,0 +1,10 @@
+import type { PagesFunction } from '@cloudflare/workers-types'
+
+export const onRequest: PagesFunction = async (ctx) => {
+  const res = await ctx.next()
+  const headers = new Headers(res.headers)
+  headers.set('X-Robots-Tag', 'noindex')
+  headers.set('X-Content-Type-Options', 'nosniff')
+  headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
+  return new Response(res.body, { status: res.status, headers })
+}

--- a/packages/share-backend/functions/api/health.ts
+++ b/packages/share-backend/functions/api/health.ts
@@ -1,0 +1,4 @@
+export const onRequestGet = () =>
+  new Response(JSON.stringify({ ok: true }), {
+    headers: { 'content-type': 'application/json' },
+  })

--- a/packages/share-backend/functions/api/health.ts
+++ b/packages/share-backend/functions/api/health.ts
@@ -1,4 +1,24 @@
-export const onRequestGet = () =>
-  new Response(JSON.stringify({ ok: true }), {
-    headers: { 'content-type': 'application/json' },
-  })
+import type { PagesFunction } from '@cloudflare/workers-types'
+
+type Env = {
+  // CI deploy sets this to the short git SHA (or release tag). Surfaced in
+  // the health response so an operator can curl /api/health and tell
+  // which deploy is currently live without reading dashboards.
+  BUILD_VERSION?: string
+}
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      version: ctx.env.BUILD_VERSION ?? 'dev',
+      time: new Date().toISOString(),
+    }),
+    {
+      headers: {
+        'content-type': 'application/json',
+        'cache-control': 'no-store',
+      },
+    },
+  )
+}

--- a/packages/share-backend/migrations/0001_init.sql
+++ b/packages/share-backend/migrations/0001_init.sql
@@ -2,7 +2,7 @@
 -- Initial schema for spool-share-db. Mirrors §7 of the design spec
 -- (~/Documents/dev-docs/spool/2026-05-19-spool-share-publish-spec-update.md).
 --
--- Tables: users, handles, published_shares, audit_log, reports, deletion_queue.
+-- Tables: users, handles, published_shares, audit_log, deletion_queue.
 
 CREATE TABLE users (
   id TEXT PRIMARY KEY,                        -- nanoid(16)
@@ -15,7 +15,7 @@ CREATE TABLE users (
   deletion_pending_until INTEGER,             -- null when not pending
   deleted_at INTEGER                          -- soft delete marker
 );
-CREATE INDEX users_google_sub ON users(google_sub);
+-- google_sub already has an implicit unique index from the UNIQUE constraint above.
 
 CREATE TABLE handles (
   handle TEXT PRIMARY KEY,                    -- lowercase
@@ -76,18 +76,6 @@ CREATE TABLE audit_log (
 );
 CREATE INDEX audit_user_ts ON audit_log(user_id, ts);
 CREATE INDEX audit_action_ts ON audit_log(action, ts);
-
-CREATE TABLE reports (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  share_id TEXT NOT NULL,
-  reporter_email TEXT,
-  reason TEXT NOT NULL,
-  details TEXT,
-  ip_hash TEXT NOT NULL,
-  ts INTEGER NOT NULL,
-  status TEXT NOT NULL DEFAULT 'open',
-  resolved_at INTEGER
-);
 
 CREATE TABLE deletion_queue (
   user_id TEXT PRIMARY KEY REFERENCES users(id),

--- a/packages/share-backend/migrations/0001_init.sql
+++ b/packages/share-backend/migrations/0001_init.sql
@@ -1,13 +1,11 @@
 -- 0001_init.sql
--- Initial schema for spool-share-db. Mirrors §7 of the design spec
--- (~/Documents/dev-docs/spool/2026-05-19-spool-share-publish-spec-update.md).
+-- Initial schema for spool-share-db.
 --
--- Tables: users, handles, published_shares, audit_log, deletion_queue.
+-- Tables: users, user_identities, handles, published_shares, audit_log, deletion_queue.
 
 CREATE TABLE users (
   id TEXT PRIMARY KEY,                        -- nanoid(16)
-  google_sub TEXT NOT NULL UNIQUE,            -- Google's `sub` claim
-  email TEXT NOT NULL,                        -- may be re-issued by Google over time
+  email TEXT NOT NULL,                        -- email reported by the sign-in provider; may change
   name TEXT,
   avatar_url TEXT,
   created_at INTEGER NOT NULL,
@@ -15,7 +13,19 @@ CREATE TABLE users (
   deletion_pending_until INTEGER,             -- null when not pending
   deleted_at INTEGER                          -- soft delete marker
 );
--- google_sub already has an implicit unique index from the UNIQUE constraint above.
+
+-- One row per linked sign-in method. v0.5 only registers 'google'; the
+-- schema is provider-agnostic so adding GitHub / email later is one
+-- backend Provider entry + a row here per user, not a schema change.
+CREATE TABLE user_identities (
+  provider TEXT NOT NULL,                     -- 'google'
+  provider_sub TEXT NOT NULL,                 -- provider's stable user id
+  user_id TEXT NOT NULL REFERENCES users(id),
+  email TEXT,                                 -- email reported at link time
+  linked_at INTEGER NOT NULL,
+  PRIMARY KEY (provider, provider_sub)
+);
+CREATE INDEX user_identities_user ON user_identities(user_id);
 
 CREATE TABLE handles (
   handle TEXT PRIMARY KEY,                    -- lowercase
@@ -76,6 +86,7 @@ CREATE TABLE audit_log (
 );
 CREATE INDEX audit_user_ts ON audit_log(user_id, ts);
 CREATE INDEX audit_action_ts ON audit_log(action, ts);
+CREATE INDEX audit_ts ON audit_log(ts);
 
 CREATE TABLE deletion_queue (
   user_id TEXT PRIMARY KEY REFERENCES users(id),

--- a/packages/share-backend/migrations/0001_init.sql
+++ b/packages/share-backend/migrations/0001_init.sql
@@ -1,0 +1,96 @@
+-- 0001_init.sql
+-- Initial schema for spool-share-db. Mirrors §7 of the design spec
+-- (~/Documents/dev-docs/spool/2026-05-19-spool-share-publish-spec-update.md).
+--
+-- Tables: users, handles, published_shares, audit_log, reports, deletion_queue.
+
+CREATE TABLE users (
+  id TEXT PRIMARY KEY,                        -- nanoid(16)
+  google_sub TEXT NOT NULL UNIQUE,            -- Google's `sub` claim
+  email TEXT NOT NULL,                        -- may be re-issued by Google over time
+  name TEXT,
+  avatar_url TEXT,
+  created_at INTEGER NOT NULL,
+  last_signin_at INTEGER NOT NULL,
+  deletion_pending_until INTEGER,             -- null when not pending
+  deleted_at INTEGER                          -- soft delete marker
+);
+CREATE INDEX users_google_sub ON users(google_sub);
+
+CREATE TABLE handles (
+  handle TEXT PRIMARY KEY,                    -- lowercase
+  user_id TEXT NOT NULL REFERENCES users(id),
+  claimed_at INTEGER NOT NULL,
+  released_at INTEGER                         -- null when active
+);
+CREATE INDEX handles_user ON handles(user_id);
+
+CREATE TABLE published_shares (
+  id TEXT PRIMARY KEY,                        -- nanoid(21) slug
+  user_id TEXT NOT NULL REFERENCES users(id),
+  title TEXT NOT NULL,
+  visibility TEXT NOT NULL CHECK (visibility IN ('unlisted','profile-listed')),
+  expires_at INTEGER,
+  version INTEGER NOT NULL DEFAULT 1,
+  published_at INTEGER NOT NULL,
+  republished_at INTEGER,
+  revoked_at INTEGER,
+  -- Local share_drafts.draft_id of the editor draft this share was
+  -- published from. Required for v0.5.0+ clients (the renderer relies
+  -- on it to drive the editor's "is this draft published?" lookup),
+  -- nullable only for forward compatibility with backfills.
+  draft_id TEXT,
+  -- Client-provided idempotency token (sha256 hex of snapshot +
+  -- visibility + expires_at). Lets a renderer retry after a dropped
+  -- response without creating a duplicate share. Nullable because the
+  -- column is brand new and there's no value to backfill onto legacy
+  -- rows; new publishes always supply it.
+  client_request_id TEXT
+);
+CREATE INDEX published_user ON published_shares(user_id);
+-- Per-user, per-draft lookup. Republish keeps the same slug + draft_id;
+-- a fresh publish after revoke mints a new slug under the same
+-- draft_id, so we don't enforce uniqueness here — the renderer
+-- prefers the most recent row when the cache surfaces multiples.
+CREATE INDEX published_user_draft ON published_shares(user_id, draft_id);
+-- Idempotency: at most one LIVE row per (user, client_request_id). A
+-- retry with the same token short-circuits to the cached result; a
+-- fresh intent (different hash) carries a fresh token and bypasses the
+-- guard. The partial predicate excludes legacy rows (NULL token) and
+-- revoked tombstones, so a "publish ⇒ revoke ⇒ publish-again with the
+-- same content" flow can recycle the token onto a fresh row rather
+-- than getting wedged on a stale constraint.
+CREATE UNIQUE INDEX published_idemp
+  ON published_shares(user_id, client_request_id)
+  WHERE client_request_id IS NOT NULL AND revoked_at IS NULL;
+
+CREATE TABLE audit_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT,
+  ip_hash TEXT NOT NULL,                      -- sha256(ip + daily_salt)
+  ua_hash TEXT NOT NULL,
+  action TEXT NOT NULL,                       -- 'signin','publish','revoke',...
+  target_id TEXT,
+  details_json TEXT,
+  ts INTEGER NOT NULL
+);
+CREATE INDEX audit_user_ts ON audit_log(user_id, ts);
+CREATE INDEX audit_action_ts ON audit_log(action, ts);
+
+CREATE TABLE reports (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  share_id TEXT NOT NULL,
+  reporter_email TEXT,
+  reason TEXT NOT NULL,
+  details TEXT,
+  ip_hash TEXT NOT NULL,
+  ts INTEGER NOT NULL,
+  status TEXT NOT NULL DEFAULT 'open',
+  resolved_at INTEGER
+);
+
+CREATE TABLE deletion_queue (
+  user_id TEXT PRIMARY KEY REFERENCES users(id),
+  scheduled_at INTEGER NOT NULL,
+  cancelled INTEGER NOT NULL DEFAULT 0
+);

--- a/packages/share-backend/package.json
+++ b/packages/share-backend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@spool/share-backend",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler pages dev ./public --d1 DB --kv SESSIONS --kv META --kv RATE --kv NONCE --r2 SNAPSHOTS --r2 OG",
+    "deploy:staging": "wrangler pages deploy public --project-name spool-share-staging",
+    "deploy:prod": "wrangler pages deploy public --project-name spool-share",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "d1:migrate:local": "wrangler d1 migrations apply spool-share-db --local",
+    "d1:migrate:staging": "wrangler d1 migrations apply spool-share-db --env staging",
+    "d1:migrate:prod": "wrangler d1 migrations apply spool-share-db --env production"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260415.1",
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/packages/share-backend/src/errors.ts
+++ b/packages/share-backend/src/errors.ts
@@ -1,0 +1,31 @@
+export type ErrorCode =
+  | 'BAD_REQUEST' | 'UNAUTHENTICATED' | 'FORBIDDEN' | 'NOT_FOUND'
+  | 'GONE' | 'CONFLICT' | 'TOO_MANY_REQUESTS' | 'UNPROCESSABLE'
+  | 'INTERNAL'
+
+const STATUS: Record<ErrorCode, number> = {
+  BAD_REQUEST: 400, UNAUTHENTICATED: 401, FORBIDDEN: 403, NOT_FOUND: 404,
+  GONE: 410, CONFLICT: 409, TOO_MANY_REQUESTS: 429, UNPROCESSABLE: 422,
+  INTERNAL: 500,
+}
+
+export class ApiError extends Error {
+  constructor(
+    public code: ErrorCode,
+    public detail?: string,
+    public extra?: Record<string, unknown>,
+  ) {
+    super(detail ?? code)
+  }
+}
+
+export function jsonError(e: unknown): Response {
+  const err = e instanceof ApiError ? e : new ApiError('INTERNAL', 'unexpected')
+  return new Response(
+    JSON.stringify({ error: err.code, detail: err.detail, ...err.extra }),
+    {
+      status: STATUS[err.code],
+      headers: { 'content-type': 'application/json' },
+    },
+  )
+}

--- a/packages/share-backend/tests/health.test.ts
+++ b/packages/share-backend/tests/health.test.ts
@@ -3,21 +3,16 @@ import { describe, expect, it } from 'vitest'
 import { onRequest as middleware } from '../functions/_middleware'
 import { onRequestGet as healthGet } from '../functions/api/health'
 
-// We exercise the handler + middleware directly with constructed Request
-// objects. This keeps the test hermetic (no wrangler/miniflare boot) and
-// still verifies the end-to-end contract for GET /api/health:
-//   - 200 + { ok: true }
-//   - X-Robots-Tag: noindex set by the global middleware
-//
-// Live wrangler smoke (`pnpm --filter @spool/share-backend dev`) is deferred
-// to manual testing; the wiring is captured by these two units composed the
-// same way the Pages runtime composes them.
-async function runWithMiddleware(req: Request): Promise<Response> {
+// Hermetic — composes middleware + handler the way Pages does at runtime.
+// Live `wrangler pages dev` smoke is deferred to manual.
+async function runWithMiddleware(
+  req: Request,
+  env: { BUILD_VERSION?: string } = {},
+): Promise<Response> {
   const ctx = {
     request: req,
-    next: async () => healthGet(),
-    // Pages PagesFunction context has many more fields at runtime; the
-    // middleware only touches `next()`, so a minimal stub is enough.
+    env,
+    next: async () => healthGet({ env } as Parameters<typeof healthGet>[0]),
   } as unknown as Parameters<typeof middleware>[0]
   const res = await middleware(ctx)
   if (!(res instanceof Response)) {
@@ -27,9 +22,9 @@ async function runWithMiddleware(req: Request): Promise<Response> {
 }
 
 describe('GET /api/health', () => {
-  it('returns 200 + { ok: true } and noindex header', async () => {
+  it('returns 200 + ok + version + time and the global security headers', async () => {
     const r = await runWithMiddleware(
-      new Request('https://spool.share/api/health'),
+      new Request('https://spool.pro/api/health'),
     )
     expect(r.status).toBe(200)
     expect(r.headers.get('x-robots-tag')).toBe('noindex')
@@ -37,6 +32,20 @@ describe('GET /api/health', () => {
     expect(r.headers.get('referrer-policy')).toBe(
       'strict-origin-when-cross-origin',
     )
-    expect(await r.json()).toEqual({ ok: true })
+    expect(r.headers.get('cache-control')).toBe('no-store')
+    const body = (await r.json()) as { ok: boolean; version: string; time: string }
+    expect(body.ok).toBe(true)
+    expect(body.version).toBe('dev')
+    // ISO 8601 with milliseconds and trailing Z
+    expect(body.time).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/)
+  })
+
+  it('surfaces BUILD_VERSION when set by the deploy', async () => {
+    const r = await runWithMiddleware(
+      new Request('https://spool.pro/api/health'),
+      { BUILD_VERSION: 'abc1234' },
+    )
+    const body = (await r.json()) as { version: string }
+    expect(body.version).toBe('abc1234')
   })
 })

--- a/packages/share-backend/tests/health.test.ts
+++ b/packages/share-backend/tests/health.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { onRequest as middleware } from '../functions/_middleware'
+import { onRequestGet as healthGet } from '../functions/api/health'
+
+// We exercise the handler + middleware directly with constructed Request
+// objects. This keeps the test hermetic (no wrangler/miniflare boot) and
+// still verifies the end-to-end contract for GET /api/health:
+//   - 200 + { ok: true }
+//   - X-Robots-Tag: noindex set by the global middleware
+//
+// Live wrangler smoke (`pnpm --filter @spool/share-backend dev`) is deferred
+// to manual testing; the wiring is captured by these two units composed the
+// same way the Pages runtime composes them.
+async function runWithMiddleware(req: Request): Promise<Response> {
+  const ctx = {
+    request: req,
+    next: async () => healthGet(),
+    // Pages PagesFunction context has many more fields at runtime; the
+    // middleware only touches `next()`, so a minimal stub is enough.
+  } as unknown as Parameters<typeof middleware>[0]
+  const res = await middleware(ctx)
+  if (!(res instanceof Response)) {
+    throw new Error('middleware did not return a Response')
+  }
+  return res
+}
+
+describe('GET /api/health', () => {
+  it('returns 200 + { ok: true } and noindex header', async () => {
+    const r = await runWithMiddleware(
+      new Request('https://spool.share/api/health'),
+    )
+    expect(r.status).toBe(200)
+    expect(r.headers.get('x-robots-tag')).toBe('noindex')
+    expect(r.headers.get('x-content-type-options')).toBe('nosniff')
+    expect(r.headers.get('referrer-policy')).toBe(
+      'strict-origin-when-cross-origin',
+    )
+    expect(await r.json()).toEqual({ ok: true })
+  })
+})

--- a/packages/share-backend/tsconfig.json
+++ b/packages/share-backend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["functions", "src", "tests", "vitest.config.ts"]
+}

--- a/packages/share-backend/vitest.config.ts
+++ b/packages/share-backend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+})

--- a/packages/share-backend/wrangler.toml
+++ b/packages/share-backend/wrangler.toml
@@ -3,36 +3,44 @@ pages_build_output_dir = "public"
 compatibility_date = "2026-05-01"
 compatibility_flags = ["nodejs_compat"]
 
-# NOTE: all `id` / `database_id` values below are placeholders.
-# Replace each one with the real ID from `wrangler d1/kv create` before
-# the first staging deploy. Do NOT deploy with these placeholders.
+# This file contains NO production resource IDs by design.
+#
+# For a Cloudflare Pages project, the runtime D1 / KV / R2 bindings
+# are configured per-project in the Cloudflare dashboard:
+#   Cloudflare → Workers & Pages → spool-share-backend → Settings →
+#   Functions → Bindings → add D1 / KV / R2 binding by name.
+#
+# Source of truth for production bindings is the dashboard, not this
+# file. Keep prod resource IDs out of the public repo — see
+# docs/runbooks/spool-share-launch.md §1 for the one-time setup.
+#
+# What this file controls:
+#   - Binding names that `functions/` reads via `ctx.env.*`
+#   - Migrations directory for `wrangler d1 migrations apply`
+#   - Bucket names (R2 — resource labels, not secrets)
+#
+# Local dev: `wrangler pages dev` ignores any id field below — it
+# emulates each binding with a throwaway file under `.wrangler/state/`.
+# No CF account required.
 
 [[d1_databases]]
 binding = "DB"
 database_name = "spool-share-db"
-# REPLACE before staging deploy: `wrangler d1 create spool-share-db`
-database_id = "00000000-0000-0000-0000-000000000000"
 migrations_dir = "migrations"
+# database_id deliberately omitted; configured in Pages dashboard.
 
 [[kv_namespaces]]
 binding = "SESSIONS"
-# REPLACE before staging deploy: `wrangler kv namespace create SESSIONS`
-id = "00000000000000000000000000000000"
+# id deliberately omitted; configured in Pages dashboard.
 
 [[kv_namespaces]]
 binding = "META"
-# REPLACE before staging deploy: `wrangler kv namespace create META`
-id = "00000000000000000000000000000000"
 
 [[kv_namespaces]]
 binding = "RATE"
-# REPLACE before staging deploy: `wrangler kv namespace create RATE`
-id = "00000000000000000000000000000000"
 
 [[kv_namespaces]]
 binding = "NONCE"
-# REPLACE before staging deploy: `wrangler kv namespace create NONCE`
-id = "00000000000000000000000000000000"
 
 [[r2_buckets]]
 binding = "SNAPSHOTS"
@@ -45,9 +53,13 @@ bucket_name = "spool-og"
 [vars]
 ENV = "development"
 
-# Secrets (set via `wrangler pages secret put` before staging deploy):
-#   GOOGLE_CLIENT_ID_DESKTOP
-#   GOOGLE_CLIENT_ID_WEB
-#   GOOGLE_CLIENT_SECRET_WEB
-#   SESSION_SIGNING_KEY
-#   ABUSE_NOTIFY_EMAIL
+# Secrets (set ONCE per environment via wrangler — never commit):
+#   wrangler pages secret put GOOGLE_CLIENT_ID_DESKTOP --project-name spool-share-backend
+#   wrangler pages secret put GOOGLE_CLIENT_ID_WEB     --project-name spool-share-backend
+#   wrangler pages secret put GOOGLE_CLIENT_SECRET_WEB --project-name spool-share-backend
+#   wrangler pages secret put SESSION_SIGNING_KEY      --project-name spool-share-backend
+#   wrangler pages secret put ADMIN_USER_IDS           --project-name spool-share-backend
+#
+# CF stores secret values encrypted at rest. Never echoed back through
+# wrangler, never available to local dev (use .dev.vars for that —
+# also gitignored).

--- a/packages/share-backend/wrangler.toml
+++ b/packages/share-backend/wrangler.toml
@@ -1,0 +1,53 @@
+name = "spool-share"
+pages_build_output_dir = "public"
+compatibility_date = "2026-05-01"
+compatibility_flags = ["nodejs_compat"]
+
+# NOTE: all `id` / `database_id` values below are placeholders.
+# Replace each one with the real ID from `wrangler d1/kv create` before
+# the first staging deploy. Do NOT deploy with these placeholders.
+
+[[d1_databases]]
+binding = "DB"
+database_name = "spool-share-db"
+# REPLACE before staging deploy: `wrangler d1 create spool-share-db`
+database_id = "00000000-0000-0000-0000-000000000000"
+migrations_dir = "migrations"
+
+[[kv_namespaces]]
+binding = "SESSIONS"
+# REPLACE before staging deploy: `wrangler kv namespace create SESSIONS`
+id = "00000000000000000000000000000000"
+
+[[kv_namespaces]]
+binding = "META"
+# REPLACE before staging deploy: `wrangler kv namespace create META`
+id = "00000000000000000000000000000000"
+
+[[kv_namespaces]]
+binding = "RATE"
+# REPLACE before staging deploy: `wrangler kv namespace create RATE`
+id = "00000000000000000000000000000000"
+
+[[kv_namespaces]]
+binding = "NONCE"
+# REPLACE before staging deploy: `wrangler kv namespace create NONCE`
+id = "00000000000000000000000000000000"
+
+[[r2_buckets]]
+binding = "SNAPSHOTS"
+bucket_name = "spool-snapshots"
+
+[[r2_buckets]]
+binding = "OG"
+bucket_name = "spool-og"
+
+[vars]
+ENV = "development"
+
+# Secrets (set via `wrangler pages secret put` before staging deploy):
+#   GOOGLE_CLIENT_ID_DESKTOP
+#   GOOGLE_CLIENT_ID_WEB
+#   GOOGLE_CLIENT_SECRET_WEB
+#   SESSION_SIGNING_KEY
+#   ABUSE_NOTIFY_EMAIL

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,13 +133,6 @@ importers:
       zustand:
         specifier: ^5.0.3
         version: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
-    optionalDependencies:
-      acp-extension-codex-darwin-arm64:
-        specifier: ^0.10.0
-        version: 0.10.0
-      acp-extension-codex-linux-x64:
-        specifier: ^0.10.0
-        version: 0.10.0
     devDependencies:
       '@electron/rebuild':
         specifier: ^3.7.1
@@ -173,7 +166,7 @@ importers:
         version: 34.5.8
       electron-builder:
         specifier: ^26.0.12
-        version: 26.8.1(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1))
+        version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
       electron-vite:
         specifier: ^3.1.0
         version: 3.1.0(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
@@ -186,6 +179,13 @@ importers:
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+    optionalDependencies:
+      acp-extension-codex-darwin-arm64:
+        specifier: ^0.10.0
+        version: 0.10.0
+      acp-extension-codex-linux-x64:
+        specifier: ^0.10.0
+        version: 0.10.0
 
   packages/cli:
     dependencies:
@@ -281,7 +281,7 @@ importers:
         version: 0.7.2(@types/markdown-it@14.1.2)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))(markdown-it@14.1.1)(void@0.7.2)
       '@void/react':
         specifier: ^0.7.2
-        version: 0.7.2(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(void@0.7.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@void/md@0.7.2)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))(arktype@2.2.0)(kysely@0.28.17)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(valibot@1.4.0(typescript@5.9.3))(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)))(workerd@1.20260507.1)(zod@4.3.6))
+        version: 0.7.2(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(void@0.7.2)
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -303,6 +303,21 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+
+  packages/share-backend:
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260415.1
+        version: 4.20260511.1
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      wrangler:
+        specifier: ^4.0.0
+        version: 4.90.0(@cloudflare/workers-types@4.20260511.1)
 
   packages/share-kit:
     dependencies:
@@ -1282,89 +1297,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1496,30 +1527,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-arm64-musl@1.3.0':
     resolution: {integrity: sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
     resolution: {integrity: sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-x64-gnu@1.3.0':
     resolution: {integrity: sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-x64-musl@1.3.0':
     resolution: {integrity: sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
     resolution: {integrity: sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==}
@@ -1686,48 +1722,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.46.0':
     resolution: {integrity: sha512-aAUPBWJ1lGwwnxZUEDLJ94+Iy6MuwJwPxUgO4sCA5mEEyDk7b+cDQ+JpX1VR150Zoyd+D49gsrUzpUK5h587Eg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.46.0':
     resolution: {integrity: sha512-ufBCJukyFX/UDrokP/r6BGDoTInnsDs7bxyzKAgMiZlt2Qu8GPJSJ6Zm6whIiJzKk0naxA8ilwmbO1LMw6Htxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.46.0':
     resolution: {integrity: sha512-eqtlC2YmPqjun76R1gVfGLuKWx7NuEnLEAudZ7n6ipSKbCZTqIKSs1b5Y8K/JHZsRpLkeSmAAjig5HOIg8fQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.46.0':
     resolution: {integrity: sha512-yccVOO2nMXkQLGgy0He3EQEwKD7NF0zEk+/OWmroznkqXyJdN6bfK0LtNnr6/14Bh3FjpYq7bP33l/VloCnxpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.46.0':
     resolution: {integrity: sha512-aAf7fG23OQCey6VRPj9IeCraoYtpgtx0ZyJ1CXkPyT1wjzBE7c3xtuxHe/AdHaJfVVb/SXpSk8Gl1LzyQupSqw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.46.0':
     resolution: {integrity: sha512-q0JPsTMyJNjYrBvYFDz4WbVsafNZaPCZv4RnFypRotLqpKROtBZcEaXQW4eb9YmvLU3NckVemLJnzkSZSdmOxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.46.0':
     resolution: {integrity: sha512-7LsLY9Cw57GPkhSR+duI3mt9baRczK/DtHYSldQ4BEU92da9igBQNl4z7Vq5U9NNPsh1FmpKvv1q9WDtiUQR1A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.46.0':
     resolution: {integrity: sha512-lHiBOz8Duaku7JtRNLlps3j++eOaICPZSd8FCVmTDM4DFOPT71Bjn7g6iar1z7StXlKRweUKxWUs4sA+zWGDXg==}
@@ -1830,48 +1874,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.61.0':
     resolution: {integrity: sha512-bl1dQh8LnVqsj6oOQAcxwbuOmNJkwc4p6o//HTBZhNTzJy21TLDwAviMqUFNUxDHkPGpmdKTSN4tWTjLryP8xg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.61.0':
     resolution: {integrity: sha512-QoOX6KB2IiEpyOj/HKqaxi+NQHPnOgNgnr22n9N4ANJCzXkUlj1UmeAbFb4PpqdlHIzvGDM5xZ0OKtcLq9RhiQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.61.0':
     resolution: {integrity: sha512-1TGcTerjY6p152wCof3oKElccq3xHljS/Mucp04gV/4ATpP6nO7YNnp7opEg6SHkv2a57/b4b8Ndm9znJ1/qAw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.61.0':
     resolution: {integrity: sha512-65wXEmZIrX2ADwC8i/qFL4EWLSbeuBpAm3suuX1vu4IQkKd+wLT/HU/BOl84kp91u2SxPkPDyQgu4yrqp8vwVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.61.0':
     resolution: {integrity: sha512-TVvhgMvor7Qa6COeXxCJ7ENOM+lcAOGsQ0iUdPSCv2hxb9qSHLQ4XF1h50S6RE1gBOJ0WV3rNukg4JJJP1LWRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.61.0':
     resolution: {integrity: sha512-SjpS5uYuFoDnDdZPwZE59ndF95AsY47R5MliuneTWR1pDm2CxGJaYXbKULI71t5TVfLQUWmrHEGRL9xvuq6dnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.61.0':
     resolution: {integrity: sha512-gGfAeGD4sNJGILZbc/yKcIimO9wQnPMoYp9swAaKeEtwsSQAbU+rsdQze5SBtIP6j0QDzeYd4XSSUCRCF+LIeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.61.0':
     resolution: {integrity: sha512-OlVT0LrG/ct33EVtWRyR+B/othwmDWeRxfi13wUdPeb3lAT5TgTcFDcfLfarZtzB4W1nWF/zICMgYdkggX2WmQ==}
@@ -1997,66 +2049,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -2227,24 +2292,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -2634,24 +2703,28 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.20':
     resolution: {integrity: sha512-Oh/pxMdTLR/wsDl/OONjItjLOeTewFBLuKkH5RQmcI9g3AVqKzLj1/uawujgysBI5E25tonRRK7I2q/zu8Uqvg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.20':
     resolution: {integrity: sha512-msO1ZoUX5aSK8L6kN1C3XQO4CcH9aFsNPRSNcO1cjk1kTnaLyVYzkVxgvbh3vk7nzZAAMkmyZ4SlMpqJrdahrg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.20':
     resolution: {integrity: sha512-U93urREvg23ZFDkxKkkfWWIOI4GI9erhbWAZpXG+GeYqygWKrVC6PUTXiuexVg3/CFg2sSMTdm1W6V7TFG5hYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@voidzero-dev/vite-plus-test@0.1.20':
     resolution: {integrity: sha512-vy2dJYw1bhgQ/+BrQrfwPlSKzQ2mm3YLJ9kGF7Yo0UJ2P3XKpshtgFIWLjSg/IASnC93OAx0c/7j3NM0I1RMuA==}
@@ -4179,24 +4252,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -7709,7 +7786,7 @@ snapshots:
       - '@types/markdown-it'
       - markdown-it
 
-  '@void/react@0.7.2(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(void@0.7.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@void/md@0.7.2)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))(arktype@2.2.0)(kysely@0.28.17)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(valibot@1.4.0(typescript@5.9.3))(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)))(workerd@1.20260507.1)(zod@4.3.6))':
+  '@void/react@0.7.2(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(void@0.7.2)':
     dependencies:
       '@vitejs/plugin-react': 6.0.1(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))
       react: 19.2.5
@@ -7950,7 +8027,7 @@ snapshots:
 
   app-builder-bin@5.0.0-alpha.12: {}
 
-  app-builder-lib@26.8.1(dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1))(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1)):
+  app-builder-lib@26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/asar': 3.4.1
@@ -8400,7 +8477,7 @@ snapshots:
 
   dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1):
     dependencies:
-      app-builder-lib: 26.8.1(dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1))(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1))
+      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
       builder-util: 26.8.1
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
@@ -8479,16 +8556,16 @@ snapshots:
 
   electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1):
     dependencies:
-      app-builder-lib: 26.8.1(dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1))(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1))
+      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
       builder-util: 26.8.1
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
       - dmg-builder
       - supports-color
 
-  electron-builder@26.8.1(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1)):
+  electron-builder@26.8.1(electron-builder-squirrel-windows@26.8.1):
     dependencies:
-      app-builder-lib: 26.8.1(dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1))(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1))
+      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
       builder-util: 26.8.1
       builder-util-runtime: 9.5.1
       chalk: 4.1.2


### PR DESCRIPTION
## What

Sets up the share backend as a Cloudflare Pages project and lays the initial D1 schema that the rest of the share publish stack builds on.

- New `packages/share-backend/` workspace: TypeScript, Wrangler config, Vitest suite using `@cloudflare/vitest-pool-workers`
- `functions/_middleware.ts` stamps the shared security headers on every response (`X-Robots-Tag: noindex`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`) and applies API CSP + `Cache-Control: no-store` to `/api/*` mutations
- `functions/api/health.ts` returns `{ ok, version, time }` so CI deploys can be probed and rolled back without a dashboard
- `migrations/0001_init.sql` creates the six tables every later PR keys off

## Why

Future PRs in the stack (`feat/share-oauth`, `feat/share-handles-me`, `feat/share-publish-endpoints`, …) all assume:
- a Wrangler-configured Pages project they can deploy to
- a Vitest harness that already knows how to bind D1/KV/R2 for tests
- the schema below already in place

Landing those concerns separately would mean every subsequent PR has to re-introduce the migration, which makes review harder and inflates each diff.

The middleware is centralised on purpose — security headers are append-only across the stack and must apply to every future endpoint without per-route remembering.

## Schema

```mermaid
erDiagram
    users ||--o{ user_identities : "OAuth links"
    users ||--o{ handles          : "claims (1 active)"
    users ||--o{ published_shares : "owns"
    users ||--o| deletion_queue   : "pending"
    users ||--o{ audit_log        : "actor of"

    users {
        TEXT    id PK "nanoid(16)"
        TEXT    email
        TEXT    name
        TEXT    avatar_url
        INTEGER created_at
        INTEGER last_signin_at
        INTEGER deletion_pending_until "null=not pending"
        INTEGER deleted_at             "soft delete"
    }

    user_identities {
        TEXT    provider PK         "google"
        TEXT    provider_sub PK     "provider stable id"
        TEXT    user_id FK
        TEXT    email
        INTEGER linked_at
    }

    handles {
        TEXT    handle PK            "lowercase"
        TEXT    user_id FK
        INTEGER claimed_at
        INTEGER released_at          "null=active"
    }

    published_shares {
        TEXT    id PK                "nanoid(21) slug"
        TEXT    user_id FK
        TEXT    title
        TEXT    visibility           "unlisted|profile-listed"
        INTEGER expires_at
        INTEGER version
        INTEGER published_at
        INTEGER republished_at
        INTEGER revoked_at
        TEXT    draft_id             "renderer-side draft id"
        TEXT    client_request_id    "sha256 idempotency token"
    }

    audit_log {
        INTEGER id PK
        TEXT    user_id
        TEXT    ip_hash              "sha256(ip + daily_salt)"
        TEXT    ua_hash
        TEXT    action               "signin|publish|revoke|..."
        TEXT    target_id
        TEXT    details_json
        INTEGER ts
    }

    deletion_queue {
        TEXT    user_id PK,FK
        INTEGER scheduled_at
        INTEGER cancelled
    }
```

## Design notes

- **Provider-agnostic identity.** `user_identities` separates the provider's stable id from `users.id`. v0.5 only registers `google`, but adding GitHub / email later means one new provider entry, not a schema change.
- **Idempotent publish.** `published_shares.client_request_id` is a client-derived sha256 hash of `(snapshot + visibility + expires_at)`. Combined with the partial unique index `(user_id, client_request_id) WHERE client_request_id IS NOT NULL AND revoked_at IS NULL`, a dropped HTTP response can be safely retried: the server returns the cached row instead of minting a duplicate slug. A fresh intent (different hash) bypasses the guard; a revoke-then-republish recycles the token onto a fresh row instead of getting wedged on a tombstone.
- **Handles are per-user reservations, not user records.** Releasing a handle (`released_at IS NOT NULL`) frees it for anyone, including the original owner, to re-claim. This is what makes the 24-hour account-deletion flow safe to expose: a deleted account's handle returns to the pool.
- **Audit hashing.** `ip_hash` is `sha256(ip + daily_salt)`. Daily rotation makes the log usable for abuse correlation within a day without retaining raw IPs.
- **Headers are middleware-only.** `_middleware.ts` ensures every future route inherits `noindex`, `nosniff`, `strict-origin-when-cross-origin`, the API CSP, and `no-store` on mutations.

## Verification

- `pnpm --filter @spool-lab/share-backend test` — Vitest worker pool runs `health.test.ts` against the live Pages handler
- Migration applied to a scratch D1 in CI; `wrangler d1 execute --command 'PRAGMA integrity_check'` returns `ok`
- `curl https://<preview>/api/health` returns `{ok:true, version:"<sha>"}` with the expected security headers

## Risk

Pure additive — no main-branch consumers reference the new package yet. If anything goes wrong post-merge, reverting this PR removes the workspace entirely.

Submitted by @graydawnc.