### PR TITLE
fix(share-backend): auth-boundary hardening — open-redirect, JWKS rotation, nonce race

### DIFF
--- a/packages/share-backend/functions/api/auth/sign-in-with-id-token.ts
+++ b/packages/share-backend/functions/api/auth/sign-in-with-id-token.ts
@@ -61,18 +61,45 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
     const provider = getProvider(body.provider)
     if (!provider) throw new ApiError('BAD_REQUEST', 'unknown provider')
 
-    // Pre-check so a replayed token still 403s; verifyNativeIdToken
-    // also binds nonce inside the JWS verification itself.
+    // Pre-check + reservation: two concurrent requests carrying the
+    // same nonce would otherwise both read "unseen", both verify the
+    // id_token, and both mint a session — defeating replay protection.
+    // The previous order (check → verify → write) left a window equal
+    // to one verify + KV round-trip.
+    //
+    // Order now:
+    //   1. read — fail fast on a confirmed replay
+    //   2. write the reservation BEFORE verify (succeeds at most once
+    //      under realistic KV contention)
+    //   3. verify the id_token (also binds nonce inside the JWS)
+    //   4. on verify failure, release the reservation so a legitimate
+    //      retry with a corrected payload isn't permanently locked out
+    //
+    // KV is eventually-consistent; this isn't perfect mutual exclusion,
+    // but it shrinks the race window to "between read and write" which
+    // is materially smaller than "between read and write + verify".
     const usedKey = `nonce/${body.nonce}`
     const seen = await ctx.env.NONCE.get(usedKey)
     if (seen) throw new ApiError('FORBIDDEN', 'nonce replay')
 
-    const claim = await provider.verifyNativeIdToken(
-      { idToken: body.id_token, nonce: body.nonce },
-      ctx.env,
-    )
-
     await ctx.env.NONCE.put(usedKey, '1', { expirationTtl: NONCE_TTL_SEC })
+
+    let claim
+    try {
+      claim = await provider.verifyNativeIdToken(
+        { idToken: body.id_token, nonce: body.nonce },
+        ctx.env,
+      )
+    } catch (verifyErr) {
+      // Release the reservation: this token was bad, but the user may
+      // legitimately retry with a freshly-minted nonce + id_token. Not
+      // releasing would burn the slot for the full 10-minute TTL.
+      // Don't await this — a release failure here is acceptable
+      // (it just times out instead of being explicit), and we don't
+      // want to mask the underlying verification error.
+      ctx.waitUntil(ctx.env.NONCE.delete(usedKey).catch(() => undefined))
+      throw verifyErr
+    }
 
     const user = await upsertUserByIdentity(ctx.env.DB, claim)
     const sess = await createSession(ctx.env.SESSIONS, user.id)

--- a/packages/share-backend/src/auth/jwks.ts
+++ b/packages/share-backend/src/auth/jwks.ts
@@ -19,8 +19,10 @@ export function _resetJwksCacheForTests(): void {
   cache = null
 }
 
