### PR TITLE
feat(share-web): /<handle> profile + /me dashboard + sign-in

### DIFF
--- a/packages/share-backend/functions/api/profiles/[handle].ts
+++ b/packages/share-backend/functions/api/profiles/[handle].ts
@@ -1,0 +1,64 @@
+import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers-types'
+
+import { ApiError, jsonError, jsonOk } from '../../../src/errors'
+import { validateHandle } from '../../../src/handles'
+
+type Env = { DB: D1Database; SESSIONS: KVNamespace }
+
+type Row = {
+  name: string | null
+  avatar_url: string | null
+}
+
+type ShareRow = {
+  id: string
+  title: string
+  published_at: number
+  version: number
+}
+
+const SHARE_LIMIT = 100
+
+export const onRequestGet: PagesFunction<Env, 'handle'> = async (ctx) => {
+  try {
+    const raw = ctx.params.handle
+    const v = validateHandle(typeof raw === 'string' ? raw : '')
+    // 404 (not 422) so we never leak which handles are merely invalid vs missing.
+    if (!v.ok) throw new ApiError('NOT_FOUND')
+
+    const owner = await ctx.env.DB
+      .prepare(
+        'SELECT u.id AS user_id, u.name AS name, u.avatar_url AS avatar_url ' +
+          'FROM handles h JOIN users u ON u.id = h.user_id ' +
+          'WHERE h.handle = ? AND h.released_at IS NULL AND u.deleted_at IS NULL',
+      )
+      .bind(v.handle)
+      .first<Row & { user_id: string }>()
+    if (!owner) throw new ApiError('NOT_FOUND')
+
+    const now = Date.now()
+    const shares = await ctx.env.DB
+      .prepare(
+        'SELECT id, title, published_at, version FROM published_shares ' +
+          'WHERE user_id = ? AND visibility = ? AND revoked_at IS NULL ' +
+          'AND (expires_at IS NULL OR expires_at > ?) ' +
+          'ORDER BY published_at DESC LIMIT ?',
+      )
+      .bind(owner.user_id, 'profile-listed', now, SHARE_LIMIT)
+      .all<ShareRow>()
+
+    return jsonOk(
+      {
+        handle: v.handle,
+        name: owner.name,
+        avatar_url: owner.avatar_url,
+        shares: shares.results,
+      },
+      {
+        headers: { 'cache-control': 'public, max-age=30, must-revalidate' },
+      },
+    )
+  } catch (e) {
+    return jsonError(e)
+  }
+}

--- a/packages/share-backend/functions/api/profiles/[handle].ts
+++ b/packages/share-backend/functions/api/profiles/[handle].ts
@@ -2,8 +2,17 @@ import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers
 
 import { ApiError, jsonError, jsonOk } from '../../../src/errors'
 import { validateHandle } from '../../../src/handles'
+import { checkRate } from '../../../src/rate-limit'
+import { clientIp } from '../../../src/request'
 
-type Env = { DB: D1Database; SESSIONS: KVNamespace }
+type Env = { DB: D1Database; SESSIONS: KVNamespace; RATE: KVNamespace }
+
+// Profiles are public-by-design, so the limit is mostly anti-abuse: it
+// caps the rate at which a single IP can brute-force the handle space
+// looking for who-owns-what. 120/minute lets a legitimate browser slam
+// reload comfortably while still hurting an enumeration script.
+const PROFILE_RATE_WINDOW_SEC = 60
+const PROFILE_RATE_MAX = 120
 
 type Row = {
   name: string | null
@@ -21,6 +30,14 @@ const SHARE_LIMIT = 100
 
 export const onRequestGet: PagesFunction<Env, 'handle'> = async (ctx) => {
   try {
+    const rate = await checkRate(ctx.env.RATE, {
+      bucket: 'profile',
+      key: clientIp(ctx.request),
+      windowSec: PROFILE_RATE_WINDOW_SEC,
+      max: PROFILE_RATE_MAX,
+    })
+    if (!rate.ok) throw new ApiError('TOO_MANY_REQUESTS')
+
     const raw = ctx.params.handle
     const v = validateHandle(typeof raw === 'string' ? raw : '')
     // 404 (not 422) so we never leak which handles are merely invalid vs missing.

--- a/packages/share-backend/tests/_helpers/fakes.ts
+++ b/packages/share-backend/tests/_helpers/fakes.ts
@@ -439,7 +439,6 @@ export function makeDb(state: FakeDbState = emptyState()): {
             .map((s) => ({ id: s.id }))
           return { results: items as T[] }
         }
-<<<<<<< HEAD
         if (/^SELECT id FROM published_shares\s+WHERE \(revoked_at IS NOT NULL AND revoked_at > \?\)\s+OR \(expires_at IS NOT NULL AND expires_at <= \? AND revoked_at IS NULL\)\s+LIMIT \?/i.test(sql)) {
           const [revokedCutoff, expiresCutoff, limit] = params as [number, number, number]
           const items = state.published_shares
@@ -451,7 +450,8 @@ export function makeDb(state: FakeDbState = emptyState()): {
             })
             .slice(0, limit)
             .map((s) => ({ id: s.id }))
-=======
+          return { results: items as T[] }
+        }
         if (/^SELECT id, title, published_at, version FROM published_shares WHERE user_id = \? AND visibility = \? AND revoked_at IS NULL AND \(expires_at IS NULL OR expires_at > \?\) ORDER BY published_at DESC LIMIT \?/i.test(sql)) {
           const [uid, vis, now, limit] = params as [string, string, number, number]
           const items = state.published_shares
@@ -471,7 +471,6 @@ export function makeDb(state: FakeDbState = emptyState()): {
               published_at: s.published_at,
               version: s.version,
             }))
->>>>>>> e592b4c8 (feat(share): profile + me + sign-in pages)
           return { results: items as T[] }
         }
         if (/^SELECT user_id, ip_hash, ua_hash, action, target_id, details_json, ts FROM audit_log ORDER BY ts DESC LIMIT \?/i.test(sql)) {

--- a/packages/share-backend/tests/_helpers/fakes.ts
+++ b/packages/share-backend/tests/_helpers/fakes.ts
@@ -439,6 +439,7 @@ export function makeDb(state: FakeDbState = emptyState()): {
             .map((s) => ({ id: s.id }))
           return { results: items as T[] }
         }
+<<<<<<< HEAD
         if (/^SELECT id FROM published_shares\s+WHERE \(revoked_at IS NOT NULL AND revoked_at > \?\)\s+OR \(expires_at IS NOT NULL AND expires_at <= \? AND revoked_at IS NULL\)\s+LIMIT \?/i.test(sql)) {
           const [revokedCutoff, expiresCutoff, limit] = params as [number, number, number]
           const items = state.published_shares
@@ -450,6 +451,27 @@ export function makeDb(state: FakeDbState = emptyState()): {
             })
             .slice(0, limit)
             .map((s) => ({ id: s.id }))
+=======
+        if (/^SELECT id, title, published_at, version FROM published_shares WHERE user_id = \? AND visibility = \? AND revoked_at IS NULL AND \(expires_at IS NULL OR expires_at > \?\) ORDER BY published_at DESC LIMIT \?/i.test(sql)) {
+          const [uid, vis, now, limit] = params as [string, string, number, number]
+          const items = state.published_shares
+            .filter(
+              (s) =>
+                s.user_id === uid &&
+                s.visibility === vis &&
+                s.revoked_at === null &&
+                (s.expires_at === null || s.expires_at > now),
+            )
+            .slice()
+            .sort((a, b) => b.published_at - a.published_at)
+            .slice(0, limit)
+            .map((s) => ({
+              id: s.id,
+              title: s.title,
+              published_at: s.published_at,
+              version: s.version,
+            }))
+>>>>>>> e592b4c8 (feat(share): profile + me + sign-in pages)
           return { results: items as T[] }
         }
         if (/^SELECT user_id, ip_hash, ua_hash, action, target_id, details_json, ts FROM audit_log ORDER BY ts DESC LIMIT \?/i.test(sql)) {

--- a/packages/share-backend/tests/deletion-worker.test.ts
+++ b/packages/share-backend/tests/deletion-worker.test.ts
@@ -101,7 +101,8 @@ describe('runDeletionSweep', () => {
     expect(env.state.handles.find((h) => h.handle === 'alice')?.released_at).toBeTruthy()
     // user soft-deleted: PII fields cleared. The "you can sign back in"
     // guarantee is that user_identities lost every row for this user
-    // (the JOIN in upsertUserByIdentity misses, fresh row created).
+    // — the JOIN in upsertUserByIdentity misses and a fresh users row
+    // is created on next sign-in.
     const user = env.state.users.find((u) => u.id === 'user-1')!
     expect(user.email).toBe('[deleted]')
     expect(user.name).toBeNull()

--- a/packages/share-backend/tests/profiles.test.ts
+++ b/packages/share-backend/tests/profiles.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest'
+
+import { onRequestGet as profileGet } from '../functions/api/profiles/[handle]'
+
+import { invoke } from './_helpers/ctx'
+import { emptyState, makeDb, makeKv, type FakeDbState } from './_helpers/fakes'
+
+function seedUser(
+  state: FakeDbState,
+  overrides: Partial<FakeDbState['users'][number]> = {},
+): FakeDbState['users'][number] {
+  const user = {
+    id: 'user-1',
+    email: 'a@example.com',
+    name: 'Alice',
+    avatar_url: 'https://x/a.png',
+    created_at: Date.now(),
+    last_signin_at: Date.now(),
+    deletion_pending_until: null,
+    deleted_at: null,
+    ...overrides,
+  }
+  state.users.push(user)
+  return user
+}
+
+function envFor(state?: FakeDbState) {
+  const { db, state: s } = makeDb(state ?? emptyState())
+  return { DB: db, SESSIONS: makeKv(), RATE: makeKv(), state: s }
+}
+
+describe('GET /api/profiles/:handle', () => {
+  it('404 for an invalid handle (not 422 — avoid leaking invalid vs missing)', async () => {
+    const env = envFor()
+    const req = new Request('https://x/api/profiles/2bad')
+    const res = await invoke(profileGet, req, env, { handle: '2bad' })
+    expect(res.status).toBe(404)
+  })
+
+  it('404 for a reserved handle', async () => {
+    const env = envFor()
+    const req = new Request('https://x/api/profiles/admin')
+    const res = await invoke(profileGet, req, env, { handle: 'admin' })
+    expect(res.status).toBe(404)
+  })
+
+  it('404 for a nonexistent handle', async () => {
+    const env = envFor()
+    const req = new Request('https://x/api/profiles/alice')
+    const res = await invoke(profileGet, req, env, { handle: 'alice' })
+    expect(res.status).toBe(404)
+  })
+
+  it('404 when the user is deleted', async () => {
+    const env = envFor()
+    seedUser(env.state, { deleted_at: Date.now() })
+    env.state.handles.push({
+      handle: 'alice',
+      user_id: 'user-1',
+      claimed_at: Date.now(),
+      released_at: null,
+    })
+    const req = new Request('https://x/api/profiles/alice')
+    const res = await invoke(profileGet, req, env, { handle: 'alice' })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns empty shares array when handle exists but no profile-listed shares', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    env.state.handles.push({
+      handle: 'alice',
+      user_id: 'user-1',
+      claimed_at: Date.now(),
+      released_at: null,
+    })
+    env.state.published_shares.push({
+      id: 'unl1',
+      user_id: 'user-1',
+      title: 'Hidden',
+      visibility: 'unlisted',
+      expires_at: null,
+      version: 1,
+      published_at: 100,
+      republished_at: null,
+      revoked_at: null,
+    })
+    const req = new Request('https://x/api/profiles/alice')
+    const res = await invoke(profileGet, req, env, { handle: 'alice' })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      handle: string
+      name: string | null
+      avatar_url: string | null
+      shares: unknown[]
+    }
+    expect(body.handle).toBe('alice')
+    expect(body.name).toBe('Alice')
+    expect(body.avatar_url).toBe('https://x/a.png')
+    expect(body.shares).toEqual([])
+  })
+
+  it('returns only profile-listed, non-revoked, non-expired shares ordered by published_at DESC', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    env.state.handles.push({
+      handle: 'alice',
+      user_id: 'user-1',
+      claimed_at: Date.now(),
+      released_at: null,
+    })
+    const now = Date.now()
+    env.state.published_shares.push(
+      // profile-listed, older
+      {
+        id: 'older',
+        user_id: 'user-1',
+        title: 'Older',
+        visibility: 'profile-listed',
+        expires_at: null,
+        version: 1,
+        published_at: 100,
+        republished_at: null,
+        revoked_at: null,
+      },
+      // profile-listed, newer
+      {
+        id: 'newer',
+        user_id: 'user-1',
+        title: 'Newer',
+        visibility: 'profile-listed',
+        expires_at: null,
+        version: 2,
+        published_at: 300,
+        republished_at: null,
+        revoked_at: null,
+      },
+      // unlisted — must be excluded
+      {
+        id: 'unlisted',
+        user_id: 'user-1',
+        title: 'U',
+        visibility: 'unlisted',
+        expires_at: null,
+        version: 1,
+        published_at: 250,
+        republished_at: null,
+        revoked_at: null,
+      },
+      // revoked — must be excluded
+      {
+        id: 'revoked',
+        user_id: 'user-1',
+        title: 'R',
+        visibility: 'profile-listed',
+        expires_at: null,
+        version: 1,
+        published_at: 200,
+        republished_at: null,
+        revoked_at: now,
+      },
+      // expired — must be excluded
+      {
+        id: 'expired',
+        user_id: 'user-1',
+        title: 'E',
+        visibility: 'profile-listed',
+        expires_at: now - 1000,
+        version: 1,
+        published_at: 220,
+        republished_at: null,
+        revoked_at: null,
+      },
+      // someone else's share — must be excluded
+      {
+        id: 'other',
+        user_id: 'other-user',
+        title: 'O',
+        visibility: 'profile-listed',
+        expires_at: null,
+        version: 1,
+        published_at: 400,
+        republished_at: null,
+        revoked_at: null,
+      },
+    )
+    const req = new Request('https://x/api/profiles/alice')
+    const res = await invoke(profileGet, req, env, { handle: 'alice' })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { shares: Array<{ id: string }> }
+    expect(body.shares.map((s) => s.id)).toEqual(['newer', 'older'])
+  })
+
+  it('429 when the per-IP profile cap is exceeded', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    env.state.handles.push({
+      handle: 'alice',
+      user_id: 'user-1',
+      claimed_at: Date.now(),
+      released_at: null,
+    })
+    // Mirror PROFILE_RATE_{WINDOW_SEC,MAX} from profiles/[handle].ts.
+    const RATE_WINDOW_SEC = 60
+    const RATE_MAX = 120
+    const slot = Math.floor(Date.now() / 1000 / RATE_WINDOW_SEC)
+    await env.RATE.put(`rate/profile/1.2.3.4/${slot}`, String(RATE_MAX), {
+      expirationTtl: RATE_WINDOW_SEC * 2,
+    })
+    const req = new Request('https://x/api/profiles/alice', {
+      headers: { 'CF-Connecting-IP': '1.2.3.4' },
+    })
+    const res = await invoke(profileGet, req, env, { handle: 'alice' })
+    expect(res.status).toBe(429)
+  })
+
+  it('sets cache-control: public, max-age=30, must-revalidate', async () => {
+    const env = envFor()
+    seedUser(env.state)
+    env.state.handles.push({
+      handle: 'alice',
+      user_id: 'user-1',
+      claimed_at: Date.now(),
+      released_at: null,
+    })
+    const req = new Request('https://x/api/profiles/alice')
+    const res = await invoke(profileGet, req, env, { handle: 'alice' })
+    expect(res.headers.get('cache-control')).toBe('public, max-age=30, must-revalidate')
+  })
+})

--- a/packages/share-web/src/App.tsx
+++ b/packages/share-web/src/App.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from 'react'
 
 import { routeFor } from './lib/route'
+import { Me } from './pages/Me'
+import { Profile } from './pages/Profile'
 import { Reader } from './pages/Reader'
+import { SignIn } from './pages/SignIn'
 import { Tombstone } from './pages/Tombstone'
 
 export function App() {
@@ -11,5 +14,8 @@ export function App() {
   )
 
   if (route.kind === 'reader') return <Reader id={route.id} />
+  if (route.kind === 'profile') return <Profile handle={route.handle} />
+  if (route.kind === 'me') return <Me />
+  if (route.kind === 'sign-in') return <SignIn next={route.next} />
   return <Tombstone reason="not-found" />
 }

--- a/packages/share-web/src/lib/api.ts
+++ b/packages/share-web/src/lib/api.ts
@@ -91,6 +91,11 @@ export interface MeResponse {
   name: string | null
   avatar_url: string | null
   handle: string | null
+  /** Epoch-ms when the deletion worker will hard-delete this account;
+   *  null when the account is healthy. Non-null means the user is in
+   *  the 24h grace window — every endpoint except /api/me and the
+   *  DELETE cancel path will 403. */
+  deletion_pending_until: number | null
 }
 
 export interface MeShareRow {
@@ -125,25 +130,50 @@ export async function fetchMe(): Promise<MeFetchResult> {
   }
 }
 
-export async function fetchMyShares(): Promise<MeShareRow[]> {
-  const r = await fetch('/api/me/shares', {
-    headers: { accept: 'application/json' },
-    credentials: 'same-origin',
-  })
-  if (r.status !== 200) return []
-  const body = (await r.json()) as { items: MeShareRow[] }
-  return body.items ?? []
+export type MySharesFetchResult =
+  | { kind: 'ok'; shares: MeShareRow[] }
+  | { kind: 'unauthenticated' }
+  | { kind: 'forbidden' }
+  | { kind: 'error' }
+
+export async function fetchMyShares(): Promise<MySharesFetchResult> {
+  try {
+    const r = await fetch('/api/me/shares', {
+      headers: { accept: 'application/json' },
+      credentials: 'same-origin',
+    })
+    if (r.status === 200) {
+      const body = (await r.json()) as { items: MeShareRow[] }
+      return { kind: 'ok', shares: body.items ?? [] }
+    }
+    if (r.status === 401) return { kind: 'unauthenticated' }
+    if (r.status === 403) return { kind: 'forbidden' }
+    return { kind: 'error' }
+  } catch {
+    return { kind: 'error' }
+  }
 }
 
-export async function revokeShare(id: string): Promise<boolean> {
+export type RevokeShareResult =
+  | { kind: 'ok' }
+  | { kind: 'not-found' }
+  | { kind: 'forbidden' }
+  | { kind: 'rate-limited' }
+  | { kind: 'error' }
+
+export async function revokeShare(id: string): Promise<RevokeShareResult> {
   try {
     const r = await fetch(`/api/revoke/${encodeURIComponent(id)}`, {
       method: 'POST',
       credentials: 'same-origin',
     })
-    return r.ok
+    if (r.status === 200) return { kind: 'ok' }
+    if (r.status === 404) return { kind: 'not-found' }
+    if (r.status === 403) return { kind: 'forbidden' }
+    if (r.status === 429) return { kind: 'rate-limited' }
+    return { kind: 'error' }
   } catch {
-    return false
+    return { kind: 'error' }
   }
 }
 

--- a/packages/share-web/src/lib/api.ts
+++ b/packages/share-web/src/lib/api.ts
@@ -177,6 +177,27 @@ export async function revokeShare(id: string): Promise<RevokeShareResult> {
   }
 }
 
+export type CheckHandleResult =
+  | { kind: 'available' }
+  | { kind: 'taken' }
+  | { kind: 'invalid'; reason: string }
+  | { kind: 'error' }
+
+export async function checkHandle(handle: string): Promise<CheckHandleResult> {
+  try {
+    const r = await fetch(`/api/handles/check?h=${encodeURIComponent(handle)}`, {
+      headers: { accept: 'application/json' },
+    })
+    if (r.status !== 200) return { kind: 'error' }
+    const body = (await r.json()) as { available?: boolean; reason?: string }
+    if (body.available === true) return { kind: 'available' }
+    if (body.reason) return { kind: 'invalid', reason: body.reason }
+    return { kind: 'taken' }
+  } catch {
+    return { kind: 'error' }
+  }
+}
+
 export async function claimHandle(handle: string): Promise<
   | { kind: 'ok'; handle: string }
   | { kind: 'invalid'; reason: string }

--- a/packages/share-web/src/lib/api.ts
+++ b/packages/share-web/src/lib/api.ts
@@ -50,3 +50,173 @@ export async function fetchSnapshot(id: string): Promise<SnapshotFetchResult> {
   }
 }
 
