### PR TITLE
chore: launch checklist + dev script for spool share publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,12 @@ dist-electron/
 # (wrangler.toml committed has placeholders; the dashboard is the
 # source of truth for prod bindings).
 wrangler.toml.local
+# Internal runbooks — kept out of git until the corresponding feature
+# ships. Authors live in ~/Documents/dev-docs/spool/; promote into
+# docs/ via a follow-up commit only after launch.
+docs/runbooks/
+# Playwright e2e screenshots / diagnostic artefacts.
+e2e-output/
 
 # Spool DB (user data, not committed)
 .spool/

--- a/packages/app/src/renderer/components/LabsTab.tsx
+++ b/packages/app/src/renderer/components/LabsTab.tsx
@@ -12,8 +12,11 @@ const FEEDBACK_URL = 'https://discord.gg/aqeDxQUs5E'
 export default function LabsTab() {
   const { t } = useTranslation()
   const shareOn = useFeature('share')
-  const sharePublishOn = useFeature('sharePublish')
   const securityOn = useSecurityEnabled()
+  // sharePublish is intentionally NOT rendered here pre-launch — see the
+  // comment near DEV_DEFAULT_ON in featureFlags.ts. To dev-test the
+  // remote publish surface, set VITE_FEATURE_SHAREPUBLISH=1 when running
+  // `pnpm dev`. The Labs row will be restored at GA.
 
   // The Security toggle is backed by the general `agents.json` config
   // (not localStorage like the LabsFlags) so the main-process scan
@@ -44,15 +47,6 @@ export default function LabsTab() {
         feedbackHref={FEEDBACK_URL}
         checked={shareOn}
         onToggle={(next) => setLabsFlag('share', next)}
-      />
-      <LabsFlagRow
-        flag="sharePublish"
-        title="Spool Share — Publish"
-        description="Publish snapshots to spool.share (alpha). Pairs with Share."
-        feedbackLabel={t('labs.share.feedback')}
-        feedbackHref={FEEDBACK_URL}
-        checked={sharePublishOn}
-        onToggle={(next) => setLabsFlag('sharePublish', next)}
       />
       {/* Only offer the Security opt-in in builds that actually ship the
        *  code (dev + VITE_FEATURE_SECURITY builds). Elsewhere the whole

--- a/packages/app/src/renderer/components/LabsTab.tsx
+++ b/packages/app/src/renderer/components/LabsTab.tsx
@@ -12,6 +12,7 @@ const FEEDBACK_URL = 'https://discord.gg/aqeDxQUs5E'
 export default function LabsTab() {
   const { t } = useTranslation()
   const shareOn = useFeature('share')
+  const sharePublishOn = useFeature('sharePublish')
   const securityOn = useSecurityEnabled()
 
   // The Security toggle is backed by the general `agents.json` config
@@ -43,6 +44,15 @@ export default function LabsTab() {
         feedbackHref={FEEDBACK_URL}
         checked={shareOn}
         onToggle={(next) => setLabsFlag('share', next)}
+      />
+      <LabsFlagRow
+        flag="sharePublish"
+        title="Spool Share — Publish"
+        description="Publish snapshots to spool.share (alpha). Pairs with Share."
+        feedbackLabel={t('labs.share.feedback')}
+        feedbackHref={FEEDBACK_URL}
+        checked={sharePublishOn}
+        onToggle={(next) => setLabsFlag('sharePublish', next)}
       />
       {/* Only offer the Security opt-in in builds that actually ship the
        *  code (dev + VITE_FEATURE_SECURITY builds). Elsewhere the whole

--- a/packages/app/src/renderer/components/SettingsPanel.tsx
+++ b/packages/app/src/renderer/components/SettingsPanel.tsx
@@ -193,22 +193,19 @@ export default function SettingsPanel({
             <h2 className="text-[22px] font-bold text-warm-text dark:text-dark-text leading-none">{t('settings.title')}</h2>
           </div>
           <div className="px-2 space-y-[2px]">
-            {TAB_DEFS
-              .filter(def => def.id !== 'security' || securityEnabled)
-              .filter(def => def.id !== 'account' || publishEnabled)
-              .map(def => (
+            {visibleTabs.map(def => (
               <button
                 key={def.id}
                 type="button"
-                aria-pressed={tab === def.id}
+                aria-pressed={activeTab === def.id}
                 onClick={() => setTab(def.id)}
                 className={`flex w-full items-center gap-[11px] rounded-lg h-9 px-3 text-[13.5px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent focus-visible:ring-offset-0 ${
-                  tab === def.id
+                  activeTab === def.id
                     ? 'text-accent dark:text-accent-dark bg-accent-bg dark:bg-accent-bg-dark'
                     : 'text-warm-text dark:text-dark-text hover:bg-warm-bg dark:hover:bg-dark-bg'
                 }`}
               >
-                <span className={tab === def.id ? 'text-accent dark:text-accent-dark' : 'text-warm-muted dark:text-dark-muted'}>
+                <span className={activeTab === def.id ? 'text-accent dark:text-accent-dark' : 'text-warm-muted dark:text-dark-muted'}>
                   {def.icon}
                 </span>
                 {tabLabel(t, def.labelKey, def.fallbackLabel)}
@@ -224,7 +221,7 @@ export default function SettingsPanel({
           <div className="flex items-center justify-between px-16 pt-8 pb-2">
             <h3 className="text-xl font-semibold text-warm-text dark:text-dark-text">
               {(() => {
-                const def = TAB_DEFS.find(d => d.id === tab) ?? TAB_DEFS[0]!
+                const def = TAB_DEFS.find(d => d.id === activeTab) ?? TAB_DEFS[0]!
                 return tabLabel(t, def.labelKey, def.fallbackLabel)
               })()}
             </h3>
@@ -250,16 +247,16 @@ export default function SettingsPanel({
             </button>
           </div>
           <div className="flex-1 overflow-y-auto px-16 pb-8 pt-4">
-            {tab === 'general' && <GeneralTab language={language} onLanguageChange={onLanguageChange} />}
-            {tab === 'appearance' && (
+            {activeTab === 'general' && <GeneralTab language={language} onLanguageChange={onLanguageChange} />}
+            {activeTab === 'appearance' && (
               <AppearanceTab themeEditor={themeEditor} onThemeEditorChange={onThemeEditorChange} />
             )}
-            {tab === 'shortcuts' && <ShortcutsTab />}
-            {tab === 'sources' && <SourcesTab claudeCount={claudeCount} codexCount={codexCount} geminiCount={geminiCount} opencodeCount={opencodeCount} />}
-            {tab === 'agent' && <AgentTab />}
-            {tab === 'account' && <SettingsAccount />}
-            {tab === 'labs' && <LabsTab />}
-            {tab === 'security' && securityEnabled && <SecurityPane />}
+            {activeTab === 'shortcuts' && <ShortcutsTab />}
+            {activeTab === 'sources' && <SourcesTab claudeCount={claudeCount} codexCount={codexCount} geminiCount={geminiCount} opencodeCount={opencodeCount} />}
+            {activeTab === 'agent' && <AgentTab />}
+            {activeTab === 'account' && <SettingsAccount />}
+            {activeTab === 'labs' && <LabsTab />}
+            {activeTab === 'security' && securityEnabled && <SecurityPane />}
           </div>
         </div>
       </div>

--- a/packages/app/src/renderer/featureFlags.test.ts
+++ b/packages/app/src/renderer/featureFlags.test.ts
@@ -57,6 +57,22 @@ describe('resolveFeatureRuntime', () => {
     resolveFeatureRuntime('share', { ...off, envEnabled: (k) => { seen.push(k); return false } })
     expect(seen).toEqual(['SHARE'])
   })
+
+  it('resolves sharePublish independently from share', () => {
+    // share on (DEV) but no env / labs opinion on sharePublish → publish off
+    expect(resolveFeatureRuntime('sharePublish', { ...off, dev: true })).toBe(true)
+    // env opts in only sharePublish
+    expect(resolveFeatureRuntime('sharePublish', {
+      ...off,
+      envEnabled: (k) => k === 'SHAREPUBLISH',
+    })).toBe(true)
+    // labs explicit OFF wins even when DEV is on
+    expect(resolveFeatureRuntime('sharePublish', {
+      ...off,
+      dev: true,
+      labsValue: (f) => (f === 'sharePublish' ? false : null),
+    })).toBe(false)
+  })
 })
 
 describe('securityBuildCapable', () => {

--- a/packages/app/src/renderer/featureFlags.test.ts
+++ b/packages/app/src/renderer/featureFlags.test.ts
@@ -58,20 +58,41 @@ describe('resolveFeatureRuntime', () => {
     expect(seen).toEqual(['SHARE'])
   })
 
-  it('resolves sharePublish independently from share', () => {
-    // share on (DEV) but no env / labs opinion on sharePublish → publish off
-    expect(resolveFeatureRuntime('sharePublish', { ...off, dev: true })).toBe(true)
-    // env opts in only sharePublish
-    expect(resolveFeatureRuntime('sharePublish', {
-      ...off,
-      envEnabled: (k) => k === 'SHAREPUBLISH',
-    })).toBe(true)
-    // labs explicit OFF wins even when DEV is on
-    expect(resolveFeatureRuntime('sharePublish', {
-      ...off,
-      dev: true,
-      labsValue: (f) => (f === 'sharePublish' ? false : null),
-    })).toBe(false)
+})
+
+describe('resolveSharePublish', () => {
+  // sharePublish is intentionally NOT a LabsFlag — it's a pure
+  // build-time env gate that Vite inlines. The resolver takes the env
+  // map directly so tests don't have to stub `import.meta.env`.
+
+  it('returns false when the env var is absent', () => {
+    expect(resolveSharePublish({})).toBe(false)
+  })
+
+  it('returns false when the env var is set to anything other than "1"', () => {
+    expect(resolveSharePublish({ VITE_FEATURE_SHAREPUBLISH: '0' })).toBe(false)
+    expect(resolveSharePublish({ VITE_FEATURE_SHAREPUBLISH: 'true' })).toBe(false)
+    expect(resolveSharePublish({ VITE_FEATURE_SHAREPUBLISH: '' })).toBe(false)
+  })
+
+  it('returns true ONLY for the exact string "1"', () => {
+    expect(resolveSharePublish({ VITE_FEATURE_SHAREPUBLISH: '1' })).toBe(true)
+  })
+
+  it('does NOT auto-enable in DEV', () => {
+    // The gate exists to keep the pre-launch publish surface invisible
+    // to contributors who haven't opted in. DEV alone is not enough.
+    expect(resolveSharePublish({ DEV: 'true', MODE: 'development' })).toBe(false)
+  })
+
+  it('ignores unrelated env vars', () => {
+    expect(
+      resolveSharePublish({
+        VITE_FEATURE_OTHER: '1',
+        SHAREPUBLISH: '1',
+        VITE_SHAREPUBLISH: '1',
+      }),
+    ).toBe(false)
   })
 })
 

--- a/packages/app/src/renderer/featureFlags.ts
+++ b/packages/app/src/renderer/featureFlags.ts
@@ -8,9 +8,28 @@ import {
 } from './lib/labsFlags.js'
 import { useSecurityEnabledConfig } from './api/securityEnabledCache.js'
 
-// Resolution order: explicit user choice (Labs) wins over DEV / env.
-// This is what makes Labs feel consistent — a user can turn a feature
-// off even when DEV or VITE_FEATURE_<NAME> would otherwise pin it on.
+// Resolution order: explicit user choice (Labs) > explicit env var > DEV
+// default per-flag. Labs explicit "0" can always turn a feature OFF —
+// this is the user's escape hatch from a DEV / env that would otherwise
+// pin it on.
+//
+// `DEV_DEFAULT_ON` is per-flag because not every feature should be
+// ergonomic in DEV:
+//
+//   share         — Phase 0 editor, already shipped on main; DEV on by
+//                   default so contributors don't have to opt in just to
+//                   see existing UI.
+//   sharePublish  — Remote publish + accounts. Pre-launch and not in
+//                   the Labs UI on purpose. Even on DEV, the feature stays
+//                   invisible until VITE_FEATURE_SHAREPUBLISH=1 is set
+//                   (or localStorage `spool.labs.sharePublish=1` for the
+//                   power-user escape hatch). Keeps the published surface
+//                   from intruding on other contributors' dev sessions
+//                   between merge and GA.
+const DEV_DEFAULT_ON: Record<LabsFlag, boolean> = {
+  share: true,
+  sharePublish: false,
+}
 
 export interface FeatureRuntimeDeps {
   dev: boolean
@@ -31,7 +50,8 @@ export function resolveFeatureRuntime(
 ): boolean {
   const labs = deps.labsValue(flag)
   if (labs !== null) return labs
-  return deps.dev || deps.envEnabled(flag.toUpperCase())
+  if (deps.envEnabled(flag.toUpperCase())) return true
+  return deps.dev && DEV_DEFAULT_ON[flag]
 }
 
 /**

--- a/packages/app/src/renderer/featureFlags.ts
+++ b/packages/app/src/renderer/featureFlags.ts
@@ -13,22 +13,14 @@ import { useSecurityEnabledConfig } from './api/securityEnabledCache.js'
 // this is the user's escape hatch from a DEV / env that would otherwise
 // pin it on.
 //
-// `DEV_DEFAULT_ON` is per-flag because not every feature should be
-// ergonomic in DEV:
+//   share — Phase 0 editor, already shipped on main; DEV on by default
+//   so contributors don't have to opt in just to see existing UI.
 //
-//   share         — Phase 0 editor, already shipped on main; DEV on by
-//                   default so contributors don't have to opt in just to
-//                   see existing UI.
-//   sharePublish  — Remote publish + accounts. Pre-launch and not in
-//                   the Labs UI on purpose. Even on DEV, the feature stays
-//                   invisible until VITE_FEATURE_SHAREPUBLISH=1 is set
-//                   (or localStorage `spool.labs.sharePublish=1` for the
-//                   power-user escape hatch). Keeps the published surface
-//                   from intruding on other contributors' dev sessions
-//                   between merge and GA.
+// `sharePublish` is intentionally NOT a LabsFlag — see useSharePublish
+// below. Pre-launch we gate that surface purely on a build-time env var
+// so it stays out of the Labs UI for other contributors.
 const DEV_DEFAULT_ON: Record<LabsFlag, boolean> = {
   share: true,
-  sharePublish: false,
 }
 
 export interface FeatureRuntimeDeps {

--- a/scripts/share-dev.sh
+++ b/scripts/share-dev.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Boot the full share-publish stack locally for end-to-end smoke tests.
+#
+# Brings up three processes in parallel:
+#   - share-backend on http://localhost:8788   (wrangler pages dev, local D1/KV/R2)
+#   - share-web      on http://localhost:3002   (vite dev, /api/* proxied to backend)
+#   - Spool app      (electron + vite, env-pinned to talk to local backend)
+#
+# Prerequisites (one-time):
+#   1. packages/share-backend/.dev.vars must exist + be filled. Copy from
+#      .dev.vars.example and follow the inline instructions to grab dev
+#      Google OAuth client ids.
+#   2. Apply migrations to local sqlite:
+#        cd packages/share-backend
+#        corepack pnpm wrangler d1 migrations apply spool-share-db --local
+#   3. SPOOL_GOOGLE_CLIENT_ID_DESKTOP env exported in your shell (the
+#      desktop OAuth client id from the same Google Console project).
+#
+# Usage:
+#   ./scripts/share-dev.sh
+#
+# Ctrl-C kills all three. Logs are interleaved on this terminal; for a
+# more readable run, point each process at its own pane (tmux / WezTerm
+# splits) using the same env vars below.
+#
+# Why VITE_FEATURE_SHAREPUBLISH=1: the renderer flag for the publish
+# surface is DEV-default-OFF (so other contributors don't see it after
+# merge). Setting it here flips the flag back on for this run only.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ ! -f packages/share-backend/.dev.vars ]]; then
+  echo "ERROR: packages/share-backend/.dev.vars missing." >&2
+  echo "       Copy .dev.vars.example to .dev.vars and fill in dev Google" >&2
+  echo "       OAuth client ids. See its header for instructions." >&2
+  exit 1
+fi
+
+if [[ -z "${SPOOL_GOOGLE_CLIENT_ID_DESKTOP:-}" ]]; then
+  echo "ERROR: SPOOL_GOOGLE_CLIENT_ID_DESKTOP must be exported." >&2
+  echo "       Same value as GOOGLE_CLIENT_ID_DESKTOP in .dev.vars." >&2
+  exit 1
+fi
+
+trap 'echo; echo "shutting down share-dev"; kill 0' INT TERM EXIT
+
+echo "→ share-backend  http://localhost:8788"
+(cd packages/share-backend && corepack pnpm dev) &
+
+echo "→ share-web      http://localhost:3002"
+(cd packages/share-web && corepack pnpm dev) &
+
+echo "→ Spool app      (electron)"
+SPOOL_SHARE_BACKEND=http://localhost:8788 \
+  VITE_FEATURE_SHAREPUBLISH=1 \
+  corepack pnpm --filter @spool/app dev &
+
+wait


### PR DESCRIPTION
## What

The last piece of the v0.6.0 share-publish stack — the launch checklist + dev tooling + a couple of cleanups that don't fit anywhere else:

- **`scripts/share-dev.sh`** — one-shot boot for the full local stack. Brings up:
  - `share-backend` on `http://localhost:8788` (wrangler pages dev with local D1/KV/R2)
  - `share-web` on `http://localhost:3002` (vite dev, `/api/*` proxied to backend)
  - Spool app (electron + vite, env-pinned to the local backend)
  Ctrl-C terminates all three. Documented prerequisites: `packages/share-backend/.dev.vars` filled out, local D1 migrations applied, `SPOOL_GOOGLE_CLIENT_ID_DESKTOP` exported.

- **`packages/app/src/renderer/featureFlags.ts`** — drops the stale `DEV_DEFAULT_ON.sharePublish` line. `useSharePublish()` is the single resolver now (covered in #362); the `DEV_DEFAULT_ON` entry was a leftover from an earlier revision and would otherwise auto-enable the surface in dev for contributors who haven't opted in via `VITE_FEATURE_SHAREPUBLISH=1`.

- **`packages/app/src/renderer/components/LabsTab.tsx`** — comment clarifying why no `sharePublish` row appears pre-launch (to keep the surface invisible to contributors who haven't opted in).

- **`packages/app/src/renderer/components/SettingsPanel.tsx`** — visibleTabs / activeTab refactor that already landed in #363; this PR's diff is the polish pass on top so the tab visibility filter has a single source of truth.

- **`packages/app/src/renderer/featureFlags.test.ts`** — locks `resolveSharePublish` behaviour: `'1'` → true, anything else → false, prod env (DEV=false, flag unset) → false. Catches the "I added DEV_DEFAULT_ON back" class of regressions before the gate flips on the wrong build.

- **`.gitignore`** — adds `docs/runbooks/` (the share runbook is held back until v0.5.0 actually ships per the launch decision) and `e2e-output/` (Playwright artifact dir).

## Why a launch-prep PR

The 11 PRs that lead up to this one each touch one slice of the system (backend, oauth, modal, web, hardening, …). None of them own "we're now ready to flip the switch":

- The dev script makes the whole local stack runnable by someone who's never touched the backend before; without it the contributor experience is "read seven READMEs and remember 4 env vars".
- Dropping `DEV_DEFAULT_ON.sharePublish` is the actual moment the gate becomes purely build-time. Until this lands, a contributor running `pnpm dev` without setting the flag would still see the publish surface — a real gating leak.
- The featureFlags test pins down the contract so a future "I'll just toggle this for testing" change can't quietly ship the gate broken.

## Gating state at end of stack

```mermaid
flowchart TD
    subgraph build["build time"]
        ENV1["VITE_FEATURE_SHARE"]
        ENV2["VITE_FEATURE_SHAREPUBLISH"]
    end
    subgraph runtime
        F1["useFeature share"]
        F2["useSharePublish"]
    end
    subgraph surfaces
        ED["Share editor"]
        PUB["Share popover + publish form"]
        TAB["SettingsPanel — Account tab"]
        SP["Published tab on SharesPage"]
        ME["Settings — Account pane"]
    end

    ENV1 --> F1
    ENV2 --> F2
    F1 --> ED
    F2 --> PUB
    F2 --> TAB
    F2 --> SP
    F2 --> ME
```

| Build | `VITE_FEATURE_SHARE` | `VITE_FEATURE_SHAREPUBLISH` | Editor | Publish surface | Account tab |
|---|---|---|---|---|---|
| prod (current `main` after this PR) | unset | unset | hidden | hidden | hidden |
| dogfood preview | `1` | unset | visible | hidden | hidden |
| internal share-publish dogfood | `1` | `1` | visible | visible | visible |
| dev contributor (`.env.development.local`) | per pref | per pref | per pref | per pref | per pref |

**Important**: GA flip is not part of this PR. The 12 PRs land all the code; flipping `VITE_FEATURE_SHAREPUBLISH=1` in the prod build remains a manual step held back until end-to-end dogfood sign-off.

## Verification

- `pnpm --filter @spool/app test` — featureFlags.test.ts pins the resolver contract
- `pnpm --filter @spool/app test:e2e` — share-related specs still pass with the popover + tab structure
- Manual: in a clean checkout with no `VITE_FEATURE_SHAREPUBLISH`, `pnpm dev` boots the editor but no Publish tab, no Account tab — the gate is closed by default
- Manual with the flag set: every share-publish surface lights up; sign-in, publish, revoke all work against the local backend booted by `share-dev.sh`

## Risk

The DEV_DEFAULT_ON drop is the only behavior-changing line for someone running plain `pnpm dev`. Contributors who relied on the dev default to see the surface need to add `VITE_FEATURE_SHAREPUBLISH=1` to `packages/app/.env.development.local`; documented in the LabsTab comment and the share-dev.sh prerequisites.

Submitted by @graydawnc.
