### PR TITLE
chore(share-backend): security hardening — CSP, cache-control, audit endpoint, pentest

### DIFF
--- a/packages/app/e2e/helpers/launch-with-gpu.ts
+++ b/packages/app/e2e/helpers/launch-with-gpu.ts
@@ -1,0 +1,68 @@
+import { _electron as electron } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { mkdtempSync, mkdirSync, cpSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Variant of `launchApp` that does NOT set `ELECTRON_DISABLE_GPU=1`.
+ * Chromium's built-in PDF viewer needs GPU rasterisation; with the
+ * harness's default GPU-disable the iframe paints a blank rectangle
+ * regardless of what's in the bytes. Use this helper for any spec
+ * that needs to verify PDF rendering.
+ */
+const FIXTURES_DIR = join(__dirname, '..', 'fixtures')
+const APP_DIR = join(__dirname, '..', '..')
+
+export interface AppContext {
+  app: ElectronApplication
+  window: Page
+  cleanup: () => Promise<void>
+}
+
+export async function launchAppWithGpu(): Promise<AppContext> {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'spool-e2e-gpu-'))
+
+  const claudeDir = join(tmpDir, 'claude', 'projects')
+  const codexDir = join(tmpDir, 'codex', 'sessions')
+  const geminiCliHome = join(tmpDir, 'gemini-cli-home')
+  const opencodeDir = join(tmpDir, 'opencode')
+  cpSync(join(FIXTURES_DIR, 'claude-projects'), claudeDir, { recursive: true })
+  cpSync(join(FIXTURES_DIR, 'codex-sessions'), codexDir, { recursive: true })
+  cpSync(join(FIXTURES_DIR, 'gemini-cli-home'), geminiCliHome, { recursive: true })
+  mkdirSync(opencodeDir, { recursive: true })
+
+  const spoolHome = join(tmpDir, 'spool-home')
+  mkdirSync(spoolHome, { recursive: true })
+  writeFileSync(join(spoolHome, 'agents.json'), JSON.stringify({}), 'utf8')
+
+  const env: Record<string, string> = {
+    ...process.env as Record<string, string>,
+    SPOOL_DATA_DIR: join(tmpDir, 'data'),
+    SPOOL_ELECTRON_USER_DATA_DIR: join(tmpDir, 'electron-user-data'),
+    SPOOL_HOME: spoolHome,
+    SPOOL_CLAUDE_DIR: claudeDir,
+    SPOOL_CODEX_DIR: codexDir,
+    SPOOL_GEMINI_DIR: geminiCliHome,
+    GEMINI_CLI_HOME: geminiCliHome,
+    SPOOL_OPENCODE_DIR: opencodeDir,
+    SPOOL_E2E_TEST: '1',
+    // Intentionally NOT setting ELECTRON_DISABLE_GPU — Chromium's PDF
+    // viewer needs GPU rasterisation to paint.
+  }
+
+  const args = [join(APP_DIR, 'out', 'main', 'index.js')]
+  if (process.platform === 'linux') args.unshift('--no-sandbox')
+  args.unshift('--force-prefers-reduced-motion')
+
+  const app = await electron.launch({ args, cwd: APP_DIR, env })
+  const window = await app.firstWindow()
+  return {
+    app,
+    window,
+    cleanup: async () => {
+      await app.close()
+      rmSync(tmpDir, { recursive: true, force: true })
+    },
+  }
+}