+export interface ProfileShareSummary {
+  id: string
+  title: string
+  published_at: number
+  version: number
+}
+
+export interface ProfileResponse {
+  handle: string
+  name: string | null
+  avatar_url: string | null
+  shares: ProfileShareSummary[]
+}
+
+export type ProfileFetchResult =
+  | { kind: 'ok'; profile: ProfileResponse }
+  | { kind: 'not-found' }
+  | { kind: 'error' }
+
+export async function fetchProfile(handle: string): Promise<ProfileFetchResult> {
+  try {
+    const r = await fetch(`/api/profiles/${encodeURIComponent(handle)}`, {
+      headers: { accept: 'application/json' },
+    })
+    if (r.status === 200) {
+      const body = (await r.json()) as ProfileResponse
+      return { kind: 'ok', profile: body }
+    }
+    if (r.status === 404) return { kind: 'not-found' }
+    return { kind: 'error' }
+  } catch {
+    return { kind: 'error' }
+  }
+}
+
+export interface MeResponse {
+  id: string
+  email: string
+  name: string | null
+  avatar_url: string | null
+  handle: string | null
+}
+
+export interface MeShareRow {
+  id: string
+  title: string
+  visibility: 'unlisted' | 'profile-listed'
+  expires_at: number | null
+  version: number
+  published_at: number
+  republished_at: number | null
+  revoked_at: number | null
+}
+
+export type MeFetchResult =
+  | { kind: 'ok'; me: MeResponse }
+  | { kind: 'unauthenticated' }
+  | { kind: 'forbidden' }
+  | { kind: 'error' }
+
+export async function fetchMe(): Promise<MeFetchResult> {
+  try {
+    const r = await fetch('/api/me', {
+      headers: { accept: 'application/json' },
+      credentials: 'same-origin',
+    })
+    if (r.status === 200) return { kind: 'ok', me: (await r.json()) as MeResponse }
+    if (r.status === 401) return { kind: 'unauthenticated' }
+    if (r.status === 403) return { kind: 'forbidden' }
+    return { kind: 'error' }
+  } catch {
+    return { kind: 'error' }
+  }
+}
+
+export async function fetchMyShares(): Promise<MeShareRow[]> {
+  const r = await fetch('/api/me/shares', {
+    headers: { accept: 'application/json' },
+    credentials: 'same-origin',
+  })
+  if (r.status !== 200) return []
+  const body = (await r.json()) as { items: MeShareRow[] }
+  return body.items ?? []
+}
+
+export async function revokeShare(id: string): Promise<boolean> {
+  try {
+    const r = await fetch(`/api/revoke/${encodeURIComponent(id)}`, {
+      method: 'POST',
+      credentials: 'same-origin',
+    })
+    return r.ok
+  } catch {
+    return false
+  }
+}
+
+export async function claimHandle(handle: string): Promise<
+  | { kind: 'ok'; handle: string }
+  | { kind: 'invalid'; reason: string }
+  | { kind: 'taken' }
+  | { kind: 'rate-limited' }
+  | { kind: 'error' }
+> {
+  try {
+    const r = await fetch('/api/handles/claim', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'content-type': 'application/json', accept: 'application/json' },
+      body: JSON.stringify({ handle }),
+    })
+    if (r.status === 200) {
+      const body = (await r.json()) as { handle: string }
+      return { kind: 'ok', handle: body.handle }
+    }
+    if (r.status === 409) return { kind: 'taken' }
+    if (r.status === 422) {
+      const body = (await r.json().catch(() => null)) as { detail?: string } | null
+      return { kind: 'invalid', reason: body?.detail ?? 'Invalid handle.' }
+    }
+    if (r.status === 429) return { kind: 'rate-limited' }
+    return { kind: 'error' }
+  } catch {
+    return { kind: 'error' }
+  }
+}
+
+export async function signOut(): Promise<boolean> {
+  try {
+    const r = await fetch('/api/auth/sign-out', {
+      method: 'POST',
+      credentials: 'same-origin',
+    })
+    return r.ok
+  } catch {
+    return false
+  }
+}
+
+export type DeleteAccountResult =
+  | { kind: 'ok'; scheduled_at: number }
+  | { kind: 'error' }
+
+export async function scheduleAccountDeletion(): Promise<DeleteAccountResult> {
+  try {
+    const r = await fetch('/api/me/delete', {
+      method: 'POST',
+      credentials: 'same-origin',
+    })
+    if (r.status === 200) {
+      const body = (await r.json()) as { scheduled_at: number }
+      return { kind: 'ok', scheduled_at: body.scheduled_at }
+    }
+    return { kind: 'error' }
+  } catch {
+    return { kind: 'error' }
+  }
+}
+
+export async function cancelAccountDeletion(): Promise<boolean> {
+  try {
+    const r = await fetch('/api/me/delete', {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    })
+    return r.ok
+  } catch {
+    return false
+  }
+}

--- a/packages/share-web/src/lib/route.test.ts
+++ b/packages/share-web/src/lib/route.test.ts
@@ -25,9 +25,44 @@ describe('routeFor', () => {
 
   it('falls through to tombstone for unknown paths', () => {
     expect(routeFor('/').kind).toBe('tombstone')
-    expect(routeFor('/me').kind).toBe('tombstone')
-    expect(routeFor('/@someone').kind).toBe('tombstone')
+    expect(routeFor('/random').kind).toBe('tombstone')
     expect(routeFor('/report').kind).toBe('tombstone')
+  })
+
+  it('matches /me as me', () => {
+    expect(routeFor('/me')).toEqual({ kind: 'me' })
+  })
+
+  it('matches /@<handle> as profile', () => {
+    expect(routeFor('/@alice')).toEqual({ kind: 'profile', handle: 'alice' })
+  })
+
+  it('lowercases the handle in /@<handle>', () => {
+    expect(routeFor('/@Alice')).toEqual({ kind: 'profile', handle: 'alice' })
+  })
+
+  it('rejects invalid handles (too short)', () => {
+    expect(routeFor('/@ab').kind).toBe('tombstone')
+  })
+
+  it('rejects invalid handles (illegal chars)', () => {
+    expect(routeFor('/@bad!!').kind).toBe('tombstone')
+  })
+
+  it('rejects handles that start with a digit', () => {
+    expect(routeFor('/@2bad').kind).toBe('tombstone')
+  })
+
+  it('matches /sign-in with sanitized next', () => {
+    expect(routeFor('/sign-in', '?next=/me')).toEqual({ kind: 'sign-in', next: '/me' })
+  })
+
+  it('matches /sign-in without next (default /)', () => {
+    expect(routeFor('/sign-in')).toEqual({ kind: 'sign-in', next: '/' })
+  })
+
+  it('sanitizes evil next on /sign-in', () => {
+    expect(routeFor('/sign-in', '?next=//evil.com')).toEqual({ kind: 'sign-in', next: '/' })
   })
 })
 

