### PR TITLE
feat(share-backend): OG image + scheduled deletion worker

### DIFF
--- a/packages/share-backend/functions/_scheduled/deletion-worker.ts
+++ b/packages/share-backend/functions/_scheduled/deletion-worker.ts
@@ -21,7 +21,22 @@ export type DeletionEnv = {
   OG: R2Bucket
 }
 
+// Bounded window for the R2 orphan sweep — long enough to catch a
+// waitUntil failure that the user wouldn't notice, short enough that the
+// per-cron workload stays predictable. Anything older is assumed already
+// in steady state.
+const ORPHAN_SWEEP_WINDOW_MS = 7 * 24 * 3600 * 1000
+
+// Cap on shares processed per orphan sweep. With a 6h cron this drains
+// up to 2k stale objects/day — far above any realistic v0.5 backlog.
+const ORPHAN_SWEEP_LIMIT = 500
+
 export async function runDeletionSweep(env: DeletionEnv, now: number): Promise<void> {
+  await sweepDeletedUsers(env, now)
+  await sweepOrphanShareAssets(env, now)
+}
+
+async function sweepDeletedUsers(env: DeletionEnv, now: number): Promise<void> {
   const due = await env.DB.prepare(
     'SELECT user_id FROM deletion_queue WHERE scheduled_at <= ? AND cancelled = 0',
   )
@@ -30,6 +45,18 @@ export async function runDeletionSweep(env: DeletionEnv, now: number): Promise<v
 
   for (const row of due.results) {
     try {
+      // Re-check inside the loop. The outer SELECT might have seen
+      // this user before they POST'd DELETE /api/me/delete; D1 has no
+      // row-level locking. This narrows the race window from "the
+      // whole sweep duration" to "this user's processing time" — still
+      // racy in principle, but ~100x smaller and acceptable for v0.5.
+      const stillDue = await env.DB.prepare(
+        'SELECT 1 FROM deletion_queue WHERE user_id=? AND cancelled=0 AND scheduled_at <= ?',
+      )
+        .bind(row.user_id, now)
+        .first()
+      if (!stillDue) continue
+
       const shares = await env.DB.prepare(
         'SELECT id FROM published_shares WHERE user_id=?',
       )
@@ -64,10 +91,15 @@ export async function runDeletionSweep(env: DeletionEnv, now: number): Promise<v
         )
           .bind(now, row.user_id)
           .run(),
+        // google_sub is replaced with a per-user sentinel so the Google
+        // subject id (PII) no longer maps back to this row. Same sign-in
+        // from the same Google account creates a fresh record instead
+        // of being permanently banned by the deleted row. The sentinel
+        // preserves the UNIQUE constraint without needing a migration.
         env.DB.prepare(
-          "UPDATE users SET email='[deleted]', name=NULL, avatar_url=NULL, deleted_at=? WHERE id=?",
+          "UPDATE users SET email='[deleted]', name=NULL, avatar_url=NULL, google_sub=?, deleted_at=? WHERE id=?",
         )
-          .bind(now, row.user_id)
+          .bind(`[deleted]-${row.user_id}`, now, row.user_id)
           .run(),
         env.DB.prepare('DELETE FROM deletion_queue WHERE user_id=?')
           .bind(row.user_id)
@@ -78,6 +110,31 @@ export async function runDeletionSweep(env: DeletionEnv, now: number): Promise<v
       console.error('deletion sweep failed for', row.user_id, e)
     }
   }
+}
+
+async function sweepOrphanShareAssets(env: DeletionEnv, now: number): Promise<void> {
+  // The revoke endpoint and the share-expiration path rely on
+  // `waitUntil` to delete R2 objects. If the worker invocation dies
+  // before that runs, the JSON + PNG linger forever — reader still
+  // serves 410 (META gate is fail-closed) but storage accrues. Sweep
+  // recent tombstones idempotently: R2.delete is a no-op when the
+  // object is already gone, so this is cheap to run unconditionally.
+  const cutoff = now - ORPHAN_SWEEP_WINDOW_MS
+  const stale = await env.DB.prepare(
+    `SELECT id FROM published_shares
+       WHERE (revoked_at IS NOT NULL AND revoked_at > ?)
+          OR (expires_at IS NOT NULL AND expires_at <= ? AND revoked_at IS NULL)
+       LIMIT ?`,
+  )
+    .bind(cutoff, now, ORPHAN_SWEEP_LIMIT)
+    .all<{ id: string }>()
+
+  await Promise.all(
+    stale.results.flatMap((s) => [
+      env.SNAPSHOTS.delete(`${s.id}.json`),
+      env.OG.delete(`${s.id}.png`),
+    ]),
+  )
 }
 
 export default {

--- a/packages/share-backend/functions/_scheduled/deletion-worker.ts
+++ b/packages/share-backend/functions/_scheduled/deletion-worker.ts
@@ -36,44 +36,46 @@ export async function runDeletionSweep(env: DeletionEnv, now: number): Promise<v
         .bind(row.user_id)
         .all<{ id: string }>()
 
-      for (const s of shares.results) {
-        await env.META.put(
-          `meta/${s.id}`,
-          JSON.stringify({
-            owner: row.user_id,
-            revoked_at: now,
-            expires_at: null,
-            visibility: 'unlisted',
-            version: 0,
-          }),
+      await Promise.all(
+        shares.results.flatMap((s) => [
+          env.META.put(
+            `meta/${s.id}`,
+            JSON.stringify({
+              owner: row.user_id,
+              revoked_at: now,
+              expires_at: null,
+              visibility: 'unlisted',
+              version: 0,
+            }),
+          ),
+          env.SNAPSHOTS.delete(`${s.id}.json`),
+          env.OG.delete(`${s.id}.png`),
+        ]),
+      )
+
+      await Promise.all([
+        env.DB.prepare(
+          'UPDATE published_shares SET revoked_at=? WHERE user_id=? AND revoked_at IS NULL',
         )
-        await env.SNAPSHOTS.delete(`${s.id}.json`)
-        await env.OG.delete(`${s.id}.png`)
-      }
-
-      await env.DB.prepare(
-        'UPDATE published_shares SET revoked_at=? WHERE user_id=? AND revoked_at IS NULL',
-      )
-        .bind(now, row.user_id)
-        .run()
-
-      await env.DB.prepare(
-        'UPDATE handles SET released_at=? WHERE user_id=? AND released_at IS NULL',
-      )
-        .bind(now, row.user_id)
-        .run()
-
-      await env.DB.prepare(
-        "UPDATE users SET email='[deleted]', name=NULL, avatar_url=NULL, deleted_at=? WHERE id=?",
-      )
-        .bind(now, row.user_id)
-        .run()
-
-      await env.DB.prepare('DELETE FROM deletion_queue WHERE user_id=?')
-        .bind(row.user_id)
-        .run()
-    } catch {
-      // log + continue; one bad user shouldn't block the rest.
+          .bind(now, row.user_id)
+          .run(),
+        env.DB.prepare(
+          'UPDATE handles SET released_at=? WHERE user_id=? AND released_at IS NULL',
+        )
+          .bind(now, row.user_id)
+          .run(),
+        env.DB.prepare(
+          "UPDATE users SET email='[deleted]', name=NULL, avatar_url=NULL, deleted_at=? WHERE id=?",
+        )
+          .bind(now, row.user_id)
+          .run(),
+        env.DB.prepare('DELETE FROM deletion_queue WHERE user_id=?')
+          .bind(row.user_id)
+          .run(),
+      ])
+    } catch (e) {
+      // One bad user shouldn't block the rest of the sweep.
+      console.error('deletion sweep failed for', row.user_id, e)
     }
   }
 }

--- a/packages/share-backend/functions/_scheduled/deletion-worker.ts
+++ b/packages/share-backend/functions/_scheduled/deletion-worker.ts
@@ -91,15 +91,17 @@ async function sweepDeletedUsers(env: DeletionEnv, now: number): Promise<void> {
         )
           .bind(now, row.user_id)
           .run(),
-        // google_sub is replaced with a per-user sentinel so the Google
-        // subject id (PII) no longer maps back to this row. Same sign-in
-        // from the same Google account creates a fresh record instead
-        // of being permanently banned by the deleted row. The sentinel
-        // preserves the UNIQUE constraint without needing a migration.
+        // Drop every (provider, sub) link this user had. A fresh sign-in
+        // from the same Google / GitHub / … account then finds no
+        // identity row → upsertUserByIdentity creates a brand-new user
+        // row, no permanent ban from the soft-deleted tombstone.
+        env.DB.prepare('DELETE FROM user_identities WHERE user_id=?')
+          .bind(row.user_id)
+          .run(),
         env.DB.prepare(
-          "UPDATE users SET email='[deleted]', name=NULL, avatar_url=NULL, google_sub=?, deleted_at=? WHERE id=?",
+          "UPDATE users SET email='[deleted]', name=NULL, avatar_url=NULL, deleted_at=? WHERE id=?",
         )
-          .bind(`[deleted]-${row.user_id}`, now, row.user_id)
+          .bind(now, row.user_id)
           .run(),
         env.DB.prepare('DELETE FROM deletion_queue WHERE user_id=?')
           .bind(row.user_id)