--- a/packages/app/e2e/pdf-iframe-with-gpu.spec.ts
+++ b/packages/app/e2e/pdf-iframe-with-gpu.spec.ts
@@ -32,7 +32,12 @@ test('PDF iframe renders with GPU enabled', async () => {
   await openShareEditorFromSessionDetail(window, SESSION_UUID)
 
   await window.locator('[data-testid="share-menu-trigger"]').click()
-  await window.locator('[data-testid="share-menu-tab-export"]').click()
+  await window.locator('[data-testid="share-menu-popover"]').waitFor({ state: 'visible' })
+  // The tab strip is only rendered when VITE_FEATURE_SHAREPUBLISH is on;
+  // e2e runs with publish disabled, so the popover opens directly on the
+  // Export tab and there's no tab button to click first.
+  const exportTab = window.locator('[data-testid="share-menu-tab-export"]')
+  if (await exportTab.count()) await exportTab.click()
   await window.locator('[data-testid="share-menu-export-pdf"]').click()
   await window.locator('[data-testid="share-menu-download"]').click()
 

--- a/packages/app/e2e/pdf-iframe-with-gpu.spec.ts
+++ b/packages/app/e2e/pdf-iframe-with-gpu.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test'
+import { launchAppWithGpu, type AppContext } from './helpers/launch-with-gpu'
+import { openShareEditorFromSessionDetail } from './helpers/share'
+import { waitForSync } from './helpers/launch'
+import { mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+// Diagnostic for the PDF preview iframe path with full GPU enabled.
+// Chromium's built-in PDF viewer needs GPU rasterisation; the regular
+// launchApp helper sets ELECTRON_DISABLE_GPU=1 which makes the iframe
+// paint grey regardless. This spec runs with GPU on so we can prove
+// whether CSP is the only thing blocking the viewer.
+
+let ctx: AppContext
+
+const SESSION_UUID = 'test-session-uuid-001'
+const ARTIFACT_PATH = join(__dirname, '..', 'e2e-output', 'pdf-iframe-with-gpu.png')
+
+test.beforeAll(async () => {
+  test.setTimeout(180_000)
+  ctx = await launchAppWithGpu()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+test('PDF iframe renders with GPU enabled', async () => {
+  test.setTimeout(180_000)
+  const { window } = ctx
+  await waitForSync(window)
+  await openShareEditorFromSessionDetail(window, SESSION_UUID)
+
+  await window.locator('[data-testid="share-menu-trigger"]').click()
+  await window.locator('[data-testid="share-menu-tab-export"]').click()
+  await window.locator('[data-testid="share-menu-export-pdf"]').click()
+  await window.locator('[data-testid="share-menu-download"]').click()
+
+  const iframe = window.locator('iframe[title]').first()
+  await expect(iframe).toBeVisible({ timeout: 30_000 })
+
+  // Generous wait for Chromium's PDF viewer to attach + paint.
+  await window.waitForTimeout(5000)
+
+  mkdirSync(dirname(ARTIFACT_PATH), { recursive: true })
+  await window
+    .locator('.fixed.inset-0.z-50')
+    .screenshot({ path: ARTIFACT_PATH })
+})

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -62,6 +62,7 @@ import { loadUIPreferences, saveThemeEditor, saveThemeSource, saveSidebarCollaps
 import { hydrateBinaryCache } from './binaryCache.js'
 import { snapshotEventLoopLag, startEventLoopMonitor } from './eventLoopMonitor.js'
 import { registerShareAuthIpc } from './ipc/share-auth.js'
+import { installRendererCsp } from './security/csp.js'
 import { registerSharePublishIpc } from './ipc/share-publish.js'
 import type Database from 'better-sqlite3'
 import type { SyncWorkerMessage } from './sync-worker.js'
@@ -612,6 +613,12 @@ function runSyncWorker(): Promise<{ added: number; updated: number; errors: numb
 }
 
 app.whenReady().then(async () => {
+  // Renderer CSP — has to land BEFORE any BrowserWindow loads its URL,
+  // otherwise the first response slips through with whatever Vite (or
+  // the bundled file:// loader) emits and Electron's "Insecure CSP"
+  // warning fires once before our header takes over.
+  installRendererCsp({ dev: isDevMode })
+
   // Hydrate the agent-binary path cache from disk before anything has a
   // chance to call `cachedResolveAsync`. Without this every cold launch
   // re-runs `<user-shell> -ilc 'command -v ...'` once per agent — three

--- a/packages/app/src/main/security/csp.test.ts
+++ b/packages/app/src/main/security/csp.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+
+import { __cspFixtures } from './csp.js'
+
+// We don't import installRendererCsp itself in tests — wiring it would
+// require an Electron `session` stub. The string fixtures cover the
+// actual product surface (drift in directives) without the harness.
+const { DEV_CSP, PROD_CSP } = __cspFixtures
+
+function directives(csp: string): Map<string, string[]> {
+  const out = new Map<string, string[]>()
+  for (const segment of csp.split(';')) {
+    const trimmed = segment.trim()
+    if (!trimmed) continue
+    const [name, ...rest] = trimmed.split(/\s+/)
+    out.set(name!, rest)
+  }
+  return out
+}
+
+describe('Renderer CSP policy', () => {
+  describe('required directives present', () => {
+    const required = [
+      'default-src',
+      'script-src',
+      'style-src',
+      'font-src',
+      'img-src',
+      'connect-src',
+      'frame-src',
+      'object-src',
+      'frame-ancestors',
+      'base-uri',
+    ] as const
+
+    for (const profile of [
+      { name: 'dev', csp: DEV_CSP },
+      { name: 'prod', csp: PROD_CSP },
+    ]) {
+      it(`${profile.name} CSP carries every directive needed to silence Electron's warning`, () => {
+        const dirs = directives(profile.csp)
+        for (const key of required) {
+          expect(dirs.has(key), `${profile.name}: missing ${key}`).toBe(true)
+        }
+      })
+    }
+  })
+
+  it('default-src restricts to self on both profiles', () => {
+    expect(directives(DEV_CSP).get('default-src')).toEqual(["'self'"])
+    expect(directives(PROD_CSP).get('default-src')).toEqual(["'self'"])
+  })
+
+  it('frame-ancestors locks down third-party embedding on both profiles', () => {
+    for (const csp of [DEV_CSP, PROD_CSP]) {
+      expect(directives(csp).get('frame-ancestors')).toEqual(["'none'"])
+    }
+  })
+
+  it('object-src allows self/blob/chrome-extension so the PDF viewer paints', () => {
+    // Chromium's built-in PDF MIME handler hosts the rendered document
+    // via an internal `<embed type="application/pdf">` whose src points
+    // back at the same `chrome-extension://` origin. Without these
+    // tokens the embed mounts but the document never paints (the
+    // iframe goes grey with no console hint). Don't tighten this
+    // without first wiring an alternative renderer like pdf.js.
+    for (const csp of [DEV_CSP, PROD_CSP]) {
+      const obj = directives(csp).get('object-src') ?? []
+      expect(obj).toContain("'self'")
+      expect(obj).toContain('blob:')
+      expect(obj).toContain('chrome-extension:')
+    }
+  })
+
+  describe('dev profile', () => {
+    it('allows Vite HMR transport (ws://localhost:5173)', () => {
+      const connect = directives(DEV_CSP).get('connect-src') ?? []
+      expect(connect).toContain('ws://localhost:5173')
+    })
+
+    it('allows the share-backend wrangler on http://localhost:8788', () => {
+      const connect = directives(DEV_CSP).get('connect-src') ?? []
+      expect(connect).toContain('http://localhost:8788')
+    })
+
+    it('allows `unsafe-eval` because vite-plugin-react fast-refresh needs it', () => {
+      // Dev only — the production bundle does not ship the fast-refresh
+      // runtime so the prod profile explicitly omits this allowance.
+      expect(directives(DEV_CSP).get('script-src')).toContain("'unsafe-eval'")
+    })
+  })
+
+  describe('prod profile', () => {
+    it('does NOT permit unsafe-eval (no fast-refresh in prod)', () => {
+      const script = directives(PROD_CSP).get('script-src') ?? []
+      expect(script).not.toContain("'unsafe-eval'")
+    })
+
+    it('does NOT permit localhost transports', () => {
+      const connect = directives(PROD_CSP).get('connect-src') ?? []
+      expect(connect.every((src) => !src.includes('localhost'))).toBe(true)
+    })
+
+    it('allows the spool.pro origin family on connect-src', () => {
+      const connect = directives(PROD_CSP).get('connect-src') ?? []
+      expect(connect).toContain('https://spool.pro')
+      expect(connect).toContain('https://*.spool.pro')
+    })
+  })
+
+  describe('frame-src (both profiles)', () => {
+    // The editor's PDF preview iframes a `blob:` URL of the rendered
+    // document so Chromium's built-in PDF MIME handler can paint the
+    // toolbar + page thumbnails. Without `blob:` here the iframe goes
+    // blank with no console hint — this was a real regression caught
+    // when we first locked CSP down. Pin it.
+    it('allows blob: and chrome-extension: so the PDF preview iframe renders', () => {
+      // The viewer iframe loads its UI from
+      // `chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/`, and the
+      // PDF document itself is the `blob:` URL we generated. Both must
+      // be in frame-src or the iframe goes silently blank.
+      for (const csp of [DEV_CSP, PROD_CSP]) {
+        const frame = directives(csp).get('frame-src') ?? []
+        expect(frame).toContain("'self'")
+        expect(frame).toContain('blob:')
+        expect(frame).toContain('chrome-extension:')
+      }
+    })
+  })
+
+  describe('connect-src (both profiles)', () => {
+    // pdf.js + savePdfFromPreview both `fetch(blobUrl)` on
+    // freshly-generated PDF Blobs. Without blob: in connect-src the
+    // fetch silently fails with "Failed to fetch" and the save dialog
+    // gets zero bytes.
+    it('allows blob: so the PDF save flow can fetch its own blob', () => {
+      for (const csp of [DEV_CSP, PROD_CSP]) {
+        const connect = directives(csp).get('connect-src') ?? []
+        expect(connect).toContain('blob:')
+      }
+    })
+  })
+
+  describe('image origins (both profiles)', () => {
+    it('allows data: and blob: for inline images + screenshot exports', () => {
+      for (const csp of [DEV_CSP, PROD_CSP]) {
+        const img = directives(csp).get('img-src') ?? []
+        expect(img).toContain('data:')
+        expect(img).toContain('blob:')
+      }
+    })
+
+    it('allows the Google user-content host for OAuth avatars', () => {
+      for (const csp of [DEV_CSP, PROD_CSP]) {
+        const img = directives(csp).get('img-src') ?? []
+        expect(img).toContain('https://lh3.googleusercontent.com')
+      }
+    })
+  })
+})

--- a/packages/app/src/main/security/csp.ts
+++ b/packages/app/src/main/security/csp.ts
@@ -1,0 +1,137 @@
+import { session as electronSession } from 'electron'
+
+/**
+ * Inject a `Content-Security-Policy` response header on every renderer
+ * response from the default session. Industry pattern (Linear / Notion
+ * / Slack desktop): drive CSP from the main process so dev + prod share
+ * a single source of truth and Electron's "Insecure CSP" dev warning
+ * disappears.
+ *
+ * The dev profile is intentionally looser:
+ *   - `'unsafe-inline'` for Vite's injected `<script>` and `<style>`
+ *     tags (the HMR runtime relies on it).
+ *   - `ws://localhost:5173` for the HMR WebSocket.
+ *   - `http://localhost:8788` so renderer-side fetches to the
+ *     share-backend wrangler instance work without falling foul of
+ *     `connect-src`.
+ *
+ * The prod profile drops everything except `'self'` plus the canonical
+ * Spool domains. Avatar CDNs are limited to the Google user-content
+ * host; if other providers land (GitHub, Apple) extend `IMG_ALLOW`.
+ *
+ * Notes:
+ *   - `frame-ancestors 'none'` blocks any other page from iframing the
+ *     renderer — Electron BrowserWindow can't be iframed, but the rule
+ *     is harmless and good hygiene.
+ *   - `object-src 'none'` kills plugin embedding which Electron doesn't
+ *     ship anyway.
+ *   - We do NOT set `report-uri` / `report-to` — the BrowserWindow has
+ *     no audience to phone home to.
+ *
+ * If a renderer page introduces a new fetch target (e.g. a new
+ * external API), add the origin to the matching directive here.
+ */
+
+const IMG_ALLOW = "'self' data: blob: https://lh3.googleusercontent.com"
+
+// The editor's PDF preview renders a generated `blob:` URL inside an
+// `<iframe>` and lets Chromium's built-in PDF MIME handler take over.
+// The handler iframes the viewer UI from
+// `chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/`, so we have
+// to allow that scheme here or the iframe paints a blank grey
+// rectangle with no console hint. `blob:` covers the document URL
+// itself; both are required.
+const FRAME_ALLOW = "'self' blob: chrome-extension:"
+
+// The Chromium PDF viewer extension hosts the rendered PDF via an
+// internal `<embed type="application/pdf">`. With `object-src 'none'`
+// the embed mounts but the document never paints; allowing
+// `chrome-extension:` keeps the viewer working without opening plugin
+// loading from arbitrary origins.
+const OBJECT_ALLOW = "'self' blob: chrome-extension:"
+
+// `blob:` in connect-src lets `fetch(blobUrl)` work — the save-PDF
+// path reads its own freshly-generated Blob back through `fetch(url)`
+// to write it to disk. Without this directive the renderer can
+// dereference the blob in `<img>` / `<iframe>` (frame-src / img-src
+// cover that) but `fetch` itself silently fails with "Failed to
+// fetch" and the save dialog never gets bytes.
+const CONNECT_BLOB = 'blob:'
+
+const DEV_CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  "style-src 'self' 'unsafe-inline'",
+  "font-src 'self' data:",
+  `img-src ${IMG_ALLOW}`,
+  `connect-src 'self' ${CONNECT_BLOB} http://localhost:8788 http://localhost:5173 ws://localhost:5173 ws://127.0.0.1:5173`,
+  `frame-src ${FRAME_ALLOW}`,
+  `object-src ${OBJECT_ALLOW}`,
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+].join('; ')
+
+const PROD_CSP = [
+  "default-src 'self'",
+  // Inline styles only — no inline scripts in the production bundle.
+  // `unsafe-eval` is required by `vite-plugin-react`'s dev fast-refresh
+  // but the prod build strips that out.
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "font-src 'self' data:",
+  `img-src ${IMG_ALLOW}`,
+  `connect-src 'self' ${CONNECT_BLOB} https://spool.pro https://*.spool.pro`,
+  `frame-src ${FRAME_ALLOW}`,
+  `object-src ${OBJECT_ALLOW}`,
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+].join('; ')
+
+export function installRendererCsp(opts: { dev: boolean }): void {
+  // Diagnostic escape hatch: setting SPOOL_DISABLE_CSP=1 skips the
+  // installation entirely so we can A/B which directive is gating a
+  // surface. Kept inside the module rather than at the call site so a
+  // future Labs toggle could flip it via the renderer too.
+  if (process.env['SPOOL_DISABLE_CSP'] === '1') return
+  const policy = opts.dev ? DEV_CSP : PROD_CSP
+  electronSession.defaultSession.webRequest.onHeadersReceived(
+    (details, callback) => {
+      // Only inject CSP into responses for the documents we actually
+      // ship. Chromium's built-in PDF viewer extension serves its UI
+      // off `chrome-extension://`; if we replace that response's CSP
+      // with ours the viewer can't load its own internal scripts /
+      // styles / embeds and the iframe paints blank grey. Extensions
+      // and Chromium-internal pages have their own appropriate CSPs;
+      // we should not impose ours on top of them. `data:` URLs are
+      // omitted deliberately — they're untrusted inline content, not
+      // documents we author, and Electron doesn't fire
+      // onHeadersReceived for them at the document level anyway.
+      const url = details.url || ''
+      const isAppDoc =
+        url.startsWith('http://') ||
+        url.startsWith('https://') ||
+        url.startsWith('file://') ||
+        url.startsWith('blob:')
+      if (!isAppDoc) {
+        // No header changes — let Electron pass the response through.
+        callback({})
+        return
+      }
+      const responseHeaders = { ...details.responseHeaders }
+      // Strip any inbound CSP — Vite dev server in particular sends a
+      // permissive header and Electron will pick whichever is most
+      // restrictive; replacing avoids any union surprises.
+      for (const key of Object.keys(responseHeaders)) {
+        if (key.toLowerCase() === 'content-security-policy') {
+          delete responseHeaders[key]
+        }
+      }
+      responseHeaders['Content-Security-Policy'] = [policy]
+      callback({ responseHeaders })
+    },
+  )
+}
+
+// Exported for snapshot tests so policy drift gets caught in CI without
+// spinning up an Electron app.
+export const __cspFixtures = { DEV_CSP, PROD_CSP }

--- a/packages/share-backend/.dev.vars.example
+++ b/packages/share-backend/.dev.vars.example
@@ -1,0 +1,33 @@
+# Local dev secrets for `wrangler pages dev`. Copy to `.dev.vars` (gitignored)
+# and fill in real values. Do NOT commit `.dev.vars`.
+#
+# How to obtain each:
+#
+# GOOGLE_CLIENT_ID_DESKTOP / GOOGLE_CLIENT_ID_WEB / GOOGLE_CLIENT_SECRET_WEB
+#   Create a "Spool Dev" project in https://console.cloud.google.com/apis/credentials
+#   • Desktop client — accepts loopback URIs without registration (RFC 8252)
+#   • Web client — register http://localhost:3002/api/auth/google/callback
+#     as an authorised redirect URI
+#   Use a SEPARATE dev OAuth client from prod — never share client ids.
+#
+# SESSION_SIGNING_KEY
+#   Any 32-byte random string. Reserved for future HMAC of state cookies.
+#   `openssl rand -base64 32` works.
+#
+# ABUSE_NOTIFY_EMAIL
+#   In dev anything is fine (e.g. dev@localhost). Production points at
+#   abuse@spool.pro and gets the manual D1 polling treatment until v1.1
+#   wires Mailchannels.
+#
+# ADMIN_USER_IDS
+#   Comma-separated list of user ids allowed to hit /api/admin/audit.
+#   In dev you'll discover your own user id by signing in once and
+#   reading the `users` row from the local D1 sqlite file; paste it back
+#   here and restart wrangler dev to admin yourself.
+
+GOOGLE_CLIENT_ID_DESKTOP=
+GOOGLE_CLIENT_ID_WEB=
+GOOGLE_CLIENT_SECRET_WEB=
+SESSION_SIGNING_KEY=
+ABUSE_NOTIFY_EMAIL=dev@localhost
+ADMIN_USER_IDS=

--- a/packages/share-backend/README.md
+++ b/packages/share-backend/README.md
@@ -1,0 +1,31 @@
+# @spool/share-backend
+
+Cloudflare Pages Functions backing `spool.share`: auth (Google OAuth desktop + web), publish/read/revoke, OG image generation, profile, /me, abuse reporting, and admin audit access.
+
+## Local development
+
+```bash
+pnpm install
+pnpm --filter @spool-lab/redact build   # share-backend transitively depends on its dist
+pnpm --filter @spool/share-backend test
+pnpm --filter @spool/share-backend typecheck
+pnpm --filter @spool/share-backend dev   # wrangler pages dev — requires CF login
+```
+
+Tests run hermetically without `wrangler dev` — the suite composes handlers against in-memory KV/D1/R2 fakes in `tests/_helpers/fakes.ts`.
+
+## Pre-deploy pentest
+
+Before promoting a build to production, run:
+
+```bash
+TARGET=https://staging.spool.share ./tests/pentest.sh
+```
+
+This probes security headers, unauthenticated access, slug + handle enumeration, and open-redirect surfaces. It exits non-zero on any failure. The script is NOT wired into CI — it is a manual gate.
+
+## Deploy
+
+Bindings (D1, KV, R2) and secrets (Google client IDs, web client secret, session key, abuse-notify email, admin user ids) must be configured in the Cloudflare dashboard before the first deploy. Placeholder IDs in `wrangler.toml` MUST be replaced.
+
+The scheduled deletion worker (`functions/_scheduled/deletion-worker.ts`) is structured as a standalone `scheduled` handler; Pages Functions do not currently trigger crons, so it should be deployed as a companion Worker against the same bindings.

--- a/packages/share-backend/README.md
+++ b/packages/share-backend/README.md
@@ -1,31 +1,54 @@
 # @spool/share-backend
 
-Cloudflare Pages Functions backing `spool.share`: auth (Google OAuth desktop + web), publish/read/revoke, OG image generation, profile, /me, abuse reporting, and admin audit access.
+Cloudflare Pages Functions backing `spool.pro`: auth (Google OAuth desktop + web), publish/read/revoke, OG image generation, profile, /me, and admin audit access.
+
+> **Resource IDs are not in this repo.** Production D1 / KV / R2 bindings are configured per-project in the Cloudflare Pages dashboard. `wrangler.toml` carries only the binding names + bucket names + binding shape — `database_id` / KV `id` fields are intentionally omitted. External contributors do not need any Cloudflare account to run the full stack locally; `wrangler pages dev` emulates every binding with throwaway files under `.wrangler/state/`. The Pages dashboard is the source of truth for production. See `docs/runbooks/spool-share-launch.md` §1 for the one-time prod setup; operator may keep a local `wrangler.toml.local` (gitignored) if they want a copy with real ids for occasional remote operations.
 
 ## Local development
 
+Tests are hermetic and need no setup:
+
 ```bash
 pnpm install
-pnpm --filter @spool-lab/redact build   # share-backend transitively depends on its dist
 pnpm --filter @spool/share-backend test
 pnpm --filter @spool/share-backend typecheck
-pnpm --filter @spool/share-backend dev   # wrangler pages dev — requires CF login
 ```
 
-Tests run hermetically without `wrangler dev` — the suite composes handlers against in-memory KV/D1/R2 fakes in `tests/_helpers/fakes.ts`.
+The suite composes handlers against in-memory KV/D1/R2 fakes in `tests/_helpers/fakes.ts`. No wrangler / Cloudflare login required.
+
+### Running the backend end-to-end against a local app
+
+For functional smoke tests (publish → read → revoke loop in a real browser, or against the Spool desktop app), boot wrangler with local D1/KV/R2 emulation:
+
+```bash
+# 1. Copy the local secrets template + fill in dev Google OAuth client ids.
+#    .dev.vars is gitignored. See the file's header for how to obtain each.
+cp packages/share-backend/.dev.vars.example packages/share-backend/.dev.vars
+$EDITOR packages/share-backend/.dev.vars
+
+# 2. Apply migrations to a local SQLite file (one-time + after schema changes).
+cd packages/share-backend
+corepack pnpm wrangler d1 migrations apply spool-share-db --local
+
+# 3. Boot. Wrangler serves on http://localhost:8788, persists D1/KV/R2 to
+#    .wrangler/state/ (gitignored). No Cloudflare account needed.
+corepack pnpm dev
+```
+
+The full three-process dev environment (share-backend + share-web + Spool app) ships as `scripts/share-dev.sh` at the repo root — invoke that to bring the whole loop up under one terminal.
 
 ## Pre-deploy pentest
 
 Before promoting a build to production, run:
 
 ```bash
-TARGET=https://staging.spool.share ./tests/pentest.sh
+TARGET=https://staging.spool.pro ./tests/pentest.sh
 ```
 
 This probes security headers, unauthenticated access, slug + handle enumeration, and open-redirect surfaces. It exits non-zero on any failure. The script is NOT wired into CI — it is a manual gate.
 
 ## Deploy
 
-Bindings (D1, KV, R2) and secrets (Google client IDs, web client secret, session key, abuse-notify email, admin user ids) must be configured in the Cloudflare dashboard before the first deploy. Placeholder IDs in `wrangler.toml` MUST be replaced.
+Bindings (D1, KV, R2) and secrets (Google client IDs, web client secret, session key, admin user ids) are configured per-Pages-project in the Cloudflare dashboard. The dashboard — not this repo — is the source of truth for production resource ids. See the launch runbook §1 for the one-time setup; on CI, `wrangler pages deploy --project-name spool-share-backend` works without any id in code because the project carries its bindings.
 
 The scheduled deletion worker (`functions/_scheduled/deletion-worker.ts`) is structured as a standalone `scheduled` handler; Pages Functions do not currently trigger crons, so it should be deployed as a companion Worker against the same bindings.

--- a/packages/share-backend/functions/_middleware.ts
+++ b/packages/share-backend/functions/_middleware.ts
@@ -1,11 +1,27 @@
 import type { PagesFunction } from '@cloudflare/workers-types'
 
+import { API_CSP } from '../src/security/csp'
+
+const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
+
 export const onRequest: PagesFunction = async (ctx) => {
   const res = await ctx.next()
   const headers = new Headers(res.headers)
   headers.set('X-Robots-Tag', 'noindex')
   headers.set('X-Content-Type-Options', 'nosniff')
   headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
+
+  const url = new URL(ctx.request.url)
+  if (url.pathname.startsWith('/api/')) {
+    headers.set('Content-Security-Policy', API_CSP)
+    if (
+      MUTATION_METHODS.has(ctx.request.method.toUpperCase()) &&
+      !headers.has('cache-control')
+    ) {
+      headers.set('Cache-Control', 'no-store')
+    }
+  }
+
   return new Response(res.body, {
     status: res.status,
     statusText: res.statusText,

--- a/packages/share-backend/functions/api/admin/audit.ts
+++ b/packages/share-backend/functions/api/admin/audit.ts
@@ -3,6 +3,7 @@ import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers
 import { audit } from '../../../src/audit'
 import { requireUser } from '../../../src/auth/require'
 import { ApiError, jsonError, jsonOk } from '../../../src/errors'
+import { CC_PRIVATE_NO_CACHE } from '../../../src/security/cache-control'
 
 type Env = {
   DB: D1Database
@@ -37,7 +38,7 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
     })
     return jsonOk(
       { items: rows.results },
-      { headers: { 'cache-control': 'private, no-cache' } },
+      { headers: { 'cache-control': CC_PRIVATE_NO_CACHE } },
     )
   } catch (e) {
     return jsonError(e)

--- a/packages/share-backend/functions/api/admin/audit.ts
+++ b/packages/share-backend/functions/api/admin/audit.ts
@@ -1,0 +1,45 @@
+import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers-types'
+
+import { audit } from '../../../src/audit'
+import { requireUser } from '../../../src/auth/require'
+import { ApiError, jsonError, jsonOk } from '../../../src/errors'
+
+type Env = {
+  DB: D1Database
+  SESSIONS: KVNamespace
+  RATE: KVNamespace
+  ADMIN_USER_IDS?: string
+}
+
+const LIMIT = 200
+
+function isAdmin(userId: string, raw: string | undefined): boolean {
+  if (!raw) return false
+  return raw.split(',').map((s) => s.trim()).filter(Boolean).includes(userId)
+}
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+  try {
+    const user = await requireUser(ctx.request, ctx.env)
+    if (!isAdmin(user.id, ctx.env.ADMIN_USER_IDS)) {
+      throw new ApiError('FORBIDDEN')
+    }
+    const rows = await ctx.env.DB
+      .prepare(
+        'SELECT user_id, ip_hash, ua_hash, action, target_id, details_json, ts ' +
+          'FROM audit_log ORDER BY ts DESC LIMIT ?',
+      )
+      .bind(LIMIT)
+      .all()
+    await audit(ctx.env.DB, ctx.env.RATE, ctx.request, {
+      user_id: user.id,
+      action: 'admin.audit.read',
+    })
+    return jsonOk(
+      { items: rows.results },
+      { headers: { 'cache-control': 'private, no-cache' } },
+    )
+  } catch (e) {
+    return jsonError(e)
+  }
+}

--- a/packages/share-backend/functions/api/auth/[provider]/callback.ts
+++ b/packages/share-backend/functions/api/auth/[provider]/callback.ts
@@ -20,6 +20,7 @@ import { ApiError, jsonError } from '../../../../src/errors'
 import { publicBaseUrl } from '../../../../src/public-url'
 import { checkRate } from '../../../../src/rate-limit'
 import { clientIp } from '../../../../src/request'
+import { CC_NO_STORE } from '../../../../src/security/cache-control'
 import { upsertUserByIdentity } from '../../../../src/store/d1'
 
 type Env = {
@@ -84,7 +85,7 @@ export const onRequestGet: PagesFunction<Env, 'provider'> = async (ctx) => {
     // compliant and workerd stops emitting non-ASCII warnings. encodeURI
     // preserves the path/query delimiters (`/`, `?`, `&`, `=`), so it's
     // an idempotent no-op on the common ASCII paths.
-    const headers = new Headers({ Location: encodeURI(next), 'Cache-Control': 'no-store' })
+    const headers = new Headers({ Location: encodeURI(next), 'Cache-Control': CC_NO_STORE })
     headers.append('Set-Cookie', buildSessionCookie(sess.token, MAX_TTL_SEC))
     headers.append('Set-Cookie', clearCookie(OAUTH_STATE_COOKIE))
     headers.append('Set-Cookie', clearCookie(OAUTH_VERIFIER_COOKIE))

--- a/packages/share-backend/functions/api/auth/[provider]/callback.ts
+++ b/packages/share-backend/functions/api/auth/[provider]/callback.ts
@@ -84,7 +84,7 @@ export const onRequestGet: PagesFunction<Env, 'provider'> = async (ctx) => {
     // compliant and workerd stops emitting non-ASCII warnings. encodeURI
     // preserves the path/query delimiters (`/`, `?`, `&`, `=`), so it's
     // an idempotent no-op on the common ASCII paths.
-    const headers = new Headers({ Location: encodeURI(next) })
+    const headers = new Headers({ Location: encodeURI(next), 'Cache-Control': 'no-store' })
     headers.append('Set-Cookie', buildSessionCookie(sess.token, MAX_TTL_SEC))
     headers.append('Set-Cookie', clearCookie(OAUTH_STATE_COOKIE))
     headers.append('Set-Cookie', clearCookie(OAUTH_VERIFIER_COOKIE))

--- a/packages/share-backend/functions/api/handles/check.ts
+++ b/packages/share-backend/functions/api/handles/check.ts
@@ -2,6 +2,7 @@ import type { D1Database, PagesFunction } from '@cloudflare/workers-types'
 
 import { jsonError, jsonOk } from '../../../src/errors'
 import { validateHandle } from '../../../src/handles'
+import { ccPublicRevalidate } from '../../../src/security/cache-control'
 
 type Env = { DB: D1Database }
 
@@ -9,7 +10,7 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
   try {
     const handle = new URL(ctx.request.url).searchParams.get('h') ?? ''
     const v = validateHandle(handle)
-    const headers = { 'cache-control': 'public, max-age=10, must-revalidate' }
+    const headers = { 'cache-control': ccPublicRevalidate(10) }
     if (!v.ok) return jsonOk({ available: false, reason: v.reason }, { headers })
     // NOTE: `handles.handle` is the table PK, so once a row exists the
     // value is occupied for INSERT purposes even after `released_at` is

--- a/packages/share-backend/functions/api/handles/check.ts
+++ b/packages/share-backend/functions/api/handles/check.ts
@@ -9,7 +9,8 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
   try {
     const handle = new URL(ctx.request.url).searchParams.get('h') ?? ''
     const v = validateHandle(handle)
-    if (!v.ok) return jsonOk({ available: false, reason: v.reason })
+    const headers = { 'cache-control': 'public, max-age=10, must-revalidate' }
+    if (!v.ok) return jsonOk({ available: false, reason: v.reason }, { headers })
     // NOTE: `handles.handle` is the table PK, so once a row exists the
     // value is occupied for INSERT purposes even after `released_at` is
     // set. This query matches the design intent (released handles are
@@ -19,7 +20,7 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
       .prepare('SELECT 1 FROM handles WHERE handle=? AND released_at IS NULL')
       .bind(v.handle)
       .first()
-    return jsonOk({ available: !row })
+    return jsonOk({ available: !row }, { headers })
   } catch (e) {
     return jsonError(e)
   }

--- a/packages/share-backend/functions/api/me/index.ts
+++ b/packages/share-backend/functions/api/me/index.ts
@@ -2,6 +2,7 @@ import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers
 
 import { requireUser } from '../../../src/auth/require'
 import { jsonError, jsonOk } from '../../../src/errors'
+import { CC_PRIVATE_NO_CACHE } from '../../../src/security/cache-control'
 
 type Env = { DB: D1Database; SESSIONS: KVNamespace }
 
@@ -25,7 +26,7 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
         handle: handle?.handle ?? null,
         deletion_pending_until: user.deletion_pending_until,
       },
-      { headers: { 'cache-control': 'private, no-cache' } },
+      { headers: { 'cache-control': CC_PRIVATE_NO_CACHE } },
     )
   } catch (e) {
     return jsonError(e)

--- a/packages/share-backend/functions/api/me/index.ts
+++ b/packages/share-backend/functions/api/me/index.ts
@@ -16,14 +16,17 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
       .prepare('SELECT handle FROM handles WHERE user_id=? AND released_at IS NULL')
       .bind(user.id)
       .first<{ handle: string }>()
-    return jsonOk({
-      id: user.id,
-      email: user.email,
-      name: user.name,
-      avatar_url: user.avatar_url,
-      handle: handle?.handle ?? null,
-      deletion_pending_until: user.deletion_pending_until,
-    })
+    return jsonOk(
+      {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        avatar_url: user.avatar_url,
+        handle: handle?.handle ?? null,
+        deletion_pending_until: user.deletion_pending_until,
+      },
+      { headers: { 'cache-control': 'private, no-cache' } },
+    )
   } catch (e) {
     return jsonError(e)
   }

--- a/packages/share-backend/functions/api/me/shares.ts
+++ b/packages/share-backend/functions/api/me/shares.ts
@@ -2,6 +2,7 @@ import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers
 
 import { requireUser } from '../../../src/auth/require'
 import { jsonError, jsonOk } from '../../../src/errors'
+import { CC_PRIVATE_NO_CACHE } from '../../../src/security/cache-control'
 
 type Env = { DB: D1Database; SESSIONS: KVNamespace }
 
@@ -17,7 +18,7 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
       .all()
     return jsonOk(
       { items: rows.results },
-      { headers: { 'cache-control': 'private, no-cache' } },
+      { headers: { 'cache-control': CC_PRIVATE_NO_CACHE } },
     )
   } catch (e) {
     return jsonError(e)

--- a/packages/share-backend/functions/api/me/shares.ts
+++ b/packages/share-backend/functions/api/me/shares.ts
@@ -15,7 +15,10 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
       )
       .bind(user.id)
       .all()
-    return jsonOk({ items: rows.results })
+    return jsonOk(
+      { items: rows.results },
+      { headers: { 'cache-control': 'private, no-cache' } },
+    )
   } catch (e) {
     return jsonError(e)
   }

--- a/packages/share-backend/functions/api/snapshots/[id].ts
+++ b/packages/share-backend/functions/api/snapshots/[id].ts
@@ -2,12 +2,13 @@ import type { KVNamespace, PagesFunction, R2Bucket } from '@cloudflare/workers-t
 
 import { ApiError, jsonError } from '../../../src/errors'
 import { isValidSlug } from '../../../src/publish/slug'
+import { CC_NO_STORE } from '../../../src/security/cache-control'
 
 type Env = { META: KVNamespace; SNAPSHOTS: R2Bucket; RATE: KVNamespace }
 
 const TOMBSTONE_HEADERS = {
   'content-type': 'application/json',
-  'cache-control': 'no-store',
+  'cache-control': CC_NO_STORE,
 }
 
 // 30s window keeps CDN cost manageable for viral shares while bounding the

--- a/packages/share-backend/migrations/0002_audit_ts_index.sql
+++ b/packages/share-backend/migrations/0002_audit_ts_index.sql
@@ -1,0 +1,8 @@
+-- 0002_audit_ts_index.sql
+-- The admin audit dashboard runs `SELECT ... FROM audit_log ORDER BY ts DESC LIMIT 200`
+-- with no WHERE clause; the existing composite indexes (user_id, ts)
+-- and (action, ts) can't satisfy a leading-column-free ORDER BY, so D1
+-- falls back to a full scan + sort. A plain ts index makes that query
+-- O(LIMIT) instead.
+
+CREATE INDEX audit_ts ON audit_log(ts);

--- a/packages/share-backend/migrations/0002_audit_ts_index.sql
+++ b/packages/share-backend/migrations/0002_audit_ts_index.sql
@@ -1,8 +1,0 @@
--- 0002_audit_ts_index.sql
--- The admin audit dashboard runs `SELECT ... FROM audit_log ORDER BY ts DESC LIMIT 200`
--- with no WHERE clause; the existing composite indexes (user_id, ts)
--- and (action, ts) can't satisfy a leading-column-free ORDER BY, so D1
--- falls back to a full scan + sort. A plain ts index makes that query
--- O(LIMIT) instead.
-
-CREATE INDEX audit_ts ON audit_log(ts);

--- a/packages/share-backend/src/auth/next.ts
+++ b/packages/share-backend/src/auth/next.ts
@@ -1,5 +1,6 @@
 export function safeNext(raw: string | null | undefined): string {
   if (!raw) return '/'
   if (!raw.startsWith('/') || raw.startsWith('//') || raw.includes('\\')) return '/'
+  if (raw.split('/').some((seg) => seg === '..')) return '/'
   return raw
 }

--- a/packages/share-backend/src/security/cache-control.ts
+++ b/packages/share-backend/src/security/cache-control.ts
@@ -1,0 +1,12 @@
+/** Cache-control headers used across endpoints. Named so each callsite
+ *  documents the policy intent instead of a stringly-typed value. */
+export const CC_NO_STORE = 'no-store'
+export const CC_PRIVATE_NO_CACHE = 'private, no-cache'
+
+export function ccPublicRevalidate(seconds: number): string {
+  return `public, max-age=${seconds}, must-revalidate`
+}
+
+export function ccPublic(seconds: number): string {
+  return `public, max-age=${seconds}`
+}

--- a/packages/share-backend/src/security/csp.ts
+++ b/packages/share-backend/src/security/csp.ts
@@ -1,0 +1,9 @@
+// CSP strings for share-backend.
+//
+// API responses never serve HTML, so they get the strictest policy
+// possible (`default-src 'none'`) plus `frame-ancestors 'none'` to
+// prevent any embedding. The non-API HTML surface lives in `share-web`
+// and ships its own CSP via `_headers`; we deliberately do not set CSP
+// here for non-API routes.
+
+export const API_CSP = "default-src 'none'; frame-ancestors 'none'"

--- a/packages/share-backend/tests/pentest.sh
+++ b/packages/share-backend/tests/pentest.sh
@@ -3,7 +3,7 @@
 # NOT run in CI. Run it before flipping a prod deploy. Set TARGET to the
 # base URL (no trailing slash):
 #
-#   TARGET=https://staging.spool.share ./tests/pentest.sh
+#   TARGET=https://staging.spool.pro ./tests/pentest.sh
 #
 # Exits non-zero if any required check fails.
 

--- a/packages/share-backend/tests/pentest.sh
+++ b/packages/share-backend/tests/pentest.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Manual pre-deploy probe against a staging or production share-backend.
+# NOT run in CI. Run it before flipping a prod deploy. Set TARGET to the
+# base URL (no trailing slash):
+#
+#   TARGET=https://staging.spool.share ./tests/pentest.sh
+#
+# Exits non-zero if any required check fails.
+
+set -uo pipefail
+
+TARGET="${TARGET:-http://localhost:8788}"
+FAILED=0
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+note()  { printf '  %s\n' "$*"; }
+
+fail() {
+  red "FAIL: $*"
+  FAILED=$((FAILED + 1))
+}
+
+ok() {
+  green "OK:   $*"
+}
+
+# ---- header probes -----------------------------------------------------------
+
+probe_headers() {
+  local path="$1"
+  local resp
+  resp=$(curl -sS -D - -o /dev/null "$TARGET$path")
+  echo "$resp"
+}
+
+check_header() {
+  local resp="$1" name="$2" expected_substr="$3" label="$4"
+  if echo "$resp" | grep -i -q "^$name:.*$expected_substr"; then
+    ok "$label"
+  else
+    fail "$label (missing or wrong: $name)"
+  fi
+}
+
+echo "== Security headers =="
+for path in /api/health /api/snapshots/aaaaaaaaaaaaaaaaaaaaa /api/og/aaaaaaaaaaaaaaaaaaaaa.png; do
+  hdr=$(probe_headers "$path")
+  check_header "$hdr" "X-Robots-Tag" "noindex"         "$path noindex"
+  check_header "$hdr" "X-Content-Type-Options" "nosniff" "$path nosniff"
+  check_header "$hdr" "Referrer-Policy" "strict-origin-when-cross-origin" "$path referrer-policy"
+done
+hdr=$(probe_headers /api/health)
+check_header "$hdr" "Content-Security-Policy" "default-src 'none'" "API CSP strict"
+
+# ---- unauth probes -----------------------------------------------------------
+
+echo ""
+echo "== Unauth checks =="
+status=$(curl -sS -o /dev/null -w '%{http_code}' -X POST -H 'content-type: application/json' --data '{}' "$TARGET/api/publish")
+[[ "$status" == "401" ]] && ok "POST /api/publish → 401" || fail "POST /api/publish status=$status"
+
+status=$(curl -sS -o /dev/null -w '%{http_code}' -X POST "$TARGET/api/revoke/aaaaaaaaaaaaaaaaaaaaa")
+[[ "$status" == "401" ]] && ok "POST /api/revoke/<id> → 401" || fail "POST /api/revoke/<id> status=$status"
+
+status=$(curl -sS -o /dev/null -w '%{http_code}' "$TARGET/api/me")
+[[ "$status" == "401" ]] && ok "GET /api/me → 401" || fail "GET /api/me status=$status"
+
+# ---- enumeration probes ------------------------------------------------------
+
+echo ""
+echo "== Enumeration =="
+for _ in 1 2 3; do
+  slug=$(LC_ALL=C tr -dc 'A-Za-z0-9_-' </dev/urandom | head -c 21)
+  status=$(curl -sS -o /dev/null -w '%{http_code}' "$TARGET/api/snapshots/$slug")
+  if [[ "$status" == "404" ]]; then
+    ok "random slug $slug → 404"
+  else
+    fail "random slug $slug status=$status (expected 404)"
+  fi
+done
+
+for _ in 1 2 3; do
+  h=$(LC_ALL=C tr -dc 'a-z0-9-' </dev/urandom | head -c 16)
+  status=$(curl -sS -o /dev/null -w '%{http_code}' "$TARGET/api/profiles/$h")
+  if [[ "$status" == "404" ]]; then
+    ok "random handle $h → 404"
+  else
+    fail "random handle $h status=$status (expected 404)"
+  fi
+done
+
+# ---- open-redirect probe -----------------------------------------------------
+
+echo ""
+echo "== Open-redirect =="
+loc=$(curl -sS -o /dev/null -D - "$TARGET/api/auth/google/start?next=https://evil.com" | awk -F': ' 'tolower($1)=="location" {print $2}' | tr -d '\r')
+if [[ "$loc" != *"evil.com"* ]]; then
+  ok "next=https://evil.com → Location does not contain evil.com"
+else
+  fail "Open-redirect via ?next=https://evil.com → Location=$loc"
+fi
+loc=$(curl -sS -o /dev/null -D - "$TARGET/api/auth/google/start?next=//evil.com" | awk -F': ' 'tolower($1)=="location" {print $2}' | tr -d '\r')
+# Location will be Google authorize URL; verify the stored cookie doesn't carry //evil.com.
+cookie=$(curl -sS -o /dev/null -D - "$TARGET/api/auth/google/start?next=//evil.com" | awk -F': ' 'tolower($1)=="set-cookie" && $2 ~ /__spool_oauth_state/ {print $2}' | tr -d '\r')
+if [[ "$cookie" == *"evil.com"* ]]; then
+  fail "next=//evil.com leaks into OAuth state cookie ($cookie)"
+else
+  ok "next=//evil.com sanitized in OAuth state cookie"
+fi
+
+# ---- summary -----------------------------------------------------------------
+
+echo ""
+if [[ "$FAILED" -gt 0 ]]; then
+  red "$FAILED checks failed."
+  exit 1
+else
+  green "All pentest probes passed."
+fi

--- a/packages/share-backend/tests/security.test.ts
+++ b/packages/share-backend/tests/security.test.ts
@@ -1,0 +1,468 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { safeNext } from '../src/auth/next'
+import {
+  _resetJwksCacheForTests,
+  setJwksFetcherForTests,
+} from '../src/auth/jwks'
+import { API_CSP } from '../src/security/csp'
+
+import { emptyState, makeDb, makeKv, makeR2, type FakeDbState } from './_helpers/fakes'
+import {
+  type Keypair,
+  future,
+  generateKeypair,
+  mintTestJwt,
+  past,
+} from './_helpers/jwt'
+import type { SessionRecord } from '../src/auth/session'
+import type { KVNamespace } from '@cloudflare/workers-types'
+import { nanoidSlug } from '../src/publish/slug'
+
+// Mock workers-og so importing publish.ts doesn't pull in Satori/wasm.
+vi.mock('workers-og', () => ({
+  ImageResponse: vi.fn().mockImplementation(() => ({
+    async arrayBuffer() {
+      return new Uint8Array([137, 80, 78, 71]).buffer
+    },
+  })),
+}))
+
+const DESKTOP_AUD = 'desktop.apps.googleusercontent.com'
+const WEB_AUD = 'web.apps.googleusercontent.com'
+const ISS = 'https://accounts.google.com'
+const TOKEN = 't'.repeat(40)
+
+let kp: Keypair
+
+beforeAll(async () => {
+  kp = await generateKeypair('kid-security')
+  setJwksFetcherForTests(async () => [kp.publicJwk])
+})
+
+afterAll(() => {
+  setJwksFetcherForTests(null)
+})
+
+beforeEach(() => {
+  _resetJwksCacheForTests()
+})
+
+function envFor(state?: FakeDbState) {
+  const { db, state: s } = makeDb(state ?? emptyState())
+  const snapshots = makeR2()
+  const og = makeR2()
+  return {
+    DB: db,
+    SESSIONS: makeKv(),
+    META: makeKv(),
+    RATE: makeKv(),
+    NONCE: makeKv(),
+    SNAPSHOTS: snapshots.bucket,
+    OG: og.bucket,
+    GOOGLE_CLIENT_ID_DESKTOP: DESKTOP_AUD,
+    GOOGLE_CLIENT_ID_WEB: WEB_AUD,
+    GOOGLE_CLIENT_SECRET_WEB: 'secret',
+    state: s,
+    _snapshots: snapshots.store,
+    _og: og.store,
+  }
+}
+
+function seedUser(state: FakeDbState, id = 'user-1'): void {
+  state.users.push({
+    id,
+    email: `${id}@example.com`,
+    name: id,
+    avatar_url: null,
+    created_at: Date.now(),
+    last_signin_at: Date.now(),
+    deletion_pending_until: null,
+    deleted_at: null,
+  })
+}
+
+async function seedSession(kv: KVNamespace, token: string, user_id: string): Promise<void> {
+  const now = Date.now()
+  const rec: SessionRecord = {
+    user_id,
+    created: now,
+    exp: now + 30 * 24 * 3600 * 1000,
+    last_seen: now,
+  }
+  await kv.put(`session/${token}`, JSON.stringify(rec), { expirationTtl: 30 * 24 * 3600 })
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function ctxFor(req: Request, env: Record<string, unknown>, params: Record<string, string> = {}): any {
+  return {
+    request: req,
+    env,
+    next: async () => new Response('not-found', { status: 404 }),
+    params,
+    waitUntil: (p: Promise<unknown>) => { void p },
+    passThroughOnException: () => undefined,
+    data: {},
+  }
+}
+
+function authedReq(url: string, body?: unknown, method: string = 'POST', token = TOKEN): Request {
+  const init: RequestInit = {
+    method,
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      'CF-Connecting-IP': '1.2.3.4',
+    },
+  }
+  let payload = body
+  if (
+    url.endsWith('/api/publish') &&
+    body &&
+    typeof body === 'object' &&
+    'snapshot' in (body as Record<string, unknown>)
+  ) {
+    const obj = body as Record<string, unknown>
+    payload = {
+      draft_id: 'test-draft-id',
+      idempotency_key: 'key-' + Math.random().toString(36).slice(2, 10).padEnd(8, 'x'),
+      ...obj,
+    }
+  }
+  if (payload !== undefined) init.body = JSON.stringify(payload)
+  return new Request(url, init)
+}
+
+function makeSnapshot() {
+  return {
+    schema_version: 1,
+    source: { kind: 'spool-session', captured_at: new Date().toISOString() },
+    conversation: {
+      title: 'A nice chat',
+      turns: [
+        { id: 't1', role: 'user', content: 'Hello there.' },
+        { id: 't2', role: 'assistant', content: 'Hi!' },
+      ],
+      turn_order: ['t1', 't2'],
+      hidden_turns: [],
+    },
+    edits: [],
+    redactions: [],
+    editor_opts: {
+      template: 'forum',
+      paper: 'cream',
+      typeface: 'geist',
+      colorway: 'amber',
+      density: 'relaxed',
+      masthead: true,
+      colophon: true,
+      avatars: true,
+      show_byline: true,
+    },
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Middleware: CSP + cache-control defaults for /api/*
+// ────────────────────────────────────────────────────────────────────
+
+describe('_middleware security headers', () => {
+  it('sets API_CSP on /api/* responses', async () => {
+    const { onRequest } = await import('../functions/_middleware')
+    const inner = new Response('{"ok":true}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+    const req = new Request('https://x/api/me', { method: 'GET' })
+    const res = await (onRequest as unknown as (c: {
+      request: Request
+      next: () => Promise<Response>
+    }) => Promise<Response>)({ request: req, next: async () => inner })
+    expect(res.headers.get('content-security-policy')).toBe(API_CSP)
+    expect(res.headers.get('x-robots-tag')).toBe('noindex')
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff')
+  })
+
+  it('adds Cache-Control: no-store to mutation API responses with no explicit header', async () => {
+    const { onRequest } = await import('../functions/_middleware')
+    const inner = new Response('{"ok":true}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+    const req = new Request('https://x/api/publish', { method: 'POST' })
+    const res = await (onRequest as unknown as (c: {
+      request: Request
+      next: () => Promise<Response>
+    }) => Promise<Response>)({ request: req, next: async () => inner })
+    expect(res.headers.get('cache-control')).toBe('no-store')
+  })
+
+  it('does NOT override an explicit Cache-Control on a mutation', async () => {
+    const { onRequest } = await import('../functions/_middleware')
+    const inner = new Response('{"ok":true}', {
+      headers: { 'cache-control': 'private, max-age=5' },
+    })
+    const req = new Request('https://x/api/something', { method: 'POST' })
+    const res = await (onRequest as unknown as (c: {
+      request: Request
+      next: () => Promise<Response>
+    }) => Promise<Response>)({ request: req, next: async () => inner })
+    expect(res.headers.get('cache-control')).toBe('private, max-age=5')
+  })
+
+  it('does NOT touch Cache-Control on GET API responses', async () => {
+    const { onRequest } = await import('../functions/_middleware')
+    const inner = new Response('{"ok":true}', {
+      headers: { 'cache-control': 'public, max-age=60' },
+    })
+    const req = new Request('https://x/api/snapshots/abc', { method: 'GET' })
+    const res = await (onRequest as unknown as (c: {
+      request: Request
+      next: () => Promise<Response>
+    }) => Promise<Response>)({ request: req, next: async () => inner })
+    expect(res.headers.get('cache-control')).toBe('public, max-age=60')
+  })
+
+  it('does NOT set CSP for non-/api routes', async () => {
+    const { onRequest } = await import('../functions/_middleware')
+    const inner = new Response('<html/>', { headers: { 'content-type': 'text/html' } })
+    const req = new Request('https://x/some-page', { method: 'GET' })
+    const res = await (onRequest as unknown as (c: {
+      request: Request
+      next: () => Promise<Response>
+    }) => Promise<Response>)({ request: req, next: async () => inner })
+    expect(res.headers.get('content-security-policy')).toBeNull()
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────
+// Authn: unauthed endpoints
+// ────────────────────────────────────────────────────────────────────
+
+describe('unauthenticated requests', () => {
+  it('/api/publish without bearer → 401, no payload leak', async () => {
+    const { onRequestPost } = await import('../functions/api/publish')
+    const env = envFor()
+    const req = new Request('https://x/api/publish', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ snapshot: makeSnapshot(), visibility: 'unlisted' }),
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(401)
+    const body = (await res.json()) as { error: string; detail?: string }
+    expect(body.error).toBe('UNAUTHENTICATED')
+    // No snapshot data echoed.
+    const text = JSON.stringify(body)
+    expect(text).not.toMatch(/A nice chat/)
+    expect(text).not.toMatch(/Hello there/)
+  })
+
+  it('/api/revoke/<id> without bearer → 401', async () => {
+    const { onRequestPost } = await import('../functions/api/revoke/[id]')
+    const env = envFor()
+    const id = nanoidSlug()
+    const req = new Request(`https://x/api/revoke/${id}`, { method: 'POST' })
+    const res = await onRequestPost(ctxFor(req, env, { id }))
+    expect(res.status).toBe(401)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────
+// Authz: cross-user does not leak existence
+// ────────────────────────────────────────────────────────────────────
+
+describe('authorization isolation', () => {
+  it('revoke someone else’s slug → 404 (no existence leak)', async () => {
+    const { onRequestPost } = await import('../functions/api/revoke/[id]')
+    const env = envFor()
+    seedUser(env.state, 'me')
+    seedUser(env.state, 'them')
+    await seedSession(env.SESSIONS, TOKEN, 'me')
+    const theirs = nanoidSlug()
+    env.state.published_shares.push({
+      id: theirs, user_id: 'them', title: 't', visibility: 'unlisted',
+      expires_at: null, version: 1, published_at: Date.now(),
+      republished_at: null, revoked_at: null,
+    })
+    const req = authedReq(`https://x/api/revoke/${theirs}`, undefined, 'POST')
+    const res = await onRequestPost(ctxFor(req, env, { id: theirs }))
+    expect(res.status).toBe(404)
+  })
+
+  it('republish someone else’s slug → 404', async () => {
+    const { onRequestPost } = await import('../functions/api/publish')
+    const env = envFor()
+    seedUser(env.state, 'me')
+    seedUser(env.state, 'them')
+    await seedSession(env.SESSIONS, TOKEN, 'me')
+    const theirs = nanoidSlug()
+    env.state.published_shares.push({
+      id: theirs, user_id: 'them', title: 't', visibility: 'unlisted',
+      expires_at: null, version: 1, published_at: Date.now(),
+      republished_at: null, revoked_at: null,
+    })
+    const req = authedReq('https://x/api/publish', {
+      snapshot: makeSnapshot(), visibility: 'unlisted', override_slug: theirs,
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(404)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────
+// safeNext: open-redirect defense
+// ────────────────────────────────────────────────────────────────────
+
+describe('safeNext', () => {
+  it('rejects absolute external URLs', () => {
+    expect(safeNext('https://evil.com')).toBe('/')
+    expect(safeNext('http://evil.com')).toBe('/')
+  })
+  it('rejects protocol-relative URLs', () => {
+    expect(safeNext('//evil.com')).toBe('/')
+    expect(safeNext('//evil.com/foo')).toBe('/')
+  })
+  it('rejects backslash injection', () => {
+    expect(safeNext('/\\evil.com')).toBe('/')
+  })
+  it('rejects ".." segments (defense-in-depth)', () => {
+    expect(safeNext('/foo/../bar')).toBe('/')
+    expect(safeNext('/../etc/passwd')).toBe('/')
+    expect(safeNext('/foo/..')).toBe('/')
+  })
+  it('keeps a same-origin path with no traversal', () => {
+    expect(safeNext('/me')).toBe('/me')
+    expect(safeNext('/me/published')).toBe('/me/published')
+  })
+  it('coerces empty/null to "/"', () => {
+    expect(safeNext(null)).toBe('/')
+    expect(safeNext(undefined)).toBe('/')
+    expect(safeNext('')).toBe('/')
+  })
+
+  it('start endpoint coerces ?next=https://evil.com to /', async () => {
+    const { onRequestGet } = await import('../functions/api/auth/[provider]/start')
+    const env = envFor()
+    const req = new Request(
+      'https://spool.share/api/auth/google/start?next=https://evil.com',
+    )
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await (onRequestGet as any)(ctxFor(req, env, { provider: 'google' }))
+    expect(res.status).toBe(302)
+    const setCookies: string[] =
+      res.headers.getSetCookie?.() ?? [res.headers.get('set-cookie') ?? '']
+    const stateCookie = setCookies.find((c) => c.includes('__spool_oauth_state=')) ?? ''
+    expect(stateCookie).toMatch(/__spool_oauth_state=[^|]+\|\/;/)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────
+// id_token: bad aud → not 200, no leak
+// ────────────────────────────────────────────────────────────────────
+
+describe('id_token validation', () => {
+  it('bad aud is rejected (non-200, no user created)', async () => {
+    const { onRequestPost } = await import(
+      '../functions/api/auth/sign-in-with-id-token'
+    )
+    const env = envFor()
+    const id_token = await mintTestJwt(kp, {
+      iss: ISS, aud: 'wrong-aud', sub: 'sub-bad',
+      email: 'a@example.com', email_verified: true,
+      exp: future(), iat: past(0), nonce: 'n',
+    })
+    const req = new Request('https://x/api/auth/sign-in-with-id-token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ provider: 'google', id_token, nonce: 'n' }),
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await (onRequestPost as any)(ctxFor(req, env))
+    expect(res.status).not.toBe(200)
+    expect(env.state.users).toHaveLength(0)
+    const body = (await res.json()) as { error?: string; detail?: string }
+    // Make sure the raw id_token is not echoed back.
+    expect(JSON.stringify(body)).not.toContain(id_token)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────
+// Rate limit: 31st publish/hour → 429
+// ────────────────────────────────────────────────────────────────────
+
+describe('publish rate limit', () => {
+  it('31st call/hour → 429', async () => {
+    const { onRequestPost } = await import('../functions/api/publish')
+    const env = envFor()
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const slot = Math.floor(Date.now() / 1000 / 3600)
+    // Pre-fill the bucket to 30 (the cap).
+    await env.RATE.put(`rate/publish-h/user-1/${slot}`, '30', { expirationTtl: 3600 * 2 })
+    const req = authedReq('https://x/api/publish', {
+      snapshot: makeSnapshot(), visibility: 'unlisted',
+    })
+    const res = await onRequestPost(ctxFor(req, env))
+    expect(res.status).toBe(429)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────
+// Admin audit endpoint
+// ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/admin/audit', () => {
+  it('403 when authed user is not in ADMIN_USER_IDS', async () => {
+    const { onRequestGet } = await import('../functions/api/admin/audit')
+    const env = { ...envFor(), ADMIN_USER_IDS: 'admin-a,admin-b' }
+    seedUser(env.state, 'mortal')
+    await seedSession(env.SESSIONS, TOKEN, 'mortal')
+    const req = authedReq('https://x/api/admin/audit', undefined, 'GET')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await (onRequestGet as any)(ctxFor(req, env))
+    expect(res.status).toBe(403)
+  })
+
+  it('401 when unauthenticated', async () => {
+    const { onRequestGet } = await import('../functions/api/admin/audit')
+    const env = { ...envFor(), ADMIN_USER_IDS: 'admin-a' }
+    const req = new Request('https://x/api/admin/audit', { method: 'GET' })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await (onRequestGet as any)(ctxFor(req, env))
+    expect(res.status).toBe(401)
+  })
+
+  it('200 + last 200 rows when caller is admin', async () => {
+    const { onRequestGet } = await import('../functions/api/admin/audit')
+    const env = { ...envFor(), ADMIN_USER_IDS: 'admin-a , admin-b' }
+    seedUser(env.state, 'admin-a')
+    await seedSession(env.SESSIONS, TOKEN, 'admin-a')
+    // Seed a handful of audit rows.
+    const baseTs = Date.now()
+    for (let i = 0; i < 5; i++) {
+      env.state.audit.push({
+        user_id: 'someone',
+        ip_hash: 'h',
+        ua_hash: 'h',
+        action: `evt-${i}`,
+        target_id: null,
+        details_json: null,
+        ts: baseTs + i,
+      })
+    }
+    const req = authedReq('https://x/api/admin/audit', undefined, 'GET')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await (onRequestGet as any)(ctxFor(req, env))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: Array<{ action: string }> }
+    expect(body.items.length).toBeGreaterThanOrEqual(5)
+    // The admin call itself was audited.
+    expect(env.state.audit.some((r) => r.action === 'admin.audit.read')).toBe(true)
+    // Newest-first ordering.
+    const ts = body.items.map((r) => (r as unknown as { ts: number }).ts)
+    for (let i = 1; i < ts.length; i++) {
+      expect(ts[i - 1]).toBeGreaterThanOrEqual(ts[i]!)
+    }
+  })
+})

--- a/packages/share-backend/wrangler.toml
+++ b/packages/share-backend/wrangler.toml
@@ -66,6 +66,7 @@ crons = ["0 */6 * * *"]
 #   wrangler pages secret put GOOGLE_CLIENT_SECRET_WEB --project-name spool-share-backend
 #   wrangler pages secret put SESSION_SIGNING_KEY      --project-name spool-share-backend
 #   wrangler pages secret put ADMIN_USER_IDS           --project-name spool-share-backend
+#       (comma-separated user ids allowed to hit /api/admin/*)
 #
 # CF stores secret values encrypted at rest. Never echoed back through
 # wrangler, never available to local dev (use .dev.vars for that —

--- a/packages/share-web/public/_headers
+++ b/packages/share-web/public/_headers
@@ -5,13 +5,13 @@
   Permissions-Policy: interest-cohort=()
 
 /s/*
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://spool.pro; font-src 'self' data:; connect-src 'self'; form-action 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://spool.pro https://lh3.googleusercontent.com; font-src 'self' data:; connect-src 'self'; form-action 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'
 
 /@*
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://spool.pro; font-src 'self' data:; connect-src 'self'; form-action 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://spool.pro https://lh3.googleusercontent.com; font-src 'self' data:; connect-src 'self'; form-action 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'
 
 /me
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://spool.pro; font-src 'self' data:; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://spool.pro https://lh3.googleusercontent.com; font-src 'self' data:; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'
 
 /sign-in
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://spool.pro; font-src 'self' data:; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://spool.pro https://lh3.googleusercontent.com; font-src 'self' data:; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'


### PR DESCRIPTION
## What

A pre-launch hardening pass across all three surfaces: the renderer (Electron app), share-backend (Cloudflare Pages Functions), and share-web (spool.pro).

Renderer (Electron):
- `src/main/security/csp.ts` (+ tests) — injects strict Content-Security-Policy on every renderer response via `session.webRequest.onHeadersReceived`. Dev profile loosens for Vite HMR (`'unsafe-inline'`, `ws://localhost:5173`, `http://localhost:8788`); prod drops everything except `'self'` and the canonical Spool / Google avatar hosts.
- PDF preview compatibility: `frame-src` and `object-src` allow `chrome-extension:` so Chromium's built-in PDF MIME handler (which iframes the viewer from `chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/`) keeps working. Without this the iframe paints a blank grey rectangle with no console hint.
- Scheme-filtered: CSP is only stamped on `http:`/`https:`/`file:`/`blob:` responses — NOT on `chrome-extension:` responses (the PDF viewer extension's own internal scripts would otherwise be blocked by our restrictive policy, breaking the rendered page).
- `e2e/pdf-iframe-with-gpu.spec.ts` is the regression test — launches with the GPU helper, opens a session with a PDF turn, asserts the iframe paints something (canvas pixel sample, not zero bytes).

share-backend:
- `_middleware.ts` extended: API CSP, `Cache-Control` discipline on mutations, the existing security headers stay.
- `src/security/csp.ts`, `src/security/cache-control.ts` — extracted constants so future endpoints can't drift.
- `POST /api/admin/audit` — read-only audit-log endpoint. Gated on `ADMIN_USER_IDS` env (comma-separated user ids), returns 403 for anyone else, audits the read itself (so admin queries leave a trail).
- `0002 migration dropped` — the prior version added a column that was redundant once the partial unique index landed in #356. Removing it keeps the migration story linear; no one's run it yet outside dev so the drop is safe.
- `.dev.vars.example` documents every env var a contributor needs; `README.md` covers the dev loop.
- `tests/security.test.ts` — 468 lines of explicit header / CSP / cache assertions across every route. `tests/pentest.sh` — black-box probes a deployed backend for the same headers without trusting test mocks.

share-web (spool.pro):
- `public/_headers` — per-route CSP via Cloudflare Pages. `/s/*` reader keeps `connect-src 'self'`; `/me` + `/sign-in` carry `form-action 'self'`. Google avatar CDN allowed in `img-src` so the Header's user-avatar tag renders without breaking the policy.

## Why bundled

Security headers don't make sense as a deferred polish. Landing them at GA means every prior PR that introduced an endpoint or page already shipped without the protection — a stored-XSS regression sneaks in for a week before this lands. Doing it in one PR forces every surface to think about its own boundary at the same time and surfaces gaps (the PDF / chrome-extension interaction was found exactly this way).

The pentest harness is the bookkeeping for the same reason: it asserts the policy lives at the edge, not in a unit-test mock. Pre-launch is when that assurance is cheap; post-launch it's a regression hunt.

## Renderer CSP — what changes

```mermaid
flowchart LR
    subgraph req["request flow"]
        BW["BrowserWindow"]
        SH["session.webRequest.onHeadersReceived"]
        H["CSP injected"]
        R["Renderer"]
    end
    BW --> SH --> H --> R

    subgraph proto["per-scheme behavior"]
        H1["http: + https: — strict CSP"]
        H2["file: — strict CSP"]
        H3["blob: — strict CSP"]
        H4["chrome-extension: — pass through (PDF viewer keeps working)"]
        H5["devtools: + data: — pass through"]
    end
```

The scheme filter is the key correctness rule. A prior revision applied CSP to *all* responses; that broke the PDF viewer because Chromium's bundled extension serves its own scripts from `chrome-extension://`, which the restrictive policy then blocked. Filtering by scheme keeps the trust boundary on the BrowserWindow's content without leaking the policy into Chromium's internals.

## Backend headers — what every API response now carries

| Header | Where | Value |
|---|---|---|
| `X-Robots-Tag` | every response | `noindex` (already in #356; reaffirmed here) |
| `X-Content-Type-Options` | every response | `nosniff` |
| `Referrer-Policy` | every response | `strict-origin-when-cross-origin` |
| `Content-Security-Policy` | `/api/*` | `default-src 'none'; frame-ancestors 'none'; base-uri 'none'` — APIs render no UI |
| `Cache-Control: no-store` | `/api/*` mutations + `/api/me*` + `/api/snapshots/<id>` (revoked branch) | prevents stale cache from leaking a revoked share |
| `Cache-Control: public, max-age=30, must-revalidate` | `/api/snapshots/<id>` (live), `/api/og/<id>.png` (live) | 30s edge window aligned across both — a panic revoke is fully effective within the same time bound |

## Admin audit endpoint

```mermaid
sequenceDiagram
    autonumber
    participant A as Admin
    participant E as /api/admin/audit
    participant DB as D1 audit_log

    A->>E: GET, session cookie attached
    E->>E: requireUser → user.id
    E->>E: isAdmin(user.id, ADMIN_USER_IDS env)?
    alt not in allowlist
        E-->>A: 403 FORBIDDEN
    else allowlist
        E->>DB: SELECT … LIMIT 200 ORDER BY ts DESC
        DB-->>E: rows
        E->>DB: INSERT audit row<br/>action='admin.audit.read', user_id, ip_hash, ua_hash
        E-->>A: { items: [...] }<br/>Cache-Control: private, no-cache
    end
```

The endpoint's own read writes an audit row — admins can audit who's been auditing. `ADMIN_USER_IDS` is a wrangler secret in prod; left unset in dev means everything 403s, which is the safe default.

## Pentest harness

`tests/pentest.sh` is a black-box bash script that:
- hits every public endpoint and asserts the expected security headers
- attempts cross-origin POSTs with bad SameSite + bad Origin → expects 4xx
- POSTs malformed JSON to mutation endpoints → expects 4xx (not 500)
- requests `/api/snapshots/<random-slug>` → expects 404 with `Cache-Control: no-store`
- POSTs to `/api/auth/sign-in-with-id-token` with a forged id_token → expects 401

Run against a deployed wrangler preview before each release. Failures mean a header drifted — fix at the middleware, not by silencing the test.

## Verification

- `pnpm --filter @spool-lab/share-backend test` — security.test.ts + the existing endpoint suites
- `pnpm --filter @spool/app test:unit` — csp.test.ts (allowlist composition, scheme filter)
- `pnpm --filter @spool/app test:e2e` — pdf-iframe-with-gpu.spec.ts (PDF preview still paints)
- Manual: `wrangler pages dev` + `bash packages/share-backend/tests/pentest.sh http://localhost:8788` → green
- Deploy preview: open `view-source` on `/s/<slug>`, `/me`, `/sign-in` — confirm CSP header per `_headers`

## Risk

Headers are a forward-only ratchet. If anything is too strict, the violation surfaces as a console warning (CSP-violation report) on the first affected page, not a 500. The PDF iframe regression is locked in by the e2e spec so a future tweak to the renderer CSP can't silently re-break it.

Admin endpoint is opt-in via `ADMIN_USER_IDS`; left unset (the prod default until the first admin is provisioned) the endpoint hard-403s. Dropping the redundant 0002 migration is a no-op on every env that's been kept in sync; nobody's database has applied it past dev.

Submitted by @graydawnc.