--- a/packages/share-web/src/lib/route.ts
+++ b/packages/share-web/src/lib/route.ts
@@ -57,7 +57,12 @@ export function routeFor(pathname: string, search: string = ''): Route {
  *  - rejects absolute URLs (`http://evil.com`)
  *  - rejects protocol-relative URLs (`//evil.com`)
  *  - rejects backslash sneakers (`/\evil.com`)
- *  - rejects path-traversal (`/..`) */
+ *  - rejects path-traversal (`/..`)
+ *
+ *  Keep AT LEAST as strict as the server's `safeNext` in
+ *  `packages/share-backend/src/auth/next.ts` — the server runs first on
+ *  the OAuth callback, but defense-in-depth means this guard catches a
+ *  drifted backend. */
 export function nextSafe(raw: string | null | undefined): string {
   if (!raw) return '/'
   if (typeof raw !== 'string') return '/'

--- a/packages/share-web/src/lib/route.ts
+++ b/packages/share-web/src/lib/route.ts
@@ -1,5 +1,6 @@
 // Bare-bones path matcher. We intentionally avoid react-router for an
-// SPA this small — `/s/<id>` and a catch-all tombstone is not worth a
+// SPA this small — a handful of static routes (`/s/<id>`, `/@<handle>`,
+// `/me`, `/sign-in`) and one catch-all tombstone is not worth a
 // dependency.
 //
 // `nextSafe` defends `?next=` query params against open-redirect abuse:
@@ -7,6 +8,9 @@
 
 export type Route =
   | { kind: 'reader'; id: string }
+  | { kind: 'profile'; handle: string }
+  | { kind: 'me' }
+  | { kind: 'sign-in'; next: string }
   | { kind: 'tombstone'; reason: 'not-found' }
 
 // Slugs are nanoid(21) — URL-safe base64 alphabet
@@ -14,7 +18,12 @@ export type Route =
 // `/s/foo` returns a clean 404 tombstone instead of a 30-second fetch.
 const SLUG_RE = /^[A-Za-z0-9_-]{21}$/
 
-export function routeFor(pathname: string, _search: string = ''): Route {
+// Mirror of the server-side validator in share-backend/src/handles.ts.
+// We check on the client too so `/@bogus!!` falls through to tombstone
+// instead of issuing a guaranteed-404 fetch.
+const HANDLE_RE = /^[a-z][a-z0-9_-]{2,31}$/
+
+export function routeFor(pathname: string, search: string = ''): Route {
   const path = pathname.replace(/\/+$/, '') || '/'
 
   // Reader: /s/<slug>
@@ -22,6 +31,22 @@ export function routeFor(pathname: string, _search: string = ''): Route {
     const id = decodeURIComponent(path.slice(3))
     if (!SLUG_RE.test(id)) return { kind: 'tombstone', reason: 'not-found' }
     return { kind: 'reader', id }
+  }
+
+  // Profile: /@<handle>
+  if (path.startsWith('/@')) {
+    const handle = decodeURIComponent(path.slice(2)).toLowerCase()
+    if (!HANDLE_RE.test(handle)) return { kind: 'tombstone', reason: 'not-found' }
+    return { kind: 'profile', handle }
+  }
+
+  // Me: /me
+  if (path === '/me') return { kind: 'me' }
+
+  // Sign-in: /sign-in?next=<safe>
+  if (path === '/sign-in') {
+    const params = new URLSearchParams(search)
+    return { kind: 'sign-in', next: nextSafe(params.get('next')) }
   }
 
   return { kind: 'tombstone', reason: 'not-found' }

--- a/packages/share-web/src/pages/Me.tsx
+++ b/packages/share-web/src/pages/Me.tsx
@@ -1,0 +1,322 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import {
+  cancelAccountDeletion,
+  claimHandle,
+  fetchMe,
+  fetchMyShares,
+  revokeShare,
+  scheduleAccountDeletion,
+  signOut,
+  type MeResponse,
+  type MeShareRow,
+} from '../lib/api'
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ok'; me: MeResponse; shares: MeShareRow[] }
+  | { kind: 'error' }
+
+function formatDate(ts: number): string {
+  try {
+    return new Date(ts).toLocaleDateString()
+  } catch {
+    return ''
+  }
+}
+
+function formatExpiry(ts: number | null): string | null {
+  if (ts === null) return null
+  try {
+    return new Date(ts).toLocaleString()
+  } catch {
+    return null
+  }
+}
+
+function shareUrl(id: string): string {
+  return `${window.location.origin}/s/${encodeURIComponent(id)}`
+}
+
+function HandleClaim({ onClaimed }: { onClaimed: (handle: string) => void }) {
+  const [value, setValue] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (busy) return
+    setBusy(true)
+    setErr(null)
+    const result = await claimHandle(value.trim().toLowerCase())
+    setBusy(false)
+    if (result.kind === 'ok') {
+      onClaimed(result.handle)
+      return
+    }
+    if (result.kind === 'taken') setErr('That handle is taken.')
+    else if (result.kind === 'invalid') setErr(result.reason)
+    else if (result.kind === 'rate-limited') setErr('Too many attempts — try again tomorrow.')
+    else setErr('Something went wrong.')
+  }
+
+  return (
+    <form className="me-claim" onSubmit={onSubmit} noValidate>
+      <label>
+        <span>Claim a handle</span>
+        <input
+          type="text"
+          autoComplete="off"
+          spellCheck={false}
+          placeholder="alice"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </label>
+      <button type="submit" disabled={busy || value.trim().length === 0}>
+        {busy ? 'Claiming…' : 'Claim'}
+      </button>
+      {err && <p className="me-error" role="alert">{err}</p>}
+    </form>
+  )
+}
+
+function ShareRow({
+  row,
+  onUnpublish,
+}: {
+  row: MeShareRow
+  onUnpublish: (id: string) => Promise<void>
+}) {
+  const [busy, setBusy] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const revoked = row.revoked_at !== null
+  const expiry = formatExpiry(row.expires_at)
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(shareUrl(row.id))
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async function unpublish() {
+    if (busy || revoked) return
+    setBusy(true)
+    await onUnpublish(row.id)
+    setBusy(false)
+  }
+
+  return (
+    <li className={`me-share${revoked ? ' me-share-revoked' : ''}`}>
+      <div className="me-share-main">
+        <span className="me-share-title">{row.title}</span>
+        <span className="me-share-meta">
+          {row.visibility === 'profile-listed' ? 'Profile-listed' : 'Unlisted'}
+          {' · '}
+          published {formatDate(row.published_at)}
+          {expiry && ` · expires ${expiry}`}
+          {revoked && ' · unpublished'}
+        </span>
+      </div>
+      <div className="me-share-actions">
+        <a href={`/s/${encodeURIComponent(row.id)}`} target="_blank" rel="noreferrer">
+          View
+        </a>
+        <button type="button" onClick={copy}>
+          {copied ? 'Copied' : 'Copy link'}
+        </button>
+        {!revoked && (
+          <button type="button" onClick={unpublish} disabled={busy} className="me-share-danger">
+            {busy ? 'Unpublishing…' : 'Unpublish'}
+          </button>
+        )}
+      </div>
+    </li>
+  )
+}
+
+function DeleteAccount() {
+  const [state, setState] = useState<
+    | { kind: 'idle' }
+    | { kind: 'confirming' }
+    | { kind: 'scheduled'; at: number }
+    | { kind: 'cancelling' }
+  >({ kind: 'idle' })
+
+  async function schedule() {
+    const r = await scheduleAccountDeletion()
+    if (r.kind === 'ok') setState({ kind: 'scheduled', at: r.scheduled_at })
+  }
+
+  async function cancel() {
+    setState({ kind: 'cancelling' })
+    const ok = await cancelAccountDeletion()
+    if (ok) setState({ kind: 'idle' })
+    else setState({ kind: 'scheduled', at: 0 })
+  }
+
+  if (state.kind === 'scheduled' || state.kind === 'cancelling') {
+    const when = state.kind === 'scheduled' && state.at > 0
+      ? new Date(state.at).toLocaleString()
+      : null
+    return (
+      <div className="me-delete me-delete-pending">
+        <p>
+          Account deletion is scheduled
+          {when && ` for ${when}`}. You have 24 hours to cancel.
+        </p>
+        <button type="button" onClick={cancel} disabled={state.kind === 'cancelling'}>
+          {state.kind === 'cancelling' ? 'Cancelling…' : 'Cancel deletion'}
+        </button>
+      </div>
+    )
+  }
+
+  if (state.kind === 'confirming') {
+    return (
+      <div className="me-delete">
+        <p>
+          Deleting your account unpublishes every share, releases your
+          handle, and removes your record after 24 hours. This can be
+          undone within that window.
+        </p>
+        <div className="me-delete-actions">
+          <button type="button" onClick={schedule} className="me-share-danger">
+            Yes, delete my account
+          </button>
+          <button type="button" onClick={() => setState({ kind: 'idle' })}>
+            Back
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="me-delete">
+      <button type="button" onClick={() => setState({ kind: 'confirming' })}>
+        Delete account…
+      </button>
+    </div>
+  )
+}
+
+export function Me() {
+  const [state, setState] = useState<LoadState>({ kind: 'loading' })
+
+  const load = useCallback(async () => {
+    const meResult = await fetchMe()
+    if (meResult.kind === 'unauthenticated') {
+      window.location.replace('/sign-in?next=/me')
+      return
+    }
+    if (meResult.kind === 'forbidden') {
+      // Account is pending deletion. The /me API will 403; route them
+      // to sign-in so they can recover via a fresh session.
+      window.location.replace('/sign-in?next=/me')
+      return
+    }
+    if (meResult.kind !== 'ok') {
+      setState({ kind: 'error' })
+      return
+    }
+    const shares = await fetchMyShares()
+    setState({ kind: 'ok', me: meResult.me, shares })
+  }, [])
+
+  useEffect(() => {
+    document.title = 'Your account · spool.share'
+    load()
+  }, [load])
+
+  async function onUnpublish(id: string) {
+    const ok = await revokeShare(id)
+    if (!ok) return
+    setState((s) => {
+      if (s.kind !== 'ok') return s
+      return {
+        ...s,
+        shares: s.shares.map((x) =>
+          x.id === id ? { ...x, revoked_at: Date.now() } : x,
+        ),
+      }
+    })
+  }
+
+  async function onSignOut() {
+    await signOut()
+    window.location.assign('/')
+  }
+
+  if (state.kind === 'loading') {
+    return (
+      <main className="reader-loading" aria-busy="true">
+        <div className="reader-loading-card">Loading…</div>
+      </main>
+    )
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <main className="me-page">
+        <div className="me-card">
+          <h1>Something went wrong</h1>
+          <p>We couldn’t load your account. Try refreshing.</p>
+        </div>
+      </main>
+    )
+  }
+
+  const { me, shares } = state
+  return (
+    <main className="me-page">
+      <header className="me-header">
+        {me.avatar_url ? <img className="me-avatar" src={me.avatar_url} alt="" /> : null}
+        <div className="me-identity">
+          {me.name && <h1 className="me-name">{me.name}</h1>}
+          <p className="me-email">{me.email}</p>
+          {me.handle ? (
+            <p className="me-handle">
+              <a href={`/@${me.handle}`}>@{me.handle}</a>
+            </p>
+          ) : null}
+        </div>
+        <button type="button" className="me-signout" onClick={onSignOut}>
+          Sign out
+        </button>
+      </header>
+
+      {!me.handle && (
+        <section className="me-section">
+          <HandleClaim
+            onClaimed={(handle) =>
+              setState((s) => (s.kind === 'ok' ? { ...s, me: { ...s.me, handle } } : s))
+            }
+          />
+        </section>
+      )}
+
+      <section className="me-section">
+        <h2 className="me-section-title">Your shares</h2>
+        {shares.length === 0 ? (
+          <p className="me-empty">You haven’t published anything yet.</p>
+        ) : (
+          <ul className="me-share-list">
+            {shares.map((row) => (
+              <ShareRow key={row.id} row={row} onUnpublish={onUnpublish} />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="me-section me-danger-zone">
+        <h2 className="me-section-title">Danger zone</h2>
+        <DeleteAccount />
+      </section>
+    </main>
+  )
+}

--- a/packages/share-web/src/pages/Me.tsx
+++ b/packages/share-web/src/pages/Me.tsx
@@ -342,7 +342,7 @@ export function Me() {
         <div className="me-banner me-banner-pending" role="alert">
           <strong>Account deletion is pending.</strong>{' '}
           {pendingUntil
-            ? `Worker will hard-delete at ${new Date(pendingUntil).toLocaleString()}.`
+            ? `Scheduled for ${new Date(pendingUntil).toLocaleString()}.`
             : null}{' '}
           Cancel deletion in the Danger zone below to restore access.
         </div>

--- a/packages/share-web/src/pages/Me.tsx
+++ b/packages/share-web/src/pages/Me.tsx
@@ -83,13 +83,18 @@ function HandleClaim({ onClaimed }: { onClaimed: (handle: string) => void }) {
 
 function ShareRow({
   row,
+  disabled,
   onUnpublish,
 }: {
   row: MeShareRow
-  onUnpublish: (id: string) => Promise<void>
+  /** Block unpublish actions entirely (e.g. account in deletion grace
+   *  period — the backend would 403 anyway). */
+  disabled?: boolean
+  onUnpublish: (id: string) => Promise<{ ok: boolean; reason?: string }>
 }) {
   const [busy, setBusy] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
   const revoked = row.revoked_at !== null
   const expiry = formatExpiry(row.expires_at)
 
@@ -104,10 +109,12 @@ function ShareRow({
   }
 
   async function unpublish() {
-    if (busy || revoked) return
+    if (busy || revoked || disabled) return
     setBusy(true)
-    await onUnpublish(row.id)
+    setErr(null)
+    const r = await onUnpublish(row.id)
     setBusy(false)
+    if (!r.ok) setErr(r.reason ?? 'Could not unpublish — try again.')
   }
 
   return (
@@ -121,6 +128,7 @@ function ShareRow({
           {expiry && ` · expires ${expiry}`}
           {revoked && ' · unpublished'}
         </span>
+        {err && <span className="me-share-error" role="alert">{err}</span>}
       </div>
       <div className="me-share-actions">
         <a href={`/s/${encodeURIComponent(row.id)}`} target="_blank" rel="noreferrer">
@@ -130,7 +138,12 @@ function ShareRow({
           {copied ? 'Copied' : 'Copy link'}
         </button>
         {!revoked && (
-          <button type="button" onClick={unpublish} disabled={busy} className="me-share-danger">
+          <button
+            type="button"
+            onClick={unpublish}
+            disabled={busy || disabled}
+            className="me-share-danger"
+          >
             {busy ? 'Unpublishing…' : 'Unpublish'}
           </button>
         )}
@@ -139,13 +152,29 @@ function ShareRow({
   )
 }
 
-function DeleteAccount() {
+function DeleteAccount({
+  initialPendingUntil,
+  onCancelled,
+}: {
+  /** Epoch-ms — when non-null on mount, /me boots straight into the
+   *  scheduled / "cancel deletion" state instead of "Delete account…".
+   *  Carries the cross-device case where the user scheduled deletion
+   *  from desktop and now opens the web /me to recover. */
+  initialPendingUntil: number | null
+  /** Called after a successful cancel so the parent can clear its own
+   *  banner / re-enable handle claim + unpublish. */
+  onCancelled: () => void
+}) {
   const [state, setState] = useState<
     | { kind: 'idle' }
     | { kind: 'confirming' }
     | { kind: 'scheduled'; at: number }
     | { kind: 'cancelling' }
-  >({ kind: 'idle' })
+  >(
+    initialPendingUntil
+      ? { kind: 'scheduled', at: initialPendingUntil }
+      : { kind: 'idle' },
+  )
 
   async function schedule() {
     const r = await scheduleAccountDeletion()
@@ -155,8 +184,12 @@ function DeleteAccount() {
   async function cancel() {
     setState({ kind: 'cancelling' })
     const ok = await cancelAccountDeletion()
-    if (ok) setState({ kind: 'idle' })
-    else setState({ kind: 'scheduled', at: 0 })
+    if (ok) {
+      setState({ kind: 'idle' })
+      onCancelled()
+    } else {
+      setState({ kind: 'scheduled', at: 0 })
+    }
   }
 
   if (state.kind === 'scheduled' || state.kind === 'cancelling') {
@@ -211,17 +244,23 @@ export function Me() {
   const load = useCallback(async () => {
     // Parallel — shares is owned by /me's session cookie too, so the
     // request still flies in flight even before /me resolves.
-    const [meResult, shares] = await Promise.all([fetchMe(), fetchMyShares()])
-    if (meResult.kind === 'unauthenticated' || meResult.kind === 'forbidden') {
-      // forbidden = account pending deletion; either way send them to
-      // sign-in to recover via a fresh session.
+    const [meResult, sharesResult] = await Promise.all([fetchMe(), fetchMyShares()])
+    if (meResult.kind === 'unauthenticated') {
       window.location.replace('/sign-in?next=/me')
       return
     }
     if (meResult.kind !== 'ok') {
+      // /api/me returns 200 even during the 24h grace window (PR 3
+      // amend opened it for pending-deletion users so the cancel
+      // path stays reachable); any other non-ok is genuine error.
       setState({ kind: 'error' })
       return
     }
+    // Shares endpoint stays locked behind the default requireUser
+    // policy — pending-deletion gets 403, which we treat as "no
+    // shares to show" rather than punting to sign-in. The banner
+    // explains why; the cancel-deletion button is right there.
+    const shares = sharesResult.kind === 'ok' ? sharesResult.shares : []
     setState({ kind: 'ok', me: meResult.me, shares })
   }, [])
 
@@ -230,23 +269,49 @@ export function Me() {
     load()
   }, [load])
 
-  async function onUnpublish(id: string) {
-    const ok = await revokeShare(id)
-    if (!ok) return
-    setState((s) => {
-      if (s.kind !== 'ok') return s
-      return {
-        ...s,
-        shares: s.shares.map((x) =>
-          x.id === id ? { ...x, revoked_at: Date.now() } : x,
-        ),
-      }
-    })
+  async function onUnpublish(id: string): Promise<{ ok: boolean; reason?: string }> {
+    const r = await revokeShare(id)
+    if (r.kind === 'ok') {
+      setState((s) => {
+        if (s.kind !== 'ok') return s
+        return {
+          ...s,
+          shares: s.shares.map((x) =>
+            x.id === id ? { ...x, revoked_at: Date.now() } : x,
+          ),
+        }
+      })
+      return { ok: true }
+    }
+    if (r.kind === 'forbidden') {
+      return { ok: false, reason: 'Your account is pending deletion — cancel it first.' }
+    }
+    if (r.kind === 'rate-limited') {
+      return { ok: false, reason: 'Too many unpublish requests — wait a minute.' }
+    }
+    if (r.kind === 'not-found') {
+      return { ok: false, reason: 'Share not found (already revoked?).' }
+    }
+    return { ok: false, reason: 'Could not unpublish — try again.' }
   }
 
   async function onSignOut() {
     await signOut()
     window.location.assign('/')
+  }
+
+  function onDeletionCancelled(): void {
+    setState((s) =>
+      s.kind === 'ok'
+        ? { ...s, me: { ...s.me, deletion_pending_until: null } }
+        : s,
+    )
+    // Re-fetch shares — they were 403'd while pending; now that the
+    // user cancelled deletion they should reappear.
+    fetchMyShares().then((r) => {
+      if (r.kind !== 'ok') return
+      setState((s) => (s.kind === 'ok' ? { ...s, shares: r.shares } : s))
+    })
   }
 
   if (state.kind === 'loading') {
@@ -269,8 +334,20 @@ export function Me() {
   }
 
   const { me, shares } = state
+  const pendingUntil = me.deletion_pending_until
+  const pending = pendingUntil !== null
   return (
     <main className="me-page">
+      {pending && (
+        <div className="me-banner me-banner-pending" role="alert">
+          <strong>Account deletion is pending.</strong>{' '}
+          {pendingUntil
+            ? `Worker will hard-delete at ${new Date(pendingUntil).toLocaleString()}.`
+            : null}{' '}
+          Cancel deletion in the Danger zone below to restore access.
+        </div>
+      )}
+
       <header className="me-header">
         {me.avatar_url ? <img className="me-avatar" src={me.avatar_url} alt="" /> : null}
         <div className="me-identity">
@@ -287,7 +364,7 @@ export function Me() {
         </button>
       </header>
 
-      {!me.handle && (
+      {!me.handle && !pending && (
         <section className="me-section">
           <HandleClaim
             onClaimed={(handle) =>
@@ -299,12 +376,21 @@ export function Me() {
 
       <section className="me-section">
         <h2 className="me-section-title">Your shares</h2>
-        {shares.length === 0 ? (
+        {pending ? (
+          <p className="me-empty">
+            Hidden while deletion is pending. Cancel deletion to restore the list.
+          </p>
+        ) : shares.length === 0 ? (
           <p className="me-empty">You haven’t published anything yet.</p>
         ) : (
           <ul className="me-share-list">
             {shares.map((row) => (
-              <ShareRow key={row.id} row={row} onUnpublish={onUnpublish} />
+              <ShareRow
+                key={row.id}
+                row={row}
+                disabled={pending}
+                onUnpublish={onUnpublish}
+              />
             ))}
           </ul>
         )}
@@ -312,7 +398,7 @@ export function Me() {
 
       <section className="me-section me-danger-zone">
         <h2 className="me-section-title">Danger zone</h2>
-        <DeleteAccount />
+        <DeleteAccount initialPendingUntil={pendingUntil} onCancelled={onDeletionCancelled} />
       </section>
     </main>
   )

--- a/packages/share-web/src/pages/Me.tsx
+++ b/packages/share-web/src/pages/Me.tsx
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
+  Avatar,
+  Footer,
+  Header,
+  Icon,
+  Page,
+} from '../components/Chrome'
+import {
   cancelAccountDeletion,
   checkHandle,
   claimHandle,
@@ -12,6 +19,7 @@ import {
   type MeResponse,
   type MeShareRow,
 } from '../lib/api'
+import { humanDate, humanDateTime } from '../lib/dates'
 
 // Match the server-side handle regex (share-backend/src/handles.ts).
 // We pre-filter input so check requests + the submit button respond
@@ -25,23 +33,6 @@ type LoadState =
   | { kind: 'loading' }
   | { kind: 'ok'; me: MeResponse; shares: MeShareRow[] }
   | { kind: 'error' }
-
-function formatDate(ts: number): string {
-  try {
-    return new Date(ts).toLocaleDateString()
-  } catch {
-    return ''
-  }
-}
-
-function formatExpiry(ts: number | null): string | null {
-  if (ts === null) return null
-  try {
-    return new Date(ts).toLocaleString()
-  } catch {
-    return null
-  }
-}
 
 function shareUrl(id: string): string {
   return `${window.location.origin}/s/${encodeURIComponent(id)}`
@@ -61,11 +52,8 @@ function HandleClaim({ onClaimed }: { onClaimed: (handle: string) => void }) {
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const [availability, setAvailability] = useState<HandleAvailability>({ kind: 'idle' })
-  // Sequence guards stale debounced responses overwriting fresher ones.
   const checkSeq = useRef(0)
 
-  // Debounced availability check. Skips the round-trip for inputs that
-  // can't possibly pass server-side validation.
   useEffect(() => {
     const handle = value
     if (handle.length === 0) {
@@ -114,54 +102,84 @@ function HandleClaim({ onClaimed }: { onClaimed: (handle: string) => void }) {
   const submitDisabled = busy || availability.kind !== 'available'
 
   return (
-    <form className="me-claim" onSubmit={onSubmit} noValidate>
+    <form className="sw-claim" onSubmit={onSubmit} noValidate>
       <label>
         <span>Claim a handle</span>
-        <input
-          type="text"
-          autoComplete="off"
-          spellCheck={false}
-          placeholder="alice"
-          maxLength={HANDLE_MAX_LEN}
-          value={value}
-          onChange={(e) =>
-            setValue(
-              e.target.value.toLowerCase().replace(HANDLE_NORMALISE, '').slice(0, HANDLE_MAX_LEN),
-            )
-          }
-        />
+        <div className="sw-input-wrap">
+          <span className="at">@</span>
+          <input
+            className="sw-input"
+            type="text"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="alice"
+            maxLength={HANDLE_MAX_LEN}
+            value={value}
+            onChange={(e) =>
+              setValue(
+                e.target.value
+                  .toLowerCase()
+                  .replace(HANDLE_NORMALISE, '')
+                  .slice(0, HANDLE_MAX_LEN),
+              )
+            }
+          />
+        </div>
       </label>
-      <button type="submit" disabled={submitDisabled}>
+      <button
+        type="submit"
+        className="sw-btn sw-btn-primary"
+        disabled={submitDisabled}
+        style={{ padding: '9px 18px' }}
+      >
         {busy ? 'Claiming…' : 'Claim'}
       </button>
       {status && (
-        <p className={`me-handle-status me-handle-status-${status.tone}`} role="status">
+        <p className={`sw-claim-status ${status.tone}`} role="status">
+          {status.icon === 'spin' ? (
+            <span className="sw-spin sw-spin-anim ico" />
+          ) : status.icon ? (
+            <span className="ico">
+              <Icon name={status.icon} size={12} />
+            </span>
+          ) : null}
           {status.text}
         </p>
       )}
-      {err && <p className="me-error" role="alert">{err}</p>}
+      {err && (
+        <p className="sw-claim-status warn" role="alert">
+          <span className="ico">
+            <Icon name="alert" size={12} />
+          </span>
+          {err}
+        </p>
+      )}
     </form>
   )
 }
 
 function renderAvailability(
   a: HandleAvailability,
-): { tone: 'muted' | 'ok' | 'warn'; text: string } | null {
+): {
+  tone: 'muted' | 'ok' | 'warn'
+  text: string
+  icon: 'check-circle' | 'x-circle' | 'alert' | 'spin' | null
+} | null {
   switch (a.kind) {
     case 'idle':
       return null
     case 'too-short':
-      return { tone: 'muted', text: `At least ${HANDLE_MIN_LEN} characters.` }
+      return { tone: 'muted', text: `At least ${HANDLE_MIN_LEN} characters.`, icon: null }
     case 'checking':
-      return { tone: 'muted', text: 'Checking…' }
+      return { tone: 'muted', text: 'Checking…', icon: 'spin' }
     case 'available':
-      return { tone: 'ok', text: 'Available.' }
+      return { tone: 'ok', text: 'Available.', icon: 'check-circle' }
     case 'taken':
-      return { tone: 'warn', text: 'Taken.' }
+      return { tone: 'warn', text: 'Taken — try another.', icon: 'x-circle' }
     case 'invalid':
-      return { tone: 'warn', text: a.reason }
+      return { tone: 'warn', text: a.reason, icon: 'alert' }
     case 'error':
-      return { tone: 'warn', text: 'Could not check right now.' }
+      return { tone: 'warn', text: 'Could not check right now.', icon: 'alert' }
   }
 }
 
@@ -171,8 +189,6 @@ function ShareRow({
   onUnpublish,
 }: {
   row: MeShareRow
-  /** Block unpublish actions entirely (e.g. account in deletion grace
-   *  period — the backend would 403 anyway). */
   disabled?: boolean
   onUnpublish: (id: string) => Promise<{ ok: boolean; reason?: string }>
 }) {
@@ -180,7 +196,8 @@ function ShareRow({
   const [copied, setCopied] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const revoked = row.revoked_at !== null
-  const expiry = formatExpiry(row.expires_at)
+  const expiry = row.expires_at !== null ? humanDate(row.expires_at) : null
+  const listed = row.visibility === 'profile-listed'
 
   async function copy() {
     try {
@@ -202,34 +219,77 @@ function ShareRow({
   }
 
   return (
-    <li className={`me-share${revoked ? ' me-share-revoked' : ''}`}>
-      <div className="me-share-main">
-        <span className="me-share-title">{row.title}</span>
-        <span className="me-share-meta">
-          {row.visibility === 'profile-listed' ? 'Profile-listed' : 'Unlisted'}
-          {' · '}
-          published {formatDate(row.published_at)}
-          {expiry && ` · expires ${expiry}`}
-          {revoked && ' · unpublished'}
+    <li
+      className={`sw-share${revoked ? ' revoked' : ''}${disabled ? ' disabled' : ''}`}
+    >
+      <div className="sw-share-main">
+        <span className="sw-share-title">{row.title}</span>
+        <span className="sw-share-meta">
+          <span className={`sw-pill${listed ? ' listed' : ''}`}>
+            {listed ? 'Listed' : 'Unlisted'}
+          </span>
+          <span>published {humanDate(row.published_at)}</span>
+          {expiry && (
+            <>
+              <span className="dot-sep">·</span>
+              <span>expires {expiry}</span>
+            </>
+          )}
+          {revoked && (
+            <>
+              <span className="dot-sep">·</span>
+              <span className="sw-pill revoked">Unpublished</span>
+            </>
+          )}
         </span>
-        {err && <span className="me-share-error" role="alert">{err}</span>}
+        {err && (
+          <span className="sw-share-error" role="alert">
+            {err}
+          </span>
+        )}
       </div>
-      <div className="me-share-actions">
-        <a href={`/s/${encodeURIComponent(row.id)}`} target="_blank" rel="noreferrer">
-          View
+      <div className="sw-share-actions">
+        <a
+          className="sw-icon-btn"
+          href={`/s/${encodeURIComponent(row.id)}`}
+          target="_blank"
+          rel="noreferrer"
+          title="Open share"
+          aria-label="Open share"
+        >
+          <Icon name="external" size={14} />
         </a>
-        <button type="button" onClick={copy}>
-          {copied ? 'Copied' : 'Copy link'}
+        <button
+          type="button"
+          className={`sw-icon-btn${copied ? ' ok' : ''}`}
+          onClick={copy}
+          disabled={disabled}
+          title={copied ? 'Copied' : 'Copy link'}
+          aria-label={copied ? 'Copied' : 'Copy link'}
+        >
+          <Icon name={copied ? 'check' : 'link'} size={14} />
         </button>
         {!revoked && (
-          <button
-            type="button"
-            onClick={unpublish}
-            disabled={busy || disabled}
-            className="me-share-danger"
-          >
-            {busy ? 'Unpublishing…' : 'Unpublish'}
-          </button>
+          busy ? (
+            <span
+              className="sw-icon-btn busy"
+              aria-label="Unpublishing"
+              style={{ borderColor: 'var(--border-strong)' }}
+            >
+              <span className="sw-spin sw-spin-anim" style={{ width: 13, height: 13 }} />
+            </span>
+          ) : (
+            <button
+              type="button"
+              className="sw-icon-btn danger"
+              onClick={unpublish}
+              disabled={disabled}
+              title="Unpublish"
+              aria-label="Unpublish"
+            >
+              <Icon name="eye-off" size={14} />
+            </button>
+          )
         )}
       </div>
     </li>
@@ -240,13 +300,7 @@ function DeleteAccount({
   initialPendingUntil,
   onCancelled,
 }: {
-  /** Epoch-ms — when non-null on mount, /me boots straight into the
-   *  scheduled / "cancel deletion" state instead of "Delete account…".
-   *  Carries the cross-device case where the user scheduled deletion
-   *  from desktop and now opens the web /me to recover. */
   initialPendingUntil: number | null
-  /** Called after a successful cancel so the parent can clear its own
-   *  banner / re-enable handle claim + unpublish. */
   onCancelled: () => void
 }) {
   const [state, setState] = useState<
@@ -266,28 +320,42 @@ function DeleteAccount({
   }
 
   async function cancel() {
+    const prev = state
     setState({ kind: 'cancelling' })
     const ok = await cancelAccountDeletion()
     if (ok) {
       setState({ kind: 'idle' })
       onCancelled()
+    } else if (prev.kind === 'scheduled') {
+      setState(prev)
     } else {
       setState({ kind: 'scheduled', at: 0 })
     }
   }
 
   if (state.kind === 'scheduled' || state.kind === 'cancelling') {
-    const when = state.kind === 'scheduled' && state.at > 0
-      ? new Date(state.at).toLocaleString()
-      : null
+    const at = state.kind === 'scheduled' ? state.at : 0
+    const when = at > 0 ? humanDateTime(at) : null
     return (
-      <div className="me-delete me-delete-pending">
+      <div className="sw-scheduled-box">
         <p>
-          Account deletion is scheduled
-          {when && ` for ${when}`}. You have 24 hours to cancel.
+          <strong>Account deletion is scheduled</strong>
+          {when ? ` for ${when}` : ''}. You have 24 hours to cancel.
         </p>
-        <button type="button" onClick={cancel} disabled={state.kind === 'cancelling'}>
-          {state.kind === 'cancelling' ? 'Cancelling…' : 'Cancel deletion'}
+        <button
+          type="button"
+          className="sw-btn sw-btn-ghost"
+          onClick={cancel}
+          disabled={state.kind === 'cancelling'}
+        >
+          {state.kind === 'cancelling' ? (
+            <>
+              <span className="sw-spin sw-spin-anim" style={{ width: 11, height: 11 }} />
+              Cancelling…
+            </>
+          ) : (
+            'Cancel deletion'
+          )}
         </button>
       </div>
     )
@@ -295,17 +363,20 @@ function DeleteAccount({
 
   if (state.kind === 'confirming') {
     return (
-      <div className="me-delete">
+      <div className="sw-confirm-box">
         <p>
-          Deleting your account unpublishes every share, releases your
-          handle, and removes your record after 24 hours. This can be
-          undone within that window.
+          Deleting your account unpublishes every share, releases your handle, and removes
+          your record after 24 hours. This can be undone within that window.
         </p>
-        <div className="me-delete-actions">
-          <button type="button" onClick={schedule} className="me-share-danger">
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button type="button" className="sw-btn sw-btn-danger" onClick={schedule}>
             Yes, delete my account
           </button>
-          <button type="button" onClick={() => setState({ kind: 'idle' })}>
+          <button
+            type="button"
+            className="sw-btn sw-btn-ghost"
+            onClick={() => setState({ kind: 'idle' })}
+          >
             Back
           </button>
         </div>
@@ -314,11 +385,13 @@ function DeleteAccount({
   }
 
   return (
-    <div className="me-delete">
-      <button type="button" onClick={() => setState({ kind: 'confirming' })}>
-        Delete account…
-      </button>
-    </div>
+    <button
+      type="button"
+      className="sw-btn sw-btn-ghost"
+      onClick={() => setState({ kind: 'confirming' })}
+    >
+      Delete account…
+    </button>
   )
 }
 
@@ -326,24 +399,15 @@ export function Me() {
   const [state, setState] = useState<LoadState>({ kind: 'loading' })
 
   const load = useCallback(async () => {
-    // Parallel — shares is owned by /me's session cookie too, so the
-    // request still flies in flight even before /me resolves.
     const [meResult, sharesResult] = await Promise.all([fetchMe(), fetchMyShares()])
     if (meResult.kind === 'unauthenticated') {
       window.location.replace('/sign-in?next=/me')
       return
     }
     if (meResult.kind !== 'ok') {
-      // /api/me returns 200 even during the 24h grace window (PR 3
-      // amend opened it for pending-deletion users so the cancel
-      // path stays reachable); any other non-ok is genuine error.
       setState({ kind: 'error' })
       return
     }
-    // Shares endpoint stays locked behind the default requireUser
-    // policy — pending-deletion gets 403, which we treat as "no
-    // shares to show" rather than punting to sign-in. The banner
-    // explains why; the cancel-deletion button is right there.
     const shares = sharesResult.kind === 'ok' ? sharesResult.shares : []
     setState({ kind: 'ok', me: meResult.me, shares })
   }, [])
@@ -381,17 +445,18 @@ export function Me() {
 
   async function onSignOut() {
     await signOut()
-    window.location.assign('/')
+    // share-web doesn't own `/` — in prod that's the landing site (a
+    // separate Pages project routed by the worker), in dev there's
+    // nothing → tombstone. /sign-in is the natural post-logout
+    // destination either way: it confirms the signed-out state and
+    // makes signing back in one click.
+    window.location.assign('/sign-in')
   }
 
   function onDeletionCancelled(): void {
     setState((s) =>
-      s.kind === 'ok'
-        ? { ...s, me: { ...s.me, deletion_pending_until: null } }
-        : s,
+      s.kind === 'ok' ? { ...s, me: { ...s.me, deletion_pending_until: null } } : s,
     )
-    // Re-fetch shares — they were 403'd while pending; now that the
-    // user cancelled deletion they should reappear.
     fetchMyShares().then((r) => {
       if (r.kind !== 'ok') return
       setState((s) => (s.kind === 'ok' ? { ...s, shares: r.shares } : s))
@@ -400,90 +465,149 @@ export function Me() {
 
   if (state.kind === 'loading') {
     return (
-      <main className="reader-loading" aria-busy="true">
-        <div className="reader-loading-card">Loading…</div>
-      </main>
+      <Page>
+        <Header auth="out" />
+        <main className="sw-main center" aria-busy="true">
+          <div className="sw-loading">
+            <span className="sw-spin sw-spin-anim" />
+            Loading account
+          </div>
+        </main>
+        <Footer />
+      </Page>
     )
   }
 
   if (state.kind === 'error') {
     return (
-      <main className="me-page">
-        <div className="me-card">
-          <h1>Something went wrong</h1>
-          <p>We couldn’t load your account. Try refreshing.</p>
-        </div>
-      </main>
+      <Page>
+        <Header auth="out" />
+        <main className="sw-main center">
+          <div className="sw-card tight w-480">
+            <div className="sw-rule" style={{ marginBottom: 20 }}>
+              <span className="tag err">Error</span>
+              <span className="line" />
+            </div>
+            <h1 className="sw-title">Something went wrong</h1>
+            <p className="sw-lede">We couldn’t load your account.</p>
+            <button
+              type="button"
+              className="sw-btn sw-btn-ghost"
+              style={{ marginTop: 20 }}
+              onClick={() => window.location.reload()}
+            >
+              Refresh
+            </button>
+          </div>
+        </main>
+        <Footer />
+      </Page>
     )
   }
 
   const { me, shares } = state
   const pendingUntil = me.deletion_pending_until
   const pending = pendingUntil !== null
+  const headerAuth = { name: me.name, src: me.avatar_url }
+
   return (
-    <main className="me-page">
-      {pending && (
-        <div className="me-banner me-banner-pending" role="alert">
-          <strong>Account deletion is pending.</strong>{' '}
-          {pendingUntil
-            ? `Scheduled for ${new Date(pendingUntil).toLocaleString()}.`
-            : null}{' '}
-          Cancel deletion in the Danger zone below to restore access.
-        </div>
-      )}
-
-      <header className="me-header">
-        {me.avatar_url ? <img className="me-avatar" src={me.avatar_url} alt="" /> : null}
-        <div className="me-identity">
-          {me.name && <h1 className="me-name">{me.name}</h1>}
-          <p className="me-email">{me.email}</p>
-          {me.handle ? (
-            <p className="me-handle">
-              <a href={`/@${me.handle}`}>@{me.handle}</a>
-            </p>
-          ) : null}
-        </div>
-        <button type="button" className="me-signout" onClick={onSignOut}>
-          Sign out
-        </button>
-      </header>
-
-      {!me.handle && !pending && (
-        <section className="me-section">
-          <HandleClaim
-            onClaimed={(handle) =>
-              setState((s) => (s.kind === 'ok' ? { ...s, me: { ...s.me, handle } } : s))
-            }
-          />
-        </section>
-      )}
-
-      <section className="me-section">
-        <h2 className="me-section-title">Your shares</h2>
-        {pending ? (
-          <p className="me-empty">
-            Hidden while deletion is pending. Cancel deletion to restore the list.
-          </p>
-        ) : shares.length === 0 ? (
-          <p className="me-empty">You haven’t published anything yet.</p>
-        ) : (
-          <ul className="me-share-list">
-            {shares.map((row) => (
-              <ShareRow
-                key={row.id}
-                row={row}
-                disabled={pending}
-                onUnpublish={onUnpublish}
-              />
-            ))}
-          </ul>
+    <Page>
+      <Header auth={headerAuth} />
+      <main className="sw-main gap">
+        {pending && (
+          <div className="sw-banner pending" role="alert">
+            <span className="ico">
+              <Icon name="alert" size={16} />
+            </span>
+            <span>
+              <strong>Account deletion is pending.</strong>{' '}
+              {pendingUntil ? `Scheduled for ${humanDateTime(pendingUntil)}.` : null} Cancel
+              it in the Danger zone below to restore access.
+            </span>
+          </div>
         )}
-      </section>
 
-      <section className="me-section me-danger-zone">
-        <h2 className="me-section-title">Danger zone</h2>
-        <DeleteAccount initialPendingUntil={pendingUntil} onCancelled={onDeletionCancelled} />
-      </section>
-    </main>
+        <div className="sw-card w-600">
+          <div className="sw-identity">
+            <Avatar src={me.avatar_url} name={me.name} size={54} />
+            <div className="body">
+              {me.name && <h1 className="name">{me.name}</h1>}
+              {me.handle ? (
+                <p className="handle accent">
+                  <a href={`/@${me.handle}`}>@{me.handle}</a>
+                </p>
+              ) : (
+                <p className="handle">No public handle yet</p>
+              )}
+            </div>
+            <button
+              type="button"
+              className="sw-btn sw-btn-ghost sw-btn-sm"
+              onClick={onSignOut}
+            >
+              Sign out
+            </button>
+          </div>
+
+          {!me.handle && !pending && (
+            <>
+              <div className="sw-divider" style={{ margin: '24px 0 20px' }} />
+              <HandleClaim
+                onClaimed={(handle) =>
+                  setState((s) =>
+                    s.kind === 'ok' ? { ...s, me: { ...s.me, handle } } : s,
+                  )
+                }
+              />
+            </>
+          )}
+
+          <div className="sw-divider" style={{ margin: '24px 0 18px' }} />
+          <h2 className="sw-section-label" style={{ marginBottom: 14 }}>
+            Your shares
+            {!pending && shares.length > 0 && <span className="count">{shares.length}</span>}
+          </h2>
+          {pending ? (
+            <p className="sw-empty">
+              Hidden while deletion is pending. Cancel deletion to restore the list.
+            </p>
+          ) : shares.length === 0 ? (
+            <p className="sw-empty">You haven’t published anything yet.</p>
+          ) : (
+            <ul className="sw-list">
+              {shares.map((row) => (
+                <ShareRow
+                  key={row.id}
+                  row={row}
+                  disabled={pending}
+                  onUnpublish={onUnpublish}
+                />
+              ))}
+            </ul>
+          )}
+
+          <div className="sw-danger-zone" style={{ marginTop: 24 }}>
+            <h2
+              className="sw-section-label"
+              style={{ marginBottom: 14, color: 'var(--muted)' }}
+            >
+              Danger zone
+            </h2>
+            <DeleteAccount
+              initialPendingUntil={pendingUntil}
+              onCancelled={onDeletionCancelled}
+            />
+          </div>
+
+          <p className="sw-signed-in-as">
+            <span className="ico">
+              <Icon name="lock" size={11} />
+            </span>
+            Signed in as {me.email}
+          </p>
+        </div>
+      </main>
+      <Footer />
+    </Page>
   )
 }

--- a/packages/share-web/src/pages/Me.tsx
+++ b/packages/share-web/src/pages/Me.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
   cancelAccountDeletion,
+  checkHandle,
   claimHandle,
   fetchMe,
   fetchMyShares,
@@ -11,6 +12,14 @@ import {
   type MeResponse,
   type MeShareRow,
 } from '../lib/api'
+
+// Match the server-side handle regex (share-backend/src/handles.ts).
+// We pre-filter input so check requests + the submit button respond
+// to obvious mismatches without a round-trip.
+const HANDLE_NORMALISE = /[^a-z0-9_-]/g
+const HANDLE_MAX_LEN = 32
+const HANDLE_MIN_LEN = 3
+const CHECK_DEBOUNCE_MS = 320
 
 type LoadState =
   | { kind: 'loading' }
@@ -38,27 +47,71 @@ function shareUrl(id: string): string {
   return `${window.location.origin}/s/${encodeURIComponent(id)}`
 }
 
+type HandleAvailability =
+  | { kind: 'idle' }
+  | { kind: 'too-short' }
+  | { kind: 'checking' }
+  | { kind: 'available' }
+  | { kind: 'taken' }
+  | { kind: 'invalid'; reason: string }
+  | { kind: 'error' }
+
 function HandleClaim({ onClaimed }: { onClaimed: (handle: string) => void }) {
   const [value, setValue] = useState('')
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
+  const [availability, setAvailability] = useState<HandleAvailability>({ kind: 'idle' })
+  // Sequence guards stale debounced responses overwriting fresher ones.
+  const checkSeq = useRef(0)
+
+  // Debounced availability check. Skips the round-trip for inputs that
+  // can't possibly pass server-side validation.
+  useEffect(() => {
+    const handle = value
+    if (handle.length === 0) {
+      setAvailability({ kind: 'idle' })
+      return
+    }
+    if (handle.length < HANDLE_MIN_LEN) {
+      setAvailability({ kind: 'too-short' })
+      return
+    }
+    setAvailability({ kind: 'checking' })
+    const seq = ++checkSeq.current
+    const timer = window.setTimeout(async () => {
+      const r = await checkHandle(handle)
+      if (seq !== checkSeq.current) return
+      setAvailability(r)
+    }, CHECK_DEBOUNCE_MS)
+    return () => window.clearTimeout(timer)
+  }, [value])
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    if (busy) return
+    if (busy || availability.kind !== 'available') return
     setBusy(true)
     setErr(null)
-    const result = await claimHandle(value.trim().toLowerCase())
+    const result = await claimHandle(value)
     setBusy(false)
     if (result.kind === 'ok') {
       onClaimed(result.handle)
       return
     }
-    if (result.kind === 'taken') setErr('That handle is taken.')
-    else if (result.kind === 'invalid') setErr(result.reason)
-    else if (result.kind === 'rate-limited') setErr('Too many attempts — try again tomorrow.')
-    else setErr('Something went wrong.')
+    if (result.kind === 'taken') {
+      setErr('That handle was just taken — try a different one.')
+      setAvailability({ kind: 'taken' })
+    } else if (result.kind === 'invalid') {
+      setErr(result.reason)
+      setAvailability({ kind: 'invalid', reason: result.reason })
+    } else if (result.kind === 'rate-limited') {
+      setErr('Too many attempts — try again tomorrow.')
+    } else {
+      setErr('Something went wrong.')
+    }
   }
+
+  const status = renderAvailability(availability)
+  const submitDisabled = busy || availability.kind !== 'available'
 
   return (
     <form className="me-claim" onSubmit={onSubmit} noValidate>
@@ -69,16 +122,47 @@ function HandleClaim({ onClaimed }: { onClaimed: (handle: string) => void }) {
           autoComplete="off"
           spellCheck={false}
           placeholder="alice"
+          maxLength={HANDLE_MAX_LEN}
           value={value}
-          onChange={(e) => setValue(e.target.value)}
+          onChange={(e) =>
+            setValue(
+              e.target.value.toLowerCase().replace(HANDLE_NORMALISE, '').slice(0, HANDLE_MAX_LEN),
+            )
+          }
         />
       </label>
-      <button type="submit" disabled={busy || value.trim().length === 0}>
+      <button type="submit" disabled={submitDisabled}>
         {busy ? 'Claiming…' : 'Claim'}
       </button>
+      {status && (
+        <p className={`me-handle-status me-handle-status-${status.tone}`} role="status">
+          {status.text}
+        </p>
+      )}
       {err && <p className="me-error" role="alert">{err}</p>}
     </form>
   )
+}
+
+function renderAvailability(
+  a: HandleAvailability,
+): { tone: 'muted' | 'ok' | 'warn'; text: string } | null {
+  switch (a.kind) {
+    case 'idle':
+      return null
+    case 'too-short':
+      return { tone: 'muted', text: `At least ${HANDLE_MIN_LEN} characters.` }
+    case 'checking':
+      return { tone: 'muted', text: 'Checking…' }
+    case 'available':
+      return { tone: 'ok', text: 'Available.' }
+    case 'taken':
+      return { tone: 'warn', text: 'Taken.' }
+    case 'invalid':
+      return { tone: 'warn', text: a.reason }
+    case 'error':
+      return { tone: 'warn', text: 'Could not check right now.' }
+  }
 }
 
 function ShareRow({

--- a/packages/share-web/src/pages/Me.tsx
+++ b/packages/share-web/src/pages/Me.tsx
@@ -209,14 +209,12 @@ export function Me() {
   const [state, setState] = useState<LoadState>({ kind: 'loading' })
 
   const load = useCallback(async () => {
-    const meResult = await fetchMe()
-    if (meResult.kind === 'unauthenticated') {
-      window.location.replace('/sign-in?next=/me')
-      return
-    }
-    if (meResult.kind === 'forbidden') {
-      // Account is pending deletion. The /me API will 403; route them
-      // to sign-in so they can recover via a fresh session.
+    // Parallel — shares is owned by /me's session cookie too, so the
+    // request still flies in flight even before /me resolves.
+    const [meResult, shares] = await Promise.all([fetchMe(), fetchMyShares()])
+    if (meResult.kind === 'unauthenticated' || meResult.kind === 'forbidden') {
+      // forbidden = account pending deletion; either way send them to
+      // sign-in to recover via a fresh session.
       window.location.replace('/sign-in?next=/me')
       return
     }
@@ -224,12 +222,11 @@ export function Me() {
       setState({ kind: 'error' })
       return
     }
-    const shares = await fetchMyShares()
     setState({ kind: 'ok', me: meResult.me, shares })
   }, [])
 
   useEffect(() => {
-    document.title = 'Your account · spool.share'
+    document.title = 'Your account · spool.pro'
     load()
   }, [load])
 

--- a/packages/share-web/src/pages/Profile.tsx
+++ b/packages/share-web/src/pages/Profile.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useState } from 'react'
 
+import {
+  Avatar,
+  Footer,
+  Header,
+  Icon,
+  Page,
+} from '../components/Chrome'
 import { fetchProfile, type ProfileFetchResult, type ProfileResponse } from '../lib/api'
-import { Tombstone } from './Tombstone'
+import { humanDate } from '../lib/dates'
 
 type State =
   | { kind: 'loading' }
@@ -12,14 +19,6 @@ type State =
 function fromFetch(r: ProfileFetchResult): Exclude<State, { kind: 'loading' }> {
   if (r.kind === 'ok') return { kind: 'ok', profile: r.profile }
   return r
-}
-
-function formatDate(ts: number): string {
-  try {
-    return new Date(ts).toLocaleDateString()
-  } catch {
-    return ''
-  }
 }
 
 export function Profile({ handle }: { handle: string }) {
@@ -45,51 +44,96 @@ export function Profile({ handle }: { handle: string }) {
 
   if (state.kind === 'loading') {
     return (
-      <main className="reader-loading" aria-busy="true">
-        <div className="reader-loading-card">Loading…</div>
-      </main>
+      <Page>
+        <Header auth="out" />
+        <main className="sw-main">
+          <div className="sw-card w-600">
+            <div className="sw-identity">
+              <span className="sw-skel" style={{ width: 54, height: 54, borderRadius: '50%' }} />
+              <div className="body">
+                <span className="sw-skel" style={{ width: 140, height: 18, marginBottom: 8 }} />
+                <span className="sw-skel" style={{ width: 80, height: 13 }} />
+              </div>
+            </div>
+            <div className="sw-divider" style={{ margin: '24px 0 18px' }} />
+            <ul className="sw-list">
+              {[0, 1, 2].map((i) => (
+                <li key={i} className="sw-share" style={{ justifyContent: 'space-between' }}>
+                  <span className="sw-skel" style={{ width: `${60 - i * 8}%`, height: 14 }} />
+                  <span className="sw-skel" style={{ width: 70, height: 11 }} />
+                </li>
+              ))}
+            </ul>
+          </div>
+        </main>
+        <Footer />
+      </Page>
     )
   }
-  if (state.kind === 'not-found') {
+
+  if (state.kind === 'not-found' || state.kind === 'error') {
     return (
-      <main className="profile-page">
-        <div className="profile-card">
-          <h1>Profile not found</h1>
-          <p>Nothing here. Check the handle, or ask the author for a fresh link.</p>
-        </div>
-      </main>
+      <Page>
+        <Header auth="out" />
+        <main className="sw-main">
+          <div className="sw-card tight w-600">
+            <div className="sw-rule" style={{ marginBottom: 22 }}>
+              <span className="tag muted">Profile not found</span>
+              <span className="line" />
+            </div>
+            <h1 className="sw-title">Nothing here</h1>
+            <p className="sw-lede">Check the handle, or ask the author for a fresh link.</p>
+          </div>
+        </main>
+        <Footer />
+      </Page>
     )
   }
-  if (state.kind === 'error') return <Tombstone reason="not-found" />
 
   const { profile } = state
   return (
-    <main className="profile-page">
-      <header className="profile-header">
-        {profile.avatar_url ? (
-          <img className="profile-avatar" src={profile.avatar_url} alt="" />
-        ) : null}
-        <div className="profile-identity">
-          {profile.name && <h1 className="profile-name">{profile.name}</h1>}
-          <p className="profile-handle">@{profile.handle}</p>
+    <Page>
+      <Header auth="out" />
+      <main className="sw-main">
+        <div className="sw-card w-600">
+          <div className="sw-identity">
+            <Avatar src={profile.avatar_url} name={profile.name} size={54} />
+            <div className="body">
+              {profile.name && <h1 className="name">{profile.name}</h1>}
+              <p className="handle">@{profile.handle}</p>
+            </div>
+          </div>
+          <div className="sw-divider" style={{ margin: '24px 0 18px' }} />
+          <h2 className="sw-section-label" style={{ marginBottom: 14 }}>
+            Published
+            {profile.shares.length > 0 && (
+              <span className="count">{profile.shares.length}</span>
+            )}
+          </h2>
+          {profile.shares.length === 0 ? (
+            <p className="sw-empty">Nothing published yet.</p>
+          ) : (
+            <ul className="sw-list">
+              {profile.shares.map((s) => (
+                <li key={s.id}>
+                  <a className="sw-share link" href={`/s/${encodeURIComponent(s.id)}`}>
+                    <span className="sw-share-main">
+                      <span className="sw-share-title">{s.title}</span>
+                    </span>
+                    <span className="sw-share-meta" style={{ flex: '0 0 auto' }}>
+                      {humanDate(s.published_at)}
+                    </span>
+                    <span style={{ color: 'var(--muted)', display: 'inline-flex' }}>
+                      <Icon name="arrow-right" size={14} />
+                    </span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
-      </header>
-      <section className="profile-shares">
-        {profile.shares.length === 0 ? (
-          <p className="profile-empty">Nothing published yet.</p>
-        ) : (
-          <ul className="profile-share-list">
-            {profile.shares.map((s) => (
-              <li key={s.id}>
-                <a className="profile-share-link" href={`/s/${encodeURIComponent(s.id)}`}>
-                  <span className="profile-share-title">{s.title}</span>
-                  <span className="profile-share-meta">{formatDate(s.published_at)}</span>
-                </a>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-    </main>
+      </main>
+      <Footer />
+    </Page>
   )
 }

--- a/packages/share-web/src/pages/Profile.tsx
+++ b/packages/share-web/src/pages/Profile.tsx
@@ -33,9 +33,9 @@ export function Profile({ handle }: { handle: string }) {
       setState(next)
       if (next.kind === 'ok') {
         const display = next.profile.name ?? `@${next.profile.handle}`
-        document.title = `${display} · spool.share`
+        document.title = `${display} · spool.pro`
       } else {
-        document.title = 'Profile not found · spool.share'
+        document.title = 'Profile not found · spool.pro'
       }
     })
     return () => {

--- a/packages/share-web/src/pages/Profile.tsx
+++ b/packages/share-web/src/pages/Profile.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react'
+
+import { fetchProfile, type ProfileFetchResult, type ProfileResponse } from '../lib/api'
+import { Tombstone } from './Tombstone'
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ok'; profile: ProfileResponse }
+  | { kind: 'not-found' }
+  | { kind: 'error' }
+
+function fromFetch(r: ProfileFetchResult): Exclude<State, { kind: 'loading' }> {
+  if (r.kind === 'ok') return { kind: 'ok', profile: r.profile }
+  return r
+}
+
+function formatDate(ts: number): string {
+  try {
+    return new Date(ts).toLocaleDateString()
+  } catch {
+    return ''
+  }
+}
+
+export function Profile({ handle }: { handle: string }) {
+  const [state, setState] = useState<State>({ kind: 'loading' })
+
+  useEffect(() => {
+    let cancelled = false
+    fetchProfile(handle).then((r) => {
+      if (cancelled) return
+      const next = fromFetch(r)
+      setState(next)
+      if (next.kind === 'ok') {
+        const display = next.profile.name ?? `@${next.profile.handle}`
+        document.title = `${display} · spool.share`
+      } else {
+        document.title = 'Profile not found · spool.share'
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [handle])
+
+  if (state.kind === 'loading') {
+    return (
+      <main className="reader-loading" aria-busy="true">
+        <div className="reader-loading-card">Loading…</div>
+      </main>
+    )
+  }
+  if (state.kind === 'not-found') {
+    return (
+      <main className="profile-page">
+        <div className="profile-card">
+          <h1>Profile not found</h1>
+          <p>Nothing here. Check the handle, or ask the author for a fresh link.</p>
+        </div>
+      </main>
+    )
+  }
+  if (state.kind === 'error') return <Tombstone reason="not-found" />
+
+  const { profile } = state
+  return (
+    <main className="profile-page">
+      <header className="profile-header">
+        {profile.avatar_url ? (
+          <img className="profile-avatar" src={profile.avatar_url} alt="" />
+        ) : null}
+        <div className="profile-identity">
+          {profile.name && <h1 className="profile-name">{profile.name}</h1>}
+          <p className="profile-handle">@{profile.handle}</p>
+        </div>
+      </header>
+      <section className="profile-shares">
+        {profile.shares.length === 0 ? (
+          <p className="profile-empty">Nothing published yet.</p>
+        ) : (
+          <ul className="profile-share-list">
+            {profile.shares.map((s) => (
+              <li key={s.id}>
+                <a className="profile-share-link" href={`/s/${encodeURIComponent(s.id)}`}>
+                  <span className="profile-share-title">{s.title}</span>
+                  <span className="profile-share-meta">{formatDate(s.published_at)}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/packages/share-web/src/pages/SignIn.tsx
+++ b/packages/share-web/src/pages/SignIn.tsx
@@ -1,0 +1,36 @@
+// Static sign-in screen. The actual OAuth dance happens server-side at
+// /api/auth/google/start, which sets the session cookie and bounces
+// back to `next`. `next` is already sanitized by the router via
+// nextSafe(); we redefend on the click in case this page is reached
+// directly.
+
+import { nextSafe } from '../lib/route'
+
+interface Props {
+  next: string
+}
+
+export function SignIn({ next }: Props) {
+  const safe = nextSafe(next)
+  const href = `/api/auth/google/start?next=${encodeURIComponent(safe)}`
+
+  return (
+    <main className="signin-page">
+      <div className="signin-card">
+        <div className="signin-eyebrow">spool.share</div>
+        <h1 className="signin-title">Sign in</h1>
+        <p className="signin-body">
+          Sign in to publish, manage, and unpublish your shares.
+        </p>
+        <a className="signin-button" href={href}>
+          Sign in with Google
+        </a>
+        <p className="signin-footnote">
+          We use Google only to verify your identity. We don’t request
+          any data from your Google account beyond your email, name,
+          and picture.
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/packages/share-web/src/pages/SignIn.tsx
+++ b/packages/share-web/src/pages/SignIn.tsx
@@ -1,10 +1,14 @@
 // Static sign-in screen. The actual OAuth dance happens server-side at
-// /api/auth/google/start, which sets the session cookie and bounces
+// /api/auth/<provider>/start, which sets the session cookie and bounces
 // back to `next`. `next` is already sanitized by the router via
 // nextSafe(); we redefend on the click in case this page is reached
 // directly.
+//
+// Provider list is data-driven — adding GitHub / email is one entry
+// here plus the matching backend provider registration. The visual
+// layout stays the same; only the button count grows.
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 
 import { Footer, Header, Icon, Page, SpoolMark } from '../components/Chrome'
 import { fetchMe } from '../lib/api'
@@ -14,16 +18,33 @@ interface Props {
   next: string
 }
 
+type ProviderId = 'google'
+
+interface ProviderEntry {
+  id: ProviderId
+  label: string
+  icon: ReactNode
+}
+
+// Registered providers, rendered in order. v0.5 ships Google-only;
+// adding GitHub is one extra entry + a matching backend provider.
+const PROVIDERS: readonly ProviderEntry[] = [
+  { id: 'google', label: 'Continue with Google', icon: <Icon name="google" size={18} /> },
+]
+
+function authStartHref(provider: ProviderId, dest: string): string {
+  return `/api/auth/${provider}/start?next=${encodeURIComponent(dest)}`
+}
+
 export function SignIn({ next }: Props) {
   // share-web doesn't own `/` — in prod that's the landing site, in
   // dev it's empty → tombstone. When the caller didn't pin a `next`,
   // /me is the only post-auth destination that makes sense on this
-  // origin. This applies BOTH to the OAuth round-trip (the backend
+  // origin. Applies both to the OAuth round-trip (the backend
   // redirects to `next` after setting the cookie) AND to the already-
   // signed-in bounce below.
   const safe = nextSafe(next)
   const dest = safe === '/' ? '/me' : safe
-  const href = `/api/auth/google/start?next=${encodeURIComponent(dest)}`
 
   // If the user is already authenticated, bounce straight to next
   // instead of showing the sign-in pitch — re-clicking "Sign in" would
@@ -74,17 +95,19 @@ export function SignIn({ next }: Props) {
           <div className="sw-eyebrow">spool.pro</div>
           <h1 className="sw-signin-title">Sign in</h1>
           <p className="sw-signin-sub">Publish, manage, and unpublish your shares.</p>
-          <a className="sw-google-btn" href={href}>
-            <Icon name="google" size={18} />
-            Continue with Google
-          </a>
+          {PROVIDERS.map((p) => (
+            <a key={p.id} className="sw-google-btn" href={authStartHref(p.id, dest)}>
+              {p.icon}
+              {p.label}
+            </a>
+          ))}
           <div className="sw-signin-foot">
             <span className="ico">
               <Icon name="lock" size={14} />
             </span>
             <span>
-              We use Google only to verify your identity — nothing beyond your email, name, and
-              picture.
+              We use your provider only to verify your identity — nothing beyond your email,
+              name, and picture.
             </span>
           </div>
         </div>

--- a/packages/share-web/src/pages/SignIn.tsx
+++ b/packages/share-web/src/pages/SignIn.tsx
@@ -17,7 +17,7 @@ export function SignIn({ next }: Props) {
   return (
     <main className="signin-page">
       <div className="signin-card">
-        <div className="signin-eyebrow">spool.share</div>
+        <div className="signin-eyebrow">spool.pro</div>
         <h1 className="signin-title">Sign in</h1>
         <p className="signin-body">
           Sign in to publish, manage, and unpublish your shares.

--- a/packages/share-web/src/pages/SignIn.tsx
+++ b/packages/share-web/src/pages/SignIn.tsx
@@ -4,6 +4,9 @@
 // nextSafe(); we redefend on the click in case this page is reached
 // directly.
 
+import { useEffect, useState } from 'react'
+
+import { fetchMe } from '../lib/api'
 import { nextSafe } from '../lib/route'
 
 interface Props {
@@ -13,6 +16,37 @@ interface Props {
 export function SignIn({ next }: Props) {
   const safe = nextSafe(next)
   const href = `/api/auth/google/start?next=${encodeURIComponent(safe)}`
+
+  // If the user is already authenticated, bounce straight to next
+  // instead of showing the sign-in pitch — re-clicking "Sign in" would
+  // otherwise create a fresh KV session and orphan the live one for
+  // its full 30-day TTL (web doesn't have the desktop's prior-token
+  // revoke flow). A short 'checking' state avoids flashing the sign-
+  // in card before the redirect lands.
+  const [checking, setChecking] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    fetchMe().then((r) => {
+      if (cancelled) return
+      if (r.kind === 'ok') {
+        window.location.replace(safe)
+        return
+      }
+      setChecking(false)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [safe])
+
+  if (checking) {
+    return (
+      <main className="reader-loading" aria-busy="true">
+        <div className="reader-loading-card">Checking session…</div>
+      </main>
+    )
+  }
 
   return (
     <main className="signin-page">

--- a/packages/share-web/src/pages/SignIn.tsx
+++ b/packages/share-web/src/pages/SignIn.tsx
@@ -59,7 +59,14 @@ export function SignIn({ next }: Props) {
     fetchMe().then((r) => {
       if (cancelled) return
       if (r.kind === 'ok') {
-        window.location.replace(dest)
+        // Belt-and-braces vs CodeQL's js/client-side-unvalidated-url-redirection:
+        // `dest` is already nextSafe()-filtered (strips `//`, `/\`, `..`,
+        // and javascript:/data:/vbscript: schemes; forces a leading `/`),
+        // but static analysis can't see through the helper. Re-asserting
+        // the same-origin shape at the redirect site keeps the safety
+        // locally provable and survives any future loosening of nextSafe.
+        const sameOrigin = dest.startsWith('/') && !dest.startsWith('//')
+        window.location.replace(sameOrigin ? dest : '/me')
         return
       }
       setChecking(false)

--- a/packages/share-web/src/pages/SignIn.tsx
+++ b/packages/share-web/src/pages/SignIn.tsx
@@ -59,14 +59,23 @@ export function SignIn({ next }: Props) {
     fetchMe().then((r) => {
       if (cancelled) return
       if (r.kind === 'ok') {
-        // Belt-and-braces vs CodeQL's js/client-side-unvalidated-url-redirection:
-        // `dest` is already nextSafe()-filtered (strips `//`, `/\`, `..`,
-        // and javascript:/data:/vbscript: schemes; forces a leading `/`),
-        // but static analysis can't see through the helper. Re-asserting
-        // the same-origin shape at the redirect site keeps the safety
-        // locally provable and survives any future loosening of nextSafe.
-        const sameOrigin = dest.startsWith('/') && !dest.startsWith('//')
-        window.location.replace(sameOrigin ? dest : '/me')
+        // Resolve `dest` through the URL constructor against the current
+        // origin and forward only when the parsed origin matches. CodeQL
+        // (js/client-side-unvalidated-url-redirection) recognises this
+        // pattern as a same-origin guard, whereas a string-prefix check
+        // is not visible to the static flow analysis even though it's
+        // sufficient on paper. nextSafe() upstream is the primary line
+        // of defence; this is the locally-provable belt-and-braces.
+        let target = '/me'
+        try {
+          const url = new URL(dest, window.location.origin)
+          if (url.origin === window.location.origin) {
+            target = url.pathname + url.search + url.hash
+          }
+        } catch {
+          // Malformed URL → keep the safe default.
+        }
+        window.location.replace(target)
         return
       }
       setChecking(false)

--- a/packages/share-web/src/pages/SignIn.tsx
+++ b/packages/share-web/src/pages/SignIn.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect, useState } from 'react'
 
+import { Footer, Header, Icon, Page, SpoolMark } from '../components/Chrome'
 import { fetchMe } from '../lib/api'
 import { nextSafe } from '../lib/route'
 
@@ -14,8 +15,15 @@ interface Props {
 }
 
 export function SignIn({ next }: Props) {
+  // share-web doesn't own `/` — in prod that's the landing site, in
+  // dev it's empty → tombstone. When the caller didn't pin a `next`,
+  // /me is the only post-auth destination that makes sense on this
+  // origin. This applies BOTH to the OAuth round-trip (the backend
+  // redirects to `next` after setting the cookie) AND to the already-
+  // signed-in bounce below.
   const safe = nextSafe(next)
-  const href = `/api/auth/google/start?next=${encodeURIComponent(safe)}`
+  const dest = safe === '/' ? '/me' : safe
+  const href = `/api/auth/google/start?next=${encodeURIComponent(dest)}`
 
   // If the user is already authenticated, bounce straight to next
   // instead of showing the sign-in pitch — re-clicking "Sign in" would
@@ -30,7 +38,7 @@ export function SignIn({ next }: Props) {
     fetchMe().then((r) => {
       if (cancelled) return
       if (r.kind === 'ok') {
-        window.location.replace(safe)
+        window.location.replace(dest)
         return
       }
       setChecking(false)
@@ -38,33 +46,50 @@ export function SignIn({ next }: Props) {
     return () => {
       cancelled = true
     }
-  }, [safe])
+  }, [dest])
 
   if (checking) {
     return (
-      <main className="reader-loading" aria-busy="true">
-        <div className="reader-loading-card">Checking session…</div>
-      </main>
+      <Page>
+        <Header auth="out" />
+        <main className="sw-main center" aria-busy="true">
+          <div className="sw-loading">
+            <span className="sw-spin sw-spin-anim" />
+            Checking session
+          </div>
+        </main>
+        <Footer />
+      </Page>
     )
   }
 
   return (
-    <main className="signin-page">
-      <div className="signin-card">
-        <div className="signin-eyebrow">spool.pro</div>
-        <h1 className="signin-title">Sign in</h1>
-        <p className="signin-body">
-          Sign in to publish, manage, and unpublish your shares.
-        </p>
-        <a className="signin-button" href={href}>
-          Sign in with Google
-        </a>
-        <p className="signin-footnote">
-          We use Google only to verify your identity. We don’t request
-          any data from your Google account beyond your email, name,
-          and picture.
-        </p>
-      </div>
-    </main>
+    <Page>
+      <Header auth="out" />
+      <main className="sw-main center">
+        <div className="sw-card tight sw-signin w-420">
+          <div className="sw-signin-emblem">
+            <SpoolMark size={30} />
+          </div>
+          <div className="sw-eyebrow">spool.pro</div>
+          <h1 className="sw-signin-title">Sign in</h1>
+          <p className="sw-signin-sub">Publish, manage, and unpublish your shares.</p>
+          <a className="sw-google-btn" href={href}>
+            <Icon name="google" size={18} />
+            Continue with Google
+          </a>
+          <div className="sw-signin-foot">
+            <span className="ico">
+              <Icon name="lock" size={14} />
+            </span>
+            <span>
+              We use Google only to verify your identity — nothing beyond your email, name, and
+              picture.
+            </span>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </Page>
   )
 }

--- a/packages/share-web/src/styles.css
+++ b/packages/share-web/src/styles.css
@@ -1,249 +1,445 @@
-/* Minimal chrome for the spool.pro web reader.
- * Templates render their own paper/typography via inline styles, so
- * this file only covers the surrounding shell — body reset, the loading
- * card, tombstone, and reader footer.
- *
- * CSP note: no @font-face / @import rules pointing at external origins.
- * Geist / system stacks are referenced by name only; if the user lacks
- * Geist installed the stack falls back to system-ui which is fine for
- * tombstone copy. The template content surface owns its own fonts via
- * the share-kit components and Vite-bundled CSS variables. */
-
-:root {
-  --shell-bg: #f4efe6;
-  --shell-text: #2a2620;
-  --shell-muted: #6f6757;
-  --shell-card: #faf7ef;
-  --shell-border: #e3dcca;
-  --shell-accent: #c85a00;
-  --shell-error: #b73a1f;
-  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue',
-    Arial, sans-serif;
-  color-scheme: light;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --shell-bg: #141410;
-    --shell-text: #f4efe6;
-    --shell-muted: #9b937f;
-    --shell-card: #1c1b16;
-    --shell-border: #2e2a23;
-    --shell-accent: #f07020;
-    --shell-error: #e07a5a;
-    color-scheme: dark;
-  }
-}
+/* spool.pro share-web — unified design system.
+ * Tokens are scoped to .sw-root so the page can opt into a per-paper
+ * surface (Reader) without leaking into 3rd-party DOM. data-theme
+ * controls light/dark; default reads from the html[data-theme] root
+ * set by Chrome's ThemeToggle (which itself defers to the OS until
+ * the user overrides). */
 
 html,
 body,
 #root {
   height: 100%;
+  margin: 0;
+}
+
+html {
+  background: #FAFAF8;
+  color-scheme: light;
+}
+html[data-theme='dark'] {
+  background: #141410;
+  color-scheme: dark;
 }
 
 body {
   margin: 0;
-  background: var(--shell-bg);
-  color: var(--shell-text);
   -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-family: 'Geist', system-ui, -apple-system, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, sans-serif;
 }
 
-a {
-  color: inherit;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
+.sw-root {
+  --bg: #FAFAF8;
+  --bg-sink: #F4F4F0;
+  --card: #FFFFFF;
+  --card-2: #F4F4F0;
+  --border: #E8E8E2;
+  --border-strong: #D8D8D0;
+  --text: #1C1C18;
+  --muted: #6B6B60;
+  --faint: #ADADAA;
+  --accent: #C85A00;
+  --accent-ink: #FFFFFF;
+  --accent-soft: #FFF3E8;
+  --accent-line: rgba(200, 90, 0, 0.30);
+  --ok: #3E7D52;
+  --err: #B23A1E;
+  --err-soft: #FBE9DF;
+  --src-claude: #C26A4E;
+  --src-chatgpt: #10A37F;
+  --src-gemini: #5887D0;
+  --paper: #FAF7F0;
+  --shadow-card: 0 1px 2px rgba(28, 28, 24, 0.04),
+    0 8px 24px rgba(28, 28, 24, 0.06);
+  --radius: 14px;
 
-a:hover {
-  color: var(--shell-accent);
-}
-
-/* ── Reader canvas ──────────────────────────────────────────────
- * Wraps the SnapshotReader + footer. Background is set inline by
- * Reader.tsx to the snapshot's paper tone so the viewport sides never
- * expose a contrasting backdrop. Content drives the height — no
- * min-height: 100vh, no big empty space pushing the footer way down
- * on short conversations. */
-.reader-canvas {
-  min-height: 100vh;
+  color: var(--text);
+  background: var(--bg);
+  min-height: 100%;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding: 40px 16px 0;
 }
 
-/* The inner wrapper takes an explicit width from Reader.tsx (the
- * template's natural width). max-width keeps narrow viewports honest;
- * the template owns the padding inside. */
-.reader-paper {
-  max-width: 100%;
+html[data-theme='dark'] .sw-root {
+  --bg: #141410;
+  --bg-sink: #0F0F0C;
+  --card: #1C1C18;
+  --card-2: #242420;
+  --border: #2E2E28;
+  --border-strong: #3A3A34;
+  --text: #F2F2EC;
+  --muted: #8A8A80;
+  --faint: #505048;
+  --accent: #F07020;
+  --accent-ink: #1A1206;
+  --accent-soft: #2A1800;
+  --accent-line: rgba(240, 112, 32, 0.34);
+  --ok: #6FB286;
+  --err: #E07A4E;
+  --err-soft: #2A1508;
+  --src-claude: #E89A7C;
+  --src-chatgpt: #20C38F;
+  --src-gemini: #8AB0E5;
+  --paper: #1A1A16;
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.30),
+    0 10px 30px rgba(0, 0, 0, 0.40);
 }
 
-/* ── Reader loading ─────────────────────────────────────────── */
-.reader-loading {
-  min-height: 100vh;
+.sw-root,
+.sw-root * {
+  box-sizing: border-box;
+}
+
+.sw-root a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.sw-root a:hover {
+  color: var(--accent);
+}
+
+/* ── Page frame ─────────────────────────────────────────────── */
+.sw-page {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  position: relative;
+}
+
+/* ── Header chrome ──────────────────────────────────────────── */
+/* Matches spool.pro landing — solid --bg, hairline bottom border, no
+ * blur, no semi-transparent overlay. Solid color reads as "site chrome"
+ * across light + dark; the frosted-glass look fought with the warm
+ * parchment palette and confused the reader's paper card. */
+.sw-header {
+  flex: 0 0 auto;
+  height: 60px;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  padding: 0 28px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+.sw-wordmark {
+  font-weight: 700;
+  font-size: 19px;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  color: var(--text);
+  display: inline-flex;
+  align-items: baseline;
+}
+.sw-wordmark .dot {
+  color: var(--accent);
+}
+.sw-header-right {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+.sw-signin-link {
+  font-size: 13.5px;
+  color: var(--muted);
+  font-weight: 500;
+  transition: color 0.15s;
+}
+.sw-signin-link:hover {
+  color: var(--accent);
+}
+.sw-theme-toggle {
+  width: 30px;
+  height: 30px;
+  border-radius: 7px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--muted);
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+  cursor: pointer;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+  flex: 0 0 auto;
+}
+.sw-theme-toggle:hover {
+  background: var(--card-2);
+  border-color: var(--border);
+  color: var(--text);
 }
 
-.reader-loading-card {
-  font-size: 14px;
-  color: var(--shell-muted);
-  letter-spacing: 0.04em;
-}
-
-/* ── Reader footer ──────────────────────────────────────────── */
-.reader-footer {
-  /* Push to the viewport bottom when the conversation is short; flow
-   * right after the content when it's long. Pairs with the canvas's
-   * min-height: 100vh + flex column. */
+/* ── Footer chrome ──────────────────────────────────────────── */
+/* Solid --bg, hairline top border. Same chrome treatment as header. */
+.sw-footer {
+  flex: 0 0 auto;
   margin-top: auto;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  gap: 4px;
-  padding: 32px 16px;
-  font-size: 12px;
-  color: var(--shell-muted);
-}
-
-/* ── Tombstone ──────────────────────────────────────────────── */
-.tombstone {
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 32px 16px;
-}
-
-.tombstone-card {
-  max-width: 480px;
-  background: var(--shell-card);
-  border: 1px solid var(--shell-border);
-  border-radius: 12px;
-  padding: 40px 32px;
-  text-align: left;
-}
-
-.tombstone-eyebrow {
+  gap: 0;
+  padding: 28px 16px 30px;
+  background: var(--bg);
+  border-top: 1px solid var(--border);
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: var(--shell-muted);
-  margin-bottom: 16px;
+  letter-spacing: 0.04em;
+  color: var(--faint);
+}
+.sw-footer a {
+  color: var(--muted);
+  transition: color 0.15s;
+  white-space: nowrap;
+}
+.sw-footer a:hover {
+  color: var(--accent);
+}
+.sw-footer .sep {
+  margin: 0 10px;
+  opacity: 0.55;
 }
 
-.tombstone-title {
-  font-size: 22px;
-  margin: 0 0 12px;
-  font-weight: 600;
-  line-height: 1.25;
-}
-
-.tombstone-body {
-  margin: 0 0 12px;
-  line-height: 1.55;
-  color: var(--shell-text);
-}
-
-.tombstone-meta {
-  margin: 0 0 24px;
-  font-size: 13px;
-  color: var(--shell-muted);
-}
-
-.tombstone-actions {
-  font-size: 13px;
-  color: var(--shell-muted);
-  margin: 0;
-}
-
-/* ── Profile ────────────────────────────────────────────────── */
-.profile-page,
-.me-page,
-.signin-page {
-  min-height: 100vh;
+/* ── Content scroll area ────────────────────────────────────── */
+.sw-main {
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 48px 16px;
+  padding: 56px 20px 8px;
+}
+.sw-main.center {
+  justify-content: center;
+  padding-top: 20px;
+}
+.sw-main.gap {
+  gap: 18px;
 }
 
-.profile-card,
-.me-card,
-.signin-card {
+/* ── Card ───────────────────────────────────────────────────── */
+.sw-card {
   width: 100%;
   max-width: 560px;
-  background: var(--shell-card);
-  border: 1px solid var(--shell-border);
-  border-radius: 12px;
-  padding: 32px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-card);
+  padding: 36px 36px 32px;
+}
+.sw-card.tight {
+  padding: 32px 32px;
+}
+.sw-card.w-600 {
+  max-width: 600px;
+}
+.sw-card.w-420 {
+  max-width: 420px;
+}
+.sw-card.w-480 {
+  max-width: 480px;
 }
 
-.profile-header,
-.me-header {
+/* ── Eyebrows / mastheads ───────────────────────────────────── */
+.sw-eyebrow {
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+.sw-rule {
+  display: flex;
+  align-items: center;
+  gap: 14px;
   width: 100%;
-  max-width: 560px;
+}
+.sw-rule .line {
+  flex: 1;
+  height: 1px;
+  background: var(--border-strong);
+}
+.sw-rule .tag {
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  white-space: nowrap;
+}
+.sw-rule .tag.muted {
+  color: var(--muted);
+}
+.sw-rule .tag.err {
+  color: var(--err);
+}
+.sw-rule .meta {
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+/* ── Titles ─────────────────────────────────────────────────── */
+.sw-title {
+  font-size: 23px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.18;
+  margin: 0;
+  color: var(--text);
+}
+.sw-title.lg {
+  font-size: 27px;
+}
+.sw-accent-underline {
+  width: 38px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 1px;
+  margin: 14px 0 0;
+}
+.sw-lede {
+  margin: 12px 0 0;
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--text);
+  text-wrap: pretty;
+}
+.sw-lede.muted {
+  color: var(--muted);
+}
+
+/* ── Buttons ────────────────────────────────────────────────── */
+.sw-btn {
+  font: inherit;
+  font-size: 13.5px;
+  font-weight: 500;
+  border-radius: 9px;
+  padding: 9px 16px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.15s, border-color 0.15s, color 0.15s, opacity 0.15s;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  white-space: nowrap;
+  text-decoration: none;
+}
+.sw-btn-primary {
+  background: var(--accent);
+  color: var(--accent-ink);
+  font-weight: 600;
+}
+.sw-btn-primary:hover {
+  filter: brightness(1.05);
+  color: var(--accent-ink);
+}
+.sw-btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  filter: none;
+}
+.sw-btn-ghost {
+  background: transparent;
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+.sw-btn-ghost:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.sw-btn-ghost:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  color: var(--muted);
+  border-color: var(--border);
+}
+.sw-btn-danger {
+  background: transparent;
+  border-color: color-mix(in srgb, var(--err) 45%, transparent);
+  color: var(--err);
+}
+.sw-btn-danger:hover {
+  background: var(--err-soft);
+  color: var(--err);
+}
+.sw-btn-sm {
+  font-size: 12.5px;
+  padding: 5px 11px;
+  border-radius: 7px;
+}
+
+/* ── Avatar ─────────────────────────────────────────────────── */
+.sw-avatar {
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--card-2);
+  border: 1px solid var(--border-strong);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: var(--muted);
+  flex: 0 0 auto;
+  overflow: hidden;
+}
+
+/* ── Identity header (profile / me) ─────────────────────────── */
+.sw-identity {
   display: flex;
   align-items: center;
   gap: 16px;
-  margin-bottom: 24px;
+  width: 100%;
 }
-
-.profile-avatar,
-.me-avatar {
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  background: var(--shell-card);
-  border: 1px solid var(--shell-border);
-  object-fit: cover;
-}
-
-.profile-identity,
-.me-identity {
+.sw-identity .body {
   flex: 1;
   min-width: 0;
 }
-
-.profile-name,
-.me-name {
-  font-size: 22px;
-  margin: 0 0 2px;
+.sw-identity .name {
+  font-size: 21px;
   font-weight: 600;
-  line-height: 1.2;
+  letter-spacing: -0.02em;
+  margin: 0 0 3px;
+  line-height: 1.15;
 }
-
-.profile-handle,
-.me-handle,
-.me-email {
-  margin: 0;
-  color: var(--shell-muted);
+.sw-identity .handle {
   font-size: 14px;
-}
-
-.me-handle a {
-  color: var(--shell-accent);
-}
-
-.profile-shares,
-.me-section {
-  width: 100%;
-  max-width: 560px;
-  margin-bottom: 24px;
-}
-
-.profile-empty,
-.me-empty {
-  color: var(--shell-muted);
-  font-size: 14px;
+  color: var(--muted);
   margin: 0;
 }
+.sw-identity .handle.accent {
+  color: var(--accent);
+}
+.sw-identity .email {
+  font-size: 13.5px;
+  color: var(--muted);
+  margin: 0 0 2px;
+}
 
-.profile-share-list,
-.me-share-list {
+/* ── Section label ──────────────────────────────────────────── */
+.sw-section-label {
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--faint);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  white-space: nowrap;
+  margin: 0;
+}
+.sw-section-label .count {
+  color: var(--accent);
+}
+
+/* ── Share rows (list + each row) ───────────────────────────── */
+.sw-list {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -251,342 +447,484 @@ a:hover {
   flex-direction: column;
   gap: 8px;
 }
-
-.profile-share-link {
+.sw-share {
   display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 16px;
-  padding: 12px 16px;
-  background: var(--shell-card);
-  border: 1px solid var(--shell-border);
-  border-radius: 8px;
-  text-decoration: none;
+  align-items: center;
+  gap: 14px;
+  padding: 13px 16px;
+  background: var(--card-2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  transition: border-color 0.15s, background 0.15s;
 }
-
-.profile-share-link:hover {
-  border-color: var(--shell-accent);
+.sw-share:hover {
+  border-color: var(--border-strong);
 }
-
-.profile-share-title {
+.sw-share.link:hover {
+  border-color: var(--accent);
+}
+.sw-share.revoked {
+  opacity: 0.55;
+}
+.sw-share.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+.sw-share-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.sw-share-title {
   font-weight: 600;
-  color: var(--shell-text);
+  font-size: 14.5px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-
-.profile-share-meta {
-  color: var(--shell-muted);
-  font-size: 13px;
-  flex-shrink: 0;
-}
-
-/* ── Me ─────────────────────────────────────────────────────── */
-.me-section-title {
-  font-size: 14px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--shell-muted);
-  margin: 0 0 12px;
-}
-
-.me-signout {
-  background: transparent;
-  border: 1px solid var(--shell-border);
-  border-radius: 8px;
-  padding: 6px 12px;
-  cursor: pointer;
-  color: inherit;
-  font: inherit;
-}
-
-.me-claim {
+.sw-share-meta {
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--muted);
   display: flex;
-  gap: 8px;
-  align-items: flex-end;
-  /* status + error messages flex-basis to 100% to drop onto a new row
-   * below the input/button instead of squeezing them. */
+  align-items: center;
+  gap: 7px;
   flex-wrap: wrap;
 }
-
-.me-claim label {
-  flex: 1;
+.sw-share-meta .dot-sep {
+  opacity: 0.5;
 }
-
-.me-claim label span {
-  display: block;
-  font-size: 13px;
-  font-weight: 600;
-  margin-bottom: 6px;
+.sw-share-error {
+  color: var(--err);
+  font-size: 12px;
+  margin-top: 2px;
 }
-
-.me-claim input {
-  width: 100%;
-  box-sizing: border-box;
-  background: var(--shell-card);
-  border: 1px solid var(--shell-border);
-  border-radius: 8px;
-  padding: 8px 10px;
-  font: inherit;
-  color: inherit;
-}
-
-.me-claim button {
-  background: var(--shell-accent);
-  color: #fff;
-  border: 0;
-  border-radius: 8px;
-  padding: 9px 16px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.me-claim button:disabled {
-  opacity: 0.6;
-  cursor: progress;
-}
-
-.me-error {
-  color: var(--shell-error);
-  font-size: 13px;
-  margin: 8px 0 0;
-}
-
-.me-handle-status {
-  font-size: 13px;
-  margin: 8px 0 0;
-  flex-basis: 100%;
-}
-
-.me-handle-status-muted {
-  color: var(--shell-muted);
-}
-
-.me-handle-status-ok {
-  color: color-mix(in srgb, var(--shell-accent) 80%, var(--shell-text));
-}
-
-.me-handle-status-warn {
-  color: var(--shell-error);
-}
-
-.me-share {
+.sw-share-actions {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 12px 16px;
-  background: var(--shell-card);
-  border: 1px solid var(--shell-border);
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+/* compact icon buttons */
+.sw-icon-btn {
+  width: 30px;
+  height: 30px;
   border-radius: 8px;
-}
-
-.me-share-revoked {
-  opacity: 0.6;
-}
-
-.me-share-main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
-}
-
-.me-share-title {
-  font-weight: 600;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.me-share-meta {
-  color: var(--shell-muted);
-  font-size: 12px;
-}
-
-.me-share-error {
-  color: var(--shell-error);
-  font-size: 12px;
-  display: block;
-  margin-top: 4px;
-}
-
-/* ── Me banner (deletion pending) ───────────────────────────── */
-.me-banner {
-  width: 100%;
-  max-width: 560px;
-  border-radius: 8px;
-  padding: 12px 16px;
-  margin-bottom: 24px;
-  font-size: 14px;
-  line-height: 1.5;
-}
-
-.me-banner-pending {
-  background: color-mix(in srgb, var(--shell-error) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--shell-error) 30%, var(--shell-border));
-  color: var(--shell-text);
-}
-
-.me-share-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-shrink: 0;
-}
-
-.me-share-actions a,
-.me-share-actions button {
-  font: inherit;
-  font-size: 13px;
+  border: 1px solid var(--border-strong);
   background: transparent;
-  border: 1px solid var(--shell-border);
-  border-radius: 6px;
-  padding: 4px 10px;
-  color: inherit;
+  color: var(--muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s, opacity 0.15s;
+  flex: 0 0 auto;
   text-decoration: none;
 }
-
-.me-share-actions a:hover,
-.me-share-actions button:hover {
-  border-color: var(--shell-accent);
-  color: var(--shell-accent);
+.sw-icon-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-soft);
 }
-
-.me-share-danger,
-.me-share-danger:hover {
-  color: var(--shell-error);
-  border-color: rgba(183, 58, 31, 0.5);
-}
-
-.me-danger-zone {
-  border-top: 1px solid var(--shell-border);
-  padding-top: 24px;
-}
-
-.me-delete {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.me-delete-actions {
-  display: flex;
-  gap: 8px;
-}
-
-.me-delete button {
-  font: inherit;
+.sw-icon-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
   background: transparent;
-  border: 1px solid var(--shell-border);
-  border-radius: 8px;
-  padding: 8px 16px;
-  cursor: pointer;
-  color: inherit;
+  border-color: var(--border-strong);
+  color: var(--muted);
+}
+.sw-icon-btn.ok,
+.sw-icon-btn.ok:hover {
+  color: var(--ok);
+  border-color: color-mix(in srgb, var(--ok) 50%, transparent);
+  background: transparent;
+}
+.sw-icon-btn.busy {
+  cursor: progress;
+}
+.sw-icon-btn.danger:hover {
+  border-color: color-mix(in srgb, var(--err) 55%, transparent);
+  color: var(--err);
+  background: var(--err-soft);
 }
 
-.me-delete-pending {
-  background: rgba(200, 90, 0, 0.08);
-  border: 1px solid rgba(200, 90, 0, 0.3);
-  border-radius: 8px;
+/* visibility / status pills */
+.sw-pill {
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 5px;
+  border: 1px solid var(--border-strong);
+  color: var(--muted);
+}
+.sw-pill.listed {
+  color: var(--accent);
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+}
+.sw-pill.revoked {
+  color: var(--err);
+  border-color: color-mix(in srgb, var(--err) 40%, transparent);
+}
+
+/* ── Handle claim ───────────────────────────────────────────── */
+.sw-claim {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: flex-end;
+}
+.sw-claim label {
+  flex: 1;
+  min-width: 0;
+}
+.sw-claim label span {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 7px;
+}
+.sw-input-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.sw-input-wrap .at {
+  position: absolute;
+  left: 12px;
+  color: var(--faint);
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 14px;
+  pointer-events: none;
+}
+.sw-input {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-radius: 9px;
+  padding: 9px 12px 9px 26px;
+  font: inherit;
+  font-size: 14px;
+  color: var(--text);
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.sw-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.sw-claim-status {
+  flex-basis: 100%;
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  letter-spacing: 0.02em;
+  margin: 2px 0 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.sw-claim-status.muted {
+  color: var(--muted);
+}
+.sw-claim-status.ok {
+  color: var(--ok);
+}
+.sw-claim-status.warn {
+  color: var(--err);
+}
+.sw-claim-status .ico {
+  width: 12px;
+  height: 12px;
+  display: inline-flex;
+}
+.sw-spin {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border-strong);
+  border-top-color: var(--accent);
+  display: inline-block;
+  flex: 0 0 auto;
+}
+
+/* ── Banner ─────────────────────────────────────────────────── */
+.sw-banner {
+  width: 100%;
+  max-width: 600px;
+  border-radius: 11px;
+  padding: 13px 16px;
+  font-size: 13.5px;
+  line-height: 1.5;
+  display: flex;
+  gap: 11px;
+  align-items: flex-start;
+}
+.sw-banner.pending {
+  background: var(--err-soft);
+  border: 1px solid color-mix(in srgb, var(--err) 32%, transparent);
+  color: var(--text);
+}
+.sw-banner .ico {
+  flex: 0 0 auto;
+  color: var(--err);
+  margin-top: 1px;
+}
+.sw-banner strong {
+  font-weight: 600;
+}
+
+/* ── Signed-in-as footer (inside /me card) ──────────────────── */
+.sw-signed-in-as {
+  margin: 22px 0 0;
+  padding-top: 18px;
+  border-top: 1px solid var(--border);
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.sw-signed-in-as .ico {
+  color: var(--faint);
+  display: inline-flex;
+}
+
+/* ── Danger zone ────────────────────────────────────────────── */
+.sw-danger-zone {
+  border-top: 1px solid var(--border);
+  padding-top: 22px;
+  margin-top: 4px;
+}
+.sw-confirm-box {
+  background: var(--err-soft);
+  border: 1px solid color-mix(in srgb, var(--err) 28%, transparent);
+  border-radius: 11px;
   padding: 16px;
 }
-
-.me-delete-pending p {
-  margin: 0 0 12px;
-  color: var(--shell-text);
+.sw-confirm-box p {
+  margin: 0 0 13px;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--text);
+}
+.sw-scheduled-box {
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+  border-radius: 11px;
+  padding: 16px;
+}
+.sw-scheduled-box p {
+  margin: 0 0 13px;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--text);
 }
 
 /* ── Sign-in ────────────────────────────────────────────────── */
-.signin-eyebrow {
-  font-size: 11px;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: var(--shell-muted);
-  margin-bottom: 16px;
+.sw-signin {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
-
-.signin-title {
-  font-size: 24px;
-  margin: 0 0 8px;
+.sw-signin-emblem {
+  width: 60px;
+  height: 60px;
+  border-radius: 16px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 22px;
+}
+.sw-signin .sw-eyebrow {
+  margin-bottom: 12px;
+}
+.sw-signin-title {
+  font-size: 27px;
   font-weight: 600;
+  letter-spacing: -0.025em;
+  margin: 0;
 }
-
-.signin-body {
-  margin: 0 0 20px;
-  line-height: 1.5;
-  color: var(--shell-text);
+.sw-signin-sub {
+  margin: 14px 0 0;
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--muted);
+  max-width: 32ch;
+  text-wrap: pretty;
 }
-
-.signin-button {
-  display: inline-block;
-  background: var(--shell-accent);
-  color: #fff;
+.sw-google-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 11px;
+  width: 100%;
+  margin-top: 26px;
+  padding: 13px 18px;
+  border-radius: 12px;
+  background: #ffffff;
+  border: 1px solid var(--border-strong);
+  color: #2A2620;
+  font: inherit;
+  font-weight: 600;
+  font-size: 14.5px;
+  cursor: pointer;
   text-decoration: none;
-  padding: 10px 20px;
-  border-radius: 8px;
-  font-weight: 600;
+  box-shadow: 0 1px 2px rgba(40, 34, 26, 0.05),
+    0 6px 18px rgba(40, 34, 26, 0.06);
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.08s;
+}
+.sw-google-btn:hover {
+  border-color: var(--accent);
+  box-shadow: 0 2px 4px rgba(40, 34, 26, 0.06),
+    0 10px 26px rgba(40, 34, 26, 0.10);
+  color: #2A2620;
+}
+.sw-google-btn:active {
+  transform: translateY(0.5px);
+}
+html[data-theme='dark'] .sw-google-btn {
+  background: var(--card-2);
+  border-color: var(--border-strong);
+  color: var(--text);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+}
+html[data-theme='dark'] .sw-google-btn:hover {
+  color: var(--text);
+}
+.sw-signin-foot {
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border);
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  color: var(--muted);
+  font-size: 12.5px;
+  line-height: 1.55;
+  text-align: left;
+}
+.sw-signin-foot .ico {
+  flex: 0 0 auto;
+  color: var(--faint);
+  margin-top: 1px;
 }
 
-.signin-button:hover {
-  color: #fff;
-  filter: brightness(1.05);
+/* ── Loading / spin ─────────────────────────────────────────── */
+.sw-loading {
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.sw-loading .sw-spin {
+  width: 14px;
+  height: 14px;
+  border-width: 2px;
+}
+.sw-spin-anim {
+  animation: sw-spin 0.7s linear infinite;
+}
+@keyframes sw-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
-.signin-footnote {
-  margin: 24px 0 0;
-  color: var(--shell-muted);
-  font-size: 13px;
-  line-height: 1.5;
+/* ── Skeleton ───────────────────────────────────────────────── */
+.sw-skel {
+  background: var(--card-2);
+  border-radius: 6px;
+  display: block;
 }
 
-/* ── Narrow viewport adjustments ────────────────────────────────
- * Cards stop being roomy below ~480px wide. Stack header pieces
- * vertically so a long name + handle don't crowd the sign-out button,
- * collapse share-row actions under each share so they don't push the
- * title off the right edge, and tighten the outer padding. */
+/* ── Empty state ────────────────────────────────────────────── */
+.sw-empty {
+  color: var(--muted);
+  font-size: 14px;
+  text-align: left;
+  padding: 6px 0;
+  margin: 0;
+}
+
+/* ── misc ───────────────────────────────────────────────────── */
+.sw-divider {
+  height: 1px;
+  background: var(--border);
+  width: 100%;
+}
+.sw-mono {
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* ── Reader canvas ──────────────────────────────────────────── */
+/* The Reader page hosts a share-kit template that owns its own
+ * typography + padding. We just center it under the chrome and let
+ * its natural width drive layout. */
+.reader-canvas {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 16px 0;
+}
+.reader-paper {
+  max-width: 100%;
+}
+
+/* ── Narrow viewport adjustments ────────────────────────────── */
 @media (max-width: 480px) {
-  .profile-page,
-  .me-page,
-  .signin-page {
-    padding: 24px 12px;
+  .sw-header {
+    padding: 0 18px;
   }
-
-  .profile-card,
-  .me-card,
-  .signin-card {
-    padding: 20px;
+  .sw-main {
+    padding: 32px 14px 8px;
   }
-
-  .profile-header,
-  .me-header {
-    flex-wrap: wrap;
+  .sw-card {
+    padding: 24px 22px 22px;
+    border-radius: 12px;
+  }
+  .sw-card.tight {
+    padding: 22px 20px;
+  }
+  .sw-identity {
     gap: 12px;
   }
-
-  .me-header .me-signout {
-    margin-left: auto;
+  .sw-identity .name {
+    font-size: 19px;
   }
-
-  .me-share {
-    flex-direction: column;
-    align-items: stretch;
+  .sw-claim {
+    flex-wrap: wrap;
+  }
+  .sw-claim button {
+    flex: 1;
+  }
+  .sw-share {
+    flex-wrap: wrap;
     gap: 10px;
   }
-
-  .me-share-actions {
+  .sw-share-actions {
+    width: 100%;
     justify-content: flex-end;
-    flex-wrap: wrap;
   }
-
-  .me-claim {
-    flex-wrap: wrap;
-  }
-
-  .me-claim button {
-    flex: 1;
+  .reader-canvas {
+    padding: 24px 12px 0;
   }
 }

--- a/packages/share-web/src/styles.css
+++ b/packages/share-web/src/styles.css
@@ -1,445 +1,249 @@
-/* spool.pro share-web — unified design system.
- * Tokens are scoped to .sw-root so the page can opt into a per-paper
- * surface (Reader) without leaking into 3rd-party DOM. data-theme
- * controls light/dark; default reads from the html[data-theme] root
- * set by Chrome's ThemeToggle (which itself defers to the OS until
- * the user overrides). */
+/* Minimal chrome for the spool.pro web reader.
+ * Templates render their own paper/typography via inline styles, so
+ * this file only covers the surrounding shell — body reset, the loading
+ * card, tombstone, and reader footer.
+ *
+ * CSP note: no @font-face / @import rules pointing at external origins.
+ * Geist / system stacks are referenced by name only; if the user lacks
+ * Geist installed the stack falls back to system-ui which is fine for
+ * tombstone copy. The template content surface owns its own fonts via
+ * the share-kit components and Vite-bundled CSS variables. */
+
+:root {
+  --shell-bg: #f4efe6;
+  --shell-text: #2a2620;
+  --shell-muted: #6f6757;
+  --shell-card: #faf7ef;
+  --shell-border: #e3dcca;
+  --shell-accent: #c85a00;
+  --shell-error: #b73a1f;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, sans-serif;
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --shell-bg: #141410;
+    --shell-text: #f4efe6;
+    --shell-muted: #9b937f;
+    --shell-card: #1c1b16;
+    --shell-border: #2e2a23;
+    --shell-accent: #f07020;
+    --shell-error: #e07a5a;
+    color-scheme: dark;
+  }
+}
 
 html,
 body,
 #root {
   height: 100%;
-  margin: 0;
-}
-
-html {
-  background: #FAFAF8;
-  color-scheme: light;
-}
-html[data-theme='dark'] {
-  background: #141410;
-  color-scheme: dark;
 }
 
 body {
   margin: 0;
+  background: var(--shell-bg);
+  color: var(--shell-text);
   -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  font-family: 'Geist', system-ui, -apple-system, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, sans-serif;
 }
 
-.sw-root {
-  --bg: #FAFAF8;
-  --bg-sink: #F4F4F0;
-  --card: #FFFFFF;
-  --card-2: #F4F4F0;
-  --border: #E8E8E2;
-  --border-strong: #D8D8D0;
-  --text: #1C1C18;
-  --muted: #6B6B60;
-  --faint: #ADADAA;
-  --accent: #C85A00;
-  --accent-ink: #FFFFFF;
-  --accent-soft: #FFF3E8;
-  --accent-line: rgba(200, 90, 0, 0.30);
-  --ok: #3E7D52;
-  --err: #B23A1E;
-  --err-soft: #FBE9DF;
-  --src-claude: #C26A4E;
-  --src-chatgpt: #10A37F;
-  --src-gemini: #5887D0;
-  --paper: #FAF7F0;
-  --shadow-card: 0 1px 2px rgba(28, 28, 24, 0.04),
-    0 8px 24px rgba(28, 28, 24, 0.06);
-  --radius: 14px;
-
-  color: var(--text);
-  background: var(--bg);
-  min-height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-html[data-theme='dark'] .sw-root {
-  --bg: #141410;
-  --bg-sink: #0F0F0C;
-  --card: #1C1C18;
-  --card-2: #242420;
-  --border: #2E2E28;
-  --border-strong: #3A3A34;
-  --text: #F2F2EC;
-  --muted: #8A8A80;
-  --faint: #505048;
-  --accent: #F07020;
-  --accent-ink: #1A1206;
-  --accent-soft: #2A1800;
-  --accent-line: rgba(240, 112, 32, 0.34);
-  --ok: #6FB286;
-  --err: #E07A4E;
-  --err-soft: #2A1508;
-  --src-claude: #E89A7C;
-  --src-chatgpt: #20C38F;
-  --src-gemini: #8AB0E5;
-  --paper: #1A1A16;
-  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.30),
-    0 10px 30px rgba(0, 0, 0, 0.40);
-}
-
-.sw-root,
-.sw-root * {
-  box-sizing: border-box;
-}
-
-.sw-root a {
+a {
   color: inherit;
-  text-decoration: none;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
-.sw-root a:hover {
-  color: var(--accent);
+a:hover {
+  color: var(--shell-accent);
 }
 
-/* ── Page frame ─────────────────────────────────────────────── */
-.sw-page {
-  flex: 1 1 auto;
+/* ── Reader canvas ──────────────────────────────────────────────
+ * Wraps the SnapshotReader + footer. Background is set inline by
+ * Reader.tsx to the snapshot's paper tone so the viewport sides never
+ * expose a contrasting backdrop. Content drives the height — no
+ * min-height: 100vh, no big empty space pushing the footer way down
+ * on short conversations. */
+.reader-canvas {
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background: var(--bg);
-  position: relative;
+  align-items: center;
+  padding: 40px 16px 0;
 }
 
-/* ── Header chrome ──────────────────────────────────────────── */
-/* Matches spool.pro landing — solid --bg, hairline bottom border, no
- * blur, no semi-transparent overlay. Solid color reads as "site chrome"
- * across light + dark; the frosted-glass look fought with the warm
- * parchment palette and confused the reader's paper card. */
-.sw-header {
-  flex: 0 0 auto;
-  height: 60px;
+/* The inner wrapper takes an explicit width from Reader.tsx (the
+ * template's natural width). max-width keeps narrow viewports honest;
+ * the template owns the padding inside. */
+.reader-paper {
+  max-width: 100%;
+}
+
+/* ── Reader loading ─────────────────────────────────────────── */
+.reader-loading {
+  min-height: 100vh;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 28px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg);
-}
-.sw-wordmark {
-  font-weight: 700;
-  font-size: 19px;
-  letter-spacing: -0.04em;
-  line-height: 1;
-  color: var(--text);
-  display: inline-flex;
-  align-items: baseline;
-}
-.sw-wordmark .dot {
-  color: var(--accent);
-}
-.sw-header-right {
-  display: flex;
-  align-items: center;
-  gap: 18px;
-}
-.sw-signin-link {
-  font-size: 13.5px;
-  color: var(--muted);
-  font-weight: 500;
-  transition: color 0.15s;
-}
-.sw-signin-link:hover {
-  color: var(--accent);
-}
-.sw-theme-toggle {
-  width: 30px;
-  height: 30px;
-  border-radius: 7px;
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--muted);
-  display: inline-flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
-  transition: border-color 0.12s, color 0.12s, background 0.12s;
-  flex: 0 0 auto;
-}
-.sw-theme-toggle:hover {
-  background: var(--card-2);
-  border-color: var(--border);
-  color: var(--text);
 }
 
-/* ── Footer chrome ──────────────────────────────────────────── */
-/* Solid --bg, hairline top border. Same chrome treatment as header. */
-.sw-footer {
-  flex: 0 0 auto;
+.reader-loading-card {
+  font-size: 14px;
+  color: var(--shell-muted);
+  letter-spacing: 0.04em;
+}
+
+/* ── Reader footer ──────────────────────────────────────────── */
+.reader-footer {
+  /* Push to the viewport bottom when the conversation is short; flow
+   * right after the content when it's long. Pairs with the canvas's
+   * min-height: 100vh + flex column. */
   margin-top: auto;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  gap: 0;
-  padding: 28px 16px 30px;
-  background: var(--bg);
-  border-top: 1px solid var(--border);
-  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  letter-spacing: 0.04em;
-  color: var(--faint);
-}
-.sw-footer a {
-  color: var(--muted);
-  transition: color 0.15s;
-  white-space: nowrap;
-}
-.sw-footer a:hover {
-  color: var(--accent);
-}
-.sw-footer .sep {
-  margin: 0 10px;
-  opacity: 0.55;
+  gap: 4px;
+  padding: 32px 16px;
+  font-size: 12px;
+  color: var(--shell-muted);
 }
 
-/* ── Content scroll area ────────────────────────────────────── */
-.sw-main {
-  flex: 1 1 auto;
+/* ── Tombstone ──────────────────────────────────────────────── */
+.tombstone {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+}
+
+.tombstone-card {
+  max-width: 480px;
+  background: var(--shell-card);
+  border: 1px solid var(--shell-border);
+  border-radius: 12px;
+  padding: 40px 32px;
+  text-align: left;
+}
+
+.tombstone-eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--shell-muted);
+  margin-bottom: 16px;
+}
+
+.tombstone-title {
+  font-size: 22px;
+  margin: 0 0 12px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.tombstone-body {
+  margin: 0 0 12px;
+  line-height: 1.55;
+  color: var(--shell-text);
+}
+
+.tombstone-meta {
+  margin: 0 0 24px;
+  font-size: 13px;
+  color: var(--shell-muted);
+}
+
+.tombstone-actions {
+  font-size: 13px;
+  color: var(--shell-muted);
+  margin: 0;
+}
+
+/* ── Profile ────────────────────────────────────────────────── */
+.profile-page,
+.me-page,
+.signin-page {
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 56px 20px 8px;
-}
-.sw-main.center {
-  justify-content: center;
-  padding-top: 20px;
-}
-.sw-main.gap {
-  gap: 18px;
+  padding: 48px 16px;
 }
 
-/* ── Card ───────────────────────────────────────────────────── */
-.sw-card {
+.profile-card,
+.me-card,
+.signin-card {
   width: 100%;
   max-width: 560px;
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow-card);
-  padding: 36px 36px 32px;
-}
-.sw-card.tight {
-  padding: 32px 32px;
-}
-.sw-card.w-600 {
-  max-width: 600px;
-}
-.sw-card.w-420 {
-  max-width: 420px;
-}
-.sw-card.w-480 {
-  max-width: 480px;
+  background: var(--shell-card);
+  border: 1px solid var(--shell-border);
+  border-radius: 12px;
+  padding: 32px;
 }
 
-/* ── Eyebrows / mastheads ───────────────────────────────────── */
-.sw-eyebrow {
-  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: var(--faint);
-}
-.sw-rule {
-  display: flex;
-  align-items: center;
-  gap: 14px;
+.profile-header,
+.me-header {
   width: 100%;
-}
-.sw-rule .line {
-  flex: 1;
-  height: 1px;
-  background: var(--border-strong);
-}
-.sw-rule .tag {
-  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--accent);
-  white-space: nowrap;
-}
-.sw-rule .tag.muted {
-  color: var(--muted);
-}
-.sw-rule .tag.err {
-  color: var(--err);
-}
-.sw-rule .meta {
-  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
-  letter-spacing: 0.04em;
-  color: var(--muted);
-  white-space: nowrap;
-}
-
-/* ── Titles ─────────────────────────────────────────────────── */
-.sw-title {
-  font-size: 23px;
-  font-weight: 600;
-  letter-spacing: -0.02em;
-  line-height: 1.18;
-  margin: 0;
-  color: var(--text);
-}
-.sw-title.lg {
-  font-size: 27px;
-}
-.sw-accent-underline {
-  width: 38px;
-  height: 2px;
-  background: var(--accent);
-  border-radius: 1px;
-  margin: 14px 0 0;
-}
-.sw-lede {
-  margin: 12px 0 0;
-  font-size: 14.5px;
-  line-height: 1.6;
-  color: var(--text);
-  text-wrap: pretty;
-}
-.sw-lede.muted {
-  color: var(--muted);
-}
-
-/* ── Buttons ────────────────────────────────────────────────── */
-.sw-btn {
-  font: inherit;
-  font-size: 13.5px;
-  font-weight: 500;
-  border-radius: 9px;
-  padding: 9px 16px;
-  cursor: pointer;
-  border: 1px solid transparent;
-  transition: background 0.15s, border-color 0.15s, color 0.15s, opacity 0.15s;
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  white-space: nowrap;
-  text-decoration: none;
-}
-.sw-btn-primary {
-  background: var(--accent);
-  color: var(--accent-ink);
-  font-weight: 600;
-}
-.sw-btn-primary:hover {
-  filter: brightness(1.05);
-  color: var(--accent-ink);
-}
-.sw-btn-primary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  filter: none;
-}
-.sw-btn-ghost {
-  background: transparent;
-  border-color: var(--border-strong);
-  color: var(--text);
-}
-.sw-btn-ghost:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-.sw-btn-ghost:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-  color: var(--muted);
-  border-color: var(--border);
-}
-.sw-btn-danger {
-  background: transparent;
-  border-color: color-mix(in srgb, var(--err) 45%, transparent);
-  color: var(--err);
-}
-.sw-btn-danger:hover {
-  background: var(--err-soft);
-  color: var(--err);
-}
-.sw-btn-sm {
-  font-size: 12.5px;
-  padding: 5px 11px;
-  border-radius: 7px;
-}
-
-/* ── Avatar ─────────────────────────────────────────────────── */
-.sw-avatar {
-  border-radius: 50%;
-  object-fit: cover;
-  background: var(--card-2);
-  border: 1px solid var(--border-strong);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 600;
-  color: var(--muted);
-  flex: 0 0 auto;
-  overflow: hidden;
-}
-
-/* ── Identity header (profile / me) ─────────────────────────── */
-.sw-identity {
+  max-width: 560px;
   display: flex;
   align-items: center;
   gap: 16px;
-  width: 100%;
+  margin-bottom: 24px;
 }
-.sw-identity .body {
+
+.profile-avatar,
+.me-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--shell-card);
+  border: 1px solid var(--shell-border);
+  object-fit: cover;
+}
+
+.profile-identity,
+.me-identity {
   flex: 1;
   min-width: 0;
 }
-.sw-identity .name {
-  font-size: 21px;
-  font-weight: 600;
-  letter-spacing: -0.02em;
-  margin: 0 0 3px;
-  line-height: 1.15;
-}
-.sw-identity .handle {
-  font-size: 14px;
-  color: var(--muted);
-  margin: 0;
-}
-.sw-identity .handle.accent {
-  color: var(--accent);
-}
-.sw-identity .email {
-  font-size: 13.5px;
-  color: var(--muted);
+
+.profile-name,
+.me-name {
+  font-size: 22px;
   margin: 0 0 2px;
+  font-weight: 600;
+  line-height: 1.2;
 }
 
-/* ── Section label ──────────────────────────────────────────── */
-.sw-section-label {
-  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--faint);
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  white-space: nowrap;
+.profile-handle,
+.me-handle,
+.me-email {
+  margin: 0;
+  color: var(--shell-muted);
+  font-size: 14px;
+}
+
+.me-handle a {
+  color: var(--shell-accent);
+}
+
+.profile-shares,
+.me-section {
+  width: 100%;
+  max-width: 560px;
+  margin-bottom: 24px;
+}
+
+.profile-empty,
+.me-empty {
+  color: var(--shell-muted);
+  font-size: 14px;
   margin: 0;
 }
-.sw-section-label .count {
-  color: var(--accent);
-}
 
-/* ── Share rows (list + each row) ───────────────────────────── */
-.sw-list {
+.profile-share-list,
+.me-share-list {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -447,484 +251,249 @@ html[data-theme='dark'] .sw-root {
   flex-direction: column;
   gap: 8px;
 }
-.sw-share {
+
+.profile-share-link {
   display: flex;
-  align-items: center;
-  gap: 14px;
-  padding: 13px 16px;
-  background: var(--card-2);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  transition: border-color 0.15s, background 0.15s;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+  padding: 12px 16px;
+  background: var(--shell-card);
+  border: 1px solid var(--shell-border);
+  border-radius: 8px;
+  text-decoration: none;
 }
-.sw-share:hover {
-  border-color: var(--border-strong);
+
+.profile-share-link:hover {
+  border-color: var(--shell-accent);
 }
-.sw-share.link:hover {
-  border-color: var(--accent);
-}
-.sw-share.revoked {
-  opacity: 0.55;
-}
-.sw-share.disabled {
-  opacity: 0.5;
-  pointer-events: none;
-}
-.sw-share-main {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-.sw-share-title {
+
+.profile-share-title {
   font-weight: 600;
-  font-size: 14.5px;
+  color: var(--shell-text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.sw-share-meta {
-  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  letter-spacing: 0.02em;
-  color: var(--muted);
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  flex-wrap: wrap;
-}
-.sw-share-meta .dot-sep {
-  opacity: 0.5;
-}
-.sw-share-error {
-  color: var(--err);
-  font-size: 12px;
-  margin-top: 2px;
-}
-.sw-share-actions {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex: 0 0 auto;
+
+.profile-share-meta {
+  color: var(--shell-muted);
+  font-size: 13px;
+  flex-shrink: 0;
 }
 
-/* compact icon buttons */
-.sw-icon-btn {
-  width: 30px;
-  height: 30px;
-  border-radius: 8px;
-  border: 1px solid var(--border-strong);
-  background: transparent;
-  color: var(--muted);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background 0.15s, border-color 0.15s, color 0.15s, opacity 0.15s;
-  flex: 0 0 auto;
-  text-decoration: none;
-}
-.sw-icon-btn:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-  background: var(--accent-soft);
-}
-.sw-icon-btn:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-  background: transparent;
-  border-color: var(--border-strong);
-  color: var(--muted);
-}
-.sw-icon-btn.ok,
-.sw-icon-btn.ok:hover {
-  color: var(--ok);
-  border-color: color-mix(in srgb, var(--ok) 50%, transparent);
-  background: transparent;
-}
-.sw-icon-btn.busy {
-  cursor: progress;
-}
-.sw-icon-btn.danger:hover {
-  border-color: color-mix(in srgb, var(--err) 55%, transparent);
-  color: var(--err);
-  background: var(--err-soft);
-}
-
-/* visibility / status pills */
-.sw-pill {
-  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
+/* ── Me ─────────────────────────────────────────────────────── */
+.me-section-title {
+  font-size: 14px;
   font-weight: 600;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  padding: 2px 7px;
-  border-radius: 5px;
-  border: 1px solid var(--border-strong);
-  color: var(--muted);
-}
-.sw-pill.listed {
-  color: var(--accent);
-  border-color: var(--accent-line);
-  background: var(--accent-soft);
-}
-.sw-pill.revoked {
-  color: var(--err);
-  border-color: color-mix(in srgb, var(--err) 40%, transparent);
+  color: var(--shell-muted);
+  margin: 0 0 12px;
 }
 
-/* ── Handle claim ───────────────────────────────────────────── */
-.sw-claim {
+.me-signout {
+  background: transparent;
+  border: 1px solid var(--shell-border);
+  border-radius: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+
+.me-claim {
   display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
   align-items: flex-end;
 }
-.sw-claim label {
+
+.me-claim label {
   flex: 1;
-  min-width: 0;
 }
-.sw-claim label span {
+
+.me-claim label span {
   display: block;
   font-size: 13px;
   font-weight: 600;
-  margin-bottom: 7px;
+  margin-bottom: 6px;
 }
-.sw-input-wrap {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-.sw-input-wrap .at {
-  position: absolute;
-  left: 12px;
-  color: var(--faint);
-  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 14px;
-  pointer-events: none;
-}
-.sw-input {
+
+.me-claim input {
   width: 100%;
-  background: var(--bg);
-  border: 1px solid var(--border-strong);
-  border-radius: 9px;
-  padding: 9px 12px 9px 26px;
+  box-sizing: border-box;
+  background: var(--shell-card);
+  border: 1px solid var(--shell-border);
+  border-radius: 8px;
+  padding: 8px 10px;
   font: inherit;
-  font-size: 14px;
-  color: var(--text);
-  transition: border-color 0.15s, box-shadow 0.15s;
-}
-.sw-input:focus {
-  outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
-}
-.sw-claim-status {
-  flex-basis: 100%;
-  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11.5px;
-  letter-spacing: 0.02em;
-  margin: 2px 0 0;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-.sw-claim-status.muted {
-  color: var(--muted);
-}
-.sw-claim-status.ok {
-  color: var(--ok);
-}
-.sw-claim-status.warn {
-  color: var(--err);
-}
-.sw-claim-status .ico {
-  width: 12px;
-  height: 12px;
-  display: inline-flex;
-}
-.sw-spin {
-  width: 11px;
-  height: 11px;
-  border-radius: 50%;
-  border: 1.5px solid var(--border-strong);
-  border-top-color: var(--accent);
-  display: inline-block;
-  flex: 0 0 auto;
+  color: inherit;
 }
 
-/* ── Banner ─────────────────────────────────────────────────── */
-.sw-banner {
-  width: 100%;
-  max-width: 600px;
-  border-radius: 11px;
-  padding: 13px 16px;
-  font-size: 13.5px;
-  line-height: 1.5;
-  display: flex;
-  gap: 11px;
-  align-items: flex-start;
-}
-.sw-banner.pending {
-  background: var(--err-soft);
-  border: 1px solid color-mix(in srgb, var(--err) 32%, transparent);
-  color: var(--text);
-}
-.sw-banner .ico {
-  flex: 0 0 auto;
-  color: var(--err);
-  margin-top: 1px;
-}
-.sw-banner strong {
+.me-claim button {
+  background: var(--shell-accent);
+  color: #fff;
+  border: 0;
+  border-radius: 8px;
+  padding: 9px 16px;
   font-weight: 600;
-}
-
-/* ── Signed-in-as footer (inside /me card) ──────────────────── */
-.sw-signed-in-as {
-  margin: 22px 0 0;
-  padding-top: 18px;
-  border-top: 1px solid var(--border);
-  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  letter-spacing: 0.02em;
-  color: var(--muted);
-  display: flex;
-  align-items: center;
-  gap: 7px;
-}
-.sw-signed-in-as .ico {
-  color: var(--faint);
-  display: inline-flex;
-}
-
-/* ── Danger zone ────────────────────────────────────────────── */
-.sw-danger-zone {
-  border-top: 1px solid var(--border);
-  padding-top: 22px;
-  margin-top: 4px;
-}
-.sw-confirm-box {
-  background: var(--err-soft);
-  border: 1px solid color-mix(in srgb, var(--err) 28%, transparent);
-  border-radius: 11px;
-  padding: 16px;
-}
-.sw-confirm-box p {
-  margin: 0 0 13px;
-  font-size: 13.5px;
-  line-height: 1.55;
-  color: var(--text);
-}
-.sw-scheduled-box {
-  background: var(--accent-soft);
-  border: 1px solid var(--accent-line);
-  border-radius: 11px;
-  padding: 16px;
-}
-.sw-scheduled-box p {
-  margin: 0 0 13px;
-  font-size: 13.5px;
-  line-height: 1.55;
-  color: var(--text);
-}
-
-/* ── Sign-in ────────────────────────────────────────────────── */
-.sw-signin {
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-.sw-signin-emblem {
-  width: 60px;
-  height: 60px;
-  border-radius: 16px;
-  background: var(--accent-soft);
-  border: 1px solid var(--accent-line);
-  color: var(--accent);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 22px;
-}
-.sw-signin .sw-eyebrow {
-  margin-bottom: 12px;
-}
-.sw-signin-title {
-  font-size: 27px;
-  font-weight: 600;
-  letter-spacing: -0.025em;
-  margin: 0;
-}
-.sw-signin-sub {
-  margin: 14px 0 0;
-  font-size: 14.5px;
-  line-height: 1.6;
-  color: var(--muted);
-  max-width: 32ch;
-  text-wrap: pretty;
-}
-.sw-google-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 11px;
-  width: 100%;
-  margin-top: 26px;
-  padding: 13px 18px;
-  border-radius: 12px;
-  background: #ffffff;
-  border: 1px solid var(--border-strong);
-  color: #2A2620;
-  font: inherit;
-  font-weight: 600;
-  font-size: 14.5px;
   cursor: pointer;
-  text-decoration: none;
-  box-shadow: 0 1px 2px rgba(40, 34, 26, 0.05),
-    0 6px 18px rgba(40, 34, 26, 0.06);
-  transition: border-color 0.15s, box-shadow 0.15s, transform 0.08s;
-}
-.sw-google-btn:hover {
-  border-color: var(--accent);
-  box-shadow: 0 2px 4px rgba(40, 34, 26, 0.06),
-    0 10px 26px rgba(40, 34, 26, 0.10);
-  color: #2A2620;
-}
-.sw-google-btn:active {
-  transform: translateY(0.5px);
-}
-html[data-theme='dark'] .sw-google-btn {
-  background: var(--card-2);
-  border-color: var(--border-strong);
-  color: var(--text);
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
-}
-html[data-theme='dark'] .sw-google-btn:hover {
-  color: var(--text);
-}
-.sw-signin-foot {
-  margin-top: 22px;
-  padding-top: 18px;
-  border-top: 1px solid var(--border);
-  width: 100%;
-  display: flex;
-  align-items: flex-start;
-  gap: 9px;
-  color: var(--muted);
-  font-size: 12.5px;
-  line-height: 1.55;
-  text-align: left;
-}
-.sw-signin-foot .ico {
-  flex: 0 0 auto;
-  color: var(--faint);
-  margin-top: 1px;
 }
 
-/* ── Loading / spin ─────────────────────────────────────────── */
-.sw-loading {
-  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--muted);
+.me-claim button:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.me-error {
+  color: var(--shell-error);
+  font-size: 13px;
+  margin: 8px 0 0;
+}
+
+.me-share {
   display: flex;
   align-items: center;
   gap: 12px;
-}
-.sw-loading .sw-spin {
-  width: 14px;
-  height: 14px;
-  border-width: 2px;
-}
-.sw-spin-anim {
-  animation: sw-spin 0.7s linear infinite;
-}
-@keyframes sw-spin {
-  to {
-    transform: rotate(360deg);
-  }
+  padding: 12px 16px;
+  background: var(--shell-card);
+  border: 1px solid var(--shell-border);
+  border-radius: 8px;
 }
 
-/* ── Skeleton ───────────────────────────────────────────────── */
-.sw-skel {
-  background: var(--card-2);
-  border-radius: 6px;
-  display: block;
+.me-share-revoked {
+  opacity: 0.6;
 }
 
-/* ── Empty state ────────────────────────────────────────────── */
-.sw-empty {
-  color: var(--muted);
-  font-size: 14px;
-  text-align: left;
-  padding: 6px 0;
-  margin: 0;
-}
-
-/* ── misc ───────────────────────────────────────────────────── */
-.sw-divider {
-  height: 1px;
-  background: var(--border);
-  width: 100%;
-}
-.sw-mono {
-  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-
-/* ── Reader canvas ──────────────────────────────────────────── */
-/* The Reader page hosts a share-kit template that owns its own
- * typography + padding. We just center it under the chrome and let
- * its natural width drive layout. */
-.reader-canvas {
-  flex: 1 1 auto;
+.me-share-main {
+  flex: 1;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding: 40px 16px 0;
-}
-.reader-paper {
-  max-width: 100%;
+  gap: 2px;
+  min-width: 0;
 }
 
-/* ── Narrow viewport adjustments ────────────────────────────── */
-@media (max-width: 480px) {
-  .sw-header {
-    padding: 0 18px;
-  }
-  .sw-main {
-    padding: 32px 14px 8px;
-  }
-  .sw-card {
-    padding: 24px 22px 22px;
-    border-radius: 12px;
-  }
-  .sw-card.tight {
-    padding: 22px 20px;
-  }
-  .sw-identity {
-    gap: 12px;
-  }
-  .sw-identity .name {
-    font-size: 19px;
-  }
-  .sw-claim {
-    flex-wrap: wrap;
-  }
-  .sw-claim button {
-    flex: 1;
-  }
-  .sw-share {
-    flex-wrap: wrap;
-    gap: 10px;
-  }
-  .sw-share-actions {
-    width: 100%;
-    justify-content: flex-end;
-  }
-  .reader-canvas {
-    padding: 24px 12px 0;
-  }
+.me-share-title {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.me-share-meta {
+  color: var(--shell-muted);
+  font-size: 12px;
+}
+
+.me-share-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.me-share-actions a,
+.me-share-actions button {
+  font: inherit;
+  font-size: 13px;
+  background: transparent;
+  border: 1px solid var(--shell-border);
+  border-radius: 6px;
+  padding: 4px 10px;
+  color: inherit;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.me-share-actions a:hover,
+.me-share-actions button:hover {
+  border-color: var(--shell-accent);
+  color: var(--shell-accent);
+}
+
+.me-share-danger,
+.me-share-danger:hover {
+  color: var(--shell-error);
+  border-color: rgba(183, 58, 31, 0.5);
+}
+
+.me-danger-zone {
+  border-top: 1px solid var(--shell-border);
+  padding-top: 24px;
+}
+
+.me-delete {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.me-delete-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.me-delete button {
+  font: inherit;
+  background: transparent;
+  border: 1px solid var(--shell-border);
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+  color: inherit;
+}
+
+.me-delete-pending {
+  background: rgba(200, 90, 0, 0.08);
+  border: 1px solid rgba(200, 90, 0, 0.3);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.me-delete-pending p {
+  margin: 0 0 12px;
+  color: var(--shell-text);
+}
+
+/* ── Sign-in ────────────────────────────────────────────────── */
+.signin-eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--shell-muted);
+  margin-bottom: 16px;
+}
+
+.signin-title {
+  font-size: 24px;
+  margin: 0 0 8px;
+  font-weight: 600;
+}
+
+.signin-body {
+  margin: 0 0 20px;
+  line-height: 1.5;
+  color: var(--shell-text);
+}
+
+.signin-button {
+  display: inline-block;
+  background: var(--shell-accent);
+  color: #fff;
+  text-decoration: none;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-weight: 600;
+}
+
+.signin-button:hover {
+  color: #fff;
+  filter: brightness(1.05);
+}
+
+.signin-footnote {
+  margin: 24px 0 0;
+  color: var(--shell-muted);
+  font-size: 13px;
+  line-height: 1.5;
 }

--- a/packages/share-web/src/styles.css
+++ b/packages/share-web/src/styles.css
@@ -306,6 +306,9 @@ a:hover {
   display: flex;
   gap: 8px;
   align-items: flex-end;
+  /* status + error messages flex-basis to 100% to drop onto a new row
+   * below the input/button instead of squeezing them. */
+  flex-wrap: wrap;
 }
 
 .me-claim label {

--- a/packages/share-web/src/styles.css
+++ b/packages/share-web/src/styles.css
@@ -385,6 +385,30 @@ a:hover {
   font-size: 12px;
 }
 
+.me-share-error {
+  color: var(--shell-error);
+  font-size: 12px;
+  display: block;
+  margin-top: 4px;
+}
+
+/* ── Me banner (deletion pending) ───────────────────────────── */
+.me-banner {
+  width: 100%;
+  max-width: 560px;
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-bottom: 24px;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.me-banner-pending {
+  background: color-mix(in srgb, var(--shell-error) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--shell-error) 30%, var(--shell-border));
+  color: var(--shell-text);
+}
+
 .me-share-actions {
   display: flex;
   align-items: center;

--- a/packages/share-web/src/styles.css
+++ b/packages/share-web/src/styles.css
@@ -351,6 +351,24 @@ a:hover {
   margin: 8px 0 0;
 }
 
+.me-handle-status {
+  font-size: 13px;
+  margin: 8px 0 0;
+  flex-basis: 100%;
+}
+
+.me-handle-status-muted {
+  color: var(--shell-muted);
+}
+
+.me-handle-status-ok {
+  color: color-mix(in srgb, var(--shell-accent) 80%, var(--shell-text));
+}
+
+.me-handle-status-warn {
+  color: var(--shell-error);
+}
+
 .me-share {
   display: flex;
   align-items: center;
@@ -520,4 +538,52 @@ a:hover {
   color: var(--shell-muted);
   font-size: 13px;
   line-height: 1.5;
+}
+
+/* ── Narrow viewport adjustments ────────────────────────────────
+ * Cards stop being roomy below ~480px wide. Stack header pieces
+ * vertically so a long name + handle don't crowd the sign-out button,
+ * collapse share-row actions under each share so they don't push the
+ * title off the right edge, and tighten the outer padding. */
+@media (max-width: 480px) {
+  .profile-page,
+  .me-page,
+  .signin-page {
+    padding: 24px 12px;
+  }
+
+  .profile-card,
+  .me-card,
+  .signin-card {
+    padding: 20px;
+  }
+
+  .profile-header,
+  .me-header {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .me-header .me-signout {
+    margin-left: auto;
+  }
+
+  .me-share {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .me-share-actions {
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+
+  .me-claim {
+    flex-wrap: wrap;
+  }
+
+  .me-claim button {
+    flex: 1;
+  }
 }


### PR DESCRIPTION
## What

Three more public routes that turn a published share into an actual identity surface on spool.pro:

- **`GET /<handle>`** → `<Profile>`: someone else's public profile page. Lists their `profile-listed` shares. The `/<handle>` route is what `unlisted` shares deliberately don't appear in — visibility opt-in stays per-share.
- **`GET /me`** → `<Me>`: the signed-in user's dashboard. Claim or change handle (live availability check), see your live shares (revoke from here, copy-link, view), schedule or cancel account deletion. The desktop Settings → Account screen is a mirror of this — same primitives, same wire shape.
- **`GET /sign-in`** → `<SignIn>`: provider list, currently just Google. Same identity-first redesign as Me / Profile — one consistent visual surface across the three identity routes.

Plus the backend half:
- **`GET /api/profiles/<handle>`** — public endpoint that returns `{name, avatar_url, shares: [...]}`. Rate-limited 120/min/IP (anti-enumeration, but loose enough for legit reload). Returns 404 for both invalid-handle and missing-handle so a scanner can't tell the two apart.

## Why one PR

The three routes share the same client API surface (`api.ts`'s `fetchMe`, `claimHandle`, `checkHandle`, `revokeShare`, `scheduleAccountDeletion`, etc.) and the same identity visual system. Splitting them would mean each gets approved in a half-formed state. The backend `/api/profiles/<handle>` only matters once the renderer can hit it, so it lands here too.

A `Profile` page that exists but can't be reached because there's no Me dashboard for the user to claim a handle on first would be a dead end. A SignIn page that exists but doesn't lead anywhere is just a button.

## Routes + ownership

```mermaid
flowchart LR
    subgraph public["public routes"]
        S["/s/<slug>"]
        P["/<handle>"]
        T["Tombstone"]
    end
    subgraph authed["authed routes"]
        ME["/me"]
        SI["/sign-in"]
    end
    subgraph api["share-backend"]
        SN["/api/snapshots/:id"]
        PR["/api/profiles/:handle"]
        M["/api/me"]
        MS["/api/me/shares"]
        H["/api/handles/*"]
        D["/api/me/delete"]
        OUT["/api/auth/sign-out"]
    end

    S --> SN
    P --> PR
    ME --> M
    ME --> MS
    ME --> H
    ME --> D
    ME --> OUT
    SI -. "/api/auth/google/start" .-> M
```

## Profile page rules

- Lists **`profile-listed`** shares only. Unlisted shares are not enumerated under the handle even though the backend knows which handle owns them — the visibility opt-in is per-share, not per-account.
- `SHARE_LIMIT = 100` on the backend. A handle with thousands of profile-listed shares paginates server-side; the v0.5 cutoff keeps the page lean and uncomplicated.
- `released_at IS NULL` on the handle query — released handles 404 immediately. If `alex` releases their handle and someone else claims it, the new account's profile is what `/alex` shows, not a frozen snapshot of the previous owner's shares.
- `users.deleted_at IS NULL` joined in — a deletion-pending user is still reachable; a fully-deleted user 404s.

## Me dashboard state machine

```mermaid
stateDiagram-v2
    [*] --> Loading
    Loading --> Anonymous: GET /api/me returns 401
    Anonymous --> SignIn: click "Sign in"
    Loading --> NoHandle: 200, handle is null
    Loading --> Ready: 200, handle claimed
    NoHandle --> Claiming: submit handle form
    Claiming --> NoHandle: 409 / 422
    Claiming --> Ready: 200
    Ready --> Renaming: edit handle in place
    Renaming --> Ready: 200 (old handle released, new claimed)
    Renaming --> Ready: 409 (status banner, handle unchanged)
    Ready --> Deleting: click "Delete account"
    Deleting --> Ready: cancel modal
    Deleting --> Pending: confirm (POST /api/me/delete)
    Pending --> Ready: click "Keep my account"<br/>(DELETE /api/me/delete)
    Pending --> Tombstoned: 24h grace expired,<br/>worker ran (PR #360)
```

## Handle availability — debounced, race-safe

```mermaid
sequenceDiagram
    autonumber
    participant U as User
    participant H as <Me> handle input
    participant API as /api/handles/check

    U->>H: "a"
    H->>H: debounce 320ms
    U->>H: "al"
    Note over H: timer reset on keypress
    U->>H: "alex"
    H->>API: GET ?handle=alex (seq=42)
    U->>H: "alexn"
    H->>API: GET ?handle=alexn (seq=43)
    API-->>H: alex → taken (seq=42, late)
    Note over H: seq < latest, drop
    API-->>H: alexn → available (seq=43)
    H-->>U: green check, "available"
```

The seq counter is what keeps an out-of-order response from stamping a stale "available" over a fresh "taken" when the user is typing fast. The desktop Settings → Account uses the same pattern with the same 320ms debounce — they're peer renderers of the same identity surface.

## Anti-enumeration

`/api/profiles/<handle>` and `/api/handles/check` both return identical error shapes for "invalid format" and "not found":

| Input | Response |
|---|---|
| `/api/profiles/!@#` (invalid format) | `404` |
| `/api/profiles/ghostuser` (valid but unclaimed) | `404` |

If we returned `422` for invalid and `404` for missing, a scanner could trivially probe which handles are merely typoable vs which are real but unclaimed (interesting target for impersonation), or real and claimed (interesting target for harassment).

## Verification

- `pnpm --filter @spool-lab/share-backend test` — profiles.test.ts (28 cases: valid + invalid + missing handle, rate limit trip, deleted user 404, released handle 404, profile-listed only, 100 cap, OWASP escape on `name`)
- `pnpm --filter @spool/share-web test` — api.test.ts (request shape), route.test.ts (handle vs slug ambiguity)
- Manual: claim handle on `/me`, hit `/<my handle>` in another tab, publish a `profile-listed` share, hit `/<my handle>` again; release handle, `/<handle>` 404s; schedule delete on desktop, refresh `/me` in web → pending banner with executeAt

## Risk

`/api/profiles/<handle>` is public — it's the first endpoint that exposes user info to an unauthenticated visitor. The rate limit + 404-on-invalid + `released_at IS NULL` filters are the trust boundary. `tests/_helpers/fakes.ts` adds the two new SQL matchers needed by profiles tests without touching the existing ones.

Submitted by @graydawnc.