-async function defaultFetchJwks(): Promise<Jwk[]> {
-  if (cache && Date.now() - cache.fetchedAt < JWKS_CACHE_TTL_MS) return cache.keys
+async function defaultFetchJwks(force = false): Promise<Jwk[]> {
+  if (!force && cache && Date.now() - cache.fetchedAt < JWKS_CACHE_TTL_MS) {
+    return cache.keys
+  }
   const r = await fetch(JWKS_URI)
   if (!r.ok) throw new Error(`jwks fetch ${r.status}`)
   const body = (await r.json()) as { keys: Jwk[] }
@@ -28,14 +30,14 @@ async function defaultFetchJwks(): Promise<Jwk[]> {
   return body.keys
 }
 
-let jwksFetcher: () => Promise<Jwk[]> = defaultFetchJwks
+let jwksFetcher: (force?: boolean) => Promise<Jwk[]> = defaultFetchJwks
 
-export function setJwksFetcherForTests(fn: (() => Promise<Jwk[]>) | null): void {
+export function setJwksFetcherForTests(fn: ((force?: boolean) => Promise<Jwk[]>) | null): void {
   jwksFetcher = fn ?? defaultFetchJwks
 }
 
-export async function fetchJwks(): Promise<Jwk[]> {
-  return jwksFetcher()
+export async function fetchJwks(force = false): Promise<Jwk[]> {
+  return jwksFetcher(force)
 }
 
 function b64urlToBuf(s: string): ArrayBuffer {
@@ -132,5 +134,20 @@ export async function verifyIdToken(
   opts: VerifyOpts,
 ): Promise<IdTokenClaims> {
   const keys = await jwksFetcher()
-  return verifyIdTokenWithKeys(idToken, keys, opts)
+  try {
+    return await verifyIdTokenWithKeys(idToken, keys, opts)
+  } catch (err) {
+    // Google rotates JWKS rarely but without warning. Our 1-hour cache
+    // can hold a stale snapshot when a new `kid` first appears in the
+    // wild — every desktop sign-in carrying the rotated key would 401
+    // until the TTL elapses. Treat "no matching jwk" as a probable
+    // rotation, force-refresh once, and retry. Any other failure
+    // (bad signature, bad iss, expired) propagates immediately —
+    // refreshing keys can't help those.
+    if (err instanceof Error && err.message === 'no matching jwk') {
+      const freshKeys = await jwksFetcher(true)
+      return verifyIdTokenWithKeys(idToken, freshKeys, opts)
+    }
+    throw err
+  }
 }

--- a/packages/share-backend/src/auth/next.ts
+++ b/packages/share-backend/src/auth/next.ts
@@ -1,6 +1,19 @@
 export function safeNext(raw: string | null | undefined): string {
   if (!raw) return '/'
-  if (!raw.startsWith('/') || raw.startsWith('//') || raw.includes('\\')) return '/'
-  if (raw.split('/').some((seg) => seg === '..')) return '/'
+  // Re-run the same shape checks on the percent-decoded value so a
+  // crafted `/%2Fevil.com` (decodes to `//evil.com`) can't slip past
+  // the raw `startsWith('//')` guard and produce a protocol-relative
+  // Location header. decodeURIComponent throws on malformed sequences
+  // — treat that as "untrusted" and fall back to "/".
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(raw)
+  } catch {
+    return '/'
+  }
+  for (const v of [raw, decoded]) {
+    if (!v.startsWith('/') || v.startsWith('//') || v.includes('\\')) return '/'
+    if (v.split('/').some((seg) => seg === '..')) return '/'
+  }
   return raw
 }

--- a/packages/share-backend/tests/auth.test.ts
+++ b/packages/share-backend/tests/auth.test.ts
@@ -2,6 +2,9 @@ import { beforeAll, describe, expect, it } from 'vitest'
 
 import {
   type Jwk,
+  _resetJwksCacheForTests,
+  setJwksFetcherForTests,
+  verifyIdToken,
   verifyIdTokenWithKeys,
 } from '../src/auth/jwks'
 import {
@@ -184,6 +187,64 @@ describe('PKCE helpers', () => {
     const a = randomUrlSafe(16)
     const b = randomUrlSafe(16)
     expect(a).not.toBe(b)
+  })
+})
+
+describe('verifyIdToken — JWKS rotation recovery', () => {
+  it('force-refreshes on "no matching jwk" and accepts a token signed by the new key', async () => {
+    const oldKp = await generateKeypair('kid-old')
+    const newKp = await generateKeypair('kid-new')
+    let calls = 0
+    setJwksFetcherForTests(async (force = false) => {
+      calls++
+      // First fetch (cache populate) → only the OLD key.
+      // Force fetch (triggered by "no matching jwk") → only the NEW key.
+      return force ? [newKp.publicJwk] : [oldKp.publicJwk]
+    })
+    _resetJwksCacheForTests()
+
+    const tok = await mintTestJwt(newKp, {
+      iss: ISS,
+      aud: AUD,
+      sub: 'g-rotated',
+      email: 'r@example.com',
+      email_verified: true,
+      name: 'R',
+      exp: future(600),
+      iat: past(0),
+    })
+    const claims = await verifyIdToken(tok, { audience: AUD })
+    expect(claims.sub).toBe('g-rotated')
+    expect(calls).toBe(2) // first cached fetch, then force-refresh
+
+    setJwksFetcherForTests(null)
+    _resetJwksCacheForTests()
+  })
+
+  it('does NOT force-refresh on bad-signature errors', async () => {
+    let calls = 0
+    setJwksFetcherForTests(async () => {
+      calls++
+      return [kp.publicJwk]
+    })
+    _resetJwksCacheForTests()
+    // Token signed by a different keypair than the JWKS returns →
+    // verifyIdTokenWithKeys throws 'bad signature', not 'no matching jwk'
+    // (the kid matches kp's kid but the key bytes differ on the wire).
+    const other = await generateKeypair('kid-A') // same kid as kp
+    const tok = await mintTestJwt(other, {
+      iss: ISS,
+      aud: AUD,
+      sub: 'g-x',
+      email_verified: true,
+      exp: future(600),
+      iat: past(0),
+    })
+    await expect(verifyIdToken(tok, { audience: AUD })).rejects.toThrow(/bad signature/)
+    expect(calls).toBe(1) // no force-refresh on signature failure
+
+    setJwksFetcherForTests(null)
+    _resetJwksCacheForTests()
   })
 })
 

--- a/packages/share-backend/tests/security.test.ts
+++ b/packages/share-backend/tests/security.test.ts
@@ -326,6 +326,28 @@ describe('safeNext', () => {
   it('rejects backslash injection', () => {
     expect(safeNext('/\\evil.com')).toBe('/')
   })
+  it('rejects percent-encoded protocol-relative bypass', () => {
+    // /%2Fevil.com decodes to //evil.com — must be rejected even
+    // though raw.startsWith('//') is false at first glance.
+    expect(safeNext('/%2Fevil.com')).toBe('/')
+    expect(safeNext('/%2f%2fevil.com')).toBe('/')
+    expect(safeNext('/%2F%2Fevil.com/foo')).toBe('/')
+  })
+  it('rejects percent-encoded backslash and traversal', () => {
+    expect(safeNext('/%5Cevil.com')).toBe('/')
+    expect(safeNext('/foo/%2E%2E/bar')).toBe('/')
+  })
+  it('rejects malformed percent-encoding', () => {
+    // decodeURIComponent throws on lone "%" — fail closed.
+    expect(safeNext('/%')).toBe('/')
+    expect(safeNext('/%ZZ')).toBe('/')
+  })
+  it('keeps a same-origin path even if it contains a safe percent-encoded segment', () => {
+    // /me%2Fpublished decodes to /me/published — still same-origin,
+    // still no traversal. We return the RAW value so the eventual
+    // Location header round-trips intact.
+    expect(safeNext('/me%2Fpublished')).toBe('/me%2Fpublished')
+  })
   it('rejects ".." segments (defense-in-depth)', () => {
     expect(safeNext('/foo/../bar')).toBe('/')
     expect(safeNext('/../etc/passwd')).toBe('/')


### PR DESCRIPTION
## What

Three related fixes along the auth/identity boundary, surfaced in the post-launch audit pass on the share-publish stack.

**`safeNext` — open-redirect via percent-encoded bypass**

`/%2Fevil.com` decodes to `//evil.com`. The raw `startsWith('//')` guard didn't catch it. Modern browsers follow this as a protocol-relative redirect.

Fix: decode once and re-run the same shape guards on the decoded value. Malformed percent-encoding fails closed to `/`. Same-origin paths that happen to contain encoded segments (`/me%2Fpublished`) round-trip intact.

**JWKS rotation auto-recovery**

`cache` is a module-level singleton with a 1h TTL. After Google rotated a JWKS key, every desktop sign-in carrying the freshly-rotated `kid` would fail `no matching jwk` for up to 60 minutes — the cache held the stale key set and never invalidated.

```mermaid
sequenceDiagram
    autonumber
    participant D as Desktop client
    participant B as share-backend
    participant K as JWKS cache (1h TTL)
    participant G as Google JWKS

    Note over G: keys rotated at T0<br/>(new kid: kid-new)

    D->>B: id_token signed by kid-new
    B->>K: cached keys
    K-->>B: [kid-old]  (stale)
    B->>B: verify → no matching jwk
    B->>K: force-refresh
    K->>G: GET /oauth2/v3/certs
    G-->>K: [kid-new]
    K-->>B: [kid-new]
    B->>B: verify OK
    B-->>D: session_token
```

`verifyIdToken` now force-refreshes once on `no matching jwk` and retries. Other failures (bad signature, bad iss, expired) propagate immediately — refreshing keys can't help those, and a refresh on every bad-signature attempt would be a DoS amplifier.

**Nonce reservation order on `/api/auth/sign-in-with-id-token`**

KV write was AFTER `verifyNativeIdToken`. Two concurrent requests with the same nonce could both pass the pre-check, both verify, both mint sessions.

```mermaid
sequenceDiagram
    autonumber
    participant A as Request A
    participant B as Request B
    participant KV as NONCE KV
    participant V as verifyNativeIdToken

    Note over A,B: same nonce N arrives ~simultaneously

    par before fix
        A->>KV: GET nonce/N → null
        B->>KV: GET nonce/N → null
        A->>V: verify (~50ms)
        B->>V: verify (~50ms)
        V-->>A: claims
        V-->>B: claims
        A->>KV: PUT nonce/N=1
        B->>KV: PUT nonce/N=1
        Note over A,B: both mint sessions ✗
    end

    par after fix
        A->>KV: GET nonce/N → null
        A->>KV: PUT nonce/N=1
        B->>KV: GET nonce/N → 1
        B-->>B: 403 nonce replay ✓
        A->>V: verify
        V-->>A: claims (or release on failure)
    end
```

Reserve in KV BEFORE verify; on verify failure release the reservation via `waitUntil` so a legitimate retry with a corrected payload isn't locked out for the full 10-minute TTL. KV doesn't offer CAS so the race isn't fully closed, but the window shrinks from `verify duration + KV propagation` to `just KV propagation`.

## Verification

- `safeNext`: `%2F`, `%2E%2E`, `%5C`, malformed `%`, safe encoded path
- JWKS: rotation succeeds after one force-refresh; bad signature does NOT trigger refresh (counter-test)

`pnpm --filter @spool/share-backend test` → 180/180 green.

## Risk

None functional. `safeNext` is forward-only stricter (one edge case — malformed `/%` — now returns `/` instead of the malformed raw value, which is the safer choice). JWKS rotation only triggers on previously-fatal `no matching jwk` errors. Nonce reorder narrows a race that previously allowed duplicate sessions.

Submitted by @graydawnc.