### PR TITLE
feat(share-backend): publish, snapshot read, revoke, republish

### DIFF
--- a/packages/share-backend/functions/api/publish.ts
+++ b/packages/share-backend/functions/api/publish.ts
@@ -10,6 +10,7 @@ import { requireUser } from '../../src/auth/require'
 import { ApiError, jsonError, jsonOk } from '../../src/errors'
 import { isValidSlug, nanoidSlug } from '../../src/publish/slug'
 import { PublishRequest } from '../../src/publish/validators'
+import { publicBaseUrl } from '../../src/public-url'
 import { checkRate } from '../../src/rate-limit'
 
 type Env = {
@@ -22,8 +23,6 @@ type Env = {
   // local share-web vite server; prod defaults to spool.pro.
   PUBLIC_BASE_URL?: string
 }
-
-const DEFAULT_PUBLIC_BASE_URL = 'https://spool.pro'
 
 // Hard cap on the raw request body — 10× the typical session export, low
 // enough that a single user can't fill R2 with a few shares.
@@ -289,11 +288,10 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
       httpMetadata: { contentType: 'application/json' },
     })
 
-    const baseUrl = ctx.env.PUBLIC_BASE_URL ?? DEFAULT_PUBLIC_BASE_URL
     return jsonOk({
       id: slug,
       version,
-      url: `${baseUrl}/s/${slug}`,
+      url: `${publicBaseUrl(ctx.env)}/s/${slug}`,
     })
   } catch (e) {
     return jsonError(e)

--- a/packages/share-backend/functions/api/publish.ts
+++ b/packages/share-backend/functions/api/publish.ts
@@ -1,0 +1,233 @@
+import type {
+  D1Database,
+  KVNamespace,
+  PagesFunction,
+  R2Bucket,
+} from '@cloudflare/workers-types'
+
+import { audit } from '../../src/audit'
+import { requireUser } from '../../src/auth/require'
+import { ApiError, jsonError, jsonOk } from '../../src/errors'
+import { isValidSlug, nanoidSlug } from '../../src/publish/slug'
+import { PublishRequest } from '../../src/publish/validators'
+import { checkRate } from '../../src/rate-limit'
+
+type Env = {
+  DB: D1Database
+  SESSIONS: KVNamespace
+  META: KVNamespace
+  RATE: KVNamespace
+  SNAPSHOTS: R2Bucket
+}
+
+const MAX_SNAPSHOT_BYTES = 2 * 1024 * 1024
+
+export const onRequestPost: PagesFunction<Env> = async (ctx) => {
+  try {
+    const user = await requireUser(ctx.request, ctx.env)
+
+    const hourly = await checkRate(ctx.env.RATE, {
+      bucket: 'publish-h',
+      key: user.id,
+      windowSec: 3600,
+      max: 30,
+    })
+    if (!hourly.ok) throw new ApiError('TOO_MANY_REQUESTS')
+    const daily = await checkRate(ctx.env.RATE, {
+      bucket: 'publish-d',
+      key: user.id,
+      windowSec: 86400,
+      max: 100,
+    })
+    if (!daily.ok) throw new ApiError('TOO_MANY_REQUESTS')
+
+    const raw = await ctx.request.text()
+    if (raw.length > MAX_SNAPSHOT_BYTES) {
+      throw new ApiError('UNPROCESSABLE', 'payload too large')
+    }
+    let json: unknown
+    try {
+      json = JSON.parse(raw)
+    } catch {
+      throw new ApiError('UNPROCESSABLE', 'invalid json')
+    }
+    const parsed = PublishRequest.safeParse(json)
+    if (!parsed.success) {
+      throw new ApiError('UNPROCESSABLE', 'invalid snapshot', {
+        issues: parsed.error.issues,
+      })
+    }
+    const req = parsed.data
+
+    if (req.visibility === 'profile-listed') {
+      const h = await ctx.env.DB.prepare(
+        'SELECT handle FROM handles WHERE user_id=? AND released_at IS NULL',
+      )
+        .bind(user.id)
+        .first<{ handle: string }>()
+      if (!h) throw new ApiError('UNPROCESSABLE', 'profile-listed requires a handle')
+    }
+
+    // Idempotency: if a prior request from this user already landed
+    // under the same token, return that result without touching state.
+    // Covers the dropped-response retry case (network drops between
+    // commit and 200 → user clicks again with the same payload →
+    // hash collides → backend short-circuits to the original slug).
+    //
+    // Skipped when the token already belongs to a revoked row — a
+    // republish-after-unpublish must mint a new slug, not resurrect
+    // the old one, so we look only at currently-live rows.
+    //
+    // When the request carries an override_slug (republish path) the
+    // short-circuit must only fire if the token's row IS that slug.
+    // A token held by a different live share is a hard collision
+    // (vanishingly rare in practice — two drafts whose content hash
+    // is identical) and surfaces as 409, not a confused 200 with a
+    // slug the renderer wasn't expecting.
+    const idempotent = await ctx.env.DB.prepare(
+      'SELECT id, version FROM published_shares WHERE user_id=? AND client_request_id=? AND revoked_at IS NULL',
+    )
+      .bind(user.id, req.idempotency_key)
+      .first<{ id: string; version: number }>()
+    if (idempotent) {
+      if (req.override_slug && idempotent.id !== req.override_slug) {
+        throw new ApiError('CONFLICT', 'another live share carries the same idempotency token; edit content or revoke the other share')
+      }
+      return jsonOk({
+        id: idempotent.id,
+        version: idempotent.version,
+        url: `${publicBaseUrl(ctx.env)}/s/${idempotent.id}`,
+      })
+    }
+
+    const isRepublish = !!req.override_slug
+    let slug: string
+    let version: number
+    if (isRepublish) {
+      if (!isValidSlug(req.override_slug!)) throw new ApiError('BAD_REQUEST', 'bad slug')
+      // Read draft_id alongside version so we can reject a republish
+      // that's trying to retarget an existing slug to a different draft —
+      // the slug ↔ draft binding is meant to be stable for the slug's
+      // lifetime.
+      const owned = await ctx.env.DB.prepare(
+        'SELECT version, draft_id FROM published_shares WHERE id=? AND user_id=? AND revoked_at IS NULL',
+      )
+        .bind(req.override_slug, user.id)
+        .first<{ version: number; draft_id: string | null }>()
+      if (!owned) throw new ApiError('NOT_FOUND', 'not owner / not found')
+      // owned.draft_id can be null for shares published before the
+      // column existed. In that case we accept the incoming draft_id
+      // and write it through on the UPDATE — the row gets healed.
+      if (owned.draft_id !== null && owned.draft_id !== req.draft_id) {
+        throw new ApiError('BAD_REQUEST', 'draft_id does not match slug')
+      }
+      slug = req.override_slug!
+      version = owned.version + 1
+    } else {
+      slug = nanoidSlug()
+      version = 1
+    }
+
+    const publishedAt = new Date().toISOString()
+    const fullSnap = {
+      ...req.snapshot,
+      id: slug,
+      owner_user_id: user.id,
+      publish: {
+        visibility: req.visibility,
+        expires_at: req.expires_at,
+        published_at: publishedAt,
+        version,
+      },
+    }
+    await ctx.env.SNAPSHOTS.put(`${slug}.json`, JSON.stringify(fullSnap), {
+      httpMetadata: { contentType: 'application/json' },
+    })
+
+    const meta = {
+      owner: user.id,
+      visibility: req.visibility,
+      expires_at: req.expires_at ? new Date(req.expires_at).getTime() : null,
+      revoked_at: null as number | null,
+      version,
+    }
+    await ctx.env.META.put(`meta/${slug}`, JSON.stringify(meta))
+
+    const now = Date.now()
+    if (isRepublish) {
+      await ctx.env.DB.prepare(
+        'UPDATE published_shares SET title=?, visibility=?, expires_at=?, version=?, republished_at=? WHERE id=?',
+      )
+        .bind(
+          req.snapshot.conversation.title,
+          req.visibility,
+          meta.expires_at,
+          version,
+          now,
+          slug,
+        )
+        .run()
+    } else {
+      await ctx.env.DB.prepare(
+        'INSERT INTO published_shares (id, user_id, title, visibility, expires_at, version, published_at) VALUES (?,?,?,?,?,?,?)',
+      )
+        .bind(
+          slug,
+          user.id,
+          req.snapshot.conversation.title,
+          req.visibility,
+          meta.expires_at,
+          version,
+          now,
+        )
+          .bind(
+            slug,
+            user.id,
+            req.snapshot.conversation.title,
+            req.visibility,
+            expiresAtMs,
+            version,
+            now,
+            req.draft_id,
+            req.idempotency_key,
+          )
+          .run()
+      } catch (insertErr) {
+        // Concurrent retry: the idempotency SELECT above raced an
+        // in-flight publish that committed between our read and write.
+        // The UNIQUE(user_id, client_request_id) partial index fires
+        // and we land here. Re-resolve the now-existing row and return
+        // it, so both racing requests get the same response instead of
+        // one of them seeing an unhelpful constraint error.
+        const msg = insertErr instanceof Error ? insertErr.message : String(insertErr)
+        if (!/UNIQUE constraint/i.test(msg)) throw insertErr
+        const settled = await ctx.env.DB.prepare(
+          'SELECT id, version FROM published_shares WHERE user_id=? AND client_request_id=? AND revoked_at IS NULL',
+        )
+          .bind(user.id, req.idempotency_key)
+          .first<{ id: string; version: number }>()
+        if (!settled) throw insertErr
+        return jsonOk({
+          id: settled.id,
+          version: settled.version,
+          url: `${publicBaseUrl(ctx.env)}/s/${settled.id}`,
+        })
+      }
+    }
+
+    await audit(ctx.env.DB, ctx.env.RATE, ctx.request, {
+      user_id: user.id,
+      action: isRepublish ? 'republish' : 'publish',
+      target_id: slug,
+      details: { version, visibility: req.visibility },
+    })
+
+    return jsonOk({
+      id: slug,
+      version,
+      url: `https://spool.pro/s/${slug}`,
+    })
+  } catch (e) {
+    return jsonError(e)
+  }
+}

--- a/packages/share-backend/functions/api/publish.ts
+++ b/packages/share-backend/functions/api/publish.ts
@@ -20,7 +20,22 @@ type Env = {
   SNAPSHOTS: R2Bucket
 }
 
+// Hard cap on the raw request body — 10× the typical session export, low
+// enough that a single user can't fill R2 with a few shares.
 const MAX_SNAPSHOT_BYTES = 2 * 1024 * 1024
+
+// Per-user publish throttles. The hourly bucket brakes runaway scripts,
+// the daily bucket caps overall storage growth per user.
+const PUBLISH_RATE_HOURLY_WINDOW_SEC = 3600
+const PUBLISH_RATE_HOURLY_MAX = 30
+const PUBLISH_RATE_DAILY_WINDOW_SEC = 86400
+const PUBLISH_RATE_DAILY_MAX = 100
+
+// expires_at must be ≥ 5 minutes out (clock skew tolerance, blocks
+// instantly-tombstoned publishes) and ≤ 1 year (matches the design
+// retention policy; long enough for any practical share lifetime).
+const MIN_EXPIRES_OFFSET_MS = 5 * 60 * 1000
+const MAX_EXPIRES_OFFSET_MS = 365 * 24 * 3600 * 1000
 
 export const onRequestPost: PagesFunction<Env> = async (ctx) => {
   try {
@@ -29,15 +44,15 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
     const hourly = await checkRate(ctx.env.RATE, {
       bucket: 'publish-h',
       key: user.id,
-      windowSec: 3600,
-      max: 30,
+      windowSec: PUBLISH_RATE_HOURLY_WINDOW_SEC,
+      max: PUBLISH_RATE_HOURLY_MAX,
     })
     if (!hourly.ok) throw new ApiError('TOO_MANY_REQUESTS')
     const daily = await checkRate(ctx.env.RATE, {
       bucket: 'publish-d',
       key: user.id,
-      windowSec: 86400,
-      max: 100,
+      windowSec: PUBLISH_RATE_DAILY_WINDOW_SEC,
+      max: PUBLISH_RATE_DAILY_MAX,
     })
     if (!daily.ok) throw new ApiError('TOO_MANY_REQUESTS')
 
@@ -58,6 +73,17 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
       })
     }
     const req = parsed.data
