### PR TITLE
feat(share-backend): handle claim + /api/me/* (require-user, schedule-delete)

### DIFF
--- a/packages/share-backend/functions/api/handles/check.ts
+++ b/packages/share-backend/functions/api/handles/check.ts
@@ -10,6 +10,11 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
     const handle = new URL(ctx.request.url).searchParams.get('h') ?? ''
     const v = validateHandle(handle)
     if (!v.ok) return jsonOk({ available: false, reason: v.reason })
+    // NOTE: `handles.handle` is the table PK, so once a row exists the
+    // value is occupied for INSERT purposes even after `released_at` is
+    // set. This query matches the design intent (released handles are
+    // re-claimable) — when the release flow ships, the claim path must
+    // switch to INSERT … ON CONFLICT(handle) DO UPDATE SET released_at=NULL.
     const row = await ctx.env.DB
       .prepare('SELECT 1 FROM handles WHERE handle=? AND released_at IS NULL')
       .bind(v.handle)

--- a/packages/share-backend/functions/api/handles/check.ts
+++ b/packages/share-backend/functions/api/handles/check.ts
@@ -1,0 +1,29 @@
+import type { D1Database, PagesFunction } from '@cloudflare/workers-types'
+
+import { jsonError } from '../../../src/errors'
+import { validateHandle } from '../../../src/handles'
+
+type Env = { DB: D1Database }
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  try {
+    const handle = new URL(ctx.request.url).searchParams.get('h') ?? ''
+    const v = validateHandle(handle)
+    if (!v.ok) {
+      return new Response(
+        JSON.stringify({ available: false, reason: v.reason }),
+        { headers: { 'content-type': 'application/json' } },
+      )
+    }
+    const row = await ctx.env.DB
+      .prepare('SELECT 1 FROM handles WHERE handle=? AND released_at IS NULL')
+      .bind(v.handle)
+      .first()
+    return new Response(
+      JSON.stringify({ available: !row }),
+      { headers: { 'content-type': 'application/json' } },
+    )
+  } catch (e) {
+    return jsonError(e)
+  }
+}

--- a/packages/share-backend/functions/api/handles/check.ts
+++ b/packages/share-backend/functions/api/handles/check.ts
@@ -1,6 +1,6 @@
 import type { D1Database, PagesFunction } from '@cloudflare/workers-types'
 
-import { jsonError } from '../../../src/errors'
+import { jsonError, jsonOk } from '../../../src/errors'
 import { validateHandle } from '../../../src/handles'
 
 type Env = { DB: D1Database }
@@ -9,20 +9,12 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
   try {
     const handle = new URL(ctx.request.url).searchParams.get('h') ?? ''
     const v = validateHandle(handle)
-    if (!v.ok) {
-      return new Response(
-        JSON.stringify({ available: false, reason: v.reason }),
-        { headers: { 'content-type': 'application/json' } },
-      )
-    }
+    if (!v.ok) return jsonOk({ available: false, reason: v.reason })
     const row = await ctx.env.DB
       .prepare('SELECT 1 FROM handles WHERE handle=? AND released_at IS NULL')
       .bind(v.handle)
       .first()
-    return new Response(
-      JSON.stringify({ available: !row }),
-      { headers: { 'content-type': 'application/json' } },
-    )
+    return jsonOk({ available: !row })
   } catch (e) {
     return jsonError(e)
   }

--- a/packages/share-backend/functions/api/handles/claim.ts
+++ b/packages/share-backend/functions/api/handles/claim.ts
@@ -1,0 +1,61 @@
+import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers-types'
+
+import { audit } from '../../../src/audit'
+import { requireUser } from '../../../src/auth/require'
+import { ApiError, jsonError } from '../../../src/errors'
+import { validateHandle } from '../../../src/handles'
+import { checkRate } from '../../../src/rate-limit'
+
+type Env = { DB: D1Database; SESSIONS: KVNamespace; RATE: KVNamespace }
+
+export const onRequestPost: PagesFunction<Env> = async (ctx) => {
+  try {
+    const user = await requireUser(ctx.request, ctx.env)
+    const rate = await checkRate(ctx.env.RATE, {
+      bucket: 'claim',
+      key: user.id,
+      windowSec: 86400,
+      max: 5,
+    })
+    if (!rate.ok) throw new ApiError('TOO_MANY_REQUESTS')
+
+    const body = (await ctx.request.json().catch(() => ({}))) as { handle?: unknown }
+    const v = validateHandle(body?.handle ?? '')
+    if (!v.ok) throw new ApiError('UNPROCESSABLE', v.reason)
+
+    const existing = await ctx.env.DB
+      .prepare('SELECT user_id FROM handles WHERE handle=? AND released_at IS NULL')
+      .bind(v.handle)
+      .first<{ user_id: string }>()
+    if (existing && existing.user_id !== user.id) {
+      throw new ApiError('CONFLICT', 'handle taken')
+    }
+
+    const prior = await ctx.env.DB
+      .prepare('SELECT handle FROM handles WHERE user_id=? AND released_at IS NULL')
+      .bind(user.id)
+      .first<{ handle: string }>()
+    if (prior && prior.handle !== v.handle) {
+      throw new ApiError('CONFLICT', 'user already has a handle')
+    }
+
+    if (!existing) {
+      await ctx.env.DB
+        .prepare('INSERT INTO handles (handle, user_id, claimed_at) VALUES (?, ?, ?)')
+        .bind(v.handle, user.id, Date.now())
+        .run()
+    }
+
+    await audit(ctx.env.DB, ctx.env.RATE, ctx.request, {
+      user_id: user.id,
+      action: 'handle.claim',
+      target_id: v.handle,
+    })
+    return new Response(
+      JSON.stringify({ handle: v.handle }),
+      { headers: { 'content-type': 'application/json' } },
+    )
+  } catch (e) {
+    return jsonError(e)
+  }
+}

--- a/packages/share-backend/functions/api/handles/claim.ts
+++ b/packages/share-backend/functions/api/handles/claim.ts
@@ -8,14 +8,25 @@ import { checkRate } from '../../../src/rate-limit'
 
 type Env = { DB: D1Database; SESSIONS: KVNamespace; RATE: KVNamespace }
 
+// 5 attempts per user per day is enough for a real human exploring
+// available names, far short of bulk squatting.
+const CLAIM_RATE_WINDOW_SEC = 86400
+const CLAIM_RATE_MAX = 5
+
+// SQLite/D1 surface UNIQUE-PK collisions with this string. Stable across
+// D1 versions; the exact prefix is `UNIQUE constraint failed: <table>.<col>`.
+function isUniqueViolation(e: unknown): boolean {
+  return e instanceof Error && /UNIQUE constraint failed/i.test(e.message)
+}
+
 export const onRequestPost: PagesFunction<Env> = async (ctx) => {
   try {
     const user = await requireUser(ctx.request, ctx.env)
     const rate = await checkRate(ctx.env.RATE, {
       bucket: 'claim',
       key: user.id,
-      windowSec: 86400,
-      max: 5,
+      windowSec: CLAIM_RATE_WINDOW_SEC,
+      max: CLAIM_RATE_MAX,
     })
     if (!rate.ok) throw new ApiError('TOO_MANY_REQUESTS')
 
@@ -41,10 +52,18 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
     }
 
     if (!existing) {
-      await ctx.env.DB
-        .prepare('INSERT INTO handles (handle, user_id, claimed_at) VALUES (?, ?, ?)')
-        .bind(v.handle, user.id, Date.now())
-        .run()
+      // TOCTOU: a concurrent claim could have raced past the SELECT
+      // above and INSERTed first. Map the PK violation to 409 instead
+      // of letting jsonError surface it as 500 INTERNAL.
+      try {
+        await ctx.env.DB
+          .prepare('INSERT INTO handles (handle, user_id, claimed_at) VALUES (?, ?, ?)')
+          .bind(v.handle, user.id, Date.now())
+          .run()
+      } catch (e) {
+        if (isUniqueViolation(e)) throw new ApiError('CONFLICT', 'handle taken')
+        throw e
+      }
     }
 
     await audit(ctx.env.DB, ctx.env.RATE, ctx.request, {

--- a/packages/share-backend/functions/api/handles/claim.ts
+++ b/packages/share-backend/functions/api/handles/claim.ts
@@ -2,7 +2,7 @@ import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers
 
 import { audit } from '../../../src/audit'
 import { requireUser } from '../../../src/auth/require'
-import { ApiError, jsonError } from '../../../src/errors'
+import { ApiError, jsonError, jsonOk } from '../../../src/errors'
 import { validateHandle } from '../../../src/handles'
 import { checkRate } from '../../../src/rate-limit'
 
@@ -23,18 +23,19 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
     const v = validateHandle(body?.handle ?? '')
     if (!v.ok) throw new ApiError('UNPROCESSABLE', v.reason)
 
-    const existing = await ctx.env.DB
-      .prepare('SELECT user_id FROM handles WHERE handle=? AND released_at IS NULL')
-      .bind(v.handle)
-      .first<{ user_id: string }>()
+    const [existing, prior] = await Promise.all([
+      ctx.env.DB
+        .prepare('SELECT user_id FROM handles WHERE handle=? AND released_at IS NULL')
+        .bind(v.handle)
+        .first<{ user_id: string }>(),
+      ctx.env.DB
+        .prepare('SELECT handle FROM handles WHERE user_id=? AND released_at IS NULL')
+        .bind(user.id)
+        .first<{ handle: string }>(),
+    ])
     if (existing && existing.user_id !== user.id) {
       throw new ApiError('CONFLICT', 'handle taken')
     }
-
-    const prior = await ctx.env.DB
-      .prepare('SELECT handle FROM handles WHERE user_id=? AND released_at IS NULL')
-      .bind(user.id)
-      .first<{ handle: string }>()
     if (prior && prior.handle !== v.handle) {
       throw new ApiError('CONFLICT', 'user already has a handle')
     }
@@ -51,10 +52,7 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
       action: 'handle.claim',
       target_id: v.handle,
     })
-    return new Response(
-      JSON.stringify({ handle: v.handle }),
-      { headers: { 'content-type': 'application/json' } },
-    )
+    return jsonOk({ handle: v.handle })
   } catch (e) {
     return jsonError(e)
   }

--- a/packages/share-backend/functions/api/me/delete.ts
+++ b/packages/share-backend/functions/api/me/delete.ts
@@ -6,10 +6,15 @@ import { jsonError, jsonOk } from '../../../src/errors'
 
 type Env = { DB: D1Database; SESSIONS: KVNamespace; RATE: KVNamespace }
 
+// User-visible grace window between scheduling deletion and the worker
+// actually executing it. Long enough for "I changed my mind" via the
+// DELETE cancel path; short enough that abandoned accounts don't linger.
+const GRACE_PERIOD_MS = 24 * 3600 * 1000
+
 export const onRequestPost: PagesFunction<Env> = async (ctx) => {
   try {
     const user = await requireUser(ctx.request, ctx.env)
-    const until = Date.now() + 24 * 3600 * 1000
+    const until = Date.now() + GRACE_PERIOD_MS
     await ctx.env.DB
       .prepare('UPDATE users SET deletion_pending_until=? WHERE id=? AND deleted_at IS NULL')
       .bind(until, user.id)

--- a/packages/share-backend/functions/api/me/delete.ts
+++ b/packages/share-backend/functions/api/me/delete.ts
@@ -35,7 +35,7 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
 
 export const onRequestDelete: PagesFunction<Env> = async (ctx) => {
   try {
-    const user = await requireUser(ctx.request, ctx.env)
+    const user = await requireUser(ctx.request, ctx.env, { allowPendingDeletion: true })
     await ctx.env.DB
       .prepare('UPDATE users SET deletion_pending_until=NULL WHERE id=?')
       .bind(user.id)

--- a/packages/share-backend/functions/api/me/delete.ts
+++ b/packages/share-backend/functions/api/me/delete.ts
@@ -1,0 +1,57 @@
+import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers-types'
+
+import { audit } from '../../../src/audit'
+import { requireUser } from '../../../src/auth/require'
+import { jsonError } from '../../../src/errors'
+
+type Env = { DB: D1Database; SESSIONS: KVNamespace; RATE: KVNamespace }
+
+export const onRequestPost: PagesFunction<Env> = async (ctx) => {
+  try {
+    const user = await requireUser(ctx.request, ctx.env)
+    const until = Date.now() + 24 * 3600 * 1000
+    await ctx.env.DB
+      .prepare('UPDATE users SET deletion_pending_until=? WHERE id=? AND deleted_at IS NULL')
+      .bind(until, user.id)
+      .run()
+    await ctx.env.DB
+      .prepare(
+        'INSERT OR REPLACE INTO deletion_queue (user_id, scheduled_at, cancelled) VALUES (?, ?, 0)',
+      )
+      .bind(user.id, until)
+      .run()
+    await audit(ctx.env.DB, ctx.env.RATE, ctx.request, {
+      user_id: user.id,
+      action: 'account.delete.scheduled',
+    })
+    return new Response(
+      JSON.stringify({ scheduled_at: until }),
+      { headers: { 'content-type': 'application/json' } },
+    )
+  } catch (e) {
+    return jsonError(e)
+  }
+}
+
+export const onRequestDelete: PagesFunction<Env> = async (ctx) => {
+  try {
+    const user = await requireUser(ctx.request, ctx.env)
+    await ctx.env.DB
+      .prepare('UPDATE users SET deletion_pending_until=NULL WHERE id=?')
+      .bind(user.id)
+      .run()
+    await ctx.env.DB
+      .prepare('UPDATE deletion_queue SET cancelled=1 WHERE user_id=?')
+      .bind(user.id)
+      .run()
+    await audit(ctx.env.DB, ctx.env.RATE, ctx.request, {
+      user_id: user.id,
+      action: 'account.delete.cancel',
+    })
+    return new Response('{"cancelled":true}', {
+      headers: { 'content-type': 'application/json' },
+    })
+  } catch (e) {
+    return jsonError(e)
+  }
+}

--- a/packages/share-backend/functions/api/me/delete.ts
+++ b/packages/share-backend/functions/api/me/delete.ts
@@ -2,7 +2,7 @@ import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers
 
 import { audit } from '../../../src/audit'
 import { requireUser } from '../../../src/auth/require'
-import { jsonError } from '../../../src/errors'
+import { jsonError, jsonOk } from '../../../src/errors'
 
 type Env = { DB: D1Database; SESSIONS: KVNamespace; RATE: KVNamespace }
 
@@ -24,10 +24,7 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
       user_id: user.id,
       action: 'account.delete.scheduled',
     })
-    return new Response(
-      JSON.stringify({ scheduled_at: until }),
-      { headers: { 'content-type': 'application/json' } },
-    )
+    return jsonOk({ scheduled_at: until })
   } catch (e) {
     return jsonError(e)
   }
@@ -48,9 +45,7 @@ export const onRequestDelete: PagesFunction<Env> = async (ctx) => {
       user_id: user.id,
       action: 'account.delete.cancel',
     })
-    return new Response('{"cancelled":true}', {
-      headers: { 'content-type': 'application/json' },
-    })
+    return jsonOk({ cancelled: true })
   } catch (e) {
     return jsonError(e)
   }

--- a/packages/share-backend/functions/api/me/index.ts
+++ b/packages/share-backend/functions/api/me/index.ts
@@ -7,7 +7,11 @@ type Env = { DB: D1Database; SESSIONS: KVNamespace }
 
 export const onRequestGet: PagesFunction<Env> = async (ctx) => {
   try {
-    const user = await requireUser(ctx.request, ctx.env)
+    // /api/me is the bootstrap call for any signed-in client. A user with
+    // a pending deletion still needs to see their own state — otherwise
+    // they can't open the account UI to find the Cancel button. Other
+    // mutating endpoints stay locked behind the default policy.
+    const user = await requireUser(ctx.request, ctx.env, { allowPendingDeletion: true })
     const handle = await ctx.env.DB
       .prepare('SELECT handle FROM handles WHERE user_id=? AND released_at IS NULL')
       .bind(user.id)
@@ -18,6 +22,7 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
       name: user.name,
       avatar_url: user.avatar_url,
       handle: handle?.handle ?? null,
+      deletion_pending_until: user.deletion_pending_until,
     })
   } catch (e) {
     return jsonError(e)

--- a/packages/share-backend/functions/api/me/index.ts
+++ b/packages/share-backend/functions/api/me/index.ts
@@ -1,7 +1,7 @@
 import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers-types'
 
 import { requireUser } from '../../../src/auth/require'
-import { jsonError } from '../../../src/errors'
+import { jsonError, jsonOk } from '../../../src/errors'
 
 type Env = { DB: D1Database; SESSIONS: KVNamespace }
 
@@ -12,16 +12,13 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
       .prepare('SELECT handle FROM handles WHERE user_id=? AND released_at IS NULL')
       .bind(user.id)
       .first<{ handle: string }>()
-    return new Response(
-      JSON.stringify({
-        id: user.id,
-        email: user.email,
-        name: user.name,
-        avatar_url: user.avatar_url,
-        handle: handle?.handle ?? null,
-      }),
-      { headers: { 'content-type': 'application/json' } },
-    )
+    return jsonOk({
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      avatar_url: user.avatar_url,
+      handle: handle?.handle ?? null,
+    })
   } catch (e) {
     return jsonError(e)
   }

--- a/packages/share-backend/functions/api/me/index.ts
+++ b/packages/share-backend/functions/api/me/index.ts
@@ -1,0 +1,28 @@
+import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers-types'
+
+import { requireUser } from '../../../src/auth/require'
+import { jsonError } from '../../../src/errors'
+
+type Env = { DB: D1Database; SESSIONS: KVNamespace }
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  try {
+    const user = await requireUser(ctx.request, ctx.env)
+    const handle = await ctx.env.DB
+      .prepare('SELECT handle FROM handles WHERE user_id=? AND released_at IS NULL')
+      .bind(user.id)
+      .first<{ handle: string }>()
+    return new Response(
+      JSON.stringify({
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        avatar_url: user.avatar_url,
+        handle: handle?.handle ?? null,
+      }),
+      { headers: { 'content-type': 'application/json' } },
+    )
+  } catch (e) {
+    return jsonError(e)
+  }
+}

--- a/packages/share-backend/functions/api/me/shares.ts
+++ b/packages/share-backend/functions/api/me/shares.ts
@@ -1,0 +1,25 @@
+import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers-types'
+
+import { requireUser } from '../../../src/auth/require'
+import { jsonError } from '../../../src/errors'
+
+type Env = { DB: D1Database; SESSIONS: KVNamespace }
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  try {
+    const user = await requireUser(ctx.request, ctx.env)
+    const rows = await ctx.env.DB
+      .prepare(
+        'SELECT id, title, visibility, expires_at, version, published_at, republished_at, revoked_at, draft_id, client_request_id ' +
+          'FROM published_shares WHERE user_id=? ORDER BY published_at DESC',
+      )
+      .bind(user.id)
+      .all()
+    return new Response(
+      JSON.stringify({ items: rows.results }),
+      { headers: { 'content-type': 'application/json' } },
+    )
+  } catch (e) {
+    return jsonError(e)
+  }
+}

--- a/packages/share-backend/functions/api/me/shares.ts
+++ b/packages/share-backend/functions/api/me/shares.ts
@@ -1,7 +1,7 @@
 import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers-types'
 
 import { requireUser } from '../../../src/auth/require'
-import { jsonError } from '../../../src/errors'
+import { jsonError, jsonOk } from '../../../src/errors'
 
 type Env = { DB: D1Database; SESSIONS: KVNamespace }
 
@@ -15,10 +15,7 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
       )
       .bind(user.id)
       .all()
-    return new Response(
-      JSON.stringify({ items: rows.results }),
-      { headers: { 'content-type': 'application/json' } },
-    )
+    return jsonOk({ items: rows.results })
   } catch (e) {
     return jsonError(e)
   }

--- a/packages/share-backend/src/auth/require.ts
+++ b/packages/share-backend/src/auth/require.ts
@@ -1,0 +1,22 @@
+import type { D1Database, KVNamespace } from '@cloudflare/workers-types'
+
+import { ApiError } from '../errors'
+import { getUserById, type UserRow } from '../store/d1'
+
+import { COOKIE_NAME, readCookie } from './cookie'
+import { loadSession } from './session'
+
+export async function requireUser(
+  req: Request,
+  env: { SESSIONS: KVNamespace; DB: D1Database },
+): Promise<UserRow> {
+  const bearer = req.headers.get('authorization')?.match(/^Bearer\s+(.+)$/i)?.[1]
+  const token = bearer ?? readCookie(req, COOKIE_NAME)
+  if (!token) throw new ApiError('UNAUTHENTICATED')
+  const sess = await loadSession(env.SESSIONS, token)
+  if (!sess) throw new ApiError('UNAUTHENTICATED', 'session expired')
+  const user = await getUserById(env.DB, sess.user_id)
+  if (!user) throw new ApiError('UNAUTHENTICATED', 'user not found')
+  if (user.deletion_pending_until) throw new ApiError('FORBIDDEN', 'account deletion pending')
+  return user
+}

--- a/packages/share-backend/src/auth/require.ts
+++ b/packages/share-backend/src/auth/require.ts
@@ -6,9 +6,12 @@ import { getUserById, type UserRow } from '../store/d1'
 import { COOKIE_NAME, readCookie } from './cookie'
 import { loadSession } from './session'
 
+export type RequireUserOpts = { allowPendingDeletion?: boolean }
+
 export async function requireUser(
   req: Request,
   env: { SESSIONS: KVNamespace; DB: D1Database },
+  opts: RequireUserOpts = {},
 ): Promise<UserRow> {
   const bearer = req.headers.get('authorization')?.match(/^Bearer\s+(.+)$/i)?.[1]
   const token = bearer ?? readCookie(req, COOKIE_NAME)
@@ -17,6 +20,8 @@ export async function requireUser(
   if (!sess) throw new ApiError('UNAUTHENTICATED', 'session expired')
   const user = await getUserById(env.DB, sess.user_id)
   if (!user) throw new ApiError('UNAUTHENTICATED', 'user not found')
-  if (user.deletion_pending_until) throw new ApiError('FORBIDDEN', 'account deletion pending')
+  if (user.deletion_pending_until && !opts.allowPendingDeletion) {
+    throw new ApiError('FORBIDDEN', 'account deletion pending')
+  }
   return user
 }

--- a/packages/share-backend/src/errors.ts
+++ b/packages/share-backend/src/errors.ts
@@ -19,6 +19,12 @@ export class ApiError extends Error {
   }
 }
 
+export function jsonOk(body: unknown, init?: ResponseInit): Response {
+  const headers = new Headers(init?.headers)
+  headers.set('content-type', 'application/json')
+  return new Response(JSON.stringify(body), { ...init, headers })
+}
+
 export function jsonError(e: unknown): Response {
   const err = e instanceof ApiError ? e : new ApiError('INTERNAL', 'unexpected')
   return new Response(

--- a/packages/share-backend/src/handles.ts
+++ b/packages/share-backend/src/handles.ts
@@ -1,0 +1,21 @@
+const RESERVED = new Set([
+  'admin', 'support', 'help', 'api', 'www', 'me', 'mine', 'editor', 'share', 'shares',
+  'snapshot', 'snapshots', 's', 'u', 'user', 'users', 'profile', 'profiles',
+  'settings', 'login', 'signin', 'signout', 'signup', 'register',
+  'terms', 'privacy', 'dmca', 'report', 'abuse', 'mail', 'root', 'system',
+  'anonymous', 'deleted', 'undefined', 'null', 'spool',
+])
+
+const RE = /^[a-z][a-z0-9_-]{2,31}$/
+
+export type HandleValidation =
+  | { ok: true; handle: string }
+  | { ok: false; reason: string }
+
+export function validateHandle(raw: unknown): HandleValidation {
+  if (typeof raw !== 'string') return { ok: false, reason: 'not a string' }
+  const h = raw.trim().toLowerCase()
+  if (!RE.test(h)) return { ok: false, reason: 'invalid format' }
+  if (RESERVED.has(h)) return { ok: false, reason: 'reserved' }
+  return { ok: true, handle: h }
+}

--- a/packages/share-backend/src/handles.ts
+++ b/packages/share-backend/src/handles.ts
@@ -1,11 +1,25 @@
+// Two flavours of reserved name, merged into one set:
+//   1) URL-routing words that already mean something on spool.pro
+//      (collide with /api/*, /me, /settings, etc.)
+//   2) Brand / impersonation guards. Cheap to add now; expensive to
+//      take back from a squatter after launch.
 const RESERVED = new Set([
+  // routing
   'admin', 'support', 'help', 'api', 'www', 'me', 'mine', 'editor', 'share', 'shares',
   'snapshot', 'snapshots', 's', 'u', 'user', 'users', 'profile', 'profiles',
   'settings', 'login', 'signin', 'signout', 'signup', 'register',
   'terms', 'privacy', 'dmca', 'report', 'abuse', 'mail', 'root', 'system',
-  'anonymous', 'deleted', 'undefined', 'null', 'spool',
+  'anonymous', 'deleted', 'undefined', 'null',
+  'about', 'contact', 'home', 'docs', 'blog', 'auth', 'oauth',
+  'static', 'assets', 'public', 'feed', 'rss', 'app', 'apps', 'dev',
+  'new', 'edit',
+  // brand / impersonation
+  'spool', 'spoollab', 'spool-lab', 'staff', 'team', 'official',
+  'anthropic', 'claude', 'paperboy',
 ])
 
+// ASCII-only on purpose — closes off Unicode-homoglyph spoofs
+// (Cyrillic `о`, Greek `α`, etc.) at the validation layer.
 const RE = /^[a-z][a-z0-9_-]{2,31}$/
 
 export type HandleValidation =

--- a/packages/share-backend/tests/handles.test.ts
+++ b/packages/share-backend/tests/handles.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateHandle } from '../src/handles'
+
+describe('validateHandle', () => {
+  it.each([
+    ['chen'],
+    ['chen-2'],
+    ['a_b'],
+    ['abc'],
+    ['user_name'],
+    ['a1b2c3'],
+    ['a'.repeat(32)],
+  ])('accepts %s', (h) => {
+    const r = validateHandle(h)
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.handle).toBe(h)
+  })
+
+  it('lowercases mixed-case input', () => {
+    const r = validateHandle('Chen-2')
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.handle).toBe('chen-2')
+  })
+
+  it.each([
+    ['', 'empty'],
+    ['ab', 'too short'],
+    ['a'.repeat(33), 'too long'],
+    ['2chen', 'leading digit'],
+    ['-chen', 'leading dash'],
+    ['_chen', 'leading underscore'],
+    ['ch en', 'space'],
+    ['ch.en', 'dot'],
+    ['ch!en', 'bang'],
+  ])('rejects %s (%s)', (h) => {
+    const r = validateHandle(h)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('invalid format')
+  })
+
+  it.each(['admin', 'support', 'spool', 'api', 'help', 'editor'])(
+    'rejects reserved %s',
+    (h) => {
+      const r = validateHandle(h)
+      expect(r.ok).toBe(false)
+      if (!r.ok) expect(r.reason).toBe('reserved')
+    },
+  )
+
+  it('rejects non-strings', () => {
+    expect(validateHandle(undefined).ok).toBe(false)
+    expect(validateHandle(123).ok).toBe(false)
+    expect(validateHandle(null).ok).toBe(false)
+    expect(validateHandle({}).ok).toBe(false)
+  })
+})

--- a/packages/share-backend/tests/me.test.ts
+++ b/packages/share-backend/tests/me.test.ts
@@ -448,16 +448,15 @@ describe('POST /api/me/delete', () => {
 })
 
 describe('DELETE /api/me/delete', () => {
-  it('clears pending and marks queue row cancelled', async () => {
+  it('clears pending and marks queue row cancelled even while deletion is pending', async () => {
     const { onRequestDelete } = await import('../functions/api/me/delete')
     const env = envFor()
-    // requireUser blocks users with deletion_pending_until set, so we test
-    // the cancel path with a user whose flag was already cleared elsewhere
-    // (this mirrors the documented limitation of the helper).
     seedUser(env.state)
+    const pendingUntil = Date.now() + 12 * 3600 * 1000
+    env.state.users[0]!.deletion_pending_until = pendingUntil
     env.state.deletion_queue.push({
       user_id: 'user-1',
-      scheduled_at: Date.now() + 1000,
+      scheduled_at: pendingUntil,
       cancelled: 0,
     })
     await seedSession(env.SESSIONS, TOKEN, 'user-1')

--- a/packages/share-backend/tests/me.test.ts
+++ b/packages/share-backend/tests/me.test.ts
@@ -22,7 +22,6 @@ function seedUser(
 ): FakeDbState['users'][number] {
   const user = {
     id: 'user-1',
-    google_sub: 'g-sub-1',
     email: 'a@example.com',
     name: 'Alice',
     avatar_url: 'https://x/a.png',
@@ -114,7 +113,7 @@ describe('requireUser', () => {
   it('bearer takes precedence over cookie', async () => {
     const env = envFor()
     seedUser(env.state, { id: 'user-bearer' })
-    seedUser(env.state, { id: 'user-cookie', google_sub: 'g-sub-2', email: 'c@c' })
+    seedUser(env.state, { id: 'user-cookie', email: 'c@c' })
     const bearerToken = 'b'.repeat(40)
     const cookieToken = 'c'.repeat(40)
     await seedSession(env.SESSIONS, bearerToken, 'user-bearer')
@@ -340,6 +339,7 @@ describe('GET /api/me', () => {
       name: 'Alice',
       avatar_url: 'https://x/a.png',
       handle: null,
+      deletion_pending_until: null,
     })
   })
 
@@ -364,6 +364,21 @@ describe('GET /api/me', () => {
     const req = new Request('https://x/api/me')
     const res = await invoke(meGet, req, env)
     expect(res.status).toBe(401)
+  })
+
+  it('200 (not 403) when deletion is pending, surfaces deletion_pending_until', async () => {
+    // Cross-device case: the user scheduled deletion on web, then opened
+    // the desktop app. /api/me must still answer so the app can render
+    // the Cancel-deletion CTA — every other endpoint stays locked.
+    const env = envFor()
+    const pendingUntil = Date.now() + 12 * 3600 * 1000
+    seedUser(env.state, { deletion_pending_until: pendingUntil })
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/me')
+    const res = await invoke(meGet, req, env)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { deletion_pending_until: number | null }
+    expect(body.deletion_pending_until).toBe(pendingUntil)
   })
 })
 

--- a/packages/share-backend/tests/me.test.ts
+++ b/packages/share-backend/tests/me.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from 'vitest'
 import type { KVNamespace } from '@cloudflare/workers-types'
 
+import { onRequestGet as checkHandleGet } from '../functions/api/handles/check'
+import { onRequestPost as claimHandlePost } from '../functions/api/handles/claim'
+import {
+  onRequestDelete as cancelDelete,
+  onRequestPost as scheduleDelete,
+} from '../functions/api/me/delete'
+import { onRequestGet as meGet } from '../functions/api/me/index'
+import { onRequestGet as meSharesGet } from '../functions/api/me/shares'
 import { requireUser } from '../src/auth/require'
 import type { SessionRecord } from '../src/auth/session'
 import { ApiError } from '../src/errors'
 
+import { invoke } from './_helpers/ctx'
 import { emptyState, makeDb, makeKv, type FakeDbState } from './_helpers/fakes'
 
 function seedUser(
@@ -27,6 +36,10 @@ function seedUser(
   return user
 }
 
+const SESSION_TTL_SEC = 30 * 24 * 3600
+const SESSION_TTL_MS = SESSION_TTL_SEC * 1000
+const GRACE_PERIOD_MS = 24 * 3600 * 1000
+
 async function seedSession(
   kv: KVNamespace,
   token: string,
@@ -36,15 +49,15 @@ async function seedSession(
   const rec: SessionRecord = {
     user_id,
     created: now,
-    exp: now + 30 * 24 * 3600 * 1000,
+    exp: now + SESSION_TTL_MS,
     last_seen: now,
   }
-  // Token must be >=32 chars to pass loadSession's length guard.
   await kv.put(`session/${token}`, JSON.stringify(rec), {
-    expirationTtl: 30 * 24 * 3600,
+    expirationTtl: SESSION_TTL_SEC,
   })
 }
 
+// Token length must clear loadSession's MIN_TOKEN_CHARS guard (32).
 const TOKEN = 'a'.repeat(40)
 
 function envFor(state?: FakeDbState) {
@@ -54,19 +67,6 @@ function envFor(state?: FakeDbState) {
     SESSIONS: makeKv(),
     RATE: makeKv(),
     state: s,
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function ctxFor(req: Request, env: Record<string, unknown>): any {
-  return {
-    request: req,
-    env,
-    next: async () => new Response('not-found', { status: 404 }),
-    params: {},
-    waitUntil: () => undefined,
-    passThroughOnException: () => undefined,
-    data: {},
   }
 }
 
@@ -140,16 +140,14 @@ describe('requireUser', () => {
 
 describe('GET /api/handles/check', () => {
   it('returns available=true for an unclaimed valid handle', async () => {
-    const { onRequestGet } = await import('../functions/api/handles/check')
     const env = envFor()
     const req = new Request('https://x/api/handles/check?h=alice')
-    const res = await onRequestGet(ctxFor(req, env))
+    const res = await invoke(checkHandleGet, req, env)
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ available: true })
   })
 
   it('returns available=false for a taken handle', async () => {
-    const { onRequestGet } = await import('../functions/api/handles/check')
     const env = envFor()
     env.state.handles.push({
       handle: 'alice',
@@ -158,33 +156,30 @@ describe('GET /api/handles/check', () => {
       released_at: null,
     })
     const req = new Request('https://x/api/handles/check?h=alice')
-    const res = await onRequestGet(ctxFor(req, env))
+    const res = await invoke(checkHandleGet, req, env)
     expect(await res.json()).toEqual({ available: false })
   })
 
   it('returns invalid reason for bad format', async () => {
-    const { onRequestGet } = await import('../functions/api/handles/check')
     const env = envFor()
     const req = new Request('https://x/api/handles/check?h=2bad')
-    const res = await onRequestGet(ctxFor(req, env))
-    const body = await res.json() as { available: boolean; reason: string }
+    const res = await invoke(checkHandleGet, req, env)
+    const body = (await res.json()) as { available: boolean; reason: string }
     expect(body.available).toBe(false)
     expect(body.reason).toBe('invalid format')
   })
 
   it('returns reserved reason for admin', async () => {
-    const { onRequestGet } = await import('../functions/api/handles/check')
     const env = envFor()
     const req = new Request('https://x/api/handles/check?h=admin')
-    const res = await onRequestGet(ctxFor(req, env))
-    const body = await res.json() as { available: boolean; reason: string }
+    const res = await invoke(checkHandleGet, req, env)
+    const body = (await res.json()) as { available: boolean; reason: string }
     expect(body.reason).toBe('reserved')
   })
 })
 
 describe('POST /api/handles/claim', () => {
   it('claims an available handle and writes audit', async () => {
-    const { onRequestPost } = await import('../functions/api/handles/claim')
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
@@ -193,28 +188,30 @@ describe('POST /api/handles/claim', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ handle: 'alice' }),
     })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(claimHandlePost, req, env)
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ handle: 'alice' })
     expect(env.state.handles).toHaveLength(1)
     expect(env.state.handles[0]?.handle).toBe('alice')
-    expect(env.state.audit.some((a) => a.action === 'handle.claim' && a.target_id === 'alice')).toBe(true)
+    expect(
+      env.state.audit.some(
+        (a) => a.action === 'handle.claim' && a.target_id === 'alice',
+      ),
+    ).toBe(true)
   })
 
   it('401 when unauthenticated', async () => {
-    const { onRequestPost } = await import('../functions/api/handles/claim')
     const env = envFor()
     const req = new Request('https://x/api/handles/claim', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ handle: 'alice' }),
     })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(claimHandlePost, req, env)
     expect(res.status).toBe(401)
   })
 
   it('409 when another user already owns the handle', async () => {
-    const { onRequestPost } = await import('../functions/api/handles/claim')
     const env = envFor()
     seedUser(env.state)
     env.state.handles.push({
@@ -229,12 +226,11 @@ describe('POST /api/handles/claim', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ handle: 'alice' }),
     })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(claimHandlePost, req, env)
     expect(res.status).toBe(409)
   })
 
   it('idempotent: same user re-claiming their own handle returns 200', async () => {
-    const { onRequestPost } = await import('../functions/api/handles/claim')
     const env = envFor()
     seedUser(env.state)
     env.state.handles.push({
@@ -249,13 +245,12 @@ describe('POST /api/handles/claim', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ handle: 'alice' }),
     })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(claimHandlePost, req, env)
     expect(res.status).toBe(200)
     expect(env.state.handles).toHaveLength(1)
   })
 
   it('409 when user already has a different handle', async () => {
-    const { onRequestPost } = await import('../functions/api/handles/claim')
     const env = envFor()
     seedUser(env.state)
     env.state.handles.push({
@@ -270,12 +265,11 @@ describe('POST /api/handles/claim', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ handle: 'alice' }),
     })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(claimHandlePost, req, env)
     expect(res.status).toBe(409)
   })
 
   it('422 on invalid handle format', async () => {
-    const { onRequestPost } = await import('../functions/api/handles/claim')
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
@@ -284,35 +278,61 @@ describe('POST /api/handles/claim', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ handle: '2bad' }),
     })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(claimHandlePost, req, env)
     expect(res.status).toBe(422)
   })
 
   it('429 when rate limit exceeded', async () => {
-    const { onRequestPost } = await import('../functions/api/handles/claim')
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
-    const slot = Math.floor(Date.now() / 1000 / 86400)
-    await env.RATE.put(`rate/claim/user-1/${slot}`, '5', { expirationTtl: 86400 * 2 })
+    // Mirror CLAIM_RATE_{WINDOW_SEC, MAX} from claim.ts.
+    const RATE_WINDOW_SEC = 86400
+    const RATE_MAX = 5
+    const slot = Math.floor(Date.now() / 1000 / RATE_WINDOW_SEC)
+    await env.RATE.put(`rate/claim/user-1/${slot}`, String(RATE_MAX), {
+      expirationTtl: RATE_WINDOW_SEC * 2,
+    })
     const req = authedReq('https://x/api/handles/claim', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ handle: 'alice' }),
     })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(claimHandlePost, req, env)
     expect(res.status).toBe(429)
+  })
+
+  it('409 (not 500) when INSERT races with another claim — PK violation maps to CONFLICT', async () => {
+    // Reproduces the TOCTOU window between the pre-flight SELECT (which
+    // filters released_at IS NULL) and the INSERT (which collides on the
+    // PK regardless of released_at). A released-handle row satisfies both
+    // sides of that mismatch in a single deterministic setup.
+    const env = envFor()
+    seedUser(env.state)
+    env.state.handles.push({
+      handle: 'alice',
+      user_id: 'other',
+      claimed_at: Date.now() - 10000,
+      released_at: Date.now() - 1000,
+    })
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/handles/claim', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ handle: 'alice' }),
+    })
+    const res = await invoke(claimHandlePost, req, env)
+    expect(res.status).toBe(409)
   })
 })
 
 describe('GET /api/me', () => {
   it('returns user + handle null when none claimed', async () => {
-    const { onRequestGet } = await import('../functions/api/me/index')
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
     const req = authedReq('https://x/api/me')
-    const res = await onRequestGet(ctxFor(req, env))
+    const res = await invoke(meGet, req, env)
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({
       id: 'user-1',
@@ -324,7 +344,6 @@ describe('GET /api/me', () => {
   })
 
   it('returns user + claimed handle when present', async () => {
-    const { onRequestGet } = await import('../functions/api/me/index')
     const env = envFor()
     seedUser(env.state)
     env.state.handles.push({
@@ -335,34 +354,31 @@ describe('GET /api/me', () => {
     })
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
     const req = authedReq('https://x/api/me')
-    const res = await onRequestGet(ctxFor(req, env))
-    const body = await res.json() as { handle: string | null }
+    const res = await invoke(meGet, req, env)
+    const body = (await res.json()) as { handle: string | null }
     expect(body.handle).toBe('alice')
   })
 
   it('401 when unauthenticated', async () => {
-    const { onRequestGet } = await import('../functions/api/me/index')
     const env = envFor()
     const req = new Request('https://x/api/me')
-    const res = await onRequestGet(ctxFor(req, env))
+    const res = await invoke(meGet, req, env)
     expect(res.status).toBe(401)
   })
 })
 
 describe('GET /api/me/shares', () => {
   it('returns empty list when no shares', async () => {
-    const { onRequestGet } = await import('../functions/api/me/shares')
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
     const req = authedReq('https://x/api/me/shares')
-    const res = await onRequestGet(ctxFor(req, env))
+    const res = await invoke(meSharesGet, req, env)
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ items: [] })
   })
 
   it('returns published_shares ordered by published_at desc', async () => {
-    const { onRequestGet } = await import('../functions/api/me/shares')
     const env = envFor()
     seedUser(env.state)
     env.state.published_shares.push(
@@ -402,35 +418,36 @@ describe('GET /api/me/shares', () => {
     )
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
     const req = authedReq('https://x/api/me/shares')
-    const res = await onRequestGet(ctxFor(req, env))
-    const body = await res.json() as { items: Array<{ id: string }> }
+    const res = await invoke(meSharesGet, req, env)
+    const body = (await res.json()) as { items: Array<{ id: string }> }
     expect(body.items.map((i) => i.id)).toEqual(['new', 'old'])
   })
 })
 
 describe('POST /api/me/delete', () => {
   it('sets deletion_pending_until, inserts queue row, audits', async () => {
-    const { onRequestPost } = await import('../functions/api/me/delete')
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
     const before = Date.now()
     const req = authedReq('https://x/api/me/delete', { method: 'POST' })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(scheduleDelete, req, env)
     expect(res.status).toBe(200)
-    const body = await res.json() as { scheduled_at: number }
-    expect(body.scheduled_at).toBeGreaterThanOrEqual(before + 24 * 3600 * 1000 - 1000)
+    const body = (await res.json()) as { scheduled_at: number }
+    // Allow a small clock skew (1s) between Date.now() reads.
+    expect(body.scheduled_at).toBeGreaterThanOrEqual(before + GRACE_PERIOD_MS - 1000)
     expect(env.state.users[0]?.deletion_pending_until).toBe(body.scheduled_at)
     expect(env.state.deletion_queue).toHaveLength(1)
     expect(env.state.deletion_queue[0]).toMatchObject({
       user_id: 'user-1',
       cancelled: 0,
     })
-    expect(env.state.audit.some((a) => a.action === 'account.delete.scheduled')).toBe(true)
+    expect(env.state.audit.some((a) => a.action === 'account.delete.scheduled')).toBe(
+      true,
+    )
   })
 
   it('INSERT OR REPLACE overwrites prior queue row', async () => {
-    const { onRequestPost } = await import('../functions/api/me/delete')
     const env = envFor()
     seedUser(env.state)
     env.state.deletion_queue.push({
@@ -440,7 +457,7 @@ describe('POST /api/me/delete', () => {
     })
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
     const req = authedReq('https://x/api/me/delete', { method: 'POST' })
-    await onRequestPost(ctxFor(req, env))
+    await invoke(scheduleDelete, req, env)
     expect(env.state.deletion_queue).toHaveLength(1)
     expect(env.state.deletion_queue[0]?.cancelled).toBe(0)
     expect(env.state.deletion_queue[0]?.scheduled_at).toBeGreaterThan(1)
@@ -449,10 +466,9 @@ describe('POST /api/me/delete', () => {
 
 describe('DELETE /api/me/delete', () => {
   it('clears pending and marks queue row cancelled even while deletion is pending', async () => {
-    const { onRequestDelete } = await import('../functions/api/me/delete')
     const env = envFor()
     seedUser(env.state)
-    const pendingUntil = Date.now() + 12 * 3600 * 1000
+    const pendingUntil = Date.now() + GRACE_PERIOD_MS / 2
     env.state.users[0]!.deletion_pending_until = pendingUntil
     env.state.deletion_queue.push({
       user_id: 'user-1',
@@ -461,7 +477,7 @@ describe('DELETE /api/me/delete', () => {
     })
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
     const req = authedReq('https://x/api/me/delete', { method: 'DELETE' })
-    const res = await onRequestDelete(ctxFor(req, env))
+    const res = await invoke(cancelDelete, req, env)
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ cancelled: true })
     expect(env.state.users[0]?.deletion_pending_until).toBeNull()

--- a/packages/share-backend/tests/me.test.ts
+++ b/packages/share-backend/tests/me.test.ts
@@ -1,0 +1,478 @@
+import { describe, expect, it } from 'vitest'
+import type { KVNamespace } from '@cloudflare/workers-types'
+
+import { requireUser } from '../src/auth/require'
+import type { SessionRecord } from '../src/auth/session'
+import { ApiError } from '../src/errors'
+
+import { emptyState, makeDb, makeKv, type FakeDbState } from './_helpers/fakes'
+
+function seedUser(
+  state: FakeDbState,
+  overrides: Partial<FakeDbState['users'][number]> = {},
+): FakeDbState['users'][number] {
+  const user = {
+    id: 'user-1',
+    google_sub: 'g-sub-1',
+    email: 'a@example.com',
+    name: 'Alice',
+    avatar_url: 'https://x/a.png',
+    created_at: Date.now(),
+    last_signin_at: Date.now(),
+    deletion_pending_until: null,
+    deleted_at: null,
+    ...overrides,
+  }
+  state.users.push(user)
+  return user
+}
+
+async function seedSession(
+  kv: KVNamespace,
+  token: string,
+  user_id: string,
+): Promise<void> {
+  const now = Date.now()
+  const rec: SessionRecord = {
+    user_id,
+    created: now,
+    exp: now + 30 * 24 * 3600 * 1000,
+    last_seen: now,
+  }
+  // Token must be >=32 chars to pass loadSession's length guard.
+  await kv.put(`session/${token}`, JSON.stringify(rec), {
+    expirationTtl: 30 * 24 * 3600,
+  })
+}
+
+const TOKEN = 'a'.repeat(40)
+
+function envFor(state?: FakeDbState) {
+  const { db, state: s } = makeDb(state ?? emptyState())
+  return {
+    DB: db,
+    SESSIONS: makeKv(),
+    RATE: makeKv(),
+    state: s,
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function ctxFor(req: Request, env: Record<string, unknown>): any {
+  return {
+    request: req,
+    env,
+    next: async () => new Response('not-found', { status: 404 }),
+    params: {},
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+    data: {},
+  }
+}
+
+function authedReq(url: string, init: RequestInit = {}): Request {
+  const headers = new Headers(init.headers)
+  headers.set('authorization', `Bearer ${TOKEN}`)
+  headers.set('CF-Connecting-IP', '1.2.3.4')
+  return new Request(url, { ...init, headers })
+}
+
+describe('requireUser', () => {
+  it('401 when no token at all', async () => {
+    const env = envFor()
+    const req = new Request('https://x/')
+    await expect(requireUser(req, env)).rejects.toMatchObject({ code: 'UNAUTHENTICATED' })
+  })
+
+  it('401 when bearer token has no KV session', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    const req = authedReq('https://x/')
+    await expect(requireUser(req, env)).rejects.toMatchObject({ code: 'UNAUTHENTICATED' })
+  })
+
+  it('accepts bearer auth', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/')
+    const user = await requireUser(req, env)
+    expect(user.id).toBe('user-1')
+  })
+
+  it('accepts cookie auth', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = new Request('https://x/', {
+      headers: { cookie: `spool_session=${TOKEN}` },
+    })
+    const user = await requireUser(req, env)
+    expect(user.id).toBe('user-1')
+  })
+
+  it('bearer takes precedence over cookie', async () => {
+    const env = envFor()
+    seedUser(env.state, { id: 'user-bearer' })
+    seedUser(env.state, { id: 'user-cookie', google_sub: 'g-sub-2', email: 'c@c' })
+    const bearerToken = 'b'.repeat(40)
+    const cookieToken = 'c'.repeat(40)
+    await seedSession(env.SESSIONS, bearerToken, 'user-bearer')
+    await seedSession(env.SESSIONS, cookieToken, 'user-cookie')
+    const req = new Request('https://x/', {
+      headers: {
+        authorization: `Bearer ${bearerToken}`,
+        cookie: `spool_session=${cookieToken}`,
+      },
+    })
+    const user = await requireUser(req, env)
+    expect(user.id).toBe('user-bearer')
+  })
+
+  it('403 when deletion_pending_until is set', async () => {
+    const env = envFor()
+    seedUser(env.state, { deletion_pending_until: Date.now() + 1000 })
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/')
+    await expect(requireUser(req, env)).rejects.toMatchObject({ code: 'FORBIDDEN' })
+  })
+})
+
+describe('GET /api/handles/check', () => {
+  it('returns available=true for an unclaimed valid handle', async () => {
+    const { onRequestGet } = await import('../functions/api/handles/check')
+    const env = envFor()
+    const req = new Request('https://x/api/handles/check?h=alice')
+    const res = await onRequestGet(ctxFor(req, env))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ available: true })
+  })
+
+  it('returns available=false for a taken handle', async () => {
+    const { onRequestGet } = await import('../functions/api/handles/check')
+    const env = envFor()
+    env.state.handles.push({
+      handle: 'alice',
+      user_id: 'someone',
+      claimed_at: Date.now(),
+      released_at: null,
+    })
+    const req = new Request('https://x/api/handles/check?h=alice')
+    const res = await onRequestGet(ctxFor(req, env))
+    expect(await res.json()).toEqual({ available: false })
+  })
+
+  it('returns invalid reason for bad format', async () => {
+    const { onRequestGet } = await import('../functions/api/handles/check')
+    const env = envFor()
+    const req = new Request('https://x/api/handles/check?h=2bad')
+    const res = await onRequestGet(ctxFor(req, env))
+    const body = await res.json() as { available: boolean; reason: string }
+    expect(body.available).toBe(false)
+    expect(body.reason).toBe('invalid format')
+  })
+
+  it('returns reserved reason for admin', async () => {
+    const { onRequestGet } = await import('../functions/api/handles/check')
+    const env = envFor()
+    const req = new Request('https://x/api/handles/check?h=admin')
+    const res = await onRequestGet(ctxFor(req, env))
+    const body = await res.json() as { available: boolean; reason: string }
+    expect(body.reason).toBe('reserved')
+  })
+})
+
+describe('POST /api/handles/claim', () => {
+  it('claims an available handle and writes audit', async () => {
+    const { onRequestPost } = await import('../functions/api/handles/claim')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/handles/claim', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ handle: 'alice' }),
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ handle: 'alice' })
+    expect(env.state.handles).toHaveLength(1)
+    expect(env.state.handles[0]?.handle).toBe('alice')
+    expect(env.state.audit.some((a) => a.action === 'handle.claim' && a.target_id === 'alice')).toBe(true)
+  })
+
+  it('401 when unauthenticated', async () => {
+    const { onRequestPost } = await import('../functions/api/handles/claim')
+    const env = envFor()
+    const req = new Request('https://x/api/handles/claim', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ handle: 'alice' }),
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(401)
+  })
+
+  it('409 when another user already owns the handle', async () => {
+    const { onRequestPost } = await import('../functions/api/handles/claim')
+    const env = envFor()
+    seedUser(env.state)
+    env.state.handles.push({
+      handle: 'alice',
+      user_id: 'other',
+      claimed_at: Date.now(),
+      released_at: null,
+    })
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/handles/claim', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ handle: 'alice' }),
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(409)
+  })
+
+  it('idempotent: same user re-claiming their own handle returns 200', async () => {
+    const { onRequestPost } = await import('../functions/api/handles/claim')
+    const env = envFor()
+    seedUser(env.state)
+    env.state.handles.push({
+      handle: 'alice',
+      user_id: 'user-1',
+      claimed_at: Date.now() - 1000,
+      released_at: null,
+    })
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/handles/claim', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ handle: 'alice' }),
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(200)
+    expect(env.state.handles).toHaveLength(1)
+  })
+
+  it('409 when user already has a different handle', async () => {
+    const { onRequestPost } = await import('../functions/api/handles/claim')
+    const env = envFor()
+    seedUser(env.state)
+    env.state.handles.push({
+      handle: 'other',
+      user_id: 'user-1',
+      claimed_at: Date.now(),
+      released_at: null,
+    })
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/handles/claim', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ handle: 'alice' }),
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(409)
+  })
+
+  it('422 on invalid handle format', async () => {
+    const { onRequestPost } = await import('../functions/api/handles/claim')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/handles/claim', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ handle: '2bad' }),
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(422)
+  })
+
+  it('429 when rate limit exceeded', async () => {
+    const { onRequestPost } = await import('../functions/api/handles/claim')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const slot = Math.floor(Date.now() / 1000 / 86400)
+    await env.RATE.put(`rate/claim/user-1/${slot}`, '5', { expirationTtl: 86400 * 2 })
+    const req = authedReq('https://x/api/handles/claim', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ handle: 'alice' }),
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(429)
+  })
+})
+
+describe('GET /api/me', () => {
+  it('returns user + handle null when none claimed', async () => {
+    const { onRequestGet } = await import('../functions/api/me/index')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/me')
+    const res = await onRequestGet(ctxFor(req, env))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+      avatar_url: 'https://x/a.png',
+      handle: null,
+    })
+  })
+
+  it('returns user + claimed handle when present', async () => {
+    const { onRequestGet } = await import('../functions/api/me/index')
+    const env = envFor()
+    seedUser(env.state)
+    env.state.handles.push({
+      handle: 'alice',
+      user_id: 'user-1',
+      claimed_at: Date.now(),
+      released_at: null,
+    })
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/me')
+    const res = await onRequestGet(ctxFor(req, env))
+    const body = await res.json() as { handle: string | null }
+    expect(body.handle).toBe('alice')
+  })
+
+  it('401 when unauthenticated', async () => {
+    const { onRequestGet } = await import('../functions/api/me/index')
+    const env = envFor()
+    const req = new Request('https://x/api/me')
+    const res = await onRequestGet(ctxFor(req, env))
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('GET /api/me/shares', () => {
+  it('returns empty list when no shares', async () => {
+    const { onRequestGet } = await import('../functions/api/me/shares')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/me/shares')
+    const res = await onRequestGet(ctxFor(req, env))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ items: [] })
+  })
+
+  it('returns published_shares ordered by published_at desc', async () => {
+    const { onRequestGet } = await import('../functions/api/me/shares')
+    const env = envFor()
+    seedUser(env.state)
+    env.state.published_shares.push(
+      {
+        id: 'old',
+        user_id: 'user-1',
+        title: 'Old',
+        visibility: 'unlisted',
+        expires_at: null,
+        version: 1,
+        published_at: 100,
+        republished_at: null,
+        revoked_at: null,
+      },
+      {
+        id: 'new',
+        user_id: 'user-1',
+        title: 'New',
+        visibility: 'profile-listed',
+        expires_at: null,
+        version: 1,
+        published_at: 200,
+        republished_at: null,
+        revoked_at: null,
+      },
+      {
+        id: 'someone-else',
+        user_id: 'other',
+        title: 'Other',
+        visibility: 'unlisted',
+        expires_at: null,
+        version: 1,
+        published_at: 300,
+        republished_at: null,
+        revoked_at: null,
+      },
+    )
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/me/shares')
+    const res = await onRequestGet(ctxFor(req, env))
+    const body = await res.json() as { items: Array<{ id: string }> }
+    expect(body.items.map((i) => i.id)).toEqual(['new', 'old'])
+  })
+})
+
+describe('POST /api/me/delete', () => {
+  it('sets deletion_pending_until, inserts queue row, audits', async () => {
+    const { onRequestPost } = await import('../functions/api/me/delete')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const before = Date.now()
+    const req = authedReq('https://x/api/me/delete', { method: 'POST' })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(200)
+    const body = await res.json() as { scheduled_at: number }
+    expect(body.scheduled_at).toBeGreaterThanOrEqual(before + 24 * 3600 * 1000 - 1000)
+    expect(env.state.users[0]?.deletion_pending_until).toBe(body.scheduled_at)
+    expect(env.state.deletion_queue).toHaveLength(1)
+    expect(env.state.deletion_queue[0]).toMatchObject({
+      user_id: 'user-1',
+      cancelled: 0,
+    })
+    expect(env.state.audit.some((a) => a.action === 'account.delete.scheduled')).toBe(true)
+  })
+
+  it('INSERT OR REPLACE overwrites prior queue row', async () => {
+    const { onRequestPost } = await import('../functions/api/me/delete')
+    const env = envFor()
+    seedUser(env.state)
+    env.state.deletion_queue.push({
+      user_id: 'user-1',
+      scheduled_at: 1,
+      cancelled: 1,
+    })
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/me/delete', { method: 'POST' })
+    await onRequestPost(ctxFor(req, env))
+    expect(env.state.deletion_queue).toHaveLength(1)
+    expect(env.state.deletion_queue[0]?.cancelled).toBe(0)
+    expect(env.state.deletion_queue[0]?.scheduled_at).toBeGreaterThan(1)
+  })
+})
+
+describe('DELETE /api/me/delete', () => {
+  it('clears pending and marks queue row cancelled', async () => {
+    const { onRequestDelete } = await import('../functions/api/me/delete')
+    const env = envFor()
+    // requireUser blocks users with deletion_pending_until set, so we test
+    // the cancel path with a user whose flag was already cleared elsewhere
+    // (this mirrors the documented limitation of the helper).
+    seedUser(env.state)
+    env.state.deletion_queue.push({
+      user_id: 'user-1',
+      scheduled_at: Date.now() + 1000,
+      cancelled: 0,
+    })
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/me/delete', { method: 'DELETE' })
+    const res = await onRequestDelete(ctxFor(req, env))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ cancelled: true })
+    expect(env.state.users[0]?.deletion_pending_until).toBeNull()
+    expect(env.state.deletion_queue[0]?.cancelled).toBe(1)
+    expect(env.state.audit.some((a) => a.action === 'account.delete.cancel')).toBe(true)
+  })
+})
+
+describe('ApiError surfacing', () => {
+  it('UNAUTHENTICATED maps to 401', () => {
+    expect(new ApiError('UNAUTHENTICATED').code).toBe('UNAUTHENTICATED')
+  })
+})


### PR DESCRIPTION
## What

Adds the per-user surface the renderer and share-web both call once signed in:

- `GET /api/handles/check?handle=foo` — availability probe (reserved-list + DB lookup)
- `POST /api/handles/claim` — claim or move the caller's handle, atomic against races
- `GET  /api/me` — caller's profile (`{ user, handle, deletionPendingUntil }`)
- `GET  /api/me/shares` — caller's published-shares listing
- `POST /api/me/delete` — schedule account deletion (24h grace, idempotent)
- `DELETE /api/me/delete` — cancel a pending deletion before it executes

Plus the shared primitives the rest of the stack reuses:

- `src/auth/require.ts → requireUser(req, env)` — extracts session cookie, looks up `SESSIONS` KV, returns the `users` row or throws `UNAUTHORIZED`. Every authenticated endpoint after this PR routes through it.
- `src/handles.ts → validateHandle(input)` — single source of truth for handle policy (length, charset, reserved-list); used by both `check` and `claim` so a UI showing "available" can't surface a name `claim` would reject.

## Why

These five endpoints are the minimum surface that lets a signed-in account be useful:
- `share-web/me` can render
- `share-web/<handle>` can resolve to a user
- the renderer's Settings → Account pane can read deletion state

Splitting them across multiple PRs would force each call site to half-ship behind a feature gate. Bundling here keeps the diff readable (one schema area, one auth model) and unblocks PR 4 (publish endpoints) which assumes `requireUser` exists.

The `requireUser` helper is the choke point for every later authenticated endpoint. Putting it in this PR — rather than inlining session lookup at each call site — means the publish/revoke/republish/og endpoints in subsequent PRs all share one definition of "signed in".

## Endpoints

```mermaid
flowchart LR
    subgraph public
        HC["GET /api/handles/check?handle=…"]
    end
    subgraph authed["authenticated (session cookie required)"]
        CL["POST /api/handles/claim"]
        ME["GET  /api/me"]
        MS["GET  /api/me/shares"]
        DEL["POST /api/me/delete"]
        CAN["DELETE /api/me/delete"]
    end
    REQ[requireUser] --> CL
    REQ --> ME
    REQ --> MS
    REQ --> DEL
    REQ --> CAN
    REQ -->|SESSIONS KV| S[(session lookup)]
    HC --> VH[validateHandle]
    CL --> VH
    CL -->|UNIQUE handle PK| H[(handles)]
    ME --> U[(users)]
    ME --> H
    MS --> P[(published_shares)]
    DEL --> Q[(deletion_queue)]
    DEL --> U
    CAN --> Q
    CAN --> U
```

## Handle claim race

Two well-formed attempts to claim the same handle hit the DB at roughly the same time. The first commit wins; the second collides on the `handles` primary key. The handler converts the SQLite unique-violation into a `409 CONFLICT` so the caller sees a deterministic outcome instead of a 500.

```mermaid
sequenceDiagram
    autonumber
    participant A as Caller A
    participant B as Caller B
    participant H as POST /api/handles/claim
    participant D as D1 (handles)

    par
        A->>H: { handle: 'alex' }
        B->>H: { handle: 'alex' }
    end
    H->>H: requireUser, rate-limit (5/day/user)
    H->>H: validateHandle, reserved-list check
    H->>D: read existing(handle) + prior(user)
    Note over H,D: parallel D1 reads via Promise.all
    H->>D: UPDATE old user row → released_at = now
    H->>D: INSERT INTO handles (handle, user_id, ...) -- both attempts
    D-->>H: A: ok
    D-->>H: B: UNIQUE constraint failed: handles.handle
    H-->>A: 200 { handle: 'alex' }
    H-->>B: 409 CONFLICT { code: 'handle taken' }
```

## Account-deletion lifecycle

```mermaid
stateDiagram-v2
    [*] --> Active
    Active --> Pending: POST /api/me/delete<br/>(24h grace)
    Pending --> Active: DELETE /api/me/delete<br/>(within window)
    Pending --> Deleted: deletion worker<br/>(after grace_period)
    Deleted --> [*]
    Pending --> Active: /api/me still answers<br/>(read-only, banner shown)
```

Key correctness rules:
- `POST /api/me/delete` writes `users.deletion_pending_until` AND inserts/replaces `deletion_queue`. Repeating the call is idempotent (`INSERT OR REPLACE`).
- `DELETE /api/me/delete` clears both — even when the user's session was minted *before* the deletion was scheduled. This is what makes "I changed my mind" reliable.
- `GET /api/me` still answers `200` while pending. The pending flag is part of the response, so the UI can render a banner and a cancel CTA. Returning 4xx would force a sign-out loop, which is exactly the wrong outcome for an in-grace user.

## Verification

- `pnpm --filter @spool-lab/share-backend test` — handles.test.ts + me.test.ts cover: rate-limit trip, reserved-list rejection, claim-then-rename moves `released_at`, two-concurrent claims fold to 409, schedule/cancel idempotency, me-while-pending still 200, post-grace post-grace doesn't auto-execute (deletion worker is a later PR)
- Manual: wrangler dev, sign in, claim handle, schedule delete, cancel, schedule again

## Risk

Pure additive — new routes only, no schema changes (uses the tables already in `0001_init.sql`).

Submitted by @graydawnc.