### PR TITLE
fix(app): destructive-action confirm — focus trap + SharesPage Unpublish modal

### DIFF
--- a/packages/app/src/renderer/components/DeleteAccountConfirmModal.tsx
+++ b/packages/app/src/renderer/components/DeleteAccountConfirmModal.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Loader2 } from 'lucide-react'
 import { useHotkeys } from '../hooks/useHotkeys.js'
+import { useFocusTrap } from '../hooks/useFocusTrap.js'
 
 type Props = {
   open: boolean
@@ -48,6 +49,10 @@ export function DeleteAccountConfirmModal({
     }
   }, [open])
 
+  // Focus trap with initial focus on Cancel — see UnpublishConfirmModal.
+  const cancelRef = useRef<HTMLButtonElement | null>(null)
+  const trapRef = useFocusTrap<HTMLDivElement>(open, cancelRef)
+
   if (!open) return null
 
   return (
@@ -56,6 +61,7 @@ export function DeleteAccountConfirmModal({
       aria-modal="true"
       aria-labelledby="delete-account-confirm-title"
       data-testid="delete-account-confirm"
+      ref={trapRef}
       onMouseDown={(e) => {
         if (e.target === e.currentTarget && !busy) onClose()
       }}
@@ -96,6 +102,7 @@ export function DeleteAccountConfirmModal({
         <div className="flex items-center justify-end gap-2 px-5 pb-5 pt-2">
           <button
             type="button"
+            ref={cancelRef}
             onClick={onClose}
             disabled={busy}
             data-testid="delete-account-confirm-cancel"

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -11,6 +11,7 @@ import { useSpoolDrop } from '../hooks/useSpoolDrop.js'
 import { sharePublicOrigin, sharePublicUrl } from '../lib/sharePublicUrl.js'
 import { FeaturedEmptyState, SmallEmptyState } from './EmptyState.js'
 import NewDraftPicker from './NewDraftPicker.js'
+import { UnpublishConfirmModal } from './share-editor/UnpublishConfirmModal.js'
 import type { PublishedShareCacheItem, ShareDraftListItem } from '@spool-lab/core'
 import {
   TemplateRender,
@@ -183,6 +184,15 @@ function PublishedList() {
   const { user, loading: authLoading, signIn } = useShareAuth()
   const { items, loading, refresh, noteLocalMutation } = usePublishedShares()
   const [busyId, setBusyId] = useState<string | null>(null)
+  // Confirmation state for the Unpublish action. Mirrors the Share
+  // popover's UnpublishConfirmModal so a single click on the row's
+  // Unpublish icon can't tombstone the share without a deliberate
+  // second action. Stores a snapshot of the target row so the modal
+  // copy can render the title and the confirm handler still has the
+  // row even if the SWR refresh between click and confirm flips
+  // `items`.
+  const [pendingUnpublish, setPendingUnpublish] = useState<PublishedShareCacheItem | null>(null)
+  const [confirmError, setConfirmError] = useState<string | null>(null)
 
   // Re-fetch the published list when this window regains focus — picks up
   // remote revocations (user opened spool.pro/me on the web and revoked)
@@ -302,9 +312,21 @@ function PublishedList() {
     window.open(sharePublicUrl(it.id), '_blank', 'noopener,noreferrer')
   }
 
-  const onUnpublish = async (it: PublishedShareCacheItem) => {
+  const requestUnpublish = (it: PublishedShareCacheItem) => {
+    // Don't open a second confirm while one is in flight. The button
+    // is also visually disabled across all rows when `busyId !== null`,
+    // so this guard is belt-and-braces; the visible disabled state
+    // matters more for user feedback than this early return.
     if (busyId) return
+    setConfirmError(null)
+    setPendingUnpublish(it)
+  }
+
+  const confirmUnpublish = async () => {
+    if (!pendingUnpublish || busyId) return
+    const it = pendingUnpublish
     setBusyId(it.id)
+    setConfirmError(null)
     // Tell the hook a local mutation is starting so any focus-triggered
     // refresh whose myShares response is in flight skips its cache
     // replaceAll — otherwise it would stomp the optimistic revoke
@@ -314,9 +336,14 @@ function PublishedList() {
     try {
       await window.spoolShare.revoke(it.id)
       toast.success('Share unpublished')
+      setPendingUnpublish(null)
       await refresh()
     } catch (err) {
       console.error('Unpublish failed:', err)
+      // Surface the error inline in the modal so the user can decide
+      // whether to retry or cancel; the toast remains a secondary cue
+      // for accessibility (screen readers announce it).
+      setConfirmError(err instanceof Error ? err.message : "Couldn't unpublish")
       toast.error("Couldn't unpublish")
     } finally {
       setBusyId(null)
@@ -324,30 +351,56 @@ function PublishedList() {
   }
 
   return (
-    <ul data-testid="published-list" className="flex flex-col gap-1 px-3 pb-6">
-      {items.map((it) => (
-        <PublishedRow
-          key={it.id}
-          item={it}
-          busy={busyId === it.id}
-          onCopy={() => void onCopy(it)}
-          onView={() => onView(it)}
-          onUnpublish={() => void onUnpublish(it)}
-        />
-      ))}
-    </ul>
+    <>
+      <ul data-testid="published-list" className="flex flex-col gap-1 px-3 pb-6">
+        {items.map((it) => (
+          <PublishedRow
+            key={it.id}
+            item={it}
+            busy={busyId === it.id}
+            // Lock every row's Unpublish button while any revoke is in
+            // flight, so clicking row B during row A's confirm/revoke
+            // can't silently no-op. The row that's actually busy gets
+            // the spinner via `busy`; other locked rows just appear
+            // disabled.
+            locked={busyId !== null && busyId !== it.id}
+            onCopy={() => void onCopy(it)}
+            onView={() => onView(it)}
+            onUnpublish={() => requestUnpublish(it)}
+          />
+        ))}
+      </ul>
+      <UnpublishConfirmModal
+        open={pendingUnpublish !== null}
+        title={pendingUnpublish?.title || 'Untitled'}
+        busy={busyId === pendingUnpublish?.id}
+        error={confirmError}
+        onClose={() => {
+          if (busyId === pendingUnpublish?.id) return
+          setPendingUnpublish(null)
+          setConfirmError(null)
+        }}
+        onConfirm={() => void confirmUnpublish()}
+      />
+    </>
   )
 }
 
 function PublishedRow({
   item,
   busy,
+  locked = false,
   onCopy,
   onView,
   onUnpublish,
 }: {
   item: PublishedShareCacheItem
   busy: boolean
+  /** True when *some other* row is currently being revoked — disable
+   *  this row's destructive control so a click doesn't silently
+   *  no-op behind the modal. The active row uses `busy` instead and
+   *  shows its own spinner. */
+  locked?: boolean
   onCopy: () => void
   onView: () => void
   onUnpublish: () => void
@@ -405,7 +458,7 @@ function PublishedRow({
         <RowAction label="View" onClick={onView}><ExternalLink size={13} strokeWidth={1.6} /></RowAction>
         <RowAction label="Copy link" onClick={onCopy}><LinkIcon size={13} strokeWidth={1.6} /></RowAction>
         {!revoked && (
-          <RowAction label={busy ? 'Unpublishing' : 'Unpublish'} onClick={onUnpublish} disabled={busy}>
+          <RowAction label={busy ? 'Unpublishing' : 'Unpublish'} onClick={onUnpublish} disabled={busy || locked}>
             {busy
               ? <Loader2 size={13} strokeWidth={1.6} className="animate-spin" />
               : <EyeOff size={13} strokeWidth={1.6} />}

--- a/packages/app/src/renderer/components/share-editor/UnpublishConfirmModal.tsx
+++ b/packages/app/src/renderer/components/share-editor/UnpublishConfirmModal.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Loader2 } from 'lucide-react'
 import { useHotkeys } from '../../hooks/useHotkeys.js'
+import { useFocusTrap } from '../../hooks/useFocusTrap.js'
 
 type Props = {
   open: boolean
@@ -51,6 +52,12 @@ export function UnpublishConfirmModal({
     }
   }, [open])
 
+  // Focus trap: Tab/Shift+Tab stays inside the modal; initial focus
+  // lands on Cancel (the safe default for a destructive confirm) so a
+  // user pressing Enter immediately on open doesn't commit the action.
+  const cancelRef = useRef<HTMLButtonElement | null>(null)
+  const trapRef = useFocusTrap<HTMLDivElement>(open, cancelRef)
+
   if (!open) return null
 
   return (
@@ -59,6 +66,7 @@ export function UnpublishConfirmModal({
       aria-modal="true"
       aria-labelledby="unpublish-confirm-title"
       data-testid="unpublish-confirm"
+      ref={trapRef}
       onMouseDown={(e) => {
         if (e.target === e.currentTarget && !busy) onClose()
       }}
@@ -98,6 +106,7 @@ export function UnpublishConfirmModal({
         <div className="flex items-center justify-end gap-2 px-5 pb-5 pt-2">
           <button
             type="button"
+            ref={cancelRef}
             onClick={onClose}
             disabled={busy}
             data-testid="unpublish-confirm-cancel"

--- a/packages/app/src/renderer/hooks/useFocusTrap.ts
+++ b/packages/app/src/renderer/hooks/useFocusTrap.ts
@@ -1,0 +1,94 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Trap Tab/Shift+Tab focus inside the container while `active` is true,
+ * and restore focus to the previously-focused element when the trap
+ * tears down.
+ *
+ * Used by destructive modals (UnpublishConfirmModal, DeleteAccountConfirmModal)
+ * where `aria-modal="true"` is a hint to assistive tech but the browser
+ * itself doesn't actually contain focus — keyboard users can Tab out of
+ * the modal into the underlying page, which on a confirmation surface is
+ * a real footgun (the next Tab might land on a destructive control the
+ * user never saw).
+ *
+ * Returns a ref to attach to the trap root. The hook auto-focuses
+ * `initialFocusRef.current` (preferred) or the first focusable element
+ * when the trap activates.
+ */
+export function useFocusTrap<T extends HTMLElement = HTMLElement>(
+  active: boolean,
+  initialFocusRef?: React.RefObject<HTMLElement | null>,
+): React.RefObject<T | null> {
+  const rootRef = useRef<T | null>(null)
+  const lastActiveRef = useRef<Element | null>(null)
+
+  useEffect(() => {
+    if (!active) return
+    lastActiveRef.current = document.activeElement
+    const root = rootRef.current
+    if (!root) return
+
+    // Focus the explicit initial target (e.g. Cancel button on a
+    // destructive confirm) so the user isn't one keypress away from
+    // committing the destructive action.
+    const initial = initialFocusRef?.current
+    if (initial) {
+      initial.focus()
+    } else {
+      const first = focusable(root)[0]
+      first?.focus()
+    }
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return
+      const list = focusable(root)
+      if (list.length === 0) {
+        e.preventDefault()
+        return
+      }
+      const first = list[0]!
+      const last = list[list.length - 1]!
+      const current = document.activeElement as HTMLElement | null
+      if (e.shiftKey) {
+        if (current === first || !root.contains(current)) {
+          e.preventDefault()
+          last.focus()
+        }
+      } else {
+        if (current === last || !root.contains(current)) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', onKey, true)
+    return () => {
+      document.removeEventListener('keydown', onKey, true)
+      const restore = lastActiveRef.current
+      if (restore instanceof HTMLElement) restore.focus()
+    }
+  }, [active, initialFocusRef])
+
+  return rootRef
+}
+
+// Standard focusable selectors. Skip disabled / aria-hidden / tabindex=-1.
+const SELECTOR =
+  'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+function focusable(root: HTMLElement): HTMLElement[] {
+  // Both predicates must hold to be included:
+  //   - element is laid out (non-zero box). offsetParent === null is
+  //     the standard "hidden" check for absolutely-positioned elements,
+  //     but it ALSO returns null for `position: fixed`, which our modal
+  //     overlay uses. Switch to offsetWidth/offsetHeight which work for
+  //     all positioning schemes.
+  //   - element is NOT aria-hidden. Was previously OR'd with offset
+  //     check via ||, which let aria-hidden elements with a visible
+  //     parent slip through as tab-stops.
+  return Array.from(root.querySelectorAll<HTMLElement>(SELECTOR)).filter(
+    (el) => el.offsetWidth > 0 && el.offsetHeight > 0 && el.getAttribute('aria-hidden') !== 'true',
+  )
+}


### PR DESCRIPTION
## What

Two renderer-side a11y/UX fixes from the post-launch audit.

**`useFocusTrap` — Tab/Shift+Tab containment on destructive modals**

`aria-modal="true"` on the confirm dialogs is a hint to assistive tech but doesn't actually contain keyboard focus — Tab/Shift+Tab could escape into the underlying page. On a destructive confirmation surface (Unpublish / Schedule deletion) this is a real footgun: the next Tab might land on a destructive control the user never saw.

New hook wires into both `UnpublishConfirmModal` and `DeleteAccountConfirmModal`:
- Initial focus lands on **Cancel** (safe default — pressing Enter immediately on open doesn't commit the action)
- Tab/Shift+Tab cycles inside the modal
- Focus restores to the previously-active element on close
- Focusable detection uses `offsetWidth > 0 && offsetHeight > 0` (NOT `offsetParent`, which returns null for `position: fixed` overlays) AND guards against `aria-hidden` tab-stops

**SharesPage Unpublish — confirm modal instead of single-click revoke**

The Share popover's unpublish already routes through `UnpublishConfirmModal`. The Published-list Unpublish action did not — clicking the EyeOff icon on a row immediately fired `spoolShare.revoke()`. Inconsistent with the destructive-action discipline elsewhere in the app.

```mermaid
stateDiagram-v2
    [*] --> Idle
    Idle --> Confirming: click EyeOff on row A
    Confirming --> Idle: cancel / Esc / outside-click
    Confirming --> Revoking: confirm
    Revoking --> Idle: 200 + cache.markRevoked + refresh
    Revoking --> Confirming: error (inline + toast)

    state Confirming {
        [*] --> RowsLocked
        RowsLocked --> RowsLocked: other rows<br/>disabled (locked prop)
    }
    state Revoking {
        [*] --> ActiveRowBusy
        ActiveRowBusy --> ActiveRowBusy: spinner on row A<br/>others stay locked
    }
```

While a revoke is in flight, every row's Unpublish button is `locked` so clicking another row can't silently no-op (the row-level `busy` spinner shows on the active row; other rows show as disabled — the user gets unambiguous feedback that the system is busy).

## Verification

- `pnpm --filter @spool/app exec tsc --noEmit` clean
- `pnpm --filter @spool/app test` → 433 unit pass (the 1 fail is the pre-existing `sessionResume.test.ts:38` macOS path-slug flake, unrelated)

## Risk

- Focus trap: changes initial focus + Tab cycling behaviour on the two confirm modals. No existing tests assert on focus.
- SharesPage Unpublish flow: replaces single-click revoke with confirm modal. The Published-list surface is gated by `VITE_FEATURE_SHAREPUBLISH` which CI doesn't set, so e2e doesn't exercise this path — covered by manual smoke.
- `locked` prop on `PublishedRow` is optional with default `false`; existing callers (none external) unaffected.

Submitted by @graydawnc.