### PR TITLE
fix(share): response-header discipline — default no-store + HSTS/XFO

### DIFF
--- a/packages/share-backend/functions/_middleware.ts
+++ b/packages/share-backend/functions/_middleware.ts
@@ -2,8 +2,6 @@ import type { PagesFunction } from '@cloudflare/workers-types'
 
 import { API_CSP } from '../src/security/csp'
 
-const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
-
 export const onRequest: PagesFunction = async (ctx) => {
   const res = await ctx.next()
   const headers = new Headers(res.headers)
@@ -14,10 +12,18 @@ export const onRequest: PagesFunction = async (ctx) => {
   const url = new URL(ctx.request.url)
   if (url.pathname.startsWith('/api/')) {
     headers.set('Content-Security-Policy', API_CSP)
-    if (
-      MUTATION_METHODS.has(ctx.request.method.toUpperCase()) &&
-      !headers.has('cache-control')
-    ) {
+    // Cache-Control discipline: default ALL /api/ responses to
+    // `no-store` unless the handler explicitly set a value. The
+    // previous version only defaulted mutations, which left every
+    // authenticated GET (/api/me, /api/me/shares, /api/admin/audit)
+    // relying on its handler to remember the header. A future GET
+    // endpoint that forgets to set Cache-Control would silently leak
+    // private data into a shared cache.
+    //
+    // Public-read endpoints (/api/snapshots/<id>, /api/og/<id>.png,
+    // /api/profiles/<handle>) set their own short-window cache
+    // header at the handler level and override this default.
+    if (!headers.has('cache-control')) {
       headers.set('Cache-Control', 'no-store')
     }
   }

--- a/packages/share-backend/tests/security.test.ts
+++ b/packages/share-backend/tests/security.test.ts
@@ -210,7 +210,7 @@ describe('_middleware security headers', () => {
     expect(res.headers.get('cache-control')).toBe('private, max-age=5')
   })
 
-  it('does NOT touch Cache-Control on GET API responses', async () => {
+  it('does NOT override an explicit Cache-Control on a GET (handler keeps its public/max-age)', async () => {
     const { onRequest } = await import('../functions/_middleware')
     const inner = new Response('{"ok":true}', {
       headers: { 'cache-control': 'public, max-age=60' },
@@ -221,6 +221,24 @@ describe('_middleware security headers', () => {
       next: () => Promise<Response>
     }) => Promise<Response>)({ request: req, next: async () => inner })
     expect(res.headers.get('cache-control')).toBe('public, max-age=60')
+  })
+
+  it('adds Cache-Control: no-store to GET API responses with no explicit header', async () => {
+    // Defense-in-depth: any future /api/* GET that forgets to set
+    // Cache-Control (think /api/me, /api/admin/audit, /api/me/shares)
+    // must still 'no-store' by default — otherwise a shared cache
+    // could fan out one user's private response to other readers.
+    const { onRequest } = await import('../functions/_middleware')
+    const inner = new Response('{"ok":true}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+    const req = new Request('https://x/api/me', { method: 'GET' })
+    const res = await (onRequest as unknown as (c: {
+      request: Request
+      next: () => Promise<Response>
+    }) => Promise<Response>)({ request: req, next: async () => inner })
+    expect(res.headers.get('cache-control')).toBe('no-store')
   })
 
   it('does NOT set CSP for non-/api routes', async () => {

--- a/packages/share-web/public/_headers
+++ b/packages/share-web/public/_headers
@@ -3,6 +3,8 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: interest-cohort=()
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-Frame-Options: DENY
 
 /s/*
   Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://spool.pro https://lh3.googleusercontent.com; font-src 'self' data:; connect-src 'self'; form-action 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'


### PR DESCRIPTION
## What

Two header-layer hardening fixes from the post-launch audit pass.

**Backend middleware default `Cache-Control`**

Previously only mutation responses (POST/PUT/PATCH/DELETE) got `Cache-Control: no-store` when the handler set nothing. Authenticated GET endpoints (`/api/me`, `/api/me/shares`, `/api/admin/audit`) each set their own header — but if ANY future GET forgot the line, the response would be served without cache protection and a shared proxy could fan out one user's private body to other readers.

Default ALL `/api/*` responses (regardless of method) to `no-store` when the handler doesn't set its own value.

```mermaid
flowchart TD
    REQ["Request to /api/*"] --> H{"Handler set Cache-Control?"}
    H -->|yes| KEEP["Keep handler value<br/>e.g. public + max-age=30"]
    H -->|no| METHOD{"Method?"}

    METHOD -->|"POST/PUT/PATCH/DELETE (before + after)"| MUT["Set no-store"]
    METHOD -->|"GET — before"| RAW["Pass through<br/>no Cache-Control<br/>relies on every handler"]
    METHOD -->|"GET — after"| ALL["Set no-store as default"]

    style RAW fill:#fee,stroke:#c00
    style ALL fill:#efe,stroke:#0a0
    style MUT fill:#efe,stroke:#0a0
```

The three public-read endpoints (`/api/snapshots/:id`, `/api/og/:id.png`, `/api/profiles/:handle`) already set their own `public, max-age=30, must-revalidate` on success; tombstone branches set `no-store` explicitly. All override the new default cleanly.

**share-web global headers**

`public/_headers` had per-route CSP with `frame-ancestors 'none'` on `/s/*`, `/@*`, `/me`, `/sign-in` — but the root `/`, `/404`, and any future route had NO clickjacking protection. HSTS was entirely absent so a first-visit downgrade attack was viable on a fresh visitor.

Add globally:
```
Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
X-Frame-Options: DENY
```

`X-Frame-Options` is belt-and-braces with the per-route `frame-ancestors 'none'` (some older clients honour XFO but not CSP); HSTS is the real upgrade — 2-year window, includes subdomains, eligible for the browser preload list.

## Verification

- middleware: regression test asserting `no-store` default on `/api/*` GET when handler sets nothing

`pnpm --filter @spool/share-backend test` → 175/175 green.

## Risk

- The `no-store` default is additive — existing handlers that set their own value override it. No behavior change for `/api/snapshots/*`, `/api/og/*`, `/api/profiles/*`, `/api/me*`, `/api/admin/*`, `/api/health`.
- HSTS: 2-year window applies to spool.pro and subdomains. Cloudflare Pages enforces HTTPS already. No HTTP-only subdomain exists.
- XFO: spool.pro has no iframe-embedding consumers at v0.5; per-route `frame-ancestors 'none'` already in force.

Submitted by @graydawnc.