+
+    const now = Date.now()
+    const expiresAtMs = req.expires_at ? new Date(req.expires_at).getTime() : null
+    if (expiresAtMs !== null) {
+      if (expiresAtMs < now + MIN_EXPIRES_OFFSET_MS) {
+        throw new ApiError('UNPROCESSABLE', 'expires_at must be in the future')
+      }
+      if (expiresAtMs > now + MAX_EXPIRES_OFFSET_MS) {
+        throw new ApiError('UNPROCESSABLE', 'expires_at cannot be more than 1 year out')
+      }
+    }
 
     if (req.visibility === 'profile-listed') {
       const h = await ctx.env.DB.prepare(
@@ -103,6 +129,7 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
     const isRepublish = !!req.override_slug
     let slug: string
     let version: number
+    let priorVersion: number | null = null
     if (isRepublish) {
       if (!isValidSlug(req.override_slug!)) throw new ApiError('BAD_REQUEST', 'bad slug')
       // Read draft_id alongside version so we can reject a republish
@@ -122,63 +149,68 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
         throw new ApiError('BAD_REQUEST', 'draft_id does not match slug')
       }
       slug = req.override_slug!
+      priorVersion = owned.version
       version = owned.version + 1
     } else {
       slug = nanoidSlug()
       version = 1
     }
 
-    const publishedAt = new Date().toISOString()
-    const fullSnap = {
-      ...req.snapshot,
-      id: slug,
-      owner_user_id: user.id,
-      publish: {
-        visibility: req.visibility,
-        expires_at: req.expires_at,
-        published_at: publishedAt,
-        version,
-      },
-    }
-    await ctx.env.SNAPSHOTS.put(`${slug}.json`, JSON.stringify(fullSnap), {
-      httpMetadata: { contentType: 'application/json' },
-    })
-
-    const meta = {
-      owner: user.id,
-      visibility: req.visibility,
-      expires_at: req.expires_at ? new Date(req.expires_at).getTime() : null,
-      revoked_at: null as number | null,
-      version,
-    }
-    await ctx.env.META.put(`meta/${slug}`, JSON.stringify(meta))
-
-    const now = Date.now()
+    // Write order is deliberate: D1 → META (KV) → R2. The D1 row is the
+    // single source of truth for "this slug exists and the user owns it";
+    // until it's in place the user has no way to see or revoke the share.
+    // KV is the tombstone gate and R2 the bulk body. Partial failures
+    // after this point are user-recoverable (republish refreshes both),
+    // whereas a public R2 object without a D1 row would be an orphan the
+    // owner doesn't even know about.
     if (isRepublish) {
-      await ctx.env.DB.prepare(
-        'UPDATE published_shares SET title=?, visibility=?, expires_at=?, version=?, republished_at=? WHERE id=?',
-      )
-        .bind(
-          req.snapshot.conversation.title,
-          req.visibility,
-          meta.expires_at,
-          version,
-          now,
-          slug,
+      // Optimistic-concurrency guard against a concurrent republish on the
+      // same row: scope the UPDATE to the version we just SELECTed. If a
+      // racing writer landed first, meta.changes will be 0 and we surface
+      // CONFLICT instead of silently overwriting their result.
+      // We also write draft_id on every republish to heal pre-existing
+      // rows that landed before the column was added, and write the new
+      // idempotency token so future retries hit the short-circuit above.
+      try {
+        const result = await ctx.env.DB.prepare(
+          'UPDATE published_shares SET title=?, visibility=?, expires_at=?, version=?, republished_at=?, draft_id=?, client_request_id=? WHERE id=? AND user_id=? AND version=?',
         )
-        .run()
+          .bind(
+            req.snapshot.conversation.title,
+            req.visibility,
+            expiresAtMs,
+            version,
+            now,
+            req.draft_id,
+            req.idempotency_key,
+            slug,
+            user.id,
+            priorVersion!,
+          )
+          .run()
+        if (result.meta.changes === 0) {
+          throw new ApiError('CONFLICT', 'concurrent republish — please retry')
+        }
+      } catch (updateErr) {
+        if (updateErr instanceof ApiError) throw updateErr
+        // The (user_id, client_request_id) unique index covers live rows.
+        // It can fire on republish only when the *same user* has another
+        // live share whose token also happens to equal this republish's
+        // token — i.e. two distinct drafts whose snapshot+visibility+
+        // expires hash to the same content. Vanishingly rare in practice
+        // (copy-pasted draft body across two share entries), but we
+        // translate it into 409 instead of 500 so the renderer can
+        // surface "edit your content or unpublish the other share".
+        const msg = updateErr instanceof Error ? updateErr.message : String(updateErr)
+        if (/UNIQUE constraint/i.test(msg)) {
+          throw new ApiError('CONFLICT', 'another live share carries the same idempotency token; edit content or revoke the other share')
+        }
+        throw updateErr
+      }
     } else {
-      await ctx.env.DB.prepare(
-        'INSERT INTO published_shares (id, user_id, title, visibility, expires_at, version, published_at) VALUES (?,?,?,?,?,?,?)',
-      )
-        .bind(
-          slug,
-          user.id,
-          req.snapshot.conversation.title,
-          req.visibility,
-          meta.expires_at,
-          version,
-          now,
+      try {
+        await ctx.env.DB.prepare(
+          'INSERT INTO published_shares (id, user_id, title, visibility, expires_at, version, published_at, draft_id, client_request_id) VALUES (?,?,?,?,?,?,?,?,?)',
         )
           .bind(
             slug,
@@ -214,6 +246,32 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
         })
       }
     }
+
+    const meta = {
+      owner: user.id,
+      visibility: req.visibility,
+      expires_at: expiresAtMs,
+      revoked_at: null as number | null,
+      version,
+    }
+    await ctx.env.META.put(`meta/${slug}`, JSON.stringify(meta))
+
+    // Drop owner_user_id from the public JSON: reader doesn't need it, and
+    // exposing the internal id lets anyone with a share URL pivot to a
+    // user enumeration vector. Author identity belongs in /api/profiles/*.
+    const fullSnap = {
+      ...req.snapshot,
+      id: slug,
+      publish: {
+        visibility: req.visibility,
+        expires_at: req.expires_at,
+        published_at: new Date(now).toISOString(),
+        version,
+      },
+    }
+    await ctx.env.SNAPSHOTS.put(`${slug}.json`, JSON.stringify(fullSnap), {
+      httpMetadata: { contentType: 'application/json' },
+    })
 
     await audit(ctx.env.DB, ctx.env.RATE, ctx.request, {
       user_id: user.id,

--- a/packages/share-backend/functions/api/publish.ts
+++ b/packages/share-backend/functions/api/publish.ts
@@ -18,7 +18,12 @@ type Env = {
   META: KVNamespace
   RATE: KVNamespace
   SNAPSHOTS: R2Bucket
+  // Origin returned in the published share URL. Dev points this at the
+  // local share-web vite server; prod defaults to spool.pro.
+  PUBLIC_BASE_URL?: string
 }
+
+const DEFAULT_PUBLIC_BASE_URL = 'https://spool.pro'
 
 // Hard cap on the raw request body — 10× the typical session export, low
 // enough that a single user can't fill R2 with a few shares.
@@ -247,6 +252,17 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
       }
     }
 
+    // Write audit right after the authoritative D1 mutation so the
+    // evidence row exists even if the downstream META/R2 writes fail
+    // partway. audit() itself writes to D1, so its outcome shares the
+    // same blast radius as the row it's recording.
+    await audit(ctx.env.DB, ctx.env.RATE, ctx.request, {
+      user_id: user.id,
+      action: isRepublish ? 'republish' : 'publish',
+      target_id: slug,
+      details: { version, visibility: req.visibility },
+    })
+
     const meta = {
       owner: user.id,
       visibility: req.visibility,
@@ -273,17 +289,11 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
       httpMetadata: { contentType: 'application/json' },
     })
 
-    await audit(ctx.env.DB, ctx.env.RATE, ctx.request, {
-      user_id: user.id,
-      action: isRepublish ? 'republish' : 'publish',
-      target_id: slug,
-      details: { version, visibility: req.visibility },
-    })
-
+    const baseUrl = ctx.env.PUBLIC_BASE_URL ?? DEFAULT_PUBLIC_BASE_URL
     return jsonOk({
       id: slug,
       version,
-      url: `https://spool.pro/s/${slug}`,
+      url: `${baseUrl}/s/${slug}`,
     })
   } catch (e) {
     return jsonError(e)

--- a/packages/share-backend/functions/api/revoke/[id].ts
+++ b/packages/share-backend/functions/api/revoke/[id].ts
@@ -9,6 +9,7 @@ import { audit } from '../../../src/audit'
 import { requireUser } from '../../../src/auth/require'
 import { ApiError, jsonError, jsonOk } from '../../../src/errors'
 import { isValidSlug } from '../../../src/publish/slug'
+import { checkRate } from '../../../src/rate-limit'
 
 type Env = {
   DB: D1Database
@@ -19,11 +20,25 @@ type Env = {
   RATE: KVNamespace
 }
 
+// Owner-scoped (you can only revoke your own), so the bucket is mostly
+// cost discipline — caps a leaked-token attacker's ability to spin up
+// META/D1/R2 writes in a tight loop. Same hourly shape as publish.
+const REVOKE_RATE_WINDOW_SEC = 3600
+const REVOKE_RATE_MAX = 60
+
 export const onRequestPost: PagesFunction<Env, 'id'> = async (ctx) => {
   try {
     const id = ctx.params.id as string
     if (!isValidSlug(id)) throw new ApiError('NOT_FOUND')
     const user = await requireUser(ctx.request, ctx.env)
+
+    const rate = await checkRate(ctx.env.RATE, {
+      bucket: 'revoke',
+      key: user.id,
+      windowSec: REVOKE_RATE_WINDOW_SEC,
+      max: REVOKE_RATE_MAX,
+    })
+    if (!rate.ok) throw new ApiError('TOO_MANY_REQUESTS')
 
     const owned = await ctx.env.DB.prepare(
       'SELECT 1 FROM published_shares WHERE id=? AND user_id=?',

--- a/packages/share-backend/functions/api/revoke/[id].ts
+++ b/packages/share-backend/functions/api/revoke/[id].ts
@@ -1,0 +1,76 @@
+import type {
+  D1Database,
+  KVNamespace,
+  PagesFunction,
+  R2Bucket,
+} from '@cloudflare/workers-types'
+
+import { audit } from '../../../src/audit'
+import { requireUser } from '../../../src/auth/require'
+import { ApiError, jsonError, jsonOk } from '../../../src/errors'
+import { isValidSlug } from '../../../src/publish/slug'
+
+type Env = {
+  DB: D1Database
+  SESSIONS: KVNamespace
+  META: KVNamespace
+  SNAPSHOTS: R2Bucket
+  OG: R2Bucket
+  RATE: KVNamespace
+}
+
+export const onRequestPost: PagesFunction<Env, 'id'> = async (ctx) => {
+  try {
+    const id = ctx.params.id as string
+    if (!isValidSlug(id)) throw new ApiError('NOT_FOUND')
+    const user = await requireUser(ctx.request, ctx.env)
+
+    const owned = await ctx.env.DB.prepare(
+      'SELECT 1 FROM published_shares WHERE id=? AND user_id=?',
+    )
+      .bind(id, user.id)
+      .first()
+    if (!owned) throw new ApiError('NOT_FOUND')
+
+    const now = Date.now()
+    // Write order matches the publish handler's discipline: D1 row
+    // is the source of truth for owner / state, KV is the tombstone
+    // cache the reader hits first. If we wrote KV first and the D1
+    // write then failed, the owner's `/api/me/shares` would still
+    // show the row as live (`revoked_at IS NULL`), the share would
+    // 410 to readers via the KV tombstone, and a subsequent
+    // republish attempt would find the live row and overwrite it
+    // — burying the tombstone without clearing it. D1 first means a
+    // partial failure leaves the row revoked from the owner's view
+    // and a retry can complete the tombstone work.
+    await ctx.env.DB.prepare(
+      'UPDATE published_shares SET revoked_at=? WHERE id=?',
+    )
+      .bind(now, id)
+      .run()
+
+    const metaRaw = await ctx.env.META.get(`meta/${id}`)
+    if (metaRaw) {
+      const m = JSON.parse(metaRaw)
+      m.revoked_at = now
+      await ctx.env.META.put(`meta/${id}`, JSON.stringify(m))
+    }
+
+    // KV tombstone already enforces 410 on reads; R2 cleanup is fire-and-forget.
+    ctx.waitUntil(
+      Promise.all([
+        ctx.env.SNAPSHOTS.delete(`${id}.json`),
+        ctx.env.OG.delete(`${id}.png`),
+      ]).then(() => undefined),
+    )
+
+    await audit(ctx.env.DB, ctx.env.RATE, ctx.request, {
+      user_id: user.id,
+      action: 'revoke',
+      target_id: id,
+    })
+    return jsonOk({ ok: true })
+  } catch (e) {
+    return jsonError(e)
+  }
+}

--- a/packages/share-backend/functions/api/snapshots/[id].ts
+++ b/packages/share-backend/functions/api/snapshots/[id].ts
@@ -10,6 +10,15 @@ const TOMBSTONE_HEADERS = {
   'cache-control': 'no-store',
 }
 
+// 30s window keeps CDN cost manageable for viral shares while bounding the
+// post-revoke vulnerability — a panic revoke is fully effective inside
+// half a minute everywhere except in already-loaded browser tabs. The
+// must-revalidate disposition forces shared caches to re-check on next
+// hit instead of refreshing lazily.
+const SNAPSHOT_CACHE_MAX_AGE_SEC = 30
+const SNAPSHOT_CACHE_HEADER =
+  `public, max-age=${SNAPSHOT_CACHE_MAX_AGE_SEC}, s-maxage=${SNAPSHOT_CACHE_MAX_AGE_SEC}, must-revalidate`
+
 type Meta = {
   owner: string
   visibility: 'unlisted' | 'profile-listed'
@@ -46,7 +55,7 @@ export const onRequestGet: PagesFunction<Env, 'id'> = async (ctx) => {
     return new Response(obj.body as unknown as BodyInit, {
       headers: {
         'content-type': 'application/json',
-        'cache-control': 'public, max-age=60, s-maxage=60',
+        'cache-control': SNAPSHOT_CACHE_HEADER,
         etag: `"${id}-${meta.version}"`,
       },
     })

--- a/packages/share-backend/functions/api/snapshots/[id].ts
+++ b/packages/share-backend/functions/api/snapshots/[id].ts
@@ -1,0 +1,56 @@
+import type { KVNamespace, PagesFunction, R2Bucket } from '@cloudflare/workers-types'
+
+import { ApiError, jsonError } from '../../../src/errors'
+import { isValidSlug } from '../../../src/publish/slug'
+
+type Env = { META: KVNamespace; SNAPSHOTS: R2Bucket; RATE: KVNamespace }
+
+const TOMBSTONE_HEADERS = {
+  'content-type': 'application/json',
+  'cache-control': 'no-store',
+}
+
+type Meta = {
+  owner: string
+  visibility: 'unlisted' | 'profile-listed'
+  expires_at: number | null
+  revoked_at: number | null
+  version: number
+}
+
+export const onRequestGet: PagesFunction<Env, 'id'> = async (ctx) => {
+  try {
+    const id = ctx.params.id as string
+    if (!isValidSlug(id)) throw new ApiError('NOT_FOUND')
+
+    const metaRaw = await ctx.env.META.get(`meta/${id}`)
+    if (!metaRaw) throw new ApiError('NOT_FOUND')
+    const meta = JSON.parse(metaRaw) as Meta
+
+    if (meta.revoked_at) {
+      return new Response(
+        JSON.stringify({ revoked: true, at: meta.revoked_at }),
+        { status: 410, headers: TOMBSTONE_HEADERS },
+      )
+    }
+    if (meta.expires_at && Date.now() > meta.expires_at) {
+      return new Response(
+        JSON.stringify({ expired: true, at: meta.expires_at }),
+        { status: 410, headers: TOMBSTONE_HEADERS },
+      )
+    }
+
+    const obj = await ctx.env.SNAPSHOTS.get(`${id}.json`)
+    if (!obj) throw new ApiError('NOT_FOUND')
+
+    return new Response(obj.body as unknown as BodyInit, {
+      headers: {
+        'content-type': 'application/json',
+        'cache-control': 'public, max-age=60, s-maxage=60',
+        etag: `"${id}-${meta.version}"`,
+      },
+    })
+  } catch (e) {
+    return jsonError(e)
+  }
+}

--- a/packages/share-backend/package.json
+++ b/packages/share-backend/package.json
@@ -13,6 +13,9 @@
     "d1:migrate:staging": "wrangler d1 migrations apply spool-share-db --env staging",
     "d1:migrate:prod": "wrangler d1 migrations apply spool-share-db --env production"
   },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260415.1",
     "typescript": "^5.7.3",

--- a/packages/share-backend/src/publish/slug.ts
+++ b/packages/share-backend/src/publish/slug.ts
@@ -1,13 +1,17 @@
+// 64-char URL-safe alphabet → 6 bits/char × 21 chars = 126 bits of entropy.
+// Comfortably above the birthday-paradox horizon for any realistic share
+// volume, so we don't bother checking for collisions before INSERT.
 const ALPHABET = '_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+const SLUG_LEN = 21
 
 export function nanoidSlug(): string {
-  const arr = new Uint8Array(21)
+  const arr = new Uint8Array(SLUG_LEN)
   crypto.getRandomValues(arr)
   let s = ''
-  for (let i = 0; i < 21; i++) s += ALPHABET[arr[i]! & 63]
+  for (let i = 0; i < SLUG_LEN; i++) s += ALPHABET[arr[i]! & 63]
   return s
 }
 
 export function isValidSlug(s: string): boolean {
-  return /^[\w-]{21}$/.test(s)
+  return new RegExp(`^[\\w-]{${SLUG_LEN}}$`).test(s)
 }

--- a/packages/share-backend/src/publish/slug.ts
+++ b/packages/share-backend/src/publish/slug.ts
@@ -1,0 +1,13 @@
+const ALPHABET = '_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+
+export function nanoidSlug(): string {
+  const arr = new Uint8Array(21)
+  crypto.getRandomValues(arr)
+  let s = ''
+  for (let i = 0; i < 21; i++) s += ALPHABET[arr[i]! & 63]
+  return s
+}
+
+export function isValidSlug(s: string): boolean {
+  return /^[\w-]{21}$/.test(s)
+}

--- a/packages/share-backend/src/publish/validators.ts
+++ b/packages/share-backend/src/publish/validators.ts
@@ -7,21 +7,43 @@ export const Snapshot = z.object({
     origin_hint: z.string().optional(),
     captured_at: z.iso.datetime(),
   }),
-  conversation: z.object({
-    title: z.string().min(1).max(200),
-    turns: z
-      .array(
-        z.object({
-          id: z.string(),
-          role: z.enum(['user', 'assistant', 'system', 'tool']),
-          content: z.string().max(200_000),
-          redacted: z.boolean().optional(),
-        }),
-      )
-      .max(500),
-    turn_order: z.array(z.string()).max(500),
-    hidden_turns: z.array(z.string()),
-  }),
+  conversation: z
+    .object({
+      title: z.string().min(1).max(200),
+      turns: z
+        .array(
+          z.object({
+            id: z.string(),
+            role: z.enum(['user', 'assistant', 'system', 'tool']),
+            content: z.string().max(200_000),
+            redacted: z.boolean().optional(),
+          }),
+        )
+        .max(500),
+      turn_order: z.array(z.string()).max(500),
+      hidden_turns: z.array(z.string()),
+    })
+    // Reader assumes turn_order indexes every turn exactly once and that
+    // hidden_turns references known turn ids. Without these checks a
+    // malformed snapshot would render an empty / partial reader page
+    // with no clear error.
+    .refine((c) => c.turn_order.length === c.turns.length, {
+      message: 'turn_order length must match turns length',
+      path: ['turn_order'],
+    })
+    .refine(
+      (c) => {
+        const ids = new Set(c.turns.map((t) => t.id))
+        return (
+          c.turn_order.every((id) => ids.has(id)) &&
+          c.hidden_turns.every((id) => ids.has(id))
+        )
+      },
+      {
+        message: 'turn_order/hidden_turns reference an unknown turn id',
+        path: ['turn_order'],
+      },
+    ),
   // editor_opts.template/paper/typeface/colorway are intentionally
   // z.string() (not enums): share-kit ships built-in values but also
   // allows custom ones; the server is the wrong place to gate that.

--- a/packages/share-backend/src/publish/validators.ts
+++ b/packages/share-backend/src/publish/validators.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod'
+
+export const Snapshot = z.object({
+  schema_version: z.literal(1),
+  source: z.object({
+    kind: z.enum(['spool-session', 'imported-file', 'imported-jsonl']),
+    origin_hint: z.string().optional(),
+    captured_at: z.iso.datetime(),
+  }),
+  conversation: z.object({
+    title: z.string().min(1).max(200),
+    turns: z
+      .array(
+        z.object({
+          id: z.string(),
+          role: z.enum(['user', 'assistant', 'system', 'tool']),
+          content: z.string().max(200_000),
+          redacted: z.boolean().optional(),
+        }),
+      )
+      .max(500),
+    turn_order: z.array(z.string()).max(500),
+    hidden_turns: z.array(z.string()),
+  }),
+  // editor_opts.template/paper/typeface/colorway are intentionally
+  // z.string() (not enums): share-kit ships built-in values but also
+  // allows custom ones; the server is the wrong place to gate that.
+  editor_opts: z.object({
+    template: z.string(),
+    paper: z.string(),
+    typeface: z.string(),
+    colorway: z.string(),
+    density: z.enum(['compact', 'relaxed']),
+    masthead: z.boolean(),
+    colophon: z.boolean(),
+    avatars: z.boolean(),
+    show_byline: z.boolean(),
+  }),
+})
+
+export const PublishRequest = z.object({
+  snapshot: Snapshot,
+  visibility: z.enum(['unlisted', 'profile-listed']),
+  // Renderer's local share_drafts.draft_id. Persisted on the share row
+  // so the editor can later look up "is this draft published?" without
+  // title heuristics. nanoid(21) is the format the renderer emits, but
+  // the server stays format-agnostic and only bounds the length so a
+  // pathological client can't bloat the column.
+  draft_id: z.string().min(1).max(128),
+  // Idempotency token for at-most-once publish on retry. The renderer
+  // derives it deterministically from the request payload (snapshot +
+  // visibility + expires_at), so retries of the same intent re-use the
+  // same token and the backend short-circuits to the prior result; a
+  // re-edited intent generates a fresh token and creates a new share.
+  // 64-char sha256 hex is the canonical value; we bound generously to
+  // accommodate future hash bumps without a schema change.
+  idempotency_key: z.string().min(8).max(256),
+  expires_at: z.iso.datetime().optional(),
+  // Mirror `isValidSlug` (slug.ts): 21 chars, URL-safe alphabet. The
+  // handler re-runs `isValidSlug()` after this, but enforcing at the
+  // schema boundary lets us reject malformed slugs before any DB
+  // round-trips fire (idempotency SELECT, ownership SELECT).
+  override_slug: z.string().regex(/^[\w-]{21}$/).optional(),
+})
+
+export type PublishRequestT = z.infer<typeof PublishRequest>
+export type SnapshotT = z.infer<typeof Snapshot>

--- a/packages/share-backend/tests/_helpers/ctx.ts
+++ b/packages/share-backend/tests/_helpers/ctx.ts
@@ -8,9 +8,10 @@ import type { EventContext, PagesFunction } from '@cloudflare/workers-types'
 // the test suite: the global `Request` we construct with `new Request(...)`
 // is structurally compatible with CF's `Request<unknown, CfProperties>`
 // at runtime, but TS treats them as distinct nominal types.
-// The optional `params` arg covers dynamic-segment routes (e.g. the
-// /api/auth/[provider]/start handler reads ctx.params.provider). Plain
-// handlers default to an empty object.
+// The optional `params` arg covers dynamic-segment routes
+// (`/api/snapshots/[id]`, `/api/revoke/[id]`, `/api/auth/[provider]/*`)
+// — Pages picks the segment name off the filename and surfaces it on
+// `ctx.params`. Plain handlers get the default empty object.
 export async function invoke<E>(
   handler: PagesFunction<E>,
   req: Request,

--- a/packages/share-backend/tests/publish.test.ts
+++ b/packages/share-backend/tests/publish.test.ts
@@ -1,0 +1,769 @@
+import { describe, expect, it } from 'vitest'
+import type { KVNamespace } from '@cloudflare/workers-types'
+
+import type { SessionRecord } from '../src/auth/session'
+import { isValidSlug, nanoidSlug } from '../src/publish/slug'
+
+import { emptyState, makeDb, makeKv, makeR2, type FakeDbState } from './_helpers/fakes'
+
+const TOKEN = 'p'.repeat(40)
+
+function seedUser(state: FakeDbState, id = 'user-1'): void {
+  state.users.push({
+    id,
+    google_sub: `g-${id}`,
+    email: `${id}@example.com`,
+    name: id,
+    avatar_url: null,
+    created_at: Date.now(),
+    last_signin_at: Date.now(),
+    deletion_pending_until: null,
+    deleted_at: null,
+  })
+}
+
+async function seedSession(kv: KVNamespace, token: string, user_id: string): Promise<void> {
+  const now = Date.now()
+  const rec: SessionRecord = {
+    user_id,
+    created: now,
+    exp: now + 30 * 24 * 3600 * 1000,
+    last_seen: now,
+  }
+  await kv.put(`session/${token}`, JSON.stringify(rec), { expirationTtl: 30 * 24 * 3600 })
+}
+
+function envFor(state?: FakeDbState) {
+  const { db, state: s } = makeDb(state ?? emptyState())
+  const snapshots = makeR2()
+  const og = makeR2()
+  return {
+    DB: db,
+    SESSIONS: makeKv(),
+    META: makeKv(),
+    RATE: makeKv(),
+    SNAPSHOTS: snapshots.bucket,
+    OG: og.bucket,
+    state: s,
+    _snapshots: snapshots.store,
+    _og: og.store,
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function ctxFor(req: Request, env: Record<string, unknown>, params: Record<string, string> = {}): any {
+  return {
+    request: req,
+    env,
+    next: async () => new Response('not-found', { status: 404 }),
+    params,
+    waitUntil: (p: Promise<unknown>) => { void p },
+    passThroughOnException: () => undefined,
+    data: {},
+  }
+}
+
+function makeSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: 1,
+    source: {
+      kind: 'spool-session',
+      captured_at: new Date().toISOString(),
+    },
+    conversation: {
+      title: 'A nice chat',
+      turns: [
+        { id: 't1', role: 'user', content: 'Hello there.' },
+        { id: 't2', role: 'assistant', content: 'Hi!' },
+      ],
+      turn_order: ['t1', 't2'],
+      hidden_turns: [],
+    },
+    editor_opts: {
+      template: 'forum',
+      paper: 'cream',
+      typeface: 'geist',
+      colorway: 'amber',
+      density: 'relaxed',
+      masthead: true,
+      colophon: true,
+      avatars: true,
+      show_byline: true,
+    },
+    ...overrides,
+  }
+}
+
+function authedReq(url: string, body?: unknown, token = TOKEN): Request {
+  const init: RequestInit = {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      'CF-Connecting-IP': '1.2.3.4',
+    },
+  }
+  // Auto-inject defaults for `draft_id` and `idempotency_key` on
+  // /api/publish so the existing body fixtures don't all need to be
+  // touched. Tests that explicitly exercise either contract should set
+  // the field on the body directly (which takes precedence — we only
+  // fill the gap). The default idempotency key is per-call-unique to
+  // mirror the renderer (a real client hashes the payload, so the same
+  // intent reuses the key; tests that need that reuse pass it explicitly).
+  let payload = body
+  if (
+    url.endsWith('/api/publish') &&
+    body &&
+    typeof body === 'object' &&
+    'snapshot' in (body as Record<string, unknown>)
+  ) {
+    const obj = body as Record<string, unknown>
+    payload = {
+      draft_id: 'test-draft-id',
+      idempotency_key: 'key-' + Math.random().toString(36).slice(2, 10).padEnd(8, 'x'),
+      ...obj,
+    }
+  }
+  if (payload !== undefined) init.body = JSON.stringify(payload)
+  return new Request(url, init)
+}
+
+// ────────────────────────────────────────────────────────────────────
+// nanoidSlug + isValidSlug
+// ────────────────────────────────────────────────────────────────────
+
+describe('nanoidSlug', () => {
+  it('returns length 21', () => {
+    expect(nanoidSlug()).toHaveLength(21)
+  })
+
+  it('only contains [\\w-] characters', () => {
+    for (let i = 0; i < 50; i++) {
+      const s = nanoidSlug()
+      expect(s).toMatch(/^[\w-]{21}$/)
+    }
+  })
+
+  it('produces 1000 distinct values', () => {
+    const seen = new Set<string>()
+    for (let i = 0; i < 1000; i++) seen.add(nanoidSlug())
+    expect(seen.size).toBe(1000)
+  })
+})
+
+describe('isValidSlug', () => {
+  it('accepts a freshly generated slug', () => {
+    expect(isValidSlug(nanoidSlug())).toBe(true)
+  })
+  it('rejects wrong length', () => {
+    expect(isValidSlug('a'.repeat(20))).toBe(false)
+    expect(isValidSlug('a'.repeat(22))).toBe(false)
+  })
+  it('rejects bad characters', () => {
+    expect(isValidSlug('!'.repeat(21))).toBe(false)
+    expect(isValidSlug('a/'.repeat(10) + 'a')).toBe(false)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────
+// POST /api/publish
+// ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/publish', () => {
+  it('401 when unauthenticated', async () => {
+    const { onRequestPost } = await import('../functions/api/publish')
+    const env = envFor()
+    const req = new Request('https://x/api/publish', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ snapshot: makeSnapshot(), visibility: 'unlisted' }),
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(401)
+  })
+
+  it('422 when payload exceeds 2MB', async () => {
+    const { onRequestPost } = await import('../functions/api/publish')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const big = 'x'.repeat(2 * 1024 * 1024 + 10)
+    const req = authedReq('https://x/api/publish', { snapshot: makeSnapshot(), visibility: 'unlisted', _pad: big })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(422)
+    expect(((await res.json()) as { detail: string }).detail).toMatch(/too large/)
+  })
+
+  it('422 + zod issues when snapshot shape is invalid', async () => {
+    const { onRequestPost } = await import('../functions/api/publish')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const bad = makeSnapshot()
+    // Break the schema — title missing.
+    delete (bad as { conversation: { title?: string } }).conversation.title
+    const req = authedReq('https://x/api/publish', { snapshot: bad, visibility: 'unlisted' })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(422)
+    const body = await res.json() as { issues?: unknown[] }
+    expect(Array.isArray(body.issues)).toBe(true)
+  })
+
+  it('accepts content that contains literal credential-looking strings (no server rescan)', async () => {
+    const { onRequestPost } = await import('../functions/api/publish')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const snap = makeSnapshot()
+    // A literal Stripe-shaped key the client failed to redact / chose
+    // to keep. The server no longer rescans — the client gate is the
+    // sole boundary for what reaches R2 — so this must succeed.
+    snap.conversation.turns = [
+      { id: 't1', role: 'user', content: 'paste: sk_xxxx_aH1xK9pQrSt7VwYzA3bC5dF8gJ' },
+    ]
+    snap.conversation.turn_order = ['t1']
+    const req = authedReq('https://x/api/publish', { snapshot: snap, visibility: 'unlisted' })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(200)
+  })
+
+  it('preserves turns[].redacted informational flag through R2', async () => {
+    const { onRequestPost } = await import('../functions/api/publish')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const snap = makeSnapshot() as ReturnType<typeof makeSnapshot> & {
+      conversation: { turns: Array<{ id: string; role: string; content: string; redacted?: boolean }> }
+    }
+    snap.conversation.turns = [
+      { id: 't1', role: 'user', content: 'I emailed [redacted].', redacted: true },
+      { id: 't2', role: 'assistant', content: 'Got it.' },
+    ]
+    snap.conversation.turn_order = ['t1', 't2']
+    const req = authedReq('https://x/api/publish', { snapshot: snap, visibility: 'unlisted' })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(200)
+    const body = await res.json() as { id: string }
+    const stored = env._snapshots.get(`${body.id}.json`)
+    expect(stored).toBeTruthy()
+    const full = JSON.parse(new TextDecoder().decode(stored!.bytes)) as {
+      conversation: { turns: Array<{ id: string; redacted?: boolean }> }
+    }
+    expect(full.conversation.turns[0]!.redacted).toBe(true)
+    expect(full.conversation.turns[1]!.redacted).toBeUndefined()
+  })
+
+  it('422 when visibility=profile-listed without a handle', async () => {
+    const { onRequestPost } = await import('../functions/api/publish')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/publish', {
+      snapshot: makeSnapshot(),
+      visibility: 'profile-listed',
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(422)
+    expect(((await res.json()) as { detail: string }).detail).toMatch(/handle/)
+  })
+
+  it('404 when republishing a slug not owned by the user', async () => {
+    const { onRequestPost } = await import('../functions/api/publish')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const otherSlug = nanoidSlug()
+    env.state.published_shares.push({
+      id: otherSlug,
+      user_id: 'someone-else',
+      title: 'theirs',
+      visibility: 'unlisted',
+      expires_at: null,
+      version: 1,
+      published_at: Date.now(),
+      republished_at: null,
+      revoked_at: null,
+    })
+    const req = authedReq('https://x/api/publish', {
+      snapshot: makeSnapshot(),
+      visibility: 'unlisted',
+      override_slug: otherSlug,
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(404)
+  })
+
+  it('429 when hourly cap is exceeded', async () => {
+    const { onRequestPost } = await import('../functions/api/publish')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const slot = Math.floor(Date.now() / 1000 / 3600)
+    await env.RATE.put(`rate/publish-h/user-1/${slot}`, '30', { expirationTtl: 3600 * 2 })
+    const req = authedReq('https://x/api/publish', {
+      snapshot: makeSnapshot(),
+      visibility: 'unlisted',
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(429)
+  })
+
+  it('happy path: snapshot in R2, KV meta written, D1 row inserted, slug returned', async () => {
+    const { onRequestPost } = await import('../functions/api/publish')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/publish', {
+      snapshot: makeSnapshot(),
+      visibility: 'unlisted',
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(200)
+    const body = await res.json() as { id: string; version: number; url: string }
+    expect(isValidSlug(body.id)).toBe(true)
+    expect(body.version).toBe(1)
+    expect(body.url).toBe(`https://spool.pro/s/${body.id}`)
+
+    expect(env._snapshots.has(`${body.id}.json`)).toBe(true)
+    const metaRaw = await env.META.get(`meta/${body.id}`)
+    expect(metaRaw).not.toBeNull()
+    const meta = JSON.parse(metaRaw!) as { owner: string; version: number; revoked_at: number | null }
+    expect(meta.owner).toBe('user-1')
+    expect(meta.version).toBe(1)
+    expect(meta.revoked_at).toBeNull()
+
+    const row = env.state.published_shares.find((s) => s.id === body.id)
+    expect(row).toBeTruthy()
+    expect(row?.user_id).toBe('user-1')
+    expect(row?.version).toBe(1)
+    expect(env.state.audit.some((a) => a.action === 'publish' && a.target_id === body.id)).toBe(true)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────
+// GET /api/snapshots/[id]
+// ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/snapshots/[id]', () => {
+  async function publishOne(env: ReturnType<typeof envFor>) {
+    const { onRequestPost } = await import('../functions/api/publish')
+    const req = authedReq('https://x/api/publish', {
+      snapshot: makeSnapshot(),
+      visibility: 'unlisted',
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    return (await res.json()) as { id: string; version: number }
+  }
+
+  it('200 + JSON body after publish', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const { id } = await publishOne(env)
+
+    const { onRequestGet } = await import('../functions/api/snapshots/[id]')
+    const req = new Request(`https://x/api/snapshots/${id}`)
+    const res = await onRequestGet(ctxFor(req, env, { id }))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('etag')).toBe(`"${id}-1"`)
+    const body = await res.json() as { id: string; publish: { version: number } }
+    expect(body.id).toBe(id)
+    expect(body.publish.version).toBe(1)
+  })
+
+  it('410 + tombstone JSON after revoke', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const { id } = await publishOne(env)
+
+    // Mark revoked in KV (revoke endpoint test below covers the full path).
+    const metaRaw = (await env.META.get(`meta/${id}`))!
+    const m = JSON.parse(metaRaw)
+    m.revoked_at = Date.now()
+    await env.META.put(`meta/${id}`, JSON.stringify(m))
+
+    const { onRequestGet } = await import('../functions/api/snapshots/[id]')
+    const req = new Request(`https://x/api/snapshots/${id}`)
+    const res = await onRequestGet(ctxFor(req, env, { id }))
+    expect(res.status).toBe(410)
+    const body = await res.json() as { revoked: boolean; at: number }
+    expect(body.revoked).toBe(true)
+    expect(typeof body.at).toBe('number')
+  })
+
+  it('404 for badly shaped slug', async () => {
+    const env = envFor()
+    const { onRequestGet } = await import('../functions/api/snapshots/[id]')
+    const req = new Request('https://x/api/snapshots/not-a-slug')
+    const res = await onRequestGet(ctxFor(req, env, { id: 'not-a-slug' }))
+    expect(res.status).toBe(404)
+  })
+
+  it('410 when expired', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const { id } = await publishOne(env)
+    const m = JSON.parse((await env.META.get(`meta/${id}`))!)
+    m.expires_at = Date.now() - 1000
+    await env.META.put(`meta/${id}`, JSON.stringify(m))
+
+    const { onRequestGet } = await import('../functions/api/snapshots/[id]')
+    const req = new Request(`https://x/api/snapshots/${id}`)
+    const res = await onRequestGet(ctxFor(req, env, { id }))
+    expect(res.status).toBe(410)
+    const body = await res.json() as { expired: boolean }
+    expect(body.expired).toBe(true)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────
+// Republish + revoke wiring
+// ────────────────────────────────────────────────────────────────────
+
+describe('republish + revoke', () => {
+  it('republish increments version, updates KV/R2, writes audit row', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+
+    const { onRequestPost: publish } = await import('../functions/api/publish')
+    const firstRes = await publish(ctxFor(
+      authedReq('https://x/api/publish', { snapshot: makeSnapshot(), visibility: 'unlisted' }),
+      env,
+    ))
+    const first = await firstRes.json() as { id: string; version: number }
+    expect(first.version).toBe(1)
+
+    const updated = makeSnapshot()
+    updated.conversation.title = 'Edited title'
+    const secondRes = await publish(ctxFor(
+      authedReq('https://x/api/publish', {
+        snapshot: updated,
+        visibility: 'unlisted',
+        override_slug: first.id,
+      }),
+      env,
+    ))
+    const second = await secondRes.json() as { id: string; version: number }
+    expect(second.id).toBe(first.id)
+    expect(second.version).toBe(2)
+
+    // D1 row updated, title changed, republished_at set.
+    const row = env.state.published_shares.find((s) => s.id === first.id)
+    expect(row?.version).toBe(2)
+    expect(row?.title).toBe('Edited title')
+    expect(row?.republished_at).toBeTruthy()
+
+    // KV meta version bumped.
+    const meta = JSON.parse((await env.META.get(`meta/${first.id}`))!) as { version: number }
+    expect(meta.version).toBe(2)
+
+    // R2 snapshot replaced.
+    const stored = env._snapshots.get(`${first.id}.json`)
+    expect(stored).toBeTruthy()
+    const fullSnap = JSON.parse(new TextDecoder().decode(stored!.bytes)) as { publish: { version: number } }
+    expect(fullSnap.publish.version).toBe(2)
+
+    // Two audit rows: one publish, one republish.
+    expect(env.state.audit.filter((a) => a.action === 'publish').length).toBe(1)
+    expect(env.state.audit.filter((a) => a.action === 'republish').length).toBe(1)
+  })
+
+  it('revoke marks meta + D1 and read returns 410', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const { onRequestPost: publish } = await import('../functions/api/publish')
+    const pRes = await publish(ctxFor(
+      authedReq('https://x/api/publish', { snapshot: makeSnapshot(), visibility: 'unlisted' }),
+      env,
+    ))
+    const { id } = await pRes.json() as { id: string }
+
+    const { onRequestPost: revoke } = await import('../functions/api/revoke/[id]')
+    const revokeReq = authedReq(`https://x/api/revoke/${id}`)
+    const revokeRes = await revoke(ctxFor(revokeReq, env, { id }))
+    expect(revokeRes.status).toBe(200)
+
+    const row = env.state.published_shares.find((s) => s.id === id)
+    expect(row?.revoked_at).toBeTruthy()
+    const meta = JSON.parse((await env.META.get(`meta/${id}`))!) as { revoked_at: number }
+    expect(typeof meta.revoked_at).toBe('number')
+    expect(env.state.audit.some((a) => a.action === 'revoke' && a.target_id === id)).toBe(true)
+
+    const { onRequestGet } = await import('../functions/api/snapshots/[id]')
+    const getReq = new Request(`https://x/api/snapshots/${id}`)
+    const getRes = await onRequestGet(ctxFor(getReq, env, { id }))
+    expect(getRes.status).toBe(410)
+  })
+
+  it('revoke 404 when slug is not owned', async () => {
+    const env = envFor()
+    seedUser(env.state, 'user-1')
+    seedUser(env.state, 'user-2')
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const otherSlug = nanoidSlug()
+    env.state.published_shares.push({
+      id: otherSlug,
+      user_id: 'user-2',
+      title: 'theirs',
+      visibility: 'unlisted',
+      expires_at: null,
+      version: 1,
+      published_at: Date.now(),
+      republished_at: null,
+      revoked_at: null,
+    })
+    const { onRequestPost: revoke } = await import('../functions/api/revoke/[id]')
+    const req = authedReq(`https://x/api/revoke/${otherSlug}`)
+    const res = await revoke(ctxFor(req, env, { id: otherSlug }))
+    expect(res.status).toBe(404)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────
+// Publish idempotency (client_request_id)
+// ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/publish — idempotency', () => {
+  it('returns the same slug + version when the same token is sent twice', async () => {
+    // Drives the "renderer's response dropped mid-flight" scenario:
+    // the user clicks Publish again with the same payload, so the same
+    // content hash, so the backend short-circuits to the original row
+    // instead of creating a second share.
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const key = 'fixed-idemp-token-abc123'
+
+    const first = await invoke(
+      publishPost,
+      authedReq('https://x/api/publish', {
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        idempotency_key: key,
+      }),
+      env,
+    )
+    expect(first.status).toBe(200)
+    const firstBody = (await first.json()) as { id: string; version: number }
+
+    const second = await invoke(
+      publishPost,
+      authedReq('https://x/api/publish', {
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        idempotency_key: key,
+      }),
+      env,
+    )
+    expect(second.status).toBe(200)
+    const secondBody = (await second.json()) as { id: string; version: number }
+
+    expect(secondBody.id).toBe(firstBody.id)
+    expect(secondBody.version).toBe(firstBody.version)
+    // No duplicate row written.
+    expect(env.state.published_shares.length).toBe(1)
+    // No second audit row (the short-circuit returns before the audit
+    // call, so the evidence of work mirrors what actually happened).
+    expect(env.state.audit.filter((a) => a.action === 'publish').length).toBe(1)
+  })
+
+  it('mints a new slug when a different token is sent for fresh content', async () => {
+    // The re-edited-intent path: user fails, edits something, retries.
+    // Different content hash ⇒ different token ⇒ a fresh publish is
+    // the correct behavior, not a short-circuit.
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+
+    const first = await invoke(
+      publishPost,
+      authedReq('https://x/api/publish', {
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        idempotency_key: 'token-AAAAA',
+      }),
+      env,
+    )
+    const second = await invoke(
+      publishPost,
+      authedReq('https://x/api/publish', {
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        idempotency_key: 'token-BBBBB',
+      }),
+      env,
+    )
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+    const a = (await first.json()) as { id: string }
+    const b = (await second.json()) as { id: string }
+    expect(b.id).not.toBe(a.id)
+    expect(env.state.published_shares.length).toBe(2)
+  })
+
+  it('ignores revoked rows when matching the token', async () => {
+    // A token that belonged to a revoked share must NOT short-circuit
+    // a fresh publish; otherwise revoke-then-publish-again would
+    // silently resurrect the tombstone (and 410 the user's "live" link).
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const key = 'reused-token'
+
+    const first = await invoke(
+      publishPost,
+      authedReq('https://x/api/publish', {
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        idempotency_key: key,
+      }),
+      env,
+    )
+    const original = (await first.json()) as { id: string }
+    // Tombstone the first share manually (simulates an explicit revoke).
+    const row = env.state.published_shares.find((s) => s.id === original.id)
+    row!.revoked_at = Date.now()
+
+    const second = await invoke(
+      publishPost,
+      authedReq('https://x/api/publish', {
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        idempotency_key: key,
+      }),
+      env,
+    )
+    expect(second.status).toBe(200)
+    const fresh = (await second.json()) as { id: string }
+    expect(fresh.id).not.toBe(original.id)
+    expect(env.state.published_shares.length).toBe(2)
+  })
+
+  it('republish carries the new token through to the row', async () => {
+    // Republish from the editor: same slug (via override_slug), but a
+    // fresh content hash from edits. After the UPDATE lands, the
+    // row's stored token is the NEW one; a re-retry of the republish
+    // with the new token short-circuits, but a re-retry of the ORIGINAL
+    // token would not (which is fine — the original intent's response
+    // was either already received or has long expired by now).
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+
+    const first = await invoke(
+      publishPost,
+      authedReq('https://x/api/publish', {
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        idempotency_key: 'token-AAAAA',
+      }),
+      env,
+    )
+    const a = (await first.json()) as { id: string }
+
+    const republished = await invoke(
+      publishPost,
+      authedReq('https://x/api/publish', {
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        override_slug: a.id,
+        idempotency_key: 'token-BBBBB',
+      }),
+      env,
+    )
+    expect(republished.status).toBe(200)
+    const row = env.state.published_shares.find((s) => s.id === a.id)
+    expect(row?.client_request_id).toBe('token-BBBBB')
+    expect(row?.version).toBe(2)
+  })
+
+  it('409 when republish lands a token already held by another live share', async () => {
+    // Two distinct drafts for the same user that happen to share
+    // identical snapshot+visibility+expires content hash to the same
+    // idempotency token. A republish that tries to bind the token to
+    // a *different* live row would violate UNIQUE(user_id,
+    // client_request_id). We want a clean 409 with a meaningful
+    // message, not a 500 leaking the raw constraint error string.
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const sharedToken = 'sharedtoken-12345'
+
+    const aRes = await invoke(
+      publishPost,
+      authedReq('https://x/api/publish', {
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        draft_id: 'draft-A',
+        idempotency_key: sharedToken,
+      }),
+      env,
+    )
+    expect(aRes.status).toBe(200)
+    const a = (await aRes.json()) as { id: string }
+
+    const bRes = await invoke(
+      publishPost,
+      authedReq('https://x/api/publish', {
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        draft_id: 'draft-B',
+        // Different token so the INSERT succeeds; this share is the
+        // "another live share" the republish is about to collide with.
+        idempotency_key: 'distinct-other-token',
+      }),
+      env,
+    )
+    expect(bRes.status).toBe(200)
+    const b = (await bRes.json()) as { id: string }
+
+    // Now republish B with the SAME token A already holds. The
+    // partial unique index fires on the UPDATE.
+    const collide = await invoke(
+      publishPost,
+      authedReq('https://x/api/publish', {
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        draft_id: 'draft-B',
+        idempotency_key: sharedToken,
+        override_slug: b.id,
+      }),
+      env,
+    )
+    expect(collide.status).toBe(409)
+    // A's row still carries the original token.
+    const aRow = env.state.published_shares.find((s) => s.id === a.id)
+    expect(aRow?.client_request_id).toBe(sharedToken)
+    // B's row is untouched (still at version 1, original token).
+    const bRow = env.state.published_shares.find((s) => s.id === b.id)
+    expect(bRow?.version).toBe(1)
+    expect(bRow?.client_request_id).toBe('distinct-other-token')
+  })
+
+  it('422 when idempotency_key is missing or too short', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    // Build the body manually so the test helper doesn't auto-fill.
+    const req = new Request('https://x/api/publish', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        'content-type': 'application/json',
+        'CF-Connecting-IP': '1.2.3.4',
+      },
+      body: JSON.stringify({
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        draft_id: 'test-draft-id',
+        // idempotency_key absent — zod min(8) should reject.
+      }),
+    })
+    const res = await invoke(publishPost, req, env)
+    expect(res.status).toBe(422)
+  })
+})

--- a/packages/share-backend/tests/publish.test.ts
+++ b/packages/share-backend/tests/publish.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import type { KVNamespace } from '@cloudflare/workers-types'
 
+import { onRequestPost as publishPost } from '../functions/api/publish'
+import { onRequestPost as revokePost } from '../functions/api/revoke/[id]'
+import { onRequestGet as snapshotGet } from '../functions/api/snapshots/[id]'
 import type { SessionRecord } from '../src/auth/session'
 import { isValidSlug, nanoidSlug } from '../src/publish/slug'
 
+import { invoke } from './_helpers/ctx'
 import { emptyState, makeDb, makeKv, makeR2, type FakeDbState } from './_helpers/fakes'
 
 const TOKEN = 'p'.repeat(40)
@@ -47,19 +51,6 @@ function envFor(state?: FakeDbState) {
     state: s,
     _snapshots: snapshots.store,
     _og: og.store,
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function ctxFor(req: Request, env: Record<string, unknown>, params: Record<string, string> = {}): any {
-  return {
-    request: req,
-    env,
-    next: async () => new Response('not-found', { status: 404 }),
-    params,
-    waitUntil: (p: Promise<unknown>) => { void p },
-    passThroughOnException: () => undefined,
-    data: {},
   }
 }
 
@@ -171,31 +162,28 @@ describe('isValidSlug', () => {
 
 describe('POST /api/publish', () => {
   it('401 when unauthenticated', async () => {
-    const { onRequestPost } = await import('../functions/api/publish')
     const env = envFor()
     const req = new Request('https://x/api/publish', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ snapshot: makeSnapshot(), visibility: 'unlisted' }),
     })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(publishPost, req, env)
     expect(res.status).toBe(401)
   })
 
   it('422 when payload exceeds 2MB', async () => {
-    const { onRequestPost } = await import('../functions/api/publish')
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
     const big = 'x'.repeat(2 * 1024 * 1024 + 10)
     const req = authedReq('https://x/api/publish', { snapshot: makeSnapshot(), visibility: 'unlisted', _pad: big })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(publishPost, req, env)
     expect(res.status).toBe(422)
     expect(((await res.json()) as { detail: string }).detail).toMatch(/too large/)
   })
 
   it('422 + zod issues when snapshot shape is invalid', async () => {
-    const { onRequestPost } = await import('../functions/api/publish')
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
@@ -203,14 +191,13 @@ describe('POST /api/publish', () => {
     // Break the schema — title missing.
     delete (bad as { conversation: { title?: string } }).conversation.title
     const req = authedReq('https://x/api/publish', { snapshot: bad, visibility: 'unlisted' })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(publishPost, req, env)
     expect(res.status).toBe(422)
     const body = await res.json() as { issues?: unknown[] }
     expect(Array.isArray(body.issues)).toBe(true)
   })
 
   it('accepts content that contains literal credential-looking strings (no server rescan)', async () => {
-    const { onRequestPost } = await import('../functions/api/publish')
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
@@ -223,12 +210,11 @@ describe('POST /api/publish', () => {
     ]
     snap.conversation.turn_order = ['t1']
     const req = authedReq('https://x/api/publish', { snapshot: snap, visibility: 'unlisted' })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(publishPost, req, env)
     expect(res.status).toBe(200)
   })
 
   it('preserves turns[].redacted informational flag through R2', async () => {
-    const { onRequestPost } = await import('../functions/api/publish')
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
@@ -241,7 +227,7 @@ describe('POST /api/publish', () => {
     ]
     snap.conversation.turn_order = ['t1', 't2']
     const req = authedReq('https://x/api/publish', { snapshot: snap, visibility: 'unlisted' })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(publishPost, req, env)
     expect(res.status).toBe(200)
     const body = await res.json() as { id: string }
     const stored = env._snapshots.get(`${body.id}.json`)
@@ -254,7 +240,6 @@ describe('POST /api/publish', () => {
   })
 
   it('422 when visibility=profile-listed without a handle', async () => {
-    const { onRequestPost } = await import('../functions/api/publish')
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
@@ -262,13 +247,12 @@ describe('POST /api/publish', () => {
       snapshot: makeSnapshot(),
       visibility: 'profile-listed',
     })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(publishPost, req, env)
     expect(res.status).toBe(422)
     expect(((await res.json()) as { detail: string }).detail).toMatch(/handle/)
   })
 
   it('404 when republishing a slug not owned by the user', async () => {
-    const { onRequestPost } = await import('../functions/api/publish')
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
@@ -289,27 +273,60 @@ describe('POST /api/publish', () => {
       visibility: 'unlisted',
       override_slug: otherSlug,
     })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(publishPost, req, env)
     expect(res.status).toBe(404)
   })
 
   it('429 when hourly cap is exceeded', async () => {
-    const { onRequestPost } = await import('../functions/api/publish')
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
-    const slot = Math.floor(Date.now() / 1000 / 3600)
-    await env.RATE.put(`rate/publish-h/user-1/${slot}`, '30', { expirationTtl: 3600 * 2 })
+    // Mirror PUBLISH_RATE_HOURLY_{WINDOW_SEC,MAX} from publish.ts.
+    const RATE_WINDOW_SEC = 3600
+    const RATE_MAX = 30
+    const slot = Math.floor(Date.now() / 1000 / RATE_WINDOW_SEC)
+    await env.RATE.put(`rate/publish-h/user-1/${slot}`, String(RATE_MAX), {
+      expirationTtl: RATE_WINDOW_SEC * 2,
+    })
     const req = authedReq('https://x/api/publish', {
       snapshot: makeSnapshot(),
       visibility: 'unlisted',
     })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(publishPost, req, env)
     expect(res.status).toBe(429)
   })
 
+  it('422 when expires_at is already in the past', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const past = new Date(Date.now() - 60_000).toISOString()
+    const req = authedReq('https://x/api/publish', {
+      snapshot: makeSnapshot(),
+      visibility: 'unlisted',
+      expires_at: past,
+    })
+    const res = await invoke(publishPost, req, env)
+    expect(res.status).toBe(422)
+    expect(((await res.json()) as { detail: string }).detail).toMatch(/future/)
+  })
+
+  it('422 when expires_at is more than 1 year out', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const farFuture = new Date(Date.now() + 366 * 24 * 3600 * 1000).toISOString()
+    const req = authedReq('https://x/api/publish', {
+      snapshot: makeSnapshot(),
+      visibility: 'unlisted',
+      expires_at: farFuture,
+    })
+    const res = await invoke(publishPost, req, env)
+    expect(res.status).toBe(422)
+    expect(((await res.json()) as { detail: string }).detail).toMatch(/1 year/)
+  })
+
   it('happy path: snapshot in R2, KV meta written, D1 row inserted, slug returned', async () => {
-    const { onRequestPost } = await import('../functions/api/publish')
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
@@ -317,7 +334,7 @@ describe('POST /api/publish', () => {
       snapshot: makeSnapshot(),
       visibility: 'unlisted',
     })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(publishPost, req, env)
     expect(res.status).toBe(200)
     const body = await res.json() as { id: string; version: number; url: string }
     expect(isValidSlug(body.id)).toBe(true)
@@ -338,6 +355,24 @@ describe('POST /api/publish', () => {
     expect(row?.version).toBe(1)
     expect(env.state.audit.some((a) => a.action === 'publish' && a.target_id === body.id)).toBe(true)
   })
+
+  it('does not leak owner_user_id in the public snapshot JSON', async () => {
+    // owner_user_id used to be embedded in the R2 body — a free pivot
+    // point for anyone with a share URL. Author identity now belongs
+    // exclusively to /api/profiles/* (joinable by handle, not by raw id).
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/publish', {
+      snapshot: makeSnapshot(),
+      visibility: 'unlisted',
+    })
+    const res = await invoke(publishPost, req, env)
+    const body = (await res.json()) as { id: string }
+    const stored = env._snapshots.get(`${body.id}.json`)!
+    const full = JSON.parse(new TextDecoder().decode(stored.bytes)) as Record<string, unknown>
+    expect(full).not.toHaveProperty('owner_user_id')
+  })
 })
 
 // ────────────────────────────────────────────────────────────────────
@@ -346,12 +381,11 @@ describe('POST /api/publish', () => {
 
 describe('GET /api/snapshots/[id]', () => {
   async function publishOne(env: ReturnType<typeof envFor>) {
-    const { onRequestPost } = await import('../functions/api/publish')
     const req = authedReq('https://x/api/publish', {
       snapshot: makeSnapshot(),
       visibility: 'unlisted',
     })
-    const res = await onRequestPost(ctxFor(req, env))
+    const res = await invoke(publishPost, req, env)
     return (await res.json()) as { id: string; version: number }
   }
 
@@ -361,14 +395,28 @@ describe('GET /api/snapshots/[id]', () => {
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
     const { id } = await publishOne(env)
 
-    const { onRequestGet } = await import('../functions/api/snapshots/[id]')
     const req = new Request(`https://x/api/snapshots/${id}`)
-    const res = await onRequestGet(ctxFor(req, env, { id }))
+    const res = await invoke(snapshotGet, req, env, { id })
     expect(res.status).toBe(200)
     expect(res.headers.get('etag')).toBe(`"${id}-1"`)
     const body = await res.json() as { id: string; publish: { version: number } }
     expect(body.id).toBe(id)
     expect(body.publish.version).toBe(1)
+  })
+
+  it('sets a short, must-revalidate cache so revokes propagate within 30s', async () => {
+    // Reader CDN entry MUST expire fast enough that a panic revoke isn't
+    // stuck behind a long shared cache. 30s is the agreed budget.
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const { id } = await publishOne(env)
+    const req = new Request(`https://x/api/snapshots/${id}`)
+    const res = await invoke(snapshotGet, req, env, { id })
+    const cc = res.headers.get('cache-control') ?? ''
+    expect(cc).toMatch(/max-age=30\b/)
+    expect(cc).toMatch(/s-maxage=30\b/)
+    expect(cc).toMatch(/must-revalidate/)
   })
 
   it('410 + tombstone JSON after revoke', async () => {
@@ -383,9 +431,8 @@ describe('GET /api/snapshots/[id]', () => {
     m.revoked_at = Date.now()
     await env.META.put(`meta/${id}`, JSON.stringify(m))
 
-    const { onRequestGet } = await import('../functions/api/snapshots/[id]')
     const req = new Request(`https://x/api/snapshots/${id}`)
-    const res = await onRequestGet(ctxFor(req, env, { id }))
+    const res = await invoke(snapshotGet, req, env, { id })
     expect(res.status).toBe(410)
     const body = await res.json() as { revoked: boolean; at: number }
     expect(body.revoked).toBe(true)
@@ -394,9 +441,8 @@ describe('GET /api/snapshots/[id]', () => {
 
   it('404 for badly shaped slug', async () => {
     const env = envFor()
-    const { onRequestGet } = await import('../functions/api/snapshots/[id]')
     const req = new Request('https://x/api/snapshots/not-a-slug')
-    const res = await onRequestGet(ctxFor(req, env, { id: 'not-a-slug' }))
+    const res = await invoke(snapshotGet, req, env, { id: 'not-a-slug' })
     expect(res.status).toBe(404)
   })
 
@@ -409,9 +455,8 @@ describe('GET /api/snapshots/[id]', () => {
     m.expires_at = Date.now() - 1000
     await env.META.put(`meta/${id}`, JSON.stringify(m))
 
-    const { onRequestGet } = await import('../functions/api/snapshots/[id]')
     const req = new Request(`https://x/api/snapshots/${id}`)
-    const res = await onRequestGet(ctxFor(req, env, { id }))
+    const res = await invoke(snapshotGet, req, env, { id })
     expect(res.status).toBe(410)
     const body = await res.json() as { expired: boolean }
     expect(body.expired).toBe(true)
@@ -428,24 +473,25 @@ describe('republish + revoke', () => {
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
 
-    const { onRequestPost: publish } = await import('../functions/api/publish')
-    const firstRes = await publish(ctxFor(
+    const firstRes = await invoke(
+      publishPost,
       authedReq('https://x/api/publish', { snapshot: makeSnapshot(), visibility: 'unlisted' }),
       env,
-    ))
+    )
     const first = await firstRes.json() as { id: string; version: number }
     expect(first.version).toBe(1)
 
     const updated = makeSnapshot()
     updated.conversation.title = 'Edited title'
-    const secondRes = await publish(ctxFor(
+    const secondRes = await invoke(
+      publishPost,
       authedReq('https://x/api/publish', {
         snapshot: updated,
         visibility: 'unlisted',
         override_slug: first.id,
       }),
       env,
-    ))
+    )
     const second = await secondRes.json() as { id: string; version: number }
     expect(second.id).toBe(first.id)
     expect(second.version).toBe(2)
@@ -471,20 +517,67 @@ describe('republish + revoke', () => {
     expect(env.state.audit.filter((a) => a.action === 'republish').length).toBe(1)
   })
 
+  it('409 when a concurrent republish bumps version before the UPDATE lands', async () => {
+    // Reproduces the SELECT-then-UPDATE race: the handler reads version=1,
+    // computes v=2, and tries to write WHERE version=1. Another worker
+    // landed a republish first (version is now 2) → UPDATE matches 0 rows
+    // → optimistic-concurrency check turns it into 409 instead of silently
+    // clobbering the winner.
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+
+    const firstRes = await invoke(
+      publishPost,
+      authedReq('https://x/api/publish', { snapshot: makeSnapshot(), visibility: 'unlisted' }),
+      env,
+    )
+    const first = await firstRes.json() as { id: string }
+
+    // Force the WHERE version=? clause to miss by mutating the stored
+    // row's version *after* the seeded SELECT path would observe v=1.
+    // Real-D1: a concurrent UPDATE landed in the same window. Test-D1:
+    // we just intercept the UPDATE to return changes=0.
+    const realPrepare = env.DB.prepare.bind(env.DB)
+    const intercept = (sql: string) => {
+      const stmt = realPrepare(sql)
+      if (/^UPDATE published_shares SET title=\?, visibility=\?/i.test(sql)) {
+        return {
+          bind: () => ({
+            run: async () => ({ success: true, meta: { changes: 0 } }),
+          }),
+        } as unknown as ReturnType<typeof realPrepare>
+      }
+      return stmt
+    }
+    ;(env.DB as unknown as { prepare: typeof realPrepare }).prepare =
+      intercept as unknown as typeof realPrepare
+
+    const res = await invoke(
+      publishPost,
+      authedReq('https://x/api/publish', {
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        override_slug: first.id,
+      }),
+      env,
+    )
+    expect(res.status).toBe(409)
+  })
+
   it('revoke marks meta + D1 and read returns 410', async () => {
     const env = envFor()
     seedUser(env.state)
     await seedSession(env.SESSIONS, TOKEN, 'user-1')
-    const { onRequestPost: publish } = await import('../functions/api/publish')
-    const pRes = await publish(ctxFor(
+    const pRes = await invoke(
+      publishPost,
       authedReq('https://x/api/publish', { snapshot: makeSnapshot(), visibility: 'unlisted' }),
       env,
-    ))
+    )
     const { id } = await pRes.json() as { id: string }
 
-    const { onRequestPost: revoke } = await import('../functions/api/revoke/[id]')
     const revokeReq = authedReq(`https://x/api/revoke/${id}`)
-    const revokeRes = await revoke(ctxFor(revokeReq, env, { id }))
+    const revokeRes = await invoke(revokePost, revokeReq, env, { id })
     expect(revokeRes.status).toBe(200)
 
     const row = env.state.published_shares.find((s) => s.id === id)
@@ -493,9 +586,8 @@ describe('republish + revoke', () => {
     expect(typeof meta.revoked_at).toBe('number')
     expect(env.state.audit.some((a) => a.action === 'revoke' && a.target_id === id)).toBe(true)
 
-    const { onRequestGet } = await import('../functions/api/snapshots/[id]')
     const getReq = new Request(`https://x/api/snapshots/${id}`)
-    const getRes = await onRequestGet(ctxFor(getReq, env, { id }))
+    const getRes = await invoke(snapshotGet, getReq, env, { id })
     expect(getRes.status).toBe(410)
   })
 
@@ -516,9 +608,8 @@ describe('republish + revoke', () => {
       republished_at: null,
       revoked_at: null,
     })
-    const { onRequestPost: revoke } = await import('../functions/api/revoke/[id]')
     const req = authedReq(`https://x/api/revoke/${otherSlug}`)
-    const res = await revoke(ctxFor(req, env, { id: otherSlug }))
+    const res = await invoke(revokePost, req, env, { id: otherSlug })
     expect(res.status).toBe(404)
   })
 })

--- a/packages/share-backend/tests/publish.test.ts
+++ b/packages/share-backend/tests/publish.test.ts
@@ -15,7 +15,6 @@ const TOKEN = 'p'.repeat(40)
 function seedUser(state: FakeDbState, id = 'user-1'): void {
   state.users.push({
     id,
-    google_sub: `g-${id}`,
     email: `${id}@example.com`,
     name: id,
     avatar_url: null,

--- a/packages/share-backend/tests/publish.test.ts
+++ b/packages/share-backend/tests/publish.test.ts
@@ -326,6 +326,77 @@ describe('POST /api/publish', () => {
     expect(((await res.json()) as { detail: string }).detail).toMatch(/1 year/)
   })
 
+  it('expires_at at the 5-minute / 1-year boundaries: just-below = 422, just-above = 200', async () => {
+    // Pin "now" indirectly: server reads Date.now() once at handler entry,
+    // so we generate offsets relative to the very recent past. The 4-min
+    // candidate is unambiguously inside the floor; the 6-min candidate is
+    // unambiguously outside it; same logic at the 1-year ceiling.
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const now = Date.now()
+    const justBelowFloor = new Date(now + 4 * 60 * 1000).toISOString()
+    const justAboveFloor = new Date(now + 6 * 60 * 1000).toISOString()
+    const justBelowCeiling = new Date(now + (365 * 24 * 3600 - 60) * 1000).toISOString()
+    const justAboveCeiling = new Date(now + (365 * 24 * 3600 + 600) * 1000).toISOString()
+
+    const cases: Array<{ at: string; status: number }> = [
+      { at: justBelowFloor, status: 422 },
+      { at: justAboveFloor, status: 200 },
+      { at: justBelowCeiling, status: 200 },
+      { at: justAboveCeiling, status: 422 },
+    ]
+    for (const c of cases) {
+      const req = authedReq('https://x/api/publish', {
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        expires_at: c.at,
+      })
+      const res = await invoke(publishPost, req, env)
+      expect(res.status, `expires_at=${c.at}`).toBe(c.status)
+    }
+  })
+
+  it('422 when turn_order length does not match turns count', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const snap = makeSnapshot()
+    // 2 turns but turn_order names 3 entries — reader would render
+    // missing content otherwise.
+    snap.conversation.turn_order = ['t1', 't2', 't3']
+    const req = authedReq('https://x/api/publish', { snapshot: snap, visibility: 'unlisted' })
+    const res = await invoke(publishPost, req, env)
+    expect(res.status).toBe(422)
+    const body = (await res.json()) as { issues: Array<{ message: string }> }
+    expect(body.issues.some((i) => /turn_order/.test(i.message))).toBe(true)
+  })
+
+  it('422 when turn_order references a turn id that does not exist', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const snap = makeSnapshot()
+    snap.conversation.turn_order = ['t1', 'nope']
+    const req = authedReq('https://x/api/publish', { snapshot: snap, visibility: 'unlisted' })
+    const res = await invoke(publishPost, req, env)
+    expect(res.status).toBe(422)
+  })
+
+  it('returns the share URL using PUBLIC_BASE_URL when present', async () => {
+    const env = { ...envFor(), PUBLIC_BASE_URL: 'http://localhost:5173' }
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/publish', {
+      snapshot: makeSnapshot(),
+      visibility: 'unlisted',
+    })
+    const res = await invoke(publishPost, req, env)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { url: string }
+    expect(body.url).toMatch(/^http:\/\/localhost:5173\/s\//)
+  })
+
   it('happy path: snapshot in R2, KV meta written, D1 row inserted, slug returned', async () => {
     const env = envFor()
     seedUser(env.state)
@@ -565,6 +636,38 @@ describe('republish + revoke', () => {
     expect(res.status).toBe(409)
   })
 
+  it('404 when republishing a slug that is already revoked', async () => {
+    // The SELECT inside publish.ts filters `revoked_at IS NULL`, so a
+    // revoked share looks like "not found" to the republish path even
+    // though the row physically exists. Without this guard a user could
+    // un-tombstone a revoked share by re-asserting it at v(N+1).
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const slug = nanoidSlug()
+    env.state.published_shares.push({
+      id: slug,
+      user_id: 'user-1',
+      title: 'mine',
+      visibility: 'unlisted',
+      expires_at: null,
+      version: 1,
+      published_at: Date.now() - 60_000,
+      republished_at: null,
+      revoked_at: Date.now() - 1000,
+    })
+    const res = await invoke(
+      publishPost,
+      authedReq('https://x/api/publish', {
+        snapshot: makeSnapshot(),
+        visibility: 'unlisted',
+        override_slug: slug,
+      }),
+      env,
+    )
+    expect(res.status).toBe(404)
+  })
+
   it('revoke marks meta + D1 and read returns 410', async () => {
     const env = envFor()
     seedUser(env.state)
@@ -589,6 +692,34 @@ describe('republish + revoke', () => {
     const getReq = new Request(`https://x/api/snapshots/${id}`)
     const getRes = await invoke(snapshotGet, getReq, env, { id })
     expect(getRes.status).toBe(410)
+  })
+
+  it('revoke 429 when the per-user hourly cap is exceeded', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const slug = nanoidSlug()
+    env.state.published_shares.push({
+      id: slug,
+      user_id: 'user-1',
+      title: 'mine',
+      visibility: 'unlisted',
+      expires_at: null,
+      version: 1,
+      published_at: Date.now(),
+      republished_at: null,
+      revoked_at: null,
+    })
+    // Mirror REVOKE_RATE_{WINDOW_SEC,MAX} from revoke/[id].ts.
+    const RATE_WINDOW_SEC = 3600
+    const RATE_MAX = 60
+    const slot = Math.floor(Date.now() / 1000 / RATE_WINDOW_SEC)
+    await env.RATE.put(`rate/revoke/user-1/${slot}`, String(RATE_MAX), {
+      expirationTtl: RATE_WINDOW_SEC * 2,
+    })
+    const req = authedReq(`https://x/api/revoke/${slug}`)
+    const res = await invoke(revokePost, req, env, { id: slug })
+    expect(res.status).toBe(429)
   })
 
   it('revoke 404 when slug is not owned', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       mdast-util-to-string:
         specifier: ^4
         version: 4.0.0
+      pure-rand:
+        specifier: ^6.1.0
+        version: 6.1.0
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -109,9 +112,6 @@ importers:
       react-virtuoso:
         specifier: ^4.18.6
         version: 4.18.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      pure-rand:
-        specifier: ^6.1.0
-        version: 6.1.0
       rehype-sanitize:
         specifier: ^6
         version: 6.0.0
@@ -305,6 +305,10 @@ importers:
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
   packages/share-backend:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20260415.1


### PR DESCRIPTION
## What

Adds the three endpoints that put / get / withdraw a share:

- `POST /api/publish` — first-publish or republish (uses optional `override_slug`); content-hash idempotent; rate-limited per-user (30/h, 100/d)
- `GET /api/snapshots/<id>` — public read; serves the snapshot body from R2 or a 410 tombstone if revoked / expired
- `POST /api/revoke/<id>` — owner-only tombstone of a live share

Plus supporting code:
- `src/publish/validators.ts` — Zod schema for the publish body (snapshot envelope, visibility, expires_at, optional `override_slug` for republish)
- `src/publish/slug.ts` — `nanoidSlug()` (21 chars) + `isValidSlug()` (regex `^[\w-]{21}$`)

## Why

These three handlers are the entire lifecycle of a share, and they all share state machines (idempotency key, version bump, tombstone semantics). Splitting them into separate PRs would mean each one carries half the helper code, half the test fixture, and the contracts would drift between landings.

The crucial invariants — D1 write first, KV tombstone second, R2 third; idempotency keyed on a client-derived sha256; `override_slug` is the **only** way to address an existing slug — only stay coherent when read as one diff.

## Write order

Every state-changing path uses the same discipline: D1 (source of truth) → KV META (read-path tombstone gate) → R2 (bulk body). Partial failure leaves the row in a consistent state from the **owner's** point of view; the reader sees a single coherent answer; a retry can complete the missing tail without orphan rows.

```mermaid
flowchart TD
    P([POST /api/publish]) -->|insert / update| D1[(D1 published_shares)]
    D1 -->|on commit| MET[(KV META)]
    MET --> R2[(R2 SNAPSHOTS)]
    R2 -.OG fire-and-forget.-> OG[(R2 OG)]

    R([POST /api/revoke/:id]) -->|UPDATE revoked_at| D1
    D1 -.->|stamp revoked_at| MET
    MET -.waitUntil.-> DEL[Delete R2 SNAPSHOT + OG]

    G([GET /api/snapshots/:id]) -->|read meta first| MET
    MET -->|live| R2
    MET -->|revoked / expired| T[410 tombstone JSON]
```

## Publish state machine

```mermaid
stateDiagram-v2
    [*] --> Validating
    Validating --> RateLimited: 30/h or 100/d trip
    Validating --> Sized: body ≤ 2MB
    Sized --> ContentHashed: snapshot hash = idempotency_key
    ContentHashed --> Idempotent_hit: token matches live row
    Idempotent_hit --> [*]: 200 with original slug
    ContentHashed --> Republish: override_slug set
    Republish --> ConcurrentRetry: meta.changes==0 → 409
    Republish --> Bumped: UPDATE OK, version++
    ContentHashed --> First: no override_slug
    First --> SlugMint: nanoid(21)
    SlugMint --> Inserted
    First --> ConcurrentInsertRetry: UNIQUE(user, token) → re-read row, 200
    Bumped --> Persisted
    Inserted --> Persisted
    Persisted --> KV_META: meta/<slug>
    KV_META --> R2_Body: <slug>.json
    R2_Body --> OG_FireAndForget
    OG_FireAndForget --> [*]
```

## Revoke + read

```mermaid
sequenceDiagram
    autonumber
    participant O as Owner
    participant Rv as POST /api/revoke/:id
    participant D as D1
    participant K as KV META
    participant R2 as R2 SNAPSHOTS
    participant Rd as Reader (GET /api/snapshots/:id)

    O->>Rv: revoke slug
    Rv->>Rv: requireUser, rate-limit (60/h), owner-scope check
    Rv->>D: UPDATE revoked_at=now WHERE id=?
    Rv->>K: meta.revoked_at = now
    Rv-->>Rv: waitUntil(delete R2 snapshot + OG)
    Rv-->>O: 200 { ok: true }
    Rd->>K: GET meta/<id>
    K-->>Rd: { revoked_at: <ts> }
    Rd-->>Rd: 410 Gone + tombstone JSON (no-store)
```

## Correctness notes

- **Idempotency lookup excludes revoked rows.** `(user_id, client_request_id) WHERE revoked_at IS NULL` lets a publish-then-revoke-then-republish recycle the same content hash onto a fresh slug instead of resurrecting the tombstoned one.
- **Republish requires `override_slug`.** No "I think you meant to update slug X" inference — the renderer either targets a specific slug or asks for a new one. Eliminates a class of "wrong share got mutated" bugs.
- **Optimistic concurrency on republish.** `UPDATE … WHERE version=?` against the version we just SELECTed. Two concurrent republishers can't silently overwrite each other — the second sees `changes=0` and gets `409 CONFLICT`.
- **`draft_id` healing.** Pre-PR rows have `draft_id IS NULL`. A republish carrying a `draft_id` writes it through; once written it's immutable (any mismatch is `400 bad request`). This keeps "which draft owns which slug" stable for the slug's lifetime without forcing a schema backfill.
- **Body cap.** 2 MiB. ~10× a typical session export and far short of anything that would exhaust a Worker memory budget.
- **`expires_at` bounds.** ≥5 min (clock-skew guard, blocks instant-tombstoned publishes) and ≤1 year (matches retention policy).
- **Tombstone JSON.** `410 Gone` with `{ revoked: true, at }` or `{ expired: true, at }`. Reader pages render this as a friendly "this share was withdrawn" page instead of a generic browser 404.
- **No `owner_user_id` in the public JSON.** Anyone with a slug already knows the share exists; exposing the internal user id would hand them a pivot into a user-enumeration vector via `/api/profiles/*`.
- **OG render is `waitUntil`.** A broken render logs but doesn't fail the publish. A user's session is published the moment the D1 row lands; the OG image catches up best-effort.

## Verification

- `pnpm --filter @spool-lab/share-backend test` — publish.test.ts covers: happy publish, republish bumps version, idempotency short-circuit, revoke-then-republish mints new slug, concurrent republish lands one 200 + one 409, body too large, expires_at bounds, profile-listed without handle 4xx, slug regex, tombstone 410 (revoked + expired), R2 missing → 404
- Manual: wrangler dev, sign in, publish a snapshot, `curl` the public read, revoke, public read returns 410

## Risk

Schema is the same as PR #356. Endpoints are additive. Renderer code that calls these endpoints comes in later stack PRs and is gated by `featureFlags.ts` `share: DEV || envFlag('SHARE')` — prod doesn't set the env, so this PR is dormant on `main` until the gate flips.

Submitted by @graydawnc.