### PR TITLE
fix(share-backend): publish-data hardening — revoke idempotency, hidden_turns cap

### DIFF
--- a/packages/share-backend/functions/api/revoke/[id].ts
+++ b/packages/share-backend/functions/api/revoke/[id].ts
@@ -40,12 +40,27 @@ export const onRequestPost: PagesFunction<Env, 'id'> = async (ctx) => {
     })
     if (!rate.ok) throw new ApiError('TOO_MANY_REQUESTS')
 
-    const owned = await ctx.env.DB.prepare(
-      'SELECT 1 FROM published_shares WHERE id=? AND user_id=?',
+    // Idempotent revoke: distinguish "not yours / never existed" from
+    // "yours but already revoked". The first is 404; the second is a
+    // 200 with no write — preserves the original revoked_at (audit
+    // trail + 7-day orphan-sweep window) without forcing every caller
+    // to special-case a 404 on stale local state. Cross-device
+    // unpublish (revoked on web, retried on desktop) is the canonical
+    // case where the desktop's local cache is stale and a retry must
+    // succeed cleanly.
+    const existing = await ctx.env.DB.prepare(
+      'SELECT revoked_at FROM published_shares WHERE id=? AND user_id=?',
     )
       .bind(id, user.id)
-      .first()
-    if (!owned) throw new ApiError('NOT_FOUND')
+      .first<{ revoked_at: number | null }>()
+    if (!existing) throw new ApiError('NOT_FOUND')
+    if (existing.revoked_at !== null) {
+      // Already tombstoned — return success without touching D1, KV,
+      // R2, or audit. No write means the original revoked_at stays
+      // pinned to the first revoke, which is what the orphan sweep
+      // and the audit log need to see.
+      return jsonOk({ ok: true })
+    }
 
     const now = Date.now()
     // Write order matches the publish handler's discipline: D1 row

--- a/packages/share-backend/src/publish/validators.ts
+++ b/packages/share-backend/src/publish/validators.ts
@@ -10,6 +10,15 @@ export const Snapshot = z.object({
   conversation: z
     .object({
       title: z.string().min(1).max(200),
+      // Array bounds sized against real-world session-length data:
+      // p99 ≈ 1,740 turns, max observed ≈ 4,565 turns on actual
+      // power-user dbs. 20,000 = ~4× the largest real session — wide
+      // enough that nobody legitimate hits it, narrow enough that
+      // zod can't be coerced into iterating millions of array
+      // entries before MAX_SNAPSHOT_BYTES (2MB) would have rejected
+      // the payload upstream. The body cap is the real defense; this
+      // is the sanity guard that prevents validator CPU bloat on a
+      // crafted-array attack.
       turns: z
         .array(
           z.object({
@@ -19,9 +28,13 @@ export const Snapshot = z.object({
             redacted: z.boolean().optional(),
           }),
         )
-        .max(500),
-      turn_order: z.array(z.string()).max(500),
-      hidden_turns: z.array(z.string()),
+        .max(20_000),
+      turn_order: z.array(z.string()).max(20_000),
+      // hidden_turns can never legitimately exceed turns.length (the
+      // refine below enforces every id is real). Same 20k cap so a
+      // crafted payload can't sit between "body fits in 2MB" and
+      // "refine catches it" pumping validator memory.
+      hidden_turns: z.array(z.string()).max(20_000),
     })
     // Reader assumes turn_order indexes every turn exactly once and that
     // hidden_turns references known turn ids. Without these checks a

--- a/packages/share-backend/tests/_helpers/fakes.ts
+++ b/packages/share-backend/tests/_helpers/fakes.ts
@@ -174,6 +174,11 @@ export function makeDb(state: FakeDbState = emptyState()): {
           )
           return (row ? ({ id: row.id, version: row.version } as T) : null)
         }
+        if (/^SELECT revoked_at FROM published_shares WHERE id=\? AND user_id=\?/i.test(sql)) {
+          const [id, uid] = params
+          const row = state.published_shares.find((s) => s.id === id && s.user_id === uid)
+          return (row ? ({ revoked_at: row.revoked_at } as T) : null)
+        }
         if (/^SELECT 1 FROM published_shares WHERE id=\? AND user_id=\?/i.test(sql)) {
           const [id, uid] = params
           const row = state.published_shares.find((s) => s.id === id && s.user_id === uid)

--- a/packages/share-backend/tests/publish.test.ts
+++ b/packages/share-backend/tests/publish.test.ts
@@ -731,6 +731,37 @@ describe('republish + revoke', () => {
     expect(res.status).toBe(429)
   })
 
+  it('revoke is idempotent on an already-revoked share — 200, original revoked_at preserved', async () => {
+    // Cross-device unpublish: user revokes on web at T0, opens the
+    // desktop app at T1 with a stale cache showing the share as live,
+    // clicks Unpublish → backend must return 200 (so the desktop UI
+    // doesn't toast an error for a no-op the user already performed)
+    // AND must NOT overwrite the original revoked_at (preserves the
+    // audit trail and the 7-day orphan-sweep window from the first
+    // revoke).
+    const env = envFor()
+    seedUser(env.state, 'user-1')
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const slug = nanoidSlug()
+    const originalRevokedAt = Date.now() - 1000 * 60 * 60 // 1h ago
+    env.state.published_shares.push({
+      id: slug,
+      user_id: 'user-1',
+      title: 'old',
+      visibility: 'unlisted',
+      expires_at: null,
+      version: 1,
+      published_at: originalRevokedAt - 1000,
+      republished_at: null,
+      revoked_at: originalRevokedAt,
+    })
+    const req = authedReq(`https://x/api/revoke/${slug}`)
+    const res = await invoke(revokePost, req, env, { id: slug })
+    expect(res.status).toBe(200)
+    const row = env.state.published_shares.find((r) => r.id === slug)!
+    expect(row.revoked_at).toBe(originalRevokedAt)
+  })
+
   it('revoke 404 when slug is not owned', async () => {
     const env = envFor()
     seedUser(env.state, 'user-1')


### PR DESCRIPTION
## What

Two follow-ups in the publish-data path, surfaced in the post-launch audit.

**Idempotent revoke**

The ownership SELECT had no `revoked_at IS NULL` clause. Re-revoking a tombstoned share would overwrite the original `revoked_at` with a newer timestamp:
- corrupts the audit trail
- shifts the row outside the 7-day orphan-sweep window — R2 artefacts go undeleted long after the share went 410

Plus a renderer-side consequence: the IPC handler does `if (!r.ok) throw`. The cross-device case (revoked on web, retried on desktop with stale local cache) used to toast `revoke 404` for what was actually a successful no-op.

```mermaid
stateDiagram-v2
    [*] --> Live: publish
    Live --> Revoked: POST /api/revoke/:id<br/>200 + revoked_at=T0
    Revoked --> Revoked: POST /api/revoke/:id (retry)<br/>200, no write<br/>(revoked_at stays T0)
    Live --> [*]: 410 Gone (reader path)
    Revoked --> [*]: 410 Gone (reader path)<br/>orphan-sweep at T0 + 7d

    state Revoked {
        [*] --> AuditTrailPreserved
    }
```

Fix shape:
- not owned / doesn't exist → `404 NOT_FOUND`
- owned but already revoked → `200 { ok: true }` (no D1/KV/R2/audit write)
- owned and live → revoke as before (D1 → KV → R2 + audit)

The renderer's existing `if (!r.ok) throw` converges cleanly without any client-side change.

**Array bounds on turns / turn_order / hidden_turns**

All three previously capped at 500. Measured against real-world session-length distribution on actual power-user dbs:

| Distribution | turns |
|---|---|
| p50 | 36 |
| p90 | 408 |
| p95 | 774 |
| p99 | 1,740 |
| max | **4,565** |

→ **9.2% of real sessions exceed 500 turns**. 500 was far too tight; the cap was rejecting legitimate publishes.

At the same time `hidden_turns` had NO cap at all — a crafted payload could ship a multi-million-entry array and bloat zod validation memory before the cross-reference refine ran.

Fix:
- `turns`, `turn_order`, `hidden_turns` → `.max(20_000)`
- ~4× the largest real session as headroom (nobody legitimate hits it)
- still acts as a validator-CPU sanity guard before `MAX_SNAPSHOT_BYTES` (2 MB) would have rejected the payload at the body-cap stage
- the body cap remains the real defense

## Verification

- revoke: `200` on already-revoked + assert original `revoked_at` preserved
- `tests/_helpers/fakes.ts`: new matcher for `SELECT revoked_at FROM published_shares` so the regression exercises the production query path

`pnpm --filter @spool/share-backend test` → 175/175 green.

## Risk

Pure correctness improvement on both fronts. The 200-idempotent shape matches what most callers already expect from an unpublish action. Raising the turns cap from 500 → 20,000 unblocks ~9% of real sessions that previously failed validation; the body-bytes ceiling (2 MB) is unchanged.

Submitted by @graydawnc.