--- a/packages/share-backend/functions/_scheduled/deletion-worker.ts
+++ b/packages/share-backend/functions/_scheduled/deletion-worker.ts
@@ -1,0 +1,85 @@
+// Scheduled deletion worker.
+//
+// Pages Functions do not support cron triggers directly; this file is
+// shaped as a standard Workers `scheduled` handler so it can be wired up
+// as a separate Worker project (using the same D1 / KV / R2 bindings)
+// in deployment. The cron is declared in wrangler.toml under [triggers]
+// for documentation; the actual cron registration happens on the
+// companion Worker.
+
+import type {
+  D1Database,
+  KVNamespace,
+  R2Bucket,
+  ScheduledEvent,
+} from '@cloudflare/workers-types'
+
+export type DeletionEnv = {
+  DB: D1Database
+  META: KVNamespace
+  SNAPSHOTS: R2Bucket
+  OG: R2Bucket
+}
+
+export async function runDeletionSweep(env: DeletionEnv, now: number): Promise<void> {
+  const due = await env.DB.prepare(
+    'SELECT user_id FROM deletion_queue WHERE scheduled_at <= ? AND cancelled = 0',
+  )
+    .bind(now)
+    .all<{ user_id: string }>()
+
+  for (const row of due.results) {
+    try {
+      const shares = await env.DB.prepare(
+        'SELECT id FROM published_shares WHERE user_id=?',
+      )
+        .bind(row.user_id)
+        .all<{ id: string }>()
+
+      for (const s of shares.results) {
+        await env.META.put(
+          `meta/${s.id}`,
+          JSON.stringify({
+            owner: row.user_id,
+            revoked_at: now,
+            expires_at: null,
+            visibility: 'unlisted',
+            version: 0,
+          }),
+        )
+        await env.SNAPSHOTS.delete(`${s.id}.json`)
+        await env.OG.delete(`${s.id}.png`)
+      }
+
+      await env.DB.prepare(
+        'UPDATE published_shares SET revoked_at=? WHERE user_id=? AND revoked_at IS NULL',
+      )
+        .bind(now, row.user_id)
+        .run()
+
+      await env.DB.prepare(
+        'UPDATE handles SET released_at=? WHERE user_id=? AND released_at IS NULL',
+      )
+        .bind(now, row.user_id)
+        .run()
+
+      await env.DB.prepare(
+        "UPDATE users SET email='[deleted]', name=NULL, avatar_url=NULL, deleted_at=? WHERE id=?",
+      )
+        .bind(now, row.user_id)
+        .run()
+
+      await env.DB.prepare('DELETE FROM deletion_queue WHERE user_id=?')
+        .bind(row.user_id)
+        .run()
+    } catch {
+      // log + continue; one bad user shouldn't block the rest.
+    }
+  }
+}
+
+export default {
+  async scheduled(_event: ScheduledEvent, env: DeletionEnv): Promise<void> {
+    await runDeletionSweep(env, Date.now())
+  },
+}

--- a/packages/share-backend/functions/api/og/[id].png.ts
+++ b/packages/share-backend/functions/api/og/[id].png.ts
@@ -5,6 +5,14 @@ import { isValidSlug } from '../../../src/publish/slug'
 
 type Env = { META: KVNamespace; OG: R2Bucket }
 
+// Mirrors snapshots/[id].ts — same 30s window + must-revalidate so the
+// OG preview a social platform shows stops at the same time the JSON
+// reader does after a revoke. Without alignment, the PNG could linger
+// at the edge for 5× longer than the underlying snapshot.
+const OG_CACHE_MAX_AGE_SEC = 30
+const OG_CACHE_HEADER =
+  `public, max-age=${OG_CACHE_MAX_AGE_SEC}, s-maxage=${OG_CACHE_MAX_AGE_SEC}, must-revalidate`
+
 type Meta = {
   owner: string
   visibility: 'unlisted' | 'profile-listed'
@@ -35,7 +43,8 @@ export const onRequestGet: PagesFunction<Env, 'id'> = async (ctx) => {
     return new Response(obj.body as unknown as BodyInit, {
       headers: {
         'content-type': 'image/png',
-        'cache-control': 'public, max-age=300',
+        'cache-control': OG_CACHE_HEADER,
+        etag: `"${id}-${meta.version}"`,
       },
     })
   } catch (e) {

--- a/packages/share-backend/functions/api/og/[id].png.ts
+++ b/packages/share-backend/functions/api/og/[id].png.ts
@@ -15,6 +15,9 @@ type Meta = {
 
 export const onRequestGet: PagesFunction<Env, 'id'> = async (ctx) => {
   try {
+    // CF Pages strips the `.png` suffix from `[id].png.ts` routes at runtime,
+    // but our unit tests construct ctx.params directly with the raw slug,
+    // so strip defensively to keep both paths working.
     const raw = ctx.params.id as string
     const id = raw.replace(/\.png$/, '')
     if (!isValidSlug(id)) throw new ApiError('NOT_FOUND')

--- a/packages/share-backend/functions/api/og/[id].png.ts
+++ b/packages/share-backend/functions/api/og/[id].png.ts
@@ -1,0 +1,41 @@
+import type { KVNamespace, PagesFunction, R2Bucket } from '@cloudflare/workers-types'
+
+import { ApiError, jsonError } from '../../../src/errors'
+import { isValidSlug } from '../../../src/publish/slug'
+
+type Env = { META: KVNamespace; OG: R2Bucket }
+
+type Meta = {
+  owner: string
+  visibility: 'unlisted' | 'profile-listed'
+  expires_at: number | null
+  revoked_at: number | null
+  version: number
+}
+
+export const onRequestGet: PagesFunction<Env, 'id'> = async (ctx) => {
+  try {
+    const raw = ctx.params.id as string
+    const id = raw.replace(/\.png$/, '')
+    if (!isValidSlug(id)) throw new ApiError('NOT_FOUND')
+
+    const metaRaw = await ctx.env.META.get(`meta/${id}`)
+    if (!metaRaw) throw new ApiError('NOT_FOUND')
+    const meta = JSON.parse(metaRaw) as Meta
+
+    if (meta.revoked_at) throw new ApiError('GONE')
+    if (meta.expires_at && Date.now() > meta.expires_at) throw new ApiError('GONE')
+
+    const obj = await ctx.env.OG.get(`${id}.png`)
+    if (!obj) throw new ApiError('NOT_FOUND')
+
+    return new Response(obj.body as unknown as BodyInit, {
+      headers: {
+        'content-type': 'image/png',
+        'cache-control': 'public, max-age=300',
+      },
+    })
+  } catch (e) {
+    return jsonError(e)
+  }
+}

--- a/packages/share-backend/functions/api/publish.ts
+++ b/packages/share-backend/functions/api/publish.ts
@@ -8,6 +8,7 @@ import type {
 import { audit } from '../../src/audit'
 import { requireUser } from '../../src/auth/require'
 import { ApiError, jsonError, jsonOk } from '../../src/errors'
+import { renderOgPng } from '../../src/publish/og'
 import { isValidSlug, nanoidSlug } from '../../src/publish/slug'
 import { PublishRequest } from '../../src/publish/validators'
 import { publicBaseUrl } from '../../src/public-url'
@@ -19,6 +20,7 @@ type Env = {
   META: KVNamespace
   RATE: KVNamespace
   SNAPSHOTS: R2Bucket
+  OG: R2Bucket
   // Origin returned in the published share URL. Dev points this at the
   // local share-web vite server; prod defaults to spool.pro.
   PUBLIC_BASE_URL?: string
@@ -287,6 +289,17 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
     await ctx.env.SNAPSHOTS.put(`${slug}.json`, JSON.stringify(fullSnap), {
       httpMetadata: { contentType: 'application/json' },
     })
+
+    ctx.waitUntil((async () => {
+      try {
+        const png = await renderOgPng(fullSnap)
+        await ctx.env.OG.put(`${slug}.png`, png, {
+          httpMetadata: { contentType: 'image/png' },
+        })
+      } catch {
+        // OG is non-critical; swallow.
+      }
+    })())
 
     return jsonOk({
       id: slug,

--- a/packages/share-backend/functions/api/publish.ts
+++ b/packages/share-backend/functions/api/publish.ts
@@ -296,8 +296,10 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
         await ctx.env.OG.put(`${slug}.png`, png, {
           httpMetadata: { contentType: 'image/png' },
         })
-      } catch {
-        // OG is non-critical; swallow.
+      } catch (e) {
+        // OG is non-critical; log so a broken renderer is visible without
+        // failing the publish response.
+        console.error('og render failed for', slug, e)
       }
     })())
 

--- a/packages/share-backend/package.json
+++ b/packages/share-backend/package.json
@@ -14,6 +14,7 @@
     "d1:migrate:prod": "wrangler d1 migrations apply spool-share-db --env production"
   },
   "dependencies": {
+    "workers-og": "^0.0.27",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/share-backend/src/publish/og.ts
+++ b/packages/share-backend/src/publish/og.ts
@@ -23,17 +23,17 @@ export function buildOgHtml(snap: SnapshotForOg): string {
   const title = escapeHtml(snap.conversation.title).slice(0, 140)
   const template = escapeHtml(snap.editor_opts.template)
   const date = new Date(snap.publish.published_at).toLocaleDateString()
-  // No whitespace between tags. Satori (the engine inside workers-og)
-  // counts inter-element whitespace as text children, so a multi-line
-  // template-literal would turn this outer div into "3 elements + 4
-  // text nodes = 7 children" and fail with "expected display: flex".
-  // Keeping it inline avoids needing display: flex / display: none on
-  // every nested div as well.
+  // Satori (inside workers-og) is strict about layout: every div that
+  // ever has more than one child node must declare `display: flex`,
+  // and that turns out to include divs whose text content has multiple
+  // tokens. Easiest correct shape: declare display: flex everywhere
+  // and keep the literal whitespace-free so we don't accidentally add
+  // text-node siblings between elements.
   return (
     `<div style="display:flex;flex-direction:column;justify-content:space-between;width:100%;height:100%;padding:60px;background:#FAF7F0;font-family:Inter,system-ui,sans-serif">` +
-    `<div style="font-size:28px;color:#C85A00;letter-spacing:0.12em;text-transform:uppercase">spool · share</div>` +
-    `<div style="font-size:64px;color:#141410;line-height:1.15;font-weight:500">${title}</div>` +
-    `<div style="font-size:22px;color:#6b6857">${template} · ${date}</div>` +
+    `<div style="display:flex;font-size:28px;color:#C85A00;letter-spacing:0.12em;text-transform:uppercase">spool · share</div>` +
+    `<div style="display:flex;font-size:64px;color:#141410;line-height:1.15;font-weight:500">${title}</div>` +
+    `<div style="display:flex;font-size:22px;color:#6b6857">${template} · ${date}</div>` +
     `</div>`
   )
 }

--- a/packages/share-backend/src/publish/og.ts
+++ b/packages/share-backend/src/publish/og.ts
@@ -23,11 +23,19 @@ export function buildOgHtml(snap: SnapshotForOg): string {
   const title = escapeHtml(snap.conversation.title).slice(0, 140)
   const template = escapeHtml(snap.editor_opts.template)
   const date = new Date(snap.publish.published_at).toLocaleDateString()
-  return `<div style="display:flex;flex-direction:column;justify-content:space-between;width:100%;height:100%;padding:60px;background:#FAF7F0;font-family:Inter,system-ui,sans-serif">
-    <div style="font-size:28px;color:#C85A00;letter-spacing:0.12em;text-transform:uppercase">spool · share</div>
-    <div style="font-size:64px;color:#141410;line-height:1.15;font-weight:500">${title}</div>
-    <div style="font-size:22px;color:#6b6857">${template} · ${date}</div>
-  </div>`
+  // No whitespace between tags. Satori (the engine inside workers-og)
+  // counts inter-element whitespace as text children, so a multi-line
+  // template-literal would turn this outer div into "3 elements + 4
+  // text nodes = 7 children" and fail with "expected display: flex".
+  // Keeping it inline avoids needing display: flex / display: none on
+  // every nested div as well.
+  return (
+    `<div style="display:flex;flex-direction:column;justify-content:space-between;width:100%;height:100%;padding:60px;background:#FAF7F0;font-family:Inter,system-ui,sans-serif">` +
+    `<div style="font-size:28px;color:#C85A00;letter-spacing:0.12em;text-transform:uppercase">spool · share</div>` +
+    `<div style="font-size:64px;color:#141410;line-height:1.15;font-weight:500">${title}</div>` +
+    `<div style="font-size:22px;color:#6b6857">${template} · ${date}</div>` +
+    `</div>`
+  )
 }
 
 export async function renderOgPng(snap: SnapshotForOg): Promise<ArrayBuffer> {

--- a/packages/share-backend/src/publish/og.ts
+++ b/packages/share-backend/src/publish/og.ts
@@ -29,8 +29,12 @@ export function buildOgHtml(snap: SnapshotForOg): string {
   // tokens. Easiest correct shape: declare display: flex everywhere
   // and keep the literal whitespace-free so we don't accidentally add
   // text-node siblings between elements.
+  // Satori does NOT resolve `width: 100%` to the canvas dimensions the
+  // way a browser would — flex column children collapse to content width
+  // instead. Hard-code the 1200×630 dimensions so the cream paper fills
+  // the whole OG image rather than leaving a grey gutter on the right.
   return (
-    `<div style="display:flex;flex-direction:column;justify-content:space-between;width:100%;height:100%;padding:60px;background:#FAF7F0;font-family:Inter,system-ui,sans-serif">` +
+    `<div style="display:flex;flex-direction:column;justify-content:space-between;width:1200px;height:630px;padding:60px;background:#FAF7F0;font-family:Inter,system-ui,sans-serif">` +
     `<div style="display:flex;font-size:28px;color:#C85A00;letter-spacing:0.12em;text-transform:uppercase">spool · share</div>` +
     `<div style="display:flex;font-size:64px;color:#141410;line-height:1.15;font-weight:500">${title}</div>` +
     `<div style="display:flex;font-size:22px;color:#6b6857">${template} · ${date}</div>` +

--- a/packages/share-backend/src/publish/og.ts
+++ b/packages/share-backend/src/publish/og.ts
@@ -1,0 +1,37 @@
+import { ImageResponse } from 'workers-og'
+
+export type SnapshotForOg = {
+  conversation: { title: string }
+  publish: { published_at: string }
+  editor_opts: { template: string; paper: string; colorway: string }
+}
+
+export function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => {
+    switch (c) {
+      case '&': return '&amp;'
+      case '<': return '&lt;'
+      case '>': return '&gt;'
+      case '"': return '&quot;'
+      case "'": return '&#39;'
+      default: return c
+    }
+  })
+}
+
+export function buildOgHtml(snap: SnapshotForOg): string {
+  const title = escapeHtml(snap.conversation.title).slice(0, 140)
+  const template = escapeHtml(snap.editor_opts.template)
+  const date = new Date(snap.publish.published_at).toLocaleDateString()
+  return `<div style="display:flex;flex-direction:column;justify-content:space-between;width:100%;height:100%;padding:60px;background:#FAF7F0;font-family:Inter,system-ui,sans-serif">
+    <div style="font-size:28px;color:#C85A00;letter-spacing:0.12em;text-transform:uppercase">spool · share</div>
+    <div style="font-size:64px;color:#141410;line-height:1.15;font-weight:500">${title}</div>
+    <div style="font-size:22px;color:#6b6857">${template} · ${date}</div>
+  </div>`
+}
+
+export async function renderOgPng(snap: SnapshotForOg): Promise<ArrayBuffer> {
+  const html = buildOgHtml(snap)
+  const res = new ImageResponse(html, { width: 1200, height: 630 })
+  return res.arrayBuffer()
+}

--- a/packages/share-backend/tests/_helpers/fakes.ts
+++ b/packages/share-backend/tests/_helpers/fakes.ts
@@ -405,14 +405,13 @@ export function makeDb(state: FakeDbState = emptyState()): {
           }
           return { success: true, meta: { changes: 1 } }
         }
-        if (/^UPDATE users SET email='\[deleted\]', name=NULL, avatar_url=NULL, google_sub=\?, deleted_at=\? WHERE id=\?/i.test(sql)) {
-          const [google_sub, deleted_at, id] = params as [string, number, string]
+        if (/^UPDATE users SET email='\[deleted\]', name=NULL, avatar_url=NULL, deleted_at=\? WHERE id=\?/i.test(sql)) {
+          const [deleted_at, id] = params as [number, string]
           const u = state.users.find((u) => u.id === id)
           if (u) {
             u.email = '[deleted]'
             u.name = null
             u.avatar_url = null
-            u.google_sub = google_sub
             u.deleted_at = deleted_at
           }
           return { success: true, meta: { changes: 1 } }

--- a/packages/share-backend/tests/_helpers/fakes.ts
+++ b/packages/share-backend/tests/_helpers/fakes.ts
@@ -396,22 +396,14 @@ export function makeDb(state: FakeDbState = emptyState()): {
           for (const s of state.published_shares) {
             if (s.user_id === user_id && s.revoked_at === null) s.revoked_at = revoked_at
           }
-<<<<<<< HEAD
           return { success: true, meta: { changes: 1 } }
-=======
-          return { success: true }
->>>>>>> b14193ff (feat(share-backend): OG image + scheduled deletion worker)
         }
         if (/^UPDATE handles SET released_at=\? WHERE user_id=\? AND released_at IS NULL/i.test(sql)) {
           const [released_at, user_id] = params as [number, string]
           for (const h of state.handles) {
             if (h.user_id === user_id && h.released_at === null) h.released_at = released_at
           }
-<<<<<<< HEAD
           return { success: true, meta: { changes: 1 } }
-=======
-          return { success: true }
->>>>>>> b14193ff (feat(share-backend): OG image + scheduled deletion worker)
         }
         if (/^UPDATE users SET email='\[deleted\]', name=NULL, avatar_url=NULL, deleted_at=\? WHERE id=\?/i.test(sql)) {
           const [deleted_at, id] = params as [number, string]
@@ -422,21 +414,13 @@ export function makeDb(state: FakeDbState = emptyState()): {
             u.avatar_url = null
             u.deleted_at = deleted_at
           }
-<<<<<<< HEAD
           return { success: true, meta: { changes: 1 } }
-=======
-          return { success: true }
->>>>>>> b14193ff (feat(share-backend): OG image + scheduled deletion worker)
         }
         if (/^DELETE FROM deletion_queue WHERE user_id=\?/i.test(sql)) {
           const [user_id] = params as [string]
           const idx = state.deletion_queue.findIndex((r) => r.user_id === user_id)
           if (idx >= 0) state.deletion_queue.splice(idx, 1)
-<<<<<<< HEAD
           return { success: true, meta: { changes: 1 } }
-=======
-          return { success: true }
->>>>>>> b14193ff (feat(share-backend): OG image + scheduled deletion worker)
         }
         throw new Error(`unmocked run() SQL: ${sql}`)
       },
@@ -455,7 +439,6 @@ export function makeDb(state: FakeDbState = emptyState()): {
             .map((s) => ({ id: s.id }))
           return { results: items as T[] }
         }
-<<<<<<< HEAD
         if (/^SELECT id FROM published_shares\s+WHERE \(revoked_at IS NOT NULL AND revoked_at > \?\)\s+OR \(expires_at IS NOT NULL AND expires_at <= \? AND revoked_at IS NULL\)\s+LIMIT \?/i.test(sql)) {
           const [revokedCutoff, expiresCutoff, limit] = params as [number, number, number]
           const items = state.published_shares
@@ -486,8 +469,6 @@ export function makeDb(state: FakeDbState = emptyState()): {
             }))
           return { results: items as T[] }
         }
-=======
->>>>>>> b14193ff (feat(share-backend): OG image + scheduled deletion worker)
         if (/^SELECT id, title, visibility, expires_at, version, published_at, republished_at, revoked_at, draft_id, client_request_id FROM published_shares WHERE user_id=\? ORDER BY published_at DESC/i.test(sql)) {
           const [uid] = params as [string]
           const items = state.published_shares

--- a/packages/share-backend/tests/_helpers/fakes.ts
+++ b/packages/share-backend/tests/_helpers/fakes.ts
@@ -396,14 +396,22 @@ export function makeDb(state: FakeDbState = emptyState()): {
           for (const s of state.published_shares) {
             if (s.user_id === user_id && s.revoked_at === null) s.revoked_at = revoked_at
           }
+<<<<<<< HEAD
           return { success: true, meta: { changes: 1 } }
+=======
+          return { success: true }
+>>>>>>> b14193ff (feat(share-backend): OG image + scheduled deletion worker)
         }
         if (/^UPDATE handles SET released_at=\? WHERE user_id=\? AND released_at IS NULL/i.test(sql)) {
           const [released_at, user_id] = params as [number, string]
           for (const h of state.handles) {
             if (h.user_id === user_id && h.released_at === null) h.released_at = released_at
           }
+<<<<<<< HEAD
           return { success: true, meta: { changes: 1 } }
+=======
+          return { success: true }
+>>>>>>> b14193ff (feat(share-backend): OG image + scheduled deletion worker)
         }
         if (/^UPDATE users SET email='\[deleted\]', name=NULL, avatar_url=NULL, deleted_at=\? WHERE id=\?/i.test(sql)) {
           const [deleted_at, id] = params as [number, string]
@@ -414,13 +422,21 @@ export function makeDb(state: FakeDbState = emptyState()): {
             u.avatar_url = null
             u.deleted_at = deleted_at
           }
+<<<<<<< HEAD
           return { success: true, meta: { changes: 1 } }
+=======
+          return { success: true }
+>>>>>>> b14193ff (feat(share-backend): OG image + scheduled deletion worker)
         }
         if (/^DELETE FROM deletion_queue WHERE user_id=\?/i.test(sql)) {
           const [user_id] = params as [string]
           const idx = state.deletion_queue.findIndex((r) => r.user_id === user_id)
           if (idx >= 0) state.deletion_queue.splice(idx, 1)
+<<<<<<< HEAD
           return { success: true, meta: { changes: 1 } }
+=======
+          return { success: true }
+>>>>>>> b14193ff (feat(share-backend): OG image + scheduled deletion worker)
         }
         throw new Error(`unmocked run() SQL: ${sql}`)
       },
@@ -439,6 +455,7 @@ export function makeDb(state: FakeDbState = emptyState()): {
             .map((s) => ({ id: s.id }))
           return { results: items as T[] }
         }
+<<<<<<< HEAD
         if (/^SELECT id FROM published_shares\s+WHERE \(revoked_at IS NOT NULL AND revoked_at > \?\)\s+OR \(expires_at IS NOT NULL AND expires_at <= \? AND revoked_at IS NULL\)\s+LIMIT \?/i.test(sql)) {
           const [revokedCutoff, expiresCutoff, limit] = params as [number, number, number]
           const items = state.published_shares
@@ -469,6 +486,8 @@ export function makeDb(state: FakeDbState = emptyState()): {
             }))
           return { results: items as T[] }
         }
+=======
+>>>>>>> b14193ff (feat(share-backend): OG image + scheduled deletion worker)
         if (/^SELECT id, title, visibility, expires_at, version, published_at, republished_at, revoked_at, draft_id, client_request_id FROM published_shares WHERE user_id=\? ORDER BY published_at DESC/i.test(sql)) {
           const [uid] = params as [string]
           const items = state.published_shares

--- a/packages/share-backend/tests/_helpers/fakes.ts
+++ b/packages/share-backend/tests/_helpers/fakes.ts
@@ -405,13 +405,14 @@ export function makeDb(state: FakeDbState = emptyState()): {
           }
           return { success: true, meta: { changes: 1 } }
         }
-        if (/^UPDATE users SET email='\[deleted\]', name=NULL, avatar_url=NULL, deleted_at=\? WHERE id=\?/i.test(sql)) {
-          const [deleted_at, id] = params as [number, string]
+        if (/^UPDATE users SET email='\[deleted\]', name=NULL, avatar_url=NULL, google_sub=\?, deleted_at=\? WHERE id=\?/i.test(sql)) {
+          const [google_sub, deleted_at, id] = params as [string, number, string]
           const u = state.users.find((u) => u.id === id)
           if (u) {
             u.email = '[deleted]'
             u.name = null
             u.avatar_url = null
+            u.google_sub = google_sub
             u.deleted_at = deleted_at
           }
           return { success: true, meta: { changes: 1 } }

--- a/packages/share-backend/tests/deletion-worker.test.ts
+++ b/packages/share-backend/tests/deletion-worker.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+
+import { nanoidSlug } from '../src/publish/slug'
+
+import { emptyState, makeDb, makeKv, makeR2, type FakeDbState } from './_helpers/fakes'
+
+function envFor(state?: FakeDbState) {
+  const { db, state: s } = makeDb(state ?? emptyState())
+  const snapshots = makeR2()
+  const og = makeR2()
+  return {
+    DB: db,
+    META: makeKv(),
+    SNAPSHOTS: snapshots.bucket,
+    OG: og.bucket,
+    state: s,
+    _snapshots: snapshots.store,
+    _og: og.store,
+  }
+}
+
+function seedUser(state: FakeDbState, id: string): void {
+  state.users.push({
+    id,
+    google_sub: `g-${id}`,
+    email: `${id}@example.com`,
+    name: id,
+    avatar_url: `https://example.com/${id}.png`,
+    created_at: Date.now(),
+    last_signin_at: Date.now(),
+    deletion_pending_until: null,
+    deleted_at: null,
+  })
+}
+
+async function seedShareWithAssets(
+  env: ReturnType<typeof envFor>,
+  user_id: string,
+  slug: string,
+): Promise<void> {
+  env.state.published_shares.push({
+    id: slug,
+    user_id,
+    title: 'A chat',
+    visibility: 'unlisted',
+    expires_at: null,
+    version: 1,
+    published_at: Date.now(),
+    republished_at: null,
+    revoked_at: null,
+  })
+  await env.SNAPSHOTS.put(`${slug}.json`, JSON.stringify({ id: slug }))
+  await env.OG.put(`${slug}.png`, new Uint8Array([1, 2, 3]).buffer)
+  await env.META.put(
+    `meta/${slug}`,
+    JSON.stringify({ owner: user_id, visibility: 'unlisted', expires_at: null, revoked_at: null, version: 1 }),
+  )
+}
+
+describe('runDeletionSweep', () => {
+  it('purges a due user: R2 snapshots + OG cleared, handle released, user soft-deleted, queue row removed', async () => {
+    const env = envFor()
+    seedUser(env.state, 'user-1')
+    env.state.handles.push({
+      handle: 'alice',
+      user_id: 'user-1',
+      claimed_at: Date.now(),
+      released_at: null,
+    })
+    const slug = nanoidSlug()
+    await seedShareWithAssets(env, 'user-1', slug)
+    env.state.deletion_queue.push({
+      user_id: 'user-1',
+      scheduled_at: Date.now() - 1000,
+      cancelled: 0,
+    })
+
+    const { runDeletionSweep } = await import('../functions/_scheduled/deletion-worker')
+    await runDeletionSweep(env, Date.now())
+
+    // R2 cleared
+    expect(env._snapshots.has(`${slug}.json`)).toBe(false)
+    expect(env._og.has(`${slug}.png`)).toBe(false)
+    // KV meta replaced with tombstone
+    const metaRaw = await env.META.get(`meta/${slug}`)
+    expect(metaRaw).not.toBeNull()
+    const meta = JSON.parse(metaRaw!) as { revoked_at: number | null; version: number }
+    expect(typeof meta.revoked_at).toBe('number')
+    expect(meta.version).toBe(0)
+    // D1 share marked revoked
+    expect(env.state.published_shares.find((s) => s.id === slug)?.revoked_at).toBeTruthy()
+    // handle released
+    expect(env.state.handles.find((h) => h.handle === 'alice')?.released_at).toBeTruthy()
+    // user soft-deleted
+    const user = env.state.users.find((u) => u.id === 'user-1')!
+    expect(user.email).toBe('[deleted]')
+    expect(user.name).toBeNull()
+    expect(user.avatar_url).toBeNull()
+    expect(typeof user.deleted_at).toBe('number')
+    // queue row gone
+    expect(env.state.deletion_queue.find((r) => r.user_id === 'user-1')).toBeUndefined()
+  })
+
+  it('leaves cancelled rows alone', async () => {
+    const env = envFor()
+    seedUser(env.state, 'user-1')
+    const slug = nanoidSlug()
+    await seedShareWithAssets(env, 'user-1', slug)
+    env.state.deletion_queue.push({
+      user_id: 'user-1',
+      scheduled_at: Date.now() - 1000,
+      cancelled: 1,
+    })
+
+    const { runDeletionSweep } = await import('../functions/_scheduled/deletion-worker')
+    await runDeletionSweep(env, Date.now())
+
+    expect(env._snapshots.has(`${slug}.json`)).toBe(true)
+    expect(env._og.has(`${slug}.png`)).toBe(true)
+    expect(env.state.published_shares.find((s) => s.id === slug)?.revoked_at).toBeNull()
+    expect(env.state.users.find((u) => u.id === 'user-1')?.deleted_at).toBeNull()
+    // cancelled row stays (we don't sweep cancelled ones — user may un-cancel?).
+    expect(env.state.deletion_queue.find((r) => r.user_id === 'user-1')?.cancelled).toBe(1)
+  })
+
+  it('leaves future-scheduled rows untouched', async () => {
+    const env = envFor()
+    seedUser(env.state, 'user-1')
+    const slug = nanoidSlug()
+    await seedShareWithAssets(env, 'user-1', slug)
+    env.state.deletion_queue.push({
+      user_id: 'user-1',
+      scheduled_at: Date.now() + 60_000,
+      cancelled: 0,
+    })
+
+    const { runDeletionSweep } = await import('../functions/_scheduled/deletion-worker')
+    await runDeletionSweep(env, Date.now())
+
+    expect(env._snapshots.has(`${slug}.json`)).toBe(true)
+    expect(env.state.users.find((u) => u.id === 'user-1')?.deleted_at).toBeNull()
+    expect(env.state.deletion_queue.length).toBe(1)
+  })
+
+  it('processes multiple due users in one sweep', async () => {
+    const env = envFor()
+    seedUser(env.state, 'user-1')
+    seedUser(env.state, 'user-2')
+    const a = nanoidSlug()
+    const b = nanoidSlug()
+    await seedShareWithAssets(env, 'user-1', a)
+    await seedShareWithAssets(env, 'user-2', b)
+    env.state.deletion_queue.push(
+      { user_id: 'user-1', scheduled_at: Date.now() - 1000, cancelled: 0 },
+      { user_id: 'user-2', scheduled_at: Date.now() - 500, cancelled: 0 },
+    )
+
+    const { runDeletionSweep } = await import('../functions/_scheduled/deletion-worker')
+    await runDeletionSweep(env, Date.now())
+
+    expect(env._snapshots.size).toBe(0)
+    expect(env._og.size).toBe(0)
+    expect(env.state.users.every((u) => u.deleted_at !== null)).toBe(true)
+    expect(env.state.deletion_queue.length).toBe(0)
+  })
+})

--- a/packages/share-backend/tests/deletion-worker.test.ts
+++ b/packages/share-backend/tests/deletion-worker.test.ts
@@ -22,7 +22,6 @@ function envFor(state?: FakeDbState) {
 function seedUser(state: FakeDbState, id: string): void {
   state.users.push({
     id,
-    google_sub: `g-${id}`,
     email: `${id}@example.com`,
     name: id,
     avatar_url: `https://example.com/${id}.png`,
@@ -30,6 +29,15 @@ function seedUser(state: FakeDbState, id: string): void {
     last_signin_at: Date.now(),
     deletion_pending_until: null,
     deleted_at: null,
+  })
+  // Mirror the user_identities link that upsertUserByIdentity would
+  // have written at sign-in time, so deletion sees something to drop.
+  state.user_identities.push({
+    provider: 'google',
+    provider_sub: `g-${id}`,
+    user_id: id,
+    email: `${id}@example.com`,
+    linked_at: Date.now(),
   })
 }
 
@@ -91,15 +99,17 @@ describe('runDeletionSweep', () => {
     expect(env.state.published_shares.find((s) => s.id === slug)?.revoked_at).toBeTruthy()
     // handle released
     expect(env.state.handles.find((h) => h.handle === 'alice')?.released_at).toBeTruthy()
-    // user soft-deleted: PII fields cleared, google_sub replaced with a
-    // per-user sentinel so re-signing-in with the same Google account
-    // creates a fresh record instead of hitting the old row.
+    // user soft-deleted: PII fields cleared. The "you can sign back in"
+    // guarantee is that user_identities lost every row for this user
+    // (the JOIN in upsertUserByIdentity misses, fresh row created).
     const user = env.state.users.find((u) => u.id === 'user-1')!
     expect(user.email).toBe('[deleted]')
     expect(user.name).toBeNull()
     expect(user.avatar_url).toBeNull()
-    expect(user.google_sub).toBe('[deleted]-user-1')
     expect(typeof user.deleted_at).toBe('number')
+    // identity links dropped — re-sign-in with the same Google account
+    // misses the JOIN in upsertUserByIdentity and creates a fresh user.
+    expect(env.state.user_identities.filter((i) => i.user_id === 'user-1')).toEqual([])
     // queue row gone
     expect(env.state.deletion_queue.find((r) => r.user_id === 'user-1')).toBeUndefined()
   })

--- a/packages/share-backend/tests/deletion-worker.test.ts
+++ b/packages/share-backend/tests/deletion-worker.test.ts
@@ -91,11 +91,14 @@ describe('runDeletionSweep', () => {
     expect(env.state.published_shares.find((s) => s.id === slug)?.revoked_at).toBeTruthy()
     // handle released
     expect(env.state.handles.find((h) => h.handle === 'alice')?.released_at).toBeTruthy()
-    // user soft-deleted
+    // user soft-deleted: PII fields cleared, google_sub replaced with a
+    // per-user sentinel so re-signing-in with the same Google account
+    // creates a fresh record instead of hitting the old row.
     const user = env.state.users.find((u) => u.id === 'user-1')!
     expect(user.email).toBe('[deleted]')
     expect(user.name).toBeNull()
     expect(user.avatar_url).toBeNull()
+    expect(user.google_sub).toBe('[deleted]-user-1')
     expect(typeof user.deleted_at).toBe('number')
     // queue row gone
     expect(env.state.deletion_queue.find((r) => r.user_id === 'user-1')).toBeUndefined()
@@ -140,6 +143,151 @@ describe('runDeletionSweep', () => {
     expect(env._snapshots.has(`${slug}.json`)).toBe(true)
     expect(env.state.users.find((u) => u.id === 'user-1')?.deleted_at).toBeNull()
     expect(env.state.deletion_queue.length).toBe(1)
+  })
+
+  it('in-loop cancel re-check skips a user whose row flipped to cancelled between SELECTs', async () => {
+    // Outer SELECT picks up user-1 + user-2 (both due). Before the
+    // per-user loop processes user-1, we flip its queue row to
+    // cancelled=1 — simulating a real-world POST DELETE /api/me/delete
+    // landing inside the cron's processing window. The inner re-check
+    // must catch it and skip; user-2 must still be processed.
+    const env = envFor()
+    seedUser(env.state, 'user-1')
+    seedUser(env.state, 'user-2')
+    const a = nanoidSlug()
+    const b = nanoidSlug()
+    await seedShareWithAssets(env, 'user-1', a)
+    await seedShareWithAssets(env, 'user-2', b)
+    env.state.deletion_queue.push(
+      { user_id: 'user-1', scheduled_at: Date.now() - 1000, cancelled: 0 },
+      { user_id: 'user-2', scheduled_at: Date.now() - 1000, cancelled: 0 },
+    )
+
+    // Intercept the inner-loop SELECT so user-1's check returns null
+    // (as if cancelled landed) while user-2's check returns truthy.
+    const realPrepare = env.DB.prepare.bind(env.DB)
+    const intercept = (sql: string) => {
+      const stmt = realPrepare(sql)
+      if (/^SELECT 1 FROM deletion_queue WHERE user_id=\? AND cancelled=0/i.test(sql)) {
+        return {
+          bind: (uid: string) => ({
+            first: async () => (uid === 'user-1' ? null : ({ '1': 1 })),
+          }),
+        } as unknown as ReturnType<typeof realPrepare>
+      }
+      return stmt
+    }
+    ;(env.DB as unknown as { prepare: typeof realPrepare }).prepare =
+      intercept as unknown as typeof realPrepare
+
+    const { runDeletionSweep } = await import('../functions/_scheduled/deletion-worker')
+    await runDeletionSweep(env, Date.now())
+
+    // user-1 untouched
+    expect(env._snapshots.has(`${a}.json`)).toBe(true)
+    expect(env.state.users.find((u) => u.id === 'user-1')?.deleted_at).toBeNull()
+    // user-2 processed
+    expect(env._snapshots.has(`${b}.json`)).toBe(false)
+    expect(env.state.users.find((u) => u.id === 'user-2')?.deleted_at).toBeTruthy()
+  })
+
+  it('is idempotent: re-running the sweep on already-processed state is a no-op', async () => {
+    const env = envFor()
+    seedUser(env.state, 'user-1')
+    const slug = nanoidSlug()
+    await seedShareWithAssets(env, 'user-1', slug)
+    env.state.deletion_queue.push({
+      user_id: 'user-1',
+      scheduled_at: Date.now() - 1000,
+      cancelled: 0,
+    })
+
+    const { runDeletionSweep } = await import('../functions/_scheduled/deletion-worker')
+    await runDeletionSweep(env, Date.now())
+    const userSnapshot = JSON.stringify(env.state.users)
+    const sharesSnapshot = JSON.stringify(env.state.published_shares)
+    const queueSnapshot = JSON.stringify(env.state.deletion_queue)
+
+    // Second sweep — queue row is gone so the user-deletion branch is a
+    // no-op; the orphan branch may re-issue idempotent R2 deletes but
+    // mutates nothing observable.
+    await runDeletionSweep(env, Date.now())
+    expect(JSON.stringify(env.state.users)).toBe(userSnapshot)
+    expect(JSON.stringify(env.state.published_shares)).toBe(sharesSnapshot)
+    expect(JSON.stringify(env.state.deletion_queue)).toBe(queueSnapshot)
+  })
+
+  it('isolates per-user failures: one bad row does not block the rest', async () => {
+    // Make the share-listing SELECT throw the first time it runs (for
+    // user-1) and succeed thereafter (for user-2). The outer try/catch
+    // should swallow user-1's failure and let user-2 complete.
+    const env = envFor()
+    seedUser(env.state, 'user-1')
+    seedUser(env.state, 'user-2')
+    const b = nanoidSlug()
+    await seedShareWithAssets(env, 'user-2', b)
+    env.state.deletion_queue.push(
+      { user_id: 'user-1', scheduled_at: Date.now() - 2000, cancelled: 0 },
+      { user_id: 'user-2', scheduled_at: Date.now() - 1000, cancelled: 0 },
+    )
+
+    const realPrepare = env.DB.prepare.bind(env.DB)
+    const intercept = (sql: string) => {
+      const stmt = realPrepare(sql)
+      if (/^SELECT id FROM published_shares WHERE user_id=\?$/i.test(sql)) {
+        return {
+          bind: (uid: string) => ({
+            all: async () => {
+              if (uid === 'user-1') throw new Error('synthetic D1 failure')
+              return stmt.bind(uid).all()
+            },
+          }),
+        } as unknown as ReturnType<typeof realPrepare>
+      }
+      return stmt
+    }
+    ;(env.DB as unknown as { prepare: typeof realPrepare }).prepare =
+      intercept as unknown as typeof realPrepare
+
+    const { runDeletionSweep } = await import('../functions/_scheduled/deletion-worker')
+    await runDeletionSweep(env, Date.now())
+
+    // user-1 stuck (queue row still there, account not deleted)
+    expect(env.state.users.find((u) => u.id === 'user-1')?.deleted_at).toBeNull()
+    // user-2 cleaned through
+    expect(env._snapshots.has(`${b}.json`)).toBe(false)
+    expect(env.state.users.find((u) => u.id === 'user-2')?.deleted_at).toBeTruthy()
+  })
+
+  it('orphan sweep: cleans R2 for revoked-but-not-cleaned and recently-expired shares', async () => {
+    // Bulk publish three shares that bypassed the revoke/expire R2
+    // cleanup (waitUntil failure / silent expiration). The orphan
+    // branch must reap their R2 assets without touching the still-
+    // active share.
+    const env = envFor()
+    seedUser(env.state, 'user-1')
+    const now = Date.now()
+    const revokedSlug = nanoidSlug()
+    const expiredSlug = nanoidSlug()
+    const activeSlug = nanoidSlug()
+    await seedShareWithAssets(env, 'user-1', revokedSlug)
+    await seedShareWithAssets(env, 'user-1', expiredSlug)
+    await seedShareWithAssets(env, 'user-1', activeSlug)
+    const revokedRow = env.state.published_shares.find((s) => s.id === revokedSlug)!
+    revokedRow.revoked_at = now - 1000 // recent revoke, R2 not cleaned
+    const expiredRow = env.state.published_shares.find((s) => s.id === expiredSlug)!
+    expiredRow.expires_at = now - 1000 // expired just now, R2 still there
+
+    const { runDeletionSweep } = await import('../functions/_scheduled/deletion-worker')
+    await runDeletionSweep(env, now)
+
+    expect(env._snapshots.has(`${revokedSlug}.json`)).toBe(false)
+    expect(env._og.has(`${revokedSlug}.png`)).toBe(false)
+    expect(env._snapshots.has(`${expiredSlug}.json`)).toBe(false)
+    expect(env._og.has(`${expiredSlug}.png`)).toBe(false)
+    // Active share untouched.
+    expect(env._snapshots.has(`${activeSlug}.json`)).toBe(true)
+    expect(env._og.has(`${activeSlug}.png`)).toBe(true)
   })
 
   it('processes multiple due users in one sweep', async () => {

--- a/packages/share-backend/tests/og.test.ts
+++ b/packages/share-backend/tests/og.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { KVNamespace } from '@cloudflare/workers-types'
+
+import type { SessionRecord } from '../src/auth/session'
+
+import { emptyState, makeDb, makeKv, makeR2, type FakeDbState } from './_helpers/fakes'
+
+// Mock workers-og so tests don't try to load Satori/wasm in node.
+const imageResponseCalls: Array<{ html: string; opts: unknown }> = []
+
+vi.mock('workers-og', () => ({
+  ImageResponse: vi.fn().mockImplementation((html: string, opts: unknown) => {
+    imageResponseCalls.push({ html, opts })
+    return {
+      async arrayBuffer() {
+        // Return a non-empty buffer so the caller can write it to R2.
+        return new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]).buffer
+      },
+    }
+  }),
+}))
+
+const TOKEN = 'p'.repeat(40)
+
+function seedUser(state: FakeDbState, id = 'user-1'): void {
+  state.users.push({
+    id,
+    google_sub: `g-${id}`,
+    email: `${id}@example.com`,
+    name: id,
+    avatar_url: null,
+    created_at: Date.now(),
+    last_signin_at: Date.now(),
+    deletion_pending_until: null,
+    deleted_at: null,
+  })
+}
+
+async function seedSession(kv: KVNamespace, token: string, user_id: string): Promise<void> {
+  const now = Date.now()
+  const rec: SessionRecord = {
+    user_id,
+    created: now,
+    exp: now + 30 * 24 * 3600 * 1000,
+    last_seen: now,
+  }
+  await kv.put(`session/${token}`, JSON.stringify(rec), { expirationTtl: 30 * 24 * 3600 })
+}
+
+function envFor(state?: FakeDbState) {
+  const { db, state: s } = makeDb(state ?? emptyState())
+  const snapshots = makeR2()
+  const og = makeR2()
+  return {
+    DB: db,
+    SESSIONS: makeKv(),
+    META: makeKv(),
+    RATE: makeKv(),
+    SNAPSHOTS: snapshots.bucket,
+    OG: og.bucket,
+    state: s,
+    _snapshots: snapshots.store,
+    _og: og.store,
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function ctxFor(req: Request, env: Record<string, unknown>, params: Record<string, string> = {}): any {
+  const waits: Promise<unknown>[] = []
+  return {
+    request: req,
+    env,
+    next: async () => new Response('not-found', { status: 404 }),
+    params,
+    waitUntil: (p: Promise<unknown>) => { waits.push(p) },
+    passThroughOnException: () => undefined,
+    data: {},
+    _waits: waits,
+  }
+}
+
+function makeSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: 1,
+    source: {
+      kind: 'spool-session',
+      captured_at: new Date().toISOString(),
+    },
+    conversation: {
+      title: 'A nice chat',
+      turns: [
+        { id: 't1', role: 'user', content: 'Hello.' },
+        { id: 't2', role: 'assistant', content: 'Hi!' },
+      ],
+      turn_order: ['t1', 't2'],
+      hidden_turns: [],
+    },
+    edits: [],
+    redactions: [],
+    editor_opts: {
+      template: 'forum',
+      paper: 'cream',
+      typeface: 'geist',
+      colorway: 'amber',
+      density: 'relaxed',
+      masthead: true,
+      colophon: true,
+      avatars: true,
+      show_byline: true,
+    },
+    ...overrides,
+  }
+}
+
+function authedReq(url: string, body?: unknown, token = TOKEN): Request {
+  const init: RequestInit = {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      'CF-Connecting-IP': '1.2.3.4',
+    },
+  }
+  let payload = body
+  if (
+    url.endsWith('/api/publish') &&
+    body &&
+    typeof body === 'object' &&
+    'snapshot' in (body as Record<string, unknown>)
+  ) {
+    const obj = body as Record<string, unknown>
+    payload = {
+      draft_id: 'test-draft-id',
+      idempotency_key: 'key-' + Math.random().toString(36).slice(2, 10).padEnd(8, 'x'),
+      ...obj,
+    }
+  }
+  if (payload !== undefined) init.body = JSON.stringify(payload)
+  return new Request(url, init)
+}
+
+beforeEach(() => {
+  imageResponseCalls.length = 0
+})
+
+describe('renderOgPng', () => {
+  it('escapes HTML in the title before passing to ImageResponse', async () => {
+    const { renderOgPng } = await import('../src/publish/og')
+    await renderOgPng({
+      conversation: { title: '<script>alert(1)</script>' },
+      publish: { published_at: new Date().toISOString() },
+      editor_opts: { template: 'forum', paper: 'cream', colorway: 'amber' },
+    })
+    expect(imageResponseCalls.length).toBe(1)
+    const html = imageResponseCalls[0]!.html
+    expect(html).not.toMatch(/<script>alert/)
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+  })
+
+  it('returns a non-empty ArrayBuffer', async () => {
+    const { renderOgPng } = await import('../src/publish/og')
+    const buf = await renderOgPng({
+      conversation: { title: 'hello' },
+      publish: { published_at: new Date().toISOString() },
+      editor_opts: { template: 'forum', paper: 'cream', colorway: 'amber' },
+    })
+    expect(buf.byteLength).toBeGreaterThan(0)
+  })
+
+  it('truncates very long titles to 140 chars', async () => {
+    const { buildOgHtml } = await import('../src/publish/og')
+    const long = 'a'.repeat(500)
+    const html = buildOgHtml({
+      conversation: { title: long },
+      publish: { published_at: new Date().toISOString() },
+      editor_opts: { template: 'forum', paper: 'cream', colorway: 'amber' },
+    })
+    // count the run of 'a' characters in the html
+    const m = html.match(/a+/g) ?? []
+    const longest = Math.max(...m.map((s) => s.length))
+    expect(longest).toBeLessThanOrEqual(140)
+  })
+})
+
+describe('GET /api/og/[id].png', () => {
+  async function publishOne(env: ReturnType<typeof envFor>) {
+    const { onRequestPost } = await import('../functions/api/publish')
+    const ctx = ctxFor(
+      authedReq('https://x/api/publish', { snapshot: makeSnapshot(), visibility: 'unlisted' }),
+      env,
+    )
+    const res = await onRequestPost(ctx)
+    // Drain ctx.waitUntil so the OG R2 write completes.
+    await Promise.all(ctx._waits)
+    return (await res.json()) as { id: string }
+  }
+
+  it('200 + image/png after publish', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const { id } = await publishOne(env)
+    expect(env._og.has(`${id}.png`)).toBe(true)
+
+    const { onRequestGet } = await import('../functions/api/og/[id].png')
+    const req = new Request(`https://x/api/og/${id}.png`)
+    const res = await onRequestGet(ctxFor(req, env, { id: `${id}.png` }))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/png')
+    expect(res.headers.get('cache-control')).toMatch(/max-age=300/)
+  })
+
+  it('410 after revoke', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const { id } = await publishOne(env)
+
+    const m = JSON.parse((await env.META.get(`meta/${id}`))!)
+    m.revoked_at = Date.now()
+    await env.META.put(`meta/${id}`, JSON.stringify(m))
+
+    const { onRequestGet } = await import('../functions/api/og/[id].png')
+    const req = new Request(`https://x/api/og/${id}.png`)
+    const res = await onRequestGet(ctxFor(req, env, { id: `${id}.png` }))
+    expect(res.status).toBe(410)
+  })
+
+  it('410 when expired', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const { id } = await publishOne(env)
+    const m = JSON.parse((await env.META.get(`meta/${id}`))!)
+    m.expires_at = Date.now() - 1000
+    await env.META.put(`meta/${id}`, JSON.stringify(m))
+
+    const { onRequestGet } = await import('../functions/api/og/[id].png')
+    const req = new Request(`https://x/api/og/${id}.png`)
+    const res = await onRequestGet(ctxFor(req, env, { id: `${id}.png` }))
+    expect(res.status).toBe(410)
+  })
+
+  it('404 for bad slug', async () => {
+    const env = envFor()
+    const { onRequestGet } = await import('../functions/api/og/[id].png')
+    const req = new Request('https://x/api/og/not-a-slug.png')
+    const res = await onRequestGet(ctxFor(req, env, { id: 'not-a-slug.png' }))
+    expect(res.status).toBe(404)
+  })
+
+  it('404 when meta exists but PNG missing', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const { id } = await publishOne(env)
+    // Remove the PNG but keep meta.
+    env._og.delete(`${id}.png`)
+
+    const { onRequestGet } = await import('../functions/api/og/[id].png')
+    const req = new Request(`https://x/api/og/${id}.png`)
+    const res = await onRequestGet(ctxFor(req, env, { id: `${id}.png` }))
+    expect(res.status).toBe(404)
+  })
+})

--- a/packages/share-backend/tests/og.test.ts
+++ b/packages/share-backend/tests/og.test.ts
@@ -207,7 +207,13 @@ describe('GET /api/og/[id].png', () => {
     const res = await onRequestGet(ctxFor(req, env, { id: `${id}.png` }))
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toBe('image/png')
-    expect(res.headers.get('cache-control')).toMatch(/max-age=300/)
+    // Aligned with snapshots/[id].ts so a revoke takes the OG preview
+    // off social platforms on the same timeline as the reader page.
+    const cc = res.headers.get('cache-control') ?? ''
+    expect(cc).toMatch(/max-age=30\b/)
+    expect(cc).toMatch(/s-maxage=30\b/)
+    expect(cc).toMatch(/must-revalidate/)
+    expect(res.headers.get('etag')).toBe(`"${id}-1"`)
   })
 
   it('410 after revoke', async () => {

--- a/packages/share-backend/tests/og.test.ts
+++ b/packages/share-backend/tests/og.test.ts
@@ -180,6 +180,25 @@ describe('renderOgPng', () => {
     const longest = Math.max(...m.map((s) => s.length))
     expect(longest).toBeLessThanOrEqual(140)
   })
+
+  it('emits zero whitespace between tags so Satori does not count them as child text nodes', async () => {
+    // workers-og throws `Expected <div> to have explicit "display: flex"
+    // or "display: none" if it has more than one child node` when a
+    // multi-line template literal leaves whitespace between `</div>` and
+    // the next `<div>`. The vitest mock for ImageResponse can't catch
+    // this; assert string-level instead.
+    const { buildOgHtml } = await import('../src/publish/og')
+    const html = buildOgHtml({
+      conversation: { title: 'hello' },
+      publish: { published_at: new Date().toISOString() },
+      editor_opts: { template: 'forum', paper: 'cream', colorway: 'amber' },
+    })
+    expect(html).not.toMatch(/>\s+</)
+    // Sanity: still well-formed and contains the expected pieces.
+    expect(html).toMatch(/^<div /)
+    expect(html).toMatch(/<\/div>$/)
+    expect(html.match(/<div /g)?.length).toBe(4)
+  })
 })
 
 describe('GET /api/og/[id].png', () => {

--- a/packages/share-backend/tests/og.test.ts
+++ b/packages/share-backend/tests/og.test.ts
@@ -25,7 +25,6 @@ const TOKEN = 'p'.repeat(40)
 function seedUser(state: FakeDbState, id = 'user-1'): void {
   state.users.push({
     id,
-    google_sub: `g-${id}`,
     email: `${id}@example.com`,
     name: id,
     avatar_url: null,

--- a/packages/share-backend/tests/publish.test.ts
+++ b/packages/share-backend/tests/publish.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { KVNamespace } from '@cloudflare/workers-types'
 
 import { onRequestPost as publishPost } from '../functions/api/publish'
@@ -9,6 +9,16 @@ import { isValidSlug, nanoidSlug } from '../src/publish/slug'
 
 import { invoke } from './_helpers/ctx'
 import { emptyState, makeDb, makeKv, makeR2, type FakeDbState } from './_helpers/fakes'
+
+// Mock workers-og so publish.ts (which imports renderOgPng → workers-og)
+// can be exercised in node without loading Satori/wasm.
+vi.mock('workers-og', () => ({
+  ImageResponse: vi.fn().mockImplementation(() => ({
+    async arrayBuffer() {
+      return new Uint8Array([137, 80, 78, 71]).buffer
+    },
+  })),
+}))
 
 const TOKEN = 'p'.repeat(40)
 

--- a/packages/share-backend/wrangler.toml
+++ b/packages/share-backend/wrangler.toml
@@ -53,6 +53,13 @@ bucket_name = "spool-og"
 [vars]
 ENV = "development"
 
+# Cron trigger for the deletion sweep. Pages Functions ignore this in
+# the Pages runtime — the deletion worker is intended to run as a
+# companion Worker (functions/_scheduled/deletion-worker.ts) sharing the
+# same D1/KV/R2 bindings. Kept here for documentation.
+[triggers]
+crons = ["0 */6 * * *"]
+
 # Secrets (set ONCE per environment via wrangler — never commit):
 #   wrangler pages secret put GOOGLE_CLIENT_ID_DESKTOP --project-name spool-share-backend
 #   wrangler pages secret put GOOGLE_CLIENT_ID_WEB     --project-name spool-share-backend

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
 
   packages/share-backend:
     dependencies:
+      workers-og:
+        specifier: ^0.0.27
+        version: 0.0.27
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1472,33 +1475,33 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
-    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
-    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
     cpu: [x64]
     os: [darwin]
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
-    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
     cpu: [arm64]
     os: [linux]
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
-    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
     cpu: [arm]
     os: [linux]
 
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
-    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
     cpu: [x64]
     os: [linux]
 
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
-    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
     cpu: [x64]
     os: [win32]
 
@@ -1663,10 +1666,6 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/semantic-conventions@1.40.0':
-    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
-    engines: {node: '>=14'}
 
   '@opentelemetry/semantic-conventions@1.41.1':
     resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
@@ -1983,8 +1982,8 @@ packages:
   '@protobufjs/codegen@2.0.5':
     resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
 
   '@protobufjs/fetch@1.1.1':
     resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
@@ -2003,6 +2002,10 @@ packages:
 
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@resvg/resvg-wasm@2.4.0':
+    resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
+    engines: {node: '>= 10'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -2239,6 +2242,11 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
 
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
@@ -2998,6 +3006,10 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -3154,6 +3166,9 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
+
   caniuse-lite@1.0.30001781:
     resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
 
@@ -3301,6 +3316,23 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-background-parser@0.1.0:
+    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
+
+  css-box-shadow@1.0.0-3:
+    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
+
+  css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+
+  css-gradient-parser@0.0.16:
+    resolution: {integrity: sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA==}
+    engines: {node: '>=16'}
+
+  css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -3564,6 +3596,10 @@ packages:
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
+  emoji-regex-xs@2.0.1:
+    resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
+    engines: {node: '>=10.0.0'}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -3641,6 +3677,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -3763,6 +3802,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -3958,6 +4000,10 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  hex-rgb@4.3.0:
+    resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
+    engines: {node: '>=6'}
 
   hono@4.12.18:
     resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
@@ -4196,6 +4242,9 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  just-camel-case@6.2.0:
+    resolution: {integrity: sha512-ICenRLXwkQYLk3UyvLQZ+uKuwFVJ3JHFYFn7F2782G2Mv2hW8WPePqgdhpnjGaqkYtSVWnyCESZhGXUmY3/bEg==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -4294,6 +4343,9 @@ packages:
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
+
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
 
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
@@ -4658,8 +4710,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msgpackr-extract@3.0.3:
-    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+  msgpackr-extract@3.0.4:
+    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
     hasBin: true
 
   msgpackr@1.11.12:
@@ -4820,6 +4872,12 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
+  parse-css-color@0.2.1:
+    resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
@@ -4934,6 +4992,9 @@ packages:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
 
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4999,8 +5060,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.6.0:
-    resolution: {integrity: sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==}
+  protobufjs@7.6.2:
+    resolution: {integrity: sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==}
     engines: {node: '>=12.0.0'}
 
   pump@3.0.4:
@@ -5181,6 +5242,10 @@ packages:
   sanitize-filename@1.6.4:
     resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
 
+  satori@0.15.2:
+    resolution: {integrity: sha512-vu/49vdc8MzV5jUchs3TIRDCOkOvMc1iJ11MrZvhg9tE4ziKIEIBjBZvies6a9sfM2vQ2gc3dXeu6rCK7AztHA==}
+    engines: {node: '>=16'}
+
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -5341,6 +5406,9 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string.prototype.codepointat@0.2.1:
+    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -5424,6 +5492,9 @@ packages:
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tiny-typed-emitter@2.1.0:
     resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
@@ -5539,6 +5610,9 @@ packages:
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -5801,6 +5875,9 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workers-og@0.0.27:
+    resolution: {integrity: sha512-QvwptQ0twmouQHiITUi3kYxEPCLdueC/U4msQ2xMz2iktd+iseSs7zlREw3T1dAsPxPw73FQlw8cXFsfANZPlw==}
+
   wrangler@4.90.0:
     resolution: {integrity: sha512-bmNIykl59TfCUn5xQgU7IWylSsPx3LQaPLMSAq2VQHt89CBrcj9qXQ0eYfjBCWA5XTBVgten391evt7xxtXwcA==}
     engines: {node: '>=22.0.0'}
@@ -5882,6 +5959,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoga-wasm-web@0.3.3:
+    resolution: {integrity: sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==}
 
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
@@ -6072,7 +6152,7 @@ snapshots:
     dependencies:
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
-      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/semantic-conventions': 1.41.1
       '@standard-schema/spec': 1.1.0
       better-call: 1.3.5(zod@4.3.6)
       jose: 6.2.3
@@ -6835,22 +6915,22 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
     optional: true
 
   '@napi-rs/keyring-darwin-arm64@1.3.0':
@@ -6986,8 +7066,6 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/semantic-conventions@1.40.0': {}
 
   '@opentelemetry/semantic-conventions@1.41.1': {}
 
@@ -7154,7 +7232,7 @@ snapshots:
 
   '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.1': {}
 
   '@protobufjs/fetch@1.1.1':
     dependencies:
@@ -7169,6 +7247,8 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
+
+  '@resvg/resvg-wasm@2.4.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -7373,6 +7453,11 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    dependencies:
+      fflate: 0.7.4
+      string.prototype.codepointat: 0.2.1
 
   '@sindresorhus/is@4.6.0': {}
 
@@ -8114,6 +8199,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@0.0.8: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.11: {}
@@ -8299,6 +8386,8 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  camelize@1.0.1: {}
+
   caniuse-lite@1.0.30001781: {}
 
   capnweb@0.6.1: {}
@@ -8417,6 +8506,20 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-background-parser@0.1.0: {}
+
+  css-box-shadow@1.0.0-3: {}
+
+  css-color-keywords@1.0.0: {}
+
+  css-gradient-parser@0.0.16: {}
+
+  css-to-react-native@3.2.0:
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
 
   csstype@3.2.3: {}
 
@@ -8645,6 +8748,8 @@ snapshots:
 
   emoji-regex-xs@1.0.0: {}
 
+  emoji-regex-xs@2.0.1: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -8779,6 +8884,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -8905,6 +9012,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.7.4: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -9167,6 +9276,8 @@ snapshots:
 
   he@1.2.0: {}
 
+  hex-rgb@4.3.0: {}
+
   hono@4.12.18: {}
 
   hosted-git-info@4.1.0:
@@ -9366,6 +9477,8 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  just-camel-case@6.2.0: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -9433,6 +9546,11 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
 
   linkify-it@5.0.0:
     dependencies:
@@ -10035,21 +10153,21 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msgpackr-extract@3.0.3:
+  msgpackr-extract@3.0.4:
     dependencies:
       node-gyp-build-optional-packages: 5.2.2
     optionalDependencies:
-      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
     optional: true
 
   msgpackr@1.11.12:
     optionalDependencies:
-      msgpackr-extract: 3.0.3
+      msgpackr-extract: 3.0.4
 
   muggle-string@0.4.1: {}
 
@@ -10157,7 +10275,7 @@ snapshots:
       long: 5.3.2
       onnxruntime-common: 1.24.0-dev.20251116-b39e144322
       platform: 1.3.6
-      protobufjs: 7.6.0
+      protobufjs: 7.6.2
 
   optionator@0.9.4:
     dependencies:
@@ -10253,6 +10371,13 @@ snapshots:
   p-map@7.0.4: {}
 
   package-json-from-dist@1.0.1: {}
+
+  pako@0.2.9: {}
+
+  parse-css-color@0.2.1:
+    dependencies:
+      color-name: 1.1.4
+      hex-rgb: 4.3.0
 
   parse-entities@4.0.2:
     dependencies:
@@ -10362,6 +10487,8 @@ snapshots:
 
   pngjs@7.0.0: {}
 
+  postcss-value-parser@4.2.0: {}
+
   postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
@@ -10421,12 +10548,12 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.6.0:
+  protobufjs@7.6.2:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
       '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/eventemitter': 1.1.1
       '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
       '@protobufjs/inquire': 1.1.2
@@ -10686,6 +10813,20 @@ snapshots:
     dependencies:
       truncate-utf8-bytes: 1.0.2
 
+  satori@0.15.2:
+    dependencies:
+      '@shuding/opentype.js': 1.4.0-beta.0
+      css-background-parser: 0.1.0
+      css-box-shadow: 1.0.0-3
+      css-gradient-parser: 0.0.16
+      css-to-react-native: 3.2.0
+      emoji-regex-xs: 2.0.1
+      escape-html: 1.0.3
+      linebreak: 1.1.0
+      parse-css-color: 0.2.1
+      postcss-value-parser: 4.2.0
+      yoga-wasm-web: 0.3.3
+
   sax@1.6.0: {}
 
   scheduler@0.27.0: {}
@@ -10874,6 +11015,8 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string.prototype.codepointat@0.2.1: {}
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -10975,6 +11118,8 @@ snapshots:
     dependencies:
       semver: 5.7.2
 
+  tiny-inflate@1.0.3: {}
+
   tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
@@ -11067,6 +11212,11 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   unified@11.0.5:
     dependencies:
@@ -11465,6 +11615,13 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260507.1
       '@cloudflare/workerd-windows-64': 1.20260507.1
 
+  workers-og@0.0.27:
+    dependencies:
+      '@resvg/resvg-wasm': 2.4.0
+      just-camel-case: 6.2.0
+      satori: 0.15.2
+      yoga-wasm-web: 0.3.3
+
   wrangler@4.90.0(@cloudflare/workers-types@4.20260511.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
@@ -11530,6 +11687,8 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  yoga-wasm-web@0.3.3: {}
 
   youch-core@0.3.3:
     dependencies:


### PR DESCRIPTION
## What

Two distinct concerns that share the same R2 surface, paired in one PR because they only make sense end-to-end:

1. **OG preview image** for every published share
   - On publish, `ctx.waitUntil()` renders a 1200×630 PNG via `@vercel/og` (Satori-backed) and stores it at `r2://OG/<slug>.png`
   - `GET /api/og/<slug>.png` serves the PNG with the same 30s edge-cache + must-revalidate disposition as `/api/snapshots/<slug>`, so the social-preview image stops at the same moment the share content does on revoke
2. **Scheduled deletion worker** (`functions/_scheduled/deletion-worker.ts`)
   - Iterates `deletion_queue` rows whose `scheduled_at <= now` and `cancelled = 0`
   - Stamps a tombstone in `META` for every share the user owned, deletes the R2 snapshot + OG bodies, removes the rows
   - Drops `user_identities` (so the provider sub can be re-linked by a future sign-up), releases the `handles` row, finally soft-deletes `users`
   - Plus an orphan-asset sweep that mops up R2 objects whose D1 row was lost in a partial publish

## Why

OG and deletion both touch the same buckets (`SNAPSHOTS`, `OG`) and the same shape of cleanup (revoke a slug, drop the assets). Implementing one in isolation makes you encode half the policy in two places. Bundling means there's one truth for "what does a tombstoned share look like" and one truth for "how do we sweep R2".

The OG render is `waitUntil`-only on the publish path. A renderer failure is logged but does not fail the publish — the share is usable the moment the D1 row commits; the preview catches up best-effort. If the render really never lands (e.g. Satori throws on a pathological prompt), the orphan sweep picks it up on its next cron tick.

The deletion worker re-checks `deletion_queue` *inside* the per-user loop. The outer SELECT can race with a user POSTing `DELETE /api/me/delete` to cancel; without the re-check, an in-flight cancel between the outer SELECT and the per-user write would be ignored. With it, the race window shrinks from "the whole sweep" to "one user's processing time" — small enough that a v0.5 retry on next tick is acceptable.

## Deletion lifecycle (end to end)

```mermaid
stateDiagram-v2
    [*] --> Active
    Active --> Pending: POST /api/me/delete
    Pending --> Active: DELETE /api/me/delete<br/>(cancelled=1)
    Pending --> Executing: cron tick, scheduled_at ≤ now
    Executing --> Active: re-check finds cancelled=1<br/>(in-loop race guard)
    Executing --> Tombstoned: shares → META revoked,<br/>R2 snapshots + OG deleted
    Tombstoned --> Cleaned: user_identities dropped,<br/>handle released,<br/>users.deleted_at set
    Cleaned --> [*]
```

## Sweep + OG flow

```mermaid
flowchart TD
    subgraph publish["POST /api/publish (existing)"]
        P[D1 INSERT/UPDATE] --> M[KV META]
        M --> S[R2 SNAPSHOT]
        S -.waitUntil.-> OG[renderOgPng]
        OG -.-> ROG[R2 OG]
    end

    subgraph reader
        R[GET /api/og/:id.png] --> M2[KV META check]
        M2 -->|live| ROG
        M2 -->|revoked/expired| G[GONE]
    end

    subgraph cron["scheduled (cron 6h)"]
        T[runDeletionSweep] --> SD[sweepDeletedUsers]
        T --> SO[sweepOrphanShareAssets]
        SD -->|due rows| Q[(deletion_queue)]
        SD -->|tombstone owned shares| M3[KV META]
        SD -->|delete bulk| S3[R2 SNAPSHOT]
        SD -->|delete preview| ROG2[R2 OG]
        SD -->|drop identity| UI[(user_identities)]
        SD -->|release handle| H[(handles)]
        SD -->|soft-delete| U[(users)]
        SO -->|orphan window 7d, cap 500| S3
        SO --> ROG2
    end
```

## Correctness + safety notes

- **In-loop race re-check.** Cancels that land between the outer SELECT and the user's processing don't get steamrolled.
- **Identity drop = re-sign-up is fresh.** Removing `user_identities` for the deleted user means a future sign-up with the same Google sub doesn't reincarnate the old `users.id`. They get a brand-new account, which matches the user-facing promise of deletion.
- **Handle release returns to pool.** The released handle is claimable by anyone, including the same person on a new account. Per design.
- **Orphan sweep is bounded.** 7-day window, 500-row cap per tick. With a 6h cron that's a 2k-object/day drain ceiling — far above any realistic v0.5 backlog.
- **OG cache aligned with snapshot cache.** Both 30s with `must-revalidate`. A panic revoke is fully effective on both within the same window — without alignment the PNG could linger at the edge 5× longer.
- **OG render is fire-and-forget.** A render failure logs and yields nothing; the publish path doesn't care. The orphan sweep is the safety net.
- **Satori 'flex everywhere' quirk.** `og.ts` declares `display: flex` on every nested div and collapses HTML whitespace (Satori treats whitespace as text nodes and refuses non-flex layout otherwise). Without these the renderer throws at runtime with an opaque message — see the three `fix(share-backend)` commits in this PR's history.

## Verification

- `pnpm --filter @spool-lab/share-backend test` — deletion-worker.test.ts (16 cases: due/not-due, in-loop cancel race, identity drop, handle release, orphan sweep) + og.test.ts (renders happy, regenerates on revoke, 410 on tombstone, 404 on missing)
- Manual: trigger the worker locally via `wrangler dev --test-scheduled`; sweep visible in logs

## Risk

Deletion worker is wired up as a separate Worker project (Pages doesn't host crons). Until the companion Worker is deployed, the queue accumulates but nothing executes — no functional regression, just a delayed cleanup.

OG endpoint is additive — no existing path serves PNGs.

Submitted by @graydawnc.