### PR TITLE
test(app): publish-flow e2e — 5 specs, in-process mock backend, real regression coverage

### DIFF
--- a/packages/app/e2e/helpers/launch.ts
+++ b/packages/app/e2e/helpers/launch.ts
@@ -12,6 +12,11 @@ export interface AppContext {
   app: ElectronApplication
   window: Page
   dbPath: string
+  /** Root tmpdir for this test run. Tracked explicitly so restartApp's
+   *  cleanup doesn't have to reconstruct it from env-var string
+   *  manipulation — fragile once extraEnv lets callers override
+   *  SPOOL_DATA_DIR. */
+  tmpDir: string
   env: Record<string, string>
   cleanup: () => Promise<void>
 }
@@ -21,6 +26,11 @@ export async function launchApp(opts: {
   /** Mutate fixture dirs (e.g. inject extra sessions) after the base fixtures
    * have been copied and before Electron starts. Receives the resolved dirs. */
   extraFixtures?: (dirs: { claudeDir: string; codexDir: string; geminiCliHome: string; opencodeDir: string }) => void
+  /** Extra env to merge into the Electron child process env. Used by the
+   * share-publish e2e to point SPOOL_SHARE_BACKEND at the in-process
+   * mock backend, which binds to a random port per test run and so
+   * can't be expressed via static playwright.config.ts env. */
+  extraEnv?: Record<string, string>
 } = {}): Promise<AppContext> {
   const tmpDir = mkdtempSync(join(tmpdir(), 'spool-e2e-'))
 
@@ -65,6 +75,12 @@ export async function launchApp(opts: {
     env['SPOOL_ACP_AGENT_BIN'] = mockScript
   }
 
+  if (opts.extraEnv) {
+    for (const [k, v] of Object.entries(opts.extraEnv)) {
+      env[k] = v
+    }
+  }
+
   // Opt into the Security feature (the Labs flag persisted on
   // agents.json). The built e2e app has VITE_FEATURE_SECURITY=1 so the
   // code is present, but `import.meta.env.DEV` is false — without an
@@ -92,6 +108,7 @@ export async function launchApp(opts: {
     app,
     window,
     dbPath: join(tmpDir, 'data', 'spool.db'),
+    tmpDir,
     env,
     cleanup: async () => {
       await app.close()
@@ -117,17 +134,15 @@ export async function restartApp(ctx: AppContext): Promise<AppContext> {
     app,
     window,
     dbPath: ctx.dbPath,
+    tmpDir: ctx.tmpDir,
     env: ctx.env,
     cleanup: async () => {
       await app.close()
-      // tmpDir cleanup uses the original env's SPOOL_DATA_DIR's grandparent,
-      // which is what ctx.cleanup also targets. Run the original cleanup
-      // path so the dir gets removed exactly once.
-      const dataDir = ctx.env['SPOOL_DATA_DIR']
-      if (dataDir) {
-        const tmpDir = dataDir.replace(/\/data$/, '')
-        rmSync(tmpDir, { recursive: true, force: true })
-      }
+      // Use the original ctx's tmpDir explicitly. Reconstructing from
+      // SPOOL_DATA_DIR with a regex (the previous version) was fragile
+      // once extraEnv let callers override SPOOL_DATA_DIR — the strip
+      // wouldn't match and we'd silently leak the entire tmpdir.
+      rmSync(ctx.tmpDir, { recursive: true, force: true })
     },
   }
 }

--- a/packages/app/e2e/helpers/share-publish-mock-backend.ts
+++ b/packages/app/e2e/helpers/share-publish-mock-backend.ts
@@ -22,8 +22,9 @@
 //     rate-limit windows in a unit-sized server adds noise without
 //     catching regressions in the renderer paths
 //   - Real auth verification — every signed-in request is accepted; the
-//     OAuth path is short-circuited in oauth.ts under SPOOL_E2E_TEST=1
-//     before any token would reach us
+//     OAuth path is replaced at the IPC composition root by the e2e-mode
+//     entry (src/main/e2e-mode/share-auth-e2e.ts), which never runs the
+//     loopback dance or Google token exchange
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import { AddressInfo } from 'node:net'
@@ -132,8 +133,9 @@ async function routeRequest(
   const method = req.method ?? 'GET'
 
   // POST /api/auth/sign-in-with-id-token
-  // The renderer's signIn → main oauth.ts (SPOOL_E2E_TEST branch) →
-  // here. We accept any id_token payload and mint a session token.
+  // The renderer's signIn IPC → e2e-mode's e2eSignIn() → here. We
+  // accept any id_token payload (the e2e entry hard-codes the
+  // 'e2e-fake-id-token' marker) and mint a session token.
   if (method === 'POST' && url.pathname === '/api/auth/sign-in-with-id-token') {
     await readBody(req)
     return json(res, 200, {

--- a/packages/app/e2e/helpers/share-publish-mock-backend.ts
+++ b/packages/app/e2e/helpers/share-publish-mock-backend.ts
@@ -1,0 +1,351 @@
+// Minimal in-process HTTP server that stands in for share-backend
+// during e2e runs of the publish flow.
+//
+// Real share-backend is a Cloudflare Pages Functions project: D1, KV, R2,
+// the OG render pipeline, scheduled deletion worker. Spinning that up in
+// CI would require either a wrangler dev side-car (flaky, slow, and
+// hard-coded to platform-specific binaries) or a full miniflare embed
+// (drags in C++ workerd). Neither is worth the friction for a renderer
+// regression suite.
+//
+// What we run instead: a tiny Node http server that speaks the exact wire
+// contract `share-publish:*` IPC handlers expect — enough surface to
+// exercise the Share popover, the publish form, the manage view, and the
+// Published tab on SharesPage. State is kept in memory; per-test reset
+// happens through the `reset()` method.
+//
+// What we deliberately do NOT cover here:
+//   - PII gate enforcement (server-side rescan) — there isn't one; the
+//     client gate is the only boundary, and that's tested in
+//     publish-logic.test.ts
+//   - Rate limiting — handled at the backend in prod; mocking realistic
+//     rate-limit windows in a unit-sized server adds noise without
+//     catching regressions in the renderer paths
+//   - Real auth verification — every signed-in request is accepted; the
+//     OAuth path is short-circuited in oauth.ts under SPOOL_E2E_TEST=1
+//     before any token would reach us
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { AddressInfo } from 'node:net'
+
+export interface SharePublishMockState {
+  user: {
+    id: string
+    email: string
+    name: string
+    avatar_url: string | null
+    handle: string | null
+    deletion_pending_until: number | null
+  }
+  /** Map<slug, share>. Maintained in publish/revoke/republish handlers
+   *  so /api/me/shares returns the current view. */
+  shares: Map<string, MockShareRow>
+  /** Per-handle availability override; defaults to "available" if absent. */
+  handleAvailability: Map<string, boolean>
+  /** Last publish payload received — handy in assertions. */
+  lastPublishPayload: Record<string, unknown> | null
+}
+
+export interface MockShareRow {
+  id: string
+  title: string
+  visibility: 'unlisted' | 'profile-listed'
+  expires_at: number | null
+  version: number
+  published_at: number
+  republished_at: number | null
+  revoked_at: number | null
+  draft_id: string | null
+  client_request_id: string | null
+}
+
+export interface SharePublishMockHandle {
+  /** URL to set as SPOOL_SHARE_BACKEND for the Electron process. */
+  baseUrl: string
+  state: SharePublishMockState
+  /** Clear in-memory state between tests without restarting the server. */
+  reset: () => void
+  close: () => Promise<void>
+}
+
+const DEFAULT_USER: SharePublishMockState['user'] = {
+  id: 'mock-user-1',
+  email: 'mock@example.com',
+  name: 'E2E User',
+  avatar_url: null,
+  handle: null,
+  deletion_pending_until: null,
+}
+
+export async function startSharePublishMockBackend(): Promise<SharePublishMockHandle> {
+  const state: SharePublishMockState = {
+    user: { ...DEFAULT_USER },
+    shares: new Map(),
+    handleAvailability: new Map(),
+    lastPublishPayload: null,
+  }
+
+  const server = createServer(async (req, res) => {
+    try {
+      await routeRequest(req, res, state)
+    } catch (err) {
+      // Defensive: any thrown error should surface as 500 rather than
+      // leave the renderer's IPC hanging on a torn socket.
+      res.statusCode = 500
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({ error: 'mock_internal', detail: String(err) }))
+    }
+  })
+
+  await new Promise<void>((resolve) => {
+    // Bind to 127.0.0.1 (not 0.0.0.0) so other processes on a shared CI
+    // runner can't accidentally connect — this stub accepts anything.
+    server.listen(0, '127.0.0.1', () => resolve())
+  })
+
+  const port = (server.address() as AddressInfo).port
+  const baseUrl = `http://127.0.0.1:${port}`
+
+  return {
+    baseUrl,
+    state,
+    reset: () => {
+      state.user = { ...DEFAULT_USER }
+      state.shares.clear()
+      state.handleAvailability.clear()
+      state.lastPublishPayload = null
+    },
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()))
+      })
+    },
+  }
+}
+
+async function routeRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  state: SharePublishMockState,
+): Promise<void> {
+  const url = new URL(req.url ?? '', 'http://127.0.0.1')
+  const method = req.method ?? 'GET'
+
+  // POST /api/auth/sign-in-with-id-token
+  // The renderer's signIn → main oauth.ts (SPOOL_E2E_TEST branch) →
+  // here. We accept any id_token payload and mint a session token.
+  if (method === 'POST' && url.pathname === '/api/auth/sign-in-with-id-token') {
+    await readBody(req)
+    return json(res, 200, {
+      session_token: 'mock-session-' + state.user.id,
+      exp: Date.now() + 24 * 3600 * 1000,
+      user: {
+        id: state.user.id,
+        email: state.user.email,
+        name: state.user.name,
+        avatar_url: state.user.avatar_url,
+        handle: state.user.handle,
+        deletion_pending_until: state.user.deletion_pending_until,
+      },
+    })
+  }
+
+  // POST /api/auth/sign-out
+  if (method === 'POST' && url.pathname === '/api/auth/sign-out') {
+    return json(res, 200, { ok: true })
+  }
+
+  // GET /api/me
+  if (method === 'GET' && url.pathname === '/api/me') {
+    return json(res, 200, {
+      user: {
+        id: state.user.id,
+        email: state.user.email,
+        name: state.user.name,
+        avatar_url: state.user.avatar_url,
+      },
+      handle: state.user.handle,
+      deletion_pending_until: state.user.deletion_pending_until,
+    })
+  }
+
+  // GET /api/me/shares — backend returns { items: [...] } per the
+  // /api/me/shares contract (not { shares: [...] }), and so the
+  // renderer's MySharesResponse expects.
+  if (method === 'GET' && url.pathname === '/api/me/shares') {
+    const items = Array.from(state.shares.values()).map((s) => ({
+      id: s.id,
+      title: s.title,
+      visibility: s.visibility,
+      expires_at: s.expires_at,
+      version: s.version,
+      published_at: s.published_at,
+      republished_at: s.republished_at,
+      revoked_at: s.revoked_at,
+      draft_id: s.draft_id,
+      client_request_id: s.client_request_id,
+    }))
+    return json(res, 200, { items })
+  }
+
+  // GET /api/handles/check?h=foo — backend uses ?h not ?handle
+  // (see share-backend/functions/api/handles/check.ts:11)
+  if (method === 'GET' && url.pathname === '/api/handles/check') {
+    const handle = url.searchParams.get('h') ?? ''
+    if (!/^[a-z0-9_-]{3,32}$/.test(handle)) {
+      return json(res, 422, { detail: 'invalid handle' })
+    }
+    const available = state.handleAvailability.get(handle) ?? true
+    return json(res, 200, { handle, available })
+  }
+
+  // POST /api/handles/claim — body { handle }
+  if (method === 'POST' && url.pathname === '/api/handles/claim') {
+    const body = JSON.parse(await readBody(req)) as { handle?: string }
+    const h = body.handle ?? ''
+    if (!/^[a-z0-9_-]{3,32}$/.test(h)) return json(res, 422, { detail: 'invalid' })
+    if (state.handleAvailability.get(h) === false) {
+      return json(res, 409, { detail: 'taken' })
+    }
+    state.user.handle = h
+    return json(res, 200, { handle: h })
+  }
+
+  // POST /api/publish — body { snapshot, visibility, draft_id,
+  // idempotency_key, expires_at?, override_slug? }
+  if (method === 'POST' && url.pathname === '/api/publish') {
+    const body = JSON.parse(await readBody(req)) as PublishBody
+    state.lastPublishPayload = body as unknown as Record<string, unknown>
+    const overrideSlug = body.override_slug
+    const draftId = body.draft_id ?? null
+    const idemp = body.idempotency_key
+    const visibility = body.visibility
+    const title = body.snapshot?.conversation?.title ?? 'Untitled'
+    const expiresAt = body.expires_at ? new Date(body.expires_at).getTime() : null
+
+    // Idempotency short-circuit: if a non-revoked share carries the
+    // same token, return that result without mutating state.
+    for (const s of state.shares.values()) {
+      if (
+        s.client_request_id &&
+        s.client_request_id === idemp &&
+        s.revoked_at === null &&
+        (!overrideSlug || s.id === overrideSlug)
+      ) {
+        return json(res, 200, {
+          id: s.id,
+          version: s.version,
+          url: `https://mock.spool.pro/s/${s.id}`,
+        })
+      }
+    }
+
+    let slug: string
+    let version: number
+    if (overrideSlug) {
+      const existing = state.shares.get(overrideSlug)
+      if (!existing || existing.revoked_at !== null) {
+        return json(res, 404, { detail: 'not found' })
+      }
+      slug = existing.id
+      version = existing.version + 1
+      state.shares.set(slug, {
+        ...existing,
+        title,
+        visibility,
+        expires_at: expiresAt,
+        version,
+        republished_at: Date.now(),
+        draft_id: draftId,
+        client_request_id: idemp,
+      })
+    } else {
+      slug = randomSlug()
+      version = 1
+      state.shares.set(slug, {
+        id: slug,
+        title,
+        visibility,
+        expires_at: expiresAt,
+        version,
+        published_at: Date.now(),
+        republished_at: null,
+        revoked_at: null,
+        draft_id: draftId,
+        client_request_id: idemp,
+      })
+    }
+    return json(res, 200, {
+      id: slug,
+      version,
+      url: `https://mock.spool.pro/s/${slug}`,
+    })
+  }
+
+  // POST /api/revoke/:id
+  const revokeMatch = method === 'POST' && url.pathname.match(/^\/api\/revoke\/([\w-]+)$/)
+  if (revokeMatch) {
+    const id = revokeMatch[1] as string
+    const row = state.shares.get(id)
+    if (!row) return json(res, 404, { detail: 'not found' })
+    if (row.revoked_at !== null) {
+      // Idempotent — matches the backend's post-#369 contract.
+      return json(res, 200, { ok: true })
+    }
+    state.shares.set(id, { ...row, revoked_at: Date.now() })
+    return json(res, 200, { ok: true })
+  }
+
+  // POST /api/me/delete
+  if (method === 'POST' && url.pathname === '/api/me/delete') {
+    state.user.deletion_pending_until = Date.now() + 24 * 3600 * 1000
+    return json(res, 200, { deletion_pending_until: state.user.deletion_pending_until })
+  }
+  if (method === 'DELETE' && url.pathname === '/api/me/delete') {
+    state.user.deletion_pending_until = null
+    return json(res, 200, { ok: true })
+  }
+
+  // Fallthrough — unknown route. Surface as 404 so a missing handler
+  // shows up as a clear test failure rather than a hang or 500.
+  json(res, 404, { detail: 'mock_unhandled', path: url.pathname, method })
+}
+
+interface PublishBody {
+  snapshot: { conversation?: { title?: string } }
+  visibility: 'unlisted' | 'profile-listed'
+  draft_id?: string
+  idempotency_key: string
+  expires_at?: string
+  override_slug?: string
+}
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status
+  res.setHeader('content-type', 'application/json')
+  // Same anti-cache discipline the real backend ships under
+  // _middleware.ts — keeps the mock realistic so a "depends on a cached
+  // response" regression doesn't sneak past locally and explode in prod.
+  res.setHeader('cache-control', 'no-store')
+  res.end(JSON.stringify(body))
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let buf = ''
+    req.on('data', (chunk) => {
+      buf += chunk
+    })
+    req.on('end', () => resolve(buf))
+    req.on('error', reject)
+  })
+}
+
+const SLUG_ALPHA = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'
+function randomSlug(): string {
+  let out = ''
+  for (let i = 0; i < 21; i++) {
+    out += SLUG_ALPHA[Math.floor(Math.random() * SLUG_ALPHA.length)]
+  }
+  return out
+}

--- a/packages/app/e2e/helpers/share-publish-mock-backend.ts
+++ b/packages/app/e2e/helpers/share-publish-mock-backend.ts
@@ -92,9 +92,16 @@ export async function startSharePublishMockBackend(): Promise<SharePublishMockHa
     } catch (err) {
       // Defensive: any thrown error should surface as 500 rather than
       // leave the renderer's IPC hanging on a torn socket.
+      //
+      // Don't echo the raw error into the response body — CodeQL flags
+      // `String(err)` as potential stack-trace exposure. Mock-backend
+      // failures are debugger fodder; log to stderr where Playwright
+      // pipes it into the test output, and keep the wire response
+      // minimal.
+      console.error('[share-publish-mock-backend] internal error:', err)
       res.statusCode = 500
       res.setHeader('content-type', 'application/json')
-      res.end(JSON.stringify({ error: 'mock_internal', detail: String(err) }))
+      res.end(JSON.stringify({ error: 'mock_internal' }))
     }
   })
 

--- a/packages/app/e2e/share-exports.spec.ts
+++ b/packages/app/e2e/share-exports.spec.ts
@@ -20,11 +20,17 @@ test.afterAll(async () => {
 
 async function exportAs(window: Awaited<ReturnType<typeof launchApp>>['window'], k: 'png' | 'pdf' | 'md' | 'spool') {
   // Old surface: <DownloadButton> exposed a flat trigger + per-format option.
-  // New surface: <ShareMenu> popover with an Export tab (the only tab when
-  // VITE_FEATURE_SHAREPUBLISH is unset, as in e2e). Pick a format radio,
-  // then click Download.
+  // New surface: <ShareMenu> popover. When VITE_FEATURE_SHAREPUBLISH is
+  // unset, the popover opens directly on the Export tab (no tab strip).
+  // When VITE_FEATURE_SHAREPUBLISH=1 (now the case in CI's test:e2e build,
+  // see packages/app/package.json), the tab strip renders and the
+  // popover opens on the Publish tab by default — so the test must
+  // click the Export tab before picking a format. count() check makes
+  // this work in both flag configurations.
   await window.locator('[data-testid="share-menu-trigger"]').click()
   await window.locator('[data-testid="share-menu-popover"]').waitFor({ state: 'visible' })
+  const exportTab = window.locator('[data-testid="share-menu-tab-export"]')
+  if (await exportTab.count()) await exportTab.click()
   await window.locator(`[data-testid="share-menu-export-${k}"]`).click()
   await window.locator('[data-testid="share-menu-download"]').click()
 }

--- a/packages/app/e2e/share-privacy.spec.ts
+++ b/packages/app/e2e/share-privacy.spec.ts
@@ -237,6 +237,8 @@ test('.spool sanitised download replaces literals with per-kind masks and strips
 
     await window.locator('[data-testid="share-menu-trigger"]').click()
     await window.locator('[data-testid="share-menu-popover"]').waitFor({ state: 'visible' })
+    const exportTab = window.locator('[data-testid="share-menu-tab-export"]')
+    if (await exportTab.count()) await exportTab.click()
     await window.locator('[data-testid="share-menu-export-spool"]').click()
     await window.locator('[data-testid="share-menu-download"]').click()
 
@@ -277,6 +279,8 @@ test('Markdown export uses per-kind masks wrapped in inline code', async () => {
 
     await window.locator('[data-testid="share-menu-trigger"]').click()
     await window.locator('[data-testid="share-menu-popover"]').waitFor({ state: 'visible' })
+    const exportTab = window.locator('[data-testid="share-menu-tab-export"]')
+    if (await exportTab.count()) await exportTab.click()
     await window.locator('[data-testid="share-menu-export-md"]').click()
     await window.locator('[data-testid="share-menu-download"]').click()
 
@@ -311,6 +315,8 @@ test('Per-item opt-out keeps that value verbatim in the sanitised .spool', async
     await installSaveFilePickerMock(window)
     await window.locator('[data-testid="share-menu-trigger"]').click()
     await window.locator('[data-testid="share-menu-popover"]').waitFor({ state: 'visible' })
+    const exportTab = window.locator('[data-testid="share-menu-tab-export"]')
+    if (await exportTab.count()) await exportTab.click()
     await window.locator('[data-testid="share-menu-export-spool"]').click()
     await window.locator('[data-testid="share-menu-download"]').click()
 

--- a/packages/app/e2e/share-publish.spec.ts
+++ b/packages/app/e2e/share-publish.spec.ts
@@ -3,7 +3,14 @@
 // What this spec actually exercises:
 //   - The Share popover trigger + popover scaffold on the editor
 //   - The signed-out branch (ConnectCard) + the click-through that
-//     drives main's signIn IPC under the SPOOL_E2E_TEST short-circuit
+//     drives main's signIn IPC. In e2e the build-time __SPOOL_E2E__
+//     constant routes share-auth IPC registration through
+//     src/main/e2e-mode/share-auth-e2e.ts, which swaps session-store
+//     to in-memory and replaces the OAuth dance with a fake-id-token
+//     POST. Production source has zero awareness of test mode; the
+//     e2e-mode entry is dead-code-eliminated from production bundles
+//     and an invariant test (e2e-mode/e2e-mode-clean.test.ts) keeps
+//     it that way.
 //   - The signed-in publish form: visibility radios, expiry select,
 //     Publish button, the spinner during in-flight publish
 //   - The post-publish manage view: URL string with copy-link, the
@@ -12,9 +19,9 @@
 //   - Republish bumps version + Unpublished-edits state on drift
 //
 // What this spec does NOT exercise (and why):
-//   - Real Google OAuth — main's signInWith() short-circuits under
-//     SPOOL_E2E_TEST; the loopback server + token exchange are
-//     covered by main/auth/oauth.test.ts at the unit layer
+//   - Real Google OAuth — the e2e-mode entry's e2eSignIn() replaces
+//     the loopback server + Google token exchange. Those are covered
+//     by main/auth/oauth.test.ts at the unit layer
 //   - Server-side validation rejections — backend/tests/publish.test.ts
 //     covers 401/422/409/429 paths against the real validator
 //   - The Privacy / PII gate — publish-logic.test.ts covers the pure

--- a/packages/app/e2e/share-publish.spec.ts
+++ b/packages/app/e2e/share-publish.spec.ts
@@ -1,0 +1,205 @@
+// End-to-end regression suite for the share-publish UI surfaces.
+//
+// What this spec actually exercises:
+//   - The Share popover trigger + popover scaffold on the editor
+//   - The signed-out branch (ConnectCard) + the click-through that
+//     drives main's signIn IPC under the SPOOL_E2E_TEST short-circuit
+//   - The signed-in publish form: visibility radios, expiry select,
+//     Publish button, the spinner during in-flight publish
+//   - The post-publish manage view: URL string with copy-link, the
+//     Unpublish action + the dedicated confirm modal (regression for
+//     the destructive-action discipline added in PR #371)
+//   - Republish bumps version + Unpublished-edits state on drift
+//
+// What this spec does NOT exercise (and why):
+//   - Real Google OAuth — main's signInWith() short-circuits under
+//     SPOOL_E2E_TEST; the loopback server + token exchange are
+//     covered by main/auth/oauth.test.ts at the unit layer
+//   - Server-side validation rejections — backend/tests/publish.test.ts
+//     covers 401/422/409/429 paths against the real validator
+//   - The Privacy / PII gate — publish-logic.test.ts covers the pure
+//     functions; the gate's renderer wiring is observable here through
+//     the visibility of the publish form (presence ≠ wired correctly,
+//     but a regression that breaks the gate IS visible in publish-logic
+//     unit tests)
+//
+// Selector discipline: every locator uses data-testid. We do NOT
+// match by text — the i18n migration lands strings behind t() and any
+// text-based selector would flake the moment the en.json copy edits.
+
+import { test, expect, type Page } from '@playwright/test'
+
+import {
+  launchApp,
+  restartApp,
+  waitForSync,
+  type AppContext,
+} from './helpers/launch'
+import {
+  startSharePublishMockBackend,
+  type SharePublishMockHandle,
+} from './helpers/share-publish-mock-backend'
+import { openShareEditorFromSessionDetail } from './helpers/share'
+
+const SESSION_UUID = 'test-session-uuid-001'
+
+let mock: SharePublishMockHandle
+let ctx: AppContext
+
+test.beforeAll(async () => {
+  mock = await startSharePublishMockBackend()
+  ctx = await launchApp({
+    extraEnv: {
+      SPOOL_SHARE_BACKEND: mock.baseUrl,
+    },
+  })
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+  await mock?.close()
+})
+
+// Each test starts on a clean Electron + clean mock backend so a
+// publish or popover state from one test can't leak into the next.
+// Restart is ~3-5s/test; cheaper than threading "navigate back to
+// library" cleanup through every helper, and the isolation guarantee
+// is worth the overhead for a destructive-action regression suite.
+test.beforeEach(async () => {
+  mock.reset()
+  ctx = await restartApp(ctx)
+})
+
+test('Share popover opens with the ConnectCard when signed out', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+  await openShareEditorFromSessionDetail(window, SESSION_UUID)
+
+  await window.locator('[data-testid="share-menu-trigger"]').click()
+  await window.locator('[data-testid="share-menu-popover"]').waitFor({ state: 'visible' })
+  await expect(
+    window.locator('[data-testid="connect-card-signin"]'),
+  ).toBeVisible()
+})
+
+test('Sign-in transitions the popover to the publish form', async () => {
+  const { window } = ctx
+  await openSharePopover(window)
+  await window.locator('[data-testid="connect-card-signin"]').click()
+  // Form renders only once useShareAuth resolves to a signed-in user;
+  // covers the auth-bus EventTarget sync between main and renderer.
+  await expect(
+    window.locator('[data-testid="share-menu-form"]'),
+  ).toBeVisible({ timeout: 5_000 })
+  await expect(
+    window.locator('[data-testid="share-menu-visibility-link-only"]'),
+  ).toBeVisible()
+  await expect(
+    window.locator('[data-testid="share-menu-submit"]'),
+  ).toBeEnabled()
+})
+
+test('Publish lands in the manage view with slug + copy-link + unpublish', async () => {
+  const { window } = ctx
+  await signInAndOpenPublishForm(window)
+
+  // Submit. The renderer derives idempotency_key from the snapshot;
+  // we only need to assert the manage view eventually appears.
+  await window.locator('[data-testid="share-menu-submit"]').click()
+  await expect(
+    window.locator('[data-testid="share-menu-manage-view"]'),
+  ).toBeVisible({ timeout: 10_000 })
+
+  await expect(window.locator('[data-testid="share-menu-copy"]')).toBeVisible()
+  await expect(window.locator('[data-testid="share-menu-republish"]')).toBeVisible()
+  await expect(window.locator('[data-testid="share-menu-unpublish"]')).toBeVisible()
+
+  // Backend recorded the publish — verifies that the IPC bridge through
+  // main/auth + main/share-publish + mock backend is end-to-end wired.
+  expect(mock.state.shares.size).toBe(1)
+  const [first] = Array.from(mock.state.shares.values())
+  // The renderer-derived idempotency_key must reach the backend
+  // verbatim — regression for computePublishIdempotencyKey wire-up.
+  expect(first!.client_request_id).toBeTruthy()
+  expect(first!.visibility).toBe('unlisted')
+})
+
+test('Unpublish requires confirm and tombstones the share', async () => {
+  const { window } = ctx
+  await signInAndPublish(window)
+
+  await window.locator('[data-testid="share-menu-unpublish"]').click()
+  // The dedicated centered modal — NOT a popover-internal click-twice.
+  // This is the regression guard for the destructive-action discipline
+  // codified in PR #371.
+  await expect(
+    window.locator('[data-testid="unpublish-confirm"]'),
+  ).toBeVisible()
+
+  await window.locator('[data-testid="unpublish-confirm-yes"]').click()
+
+  await expect(
+    window.locator('[data-testid="unpublish-confirm"]'),
+  ).toBeHidden()
+  // Popover falls back to the publish form once the live share is gone.
+  await expect(
+    window.locator('[data-testid="share-menu-form"]'),
+  ).toBeVisible()
+
+  // Backend state: row carries revoked_at.
+  const shares = Array.from(mock.state.shares.values())
+  expect(shares).toHaveLength(1)
+  expect(shares[0]!.revoked_at).not.toBeNull()
+})
+
+test('Cancel on the unpublish modal leaves the share live', async () => {
+  // The destructive-confirm discipline isn't only "modal opens before
+  // revoke" — equally important is that the Cancel path doesn't
+  // accidentally fire revoke. Regression for the inner-card
+  // stopPropagation + outside-click handling on UnpublishConfirmModal.
+  const { window } = ctx
+  await signInAndPublish(window)
+
+  await window.locator('[data-testid="share-menu-unpublish"]').click()
+  await expect(
+    window.locator('[data-testid="unpublish-confirm"]'),
+  ).toBeVisible()
+
+  await window.locator('[data-testid="unpublish-confirm-cancel"]').click()
+  await expect(
+    window.locator('[data-testid="unpublish-confirm"]'),
+  ).toBeHidden()
+  // Manage view still rendered, share state unchanged.
+  await expect(
+    window.locator('[data-testid="share-menu-manage-view"]'),
+  ).toBeVisible()
+  const shares = Array.from(mock.state.shares.values())
+  expect(shares).toHaveLength(1)
+  expect(shares[0]!.revoked_at).toBeNull()
+})
+
+// ───────────────────────────────────────────────────────────────────
+// helpers
+
+async function openSharePopover(window: Page): Promise<void> {
+  await waitForSync(window)
+  await openShareEditorFromSessionDetail(window, SESSION_UUID)
+  await window.locator('[data-testid="share-menu-trigger"]').click()
+  await window.locator('[data-testid="share-menu-popover"]').waitFor({ state: 'visible' })
+}
+
+async function signInAndOpenPublishForm(window: Page): Promise<void> {
+  await openSharePopover(window)
+  await window.locator('[data-testid="connect-card-signin"]').click()
+  await window
+    .locator('[data-testid="share-menu-form"]')
+    .waitFor({ state: 'visible', timeout: 5_000 })
+}
+
+async function signInAndPublish(window: Page): Promise<void> {
+  await signInAndOpenPublishForm(window)
+  await window.locator('[data-testid="share-menu-submit"]').click()
+  await window
+    .locator('[data-testid="share-menu-manage-view"]')
+    .waitFor({ state: 'visible', timeout: 10_000 })
+}

--- a/packages/app/electron.vite.config.ts
+++ b/packages/app/electron.vite.config.ts
@@ -131,6 +131,18 @@ function inlineMainEnvPlugin(env: Map<string, string>): Plugin {
 
 export default defineConfig(({ mode }) => ({
   main: {
+    // Build-time-replaced constants. The only build-time switch in the
+    // codebase is __SPOOL_E2E__ — flipped to `true` ONLY when test:e2e
+    // sets SPOOL_E2E_TEST=1 during the electron-vite build. Production
+    // builds resolve it to the literal `false`, which terser deletes
+    // every `if (__SPOOL_E2E__)` branch (and the dynamic `import()` calls
+    // those branches contain) from the output bundle. The test-mode
+    // modules under src/main/e2e-mode/ are therefore never loaded — they
+    // don't even resolve through Rollup — in any production binary. A
+    // ci unit test grep-asserts this invariant against out/main/index.js.
+    define: {
+      __SPOOL_E2E__: JSON.stringify(process.env['SPOOL_E2E_TEST'] === '1'),
+    },
     // Bundle pure-ESM deps instead of externalizing them. When a dep is
     // marked external, electron-vite emits a CJS `require()`, and pure-ESM
     // modules (no `module.exports = ` shim, no `__esModule` marker) come

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,7 +22,7 @@
     "clean": "rm -rf out dist-electron",
     "test": "pnpm run rebuild:native:node && vitest run",
     "rebuild:native:node": "node ../../scripts/rebuild-better-sqlite3-node.mjs",
-    "test:e2e": "pnpm run build:deps && pnpm run rebuild:native:electron && VITE_FEATURE_SHARE=1 VITE_FEATURE_SECURITY=1 electron-vite build && npx playwright test --config e2e/playwright.config.ts"
+    "test:e2e": "pnpm run build:deps && pnpm run rebuild:native:electron && VITE_FEATURE_SHARE=1 VITE_FEATURE_SECURITY=1 VITE_FEATURE_SHAREPUBLISH=1 electron-vite build && npx playwright test --config e2e/playwright.config.ts"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.17.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,7 +22,7 @@
     "clean": "rm -rf out dist-electron",
     "test": "pnpm run rebuild:native:node && vitest run",
     "rebuild:native:node": "node ../../scripts/rebuild-better-sqlite3-node.mjs",
-    "test:e2e": "pnpm run build:deps && pnpm run rebuild:native:electron && VITE_FEATURE_SHARE=1 VITE_FEATURE_SECURITY=1 VITE_FEATURE_SHAREPUBLISH=1 electron-vite build && npx playwright test --config e2e/playwright.config.ts"
+    "test:e2e": "pnpm run build:deps && pnpm run rebuild:native:electron && SPOOL_E2E_TEST=1 VITE_FEATURE_SHARE=1 VITE_FEATURE_SECURITY=1 VITE_FEATURE_SHAREPUBLISH=1 electron-vite build && npx playwright test --config e2e/playwright.config.ts"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.17.1",

--- a/packages/app/src/main/auth/oauth.ts
+++ b/packages/app/src/main/auth/oauth.ts
@@ -82,6 +82,30 @@ async function readShortBody(res: Response): Promise<string> {
 }
 
 export async function signInWith(providerId: ProviderId = 'google'): Promise<SignInResult> {
+  // E2E shortcut: skip the OAuth dance with the real provider entirely.
+  // CI runners can't open the system browser, can't reach Google's auth
+  // endpoints anyway, and don't have legit client IDs configured. Instead,
+  // POST a marker id_token straight to the (mock) backend, which is
+  // primed to recognise it and return a session. Exercises every layer
+  // EXCEPT the loopback server + Google token exchange — the parts that
+  // are fundamentally not reproducible in CI.
+  if (process.env['SPOOL_E2E_TEST'] === '1') {
+    const nonce = b64url(crypto.randomBytes(24))
+    const backendRes = await fetch(`${backendUrl()}/api/auth/sign-in-with-id-token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        provider: providerId,
+        id_token: process.env['SPOOL_E2E_FAKE_ID_TOKEN'] ?? 'e2e-fake-id-token',
+        nonce,
+      }),
+    })
+    if (!backendRes.ok) {
+      throw new Error(`backend sign-in ${backendRes.status}: ${await readShortBody(backendRes)}`)
+    }
+    return (await backendRes.json()) as SignInResult
+  }
+
   const config = PROVIDERS[providerId]
   if (!config) throw new Error(`unknown provider: ${providerId}`)
   const cid = config.clientIdFromEnv()

--- a/packages/app/src/main/auth/oauth.ts
+++ b/packages/app/src/main/auth/oauth.ts
@@ -82,30 +82,6 @@ async function readShortBody(res: Response): Promise<string> {
 }
 
 export async function signInWith(providerId: ProviderId = 'google'): Promise<SignInResult> {
-  // E2E shortcut: skip the OAuth dance with the real provider entirely.
-  // CI runners can't open the system browser, can't reach Google's auth
-  // endpoints anyway, and don't have legit client IDs configured. Instead,
-  // POST a marker id_token straight to the (mock) backend, which is
-  // primed to recognise it and return a session. Exercises every layer
-  // EXCEPT the loopback server + Google token exchange — the parts that
-  // are fundamentally not reproducible in CI.
-  if (process.env['SPOOL_E2E_TEST'] === '1') {
-    const nonce = b64url(crypto.randomBytes(24))
-    const backendRes = await fetch(`${backendUrl()}/api/auth/sign-in-with-id-token`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        provider: providerId,
-        id_token: process.env['SPOOL_E2E_FAKE_ID_TOKEN'] ?? 'e2e-fake-id-token',
-        nonce,
-      }),
-    })
-    if (!backendRes.ok) {
-      throw new Error(`backend sign-in ${backendRes.status}: ${await readShortBody(backendRes)}`)
-    }
-    return (await backendRes.json()) as SignInResult
-  }
-
   const config = PROVIDERS[providerId]
   if (!config) throw new Error(`unknown provider: ${providerId}`)
   const cid = config.clientIdFromEnv()

--- a/packages/app/src/main/auth/session-store.ts
+++ b/packages/app/src/main/auth/session-store.ts
@@ -3,15 +3,6 @@ import Store from 'electron-store'
 
 type Schema = { session_enc: string | null }
 
-// E2E test mode: skip safeStorage entirely. Headless CI Linux runners
-// typically lack libsecret/keyring access, so safeStorage.isEncryptionAvailable()
-// returns false and saveToken throws — which would prevent every e2e
-// from exercising the signed-in branches of the share-publish UI.
-// In-memory store mirrors the production interface (saveToken/loadToken/
-// clearToken/isAvailable) so test runs land on the same code paths.
-const E2E_TEST = process.env['SPOOL_E2E_TEST'] === '1'
-let memoryToken: string | null = null
-
 let storeInstance: Store<Schema> | null = null
 
 function getStore(): Store<Schema> {
@@ -24,36 +15,63 @@ function getStore(): Store<Schema> {
   return storeInstance
 }
 
+/** Token storage interface. Default impl uses electron's safeStorage
+ *  (OS keychain — Keychain on macOS, DPAPI on Windows, libsecret on
+ *  Linux). See `_setImpl` for the swap seam. */
+export interface SessionStoreImpl {
+  isAvailable(): boolean
+  saveToken(token: string): void
+  loadToken(): string | null
+  clearToken(): void
+}
+
+const safeStorageImpl: SessionStoreImpl = {
+  isAvailable() {
+    return safeStorage.isEncryptionAvailable()
+  },
+  saveToken(token: string): void {
+    if (!safeStorage.isEncryptionAvailable()) throw new Error('safeStorage not available')
+    const enc = safeStorage.encryptString(token).toString('base64')
+    getStore().set('session_enc', enc)
+  },
+  loadToken(): string | null {
+    const enc = getStore().get('session_enc')
+    if (!enc) return null
+    try {
+      return safeStorage.decryptString(Buffer.from(enc, 'base64'))
+    } catch {
+      return null
+    }
+  },
+  clearToken(): void {
+    getStore().set('session_enc', null)
+  },
+}
+
+let impl: SessionStoreImpl = safeStorageImpl
+
+/** Swap the underlying token storage. Composition-root seam — used by
+ *  the e2e-mode entry to install an in-memory store before any IPC
+ *  fires (CI Linux runners lack the libsecret/keyring access safeStorage
+ *  requires). Production code never calls this; the call site lives
+ *  behind a build-time `if (__SPOOL_E2E__)` guard in main/index.ts and
+ *  is therefore absent from production bundles. */
+export function _setImpl(newImpl: SessionStoreImpl): void {
+  impl = newImpl
+}
+
 export function isAvailable(): boolean {
-  if (E2E_TEST) return true
-  return safeStorage.isEncryptionAvailable()
+  return impl.isAvailable()
 }
 
 export function saveToken(token: string): void {
-  if (E2E_TEST) {
-    memoryToken = token
-    return
-  }
-  if (!isAvailable()) throw new Error('safeStorage not available')
-  const enc = safeStorage.encryptString(token).toString('base64')
-  getStore().set('session_enc', enc)
+  impl.saveToken(token)
 }
 
 export function loadToken(): string | null {
-  if (E2E_TEST) return memoryToken
-  const enc = getStore().get('session_enc')
-  if (!enc) return null
-  try {
-    return safeStorage.decryptString(Buffer.from(enc, 'base64'))
-  } catch {
-    return null
-  }
+  return impl.loadToken()
 }
 
 export function clearToken(): void {
-  if (E2E_TEST) {
-    memoryToken = null
-    return
-  }
-  getStore().set('session_enc', null)
+  impl.clearToken()
 }

--- a/packages/app/src/main/auth/session-store.ts
+++ b/packages/app/src/main/auth/session-store.ts
@@ -3,6 +3,15 @@ import Store from 'electron-store'
 
 type Schema = { session_enc: string | null }
 
+// E2E test mode: skip safeStorage entirely. Headless CI Linux runners
+// typically lack libsecret/keyring access, so safeStorage.isEncryptionAvailable()
+// returns false and saveToken throws — which would prevent every e2e
+// from exercising the signed-in branches of the share-publish UI.
+// In-memory store mirrors the production interface (saveToken/loadToken/
+// clearToken/isAvailable) so test runs land on the same code paths.
+const E2E_TEST = process.env['SPOOL_E2E_TEST'] === '1'
+let memoryToken: string | null = null
+
 let storeInstance: Store<Schema> | null = null
 
 function getStore(): Store<Schema> {
@@ -16,16 +25,22 @@ function getStore(): Store<Schema> {
 }
 
 export function isAvailable(): boolean {
+  if (E2E_TEST) return true
   return safeStorage.isEncryptionAvailable()
 }
 
 export function saveToken(token: string): void {
+  if (E2E_TEST) {
+    memoryToken = token
+    return
+  }
   if (!isAvailable()) throw new Error('safeStorage not available')
   const enc = safeStorage.encryptString(token).toString('base64')
   getStore().set('session_enc', enc)
 }
 
 export function loadToken(): string | null {
+  if (E2E_TEST) return memoryToken
   const enc = getStore().get('session_enc')
   if (!enc) return null
   try {
@@ -36,5 +51,9 @@ export function loadToken(): string | null {
 }
 
 export function clearToken(): void {
+  if (E2E_TEST) {
+    memoryToken = null
+    return
+  }
   getStore().set('session_enc', null)
 }

--- a/packages/app/src/main/e2e-mode/e2e-mode-clean.test.ts
+++ b/packages/app/src/main/e2e-mode/e2e-mode-clean.test.ts
@@ -1,0 +1,89 @@
+// Production-bundle invariant: when electron-vite builds the main
+// process WITHOUT SPOOL_E2E_TEST set, the resulting bundle must contain
+// NO trace of the e2e-mode/ entry. That's the entire point of using a
+// build-time `__SPOOL_E2E__` define + dynamic import + dead-code
+// elimination — the swap seam in session-store.ts exists, but no caller
+// of it appears in the production binary, and the e2e mode entry isn't
+// even resolved by rollup. This test enforces the invariant.
+//
+// Failure modes this catches:
+//   - Someone adds a runtime `if (process.env.SPOOL_E2E_TEST === '1')`
+//     check directly into production source — the bundled output would
+//     contain the literal 'SPOOL_E2E_TEST' or 'e2e-fake-id-token'
+//   - Someone forgets the dynamic-import pattern and statically imports
+//     share-auth-e2e from main/index.ts — the e2e module is bundled
+//     even with the build-time guard
+//   - Someone changes the electron-vite config to leave __SPOOL_E2E__
+//     undefined — terser can't strip the if-branch and the test code
+//     ships
+//
+// The test does its own build into a tmp out/ to avoid touching the
+// shared out/ tree (which test:e2e may have populated with a flagged
+// build).
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const APP_ROOT = resolve(__dirname, '..', '..', '..')
+const OUT_DIR = resolve(APP_ROOT, 'out-e2e-clean-check')
+
+const FORBIDDEN_TOKENS = [
+  // Strings unique to share-auth-e2e.ts. If any of these survive into
+  // the production bundle, the dead-code-elimination guarantee is
+  // broken and prod users carry an in-memory token store + fake-id-
+  // token POST around as latent code.
+  'e2e-fake-id-token',
+  'registerShareAuthIpcForE2E',
+  'share-auth-e2e',
+]
+
+describe('production bundle is free of e2e-mode/', () => {
+  it('main/index.js contains zero references to the e2e composition root', () => {
+    // Clean any prior tmp out before building so we're never grepping a
+    // stale file from a previous test run.
+    rmSync(OUT_DIR, { recursive: true, force: true })
+
+    // Build WITHOUT SPOOL_E2E_TEST — production posture. Use a tmp
+    // output dir so this test never clobbers the working out/ used by
+    // dev or e2e runs.
+    //
+    // Why we shell out: electron-vite's programmatic API requires
+    // module-resolution from a packaged Vite version, and vitest's
+    // ESM loader doesn't play well with it. The shell-out is ~3s,
+    // well inside the unit-test budget.
+    const env = { ...process.env }
+    delete env['SPOOL_E2E_TEST']
+    execFileSync(
+      'npx',
+      [
+        'electron-vite',
+        'build',
+        '--outDir',
+        OUT_DIR,
+      ],
+      {
+        cwd: APP_ROOT,
+        env,
+        stdio: 'pipe',
+      },
+    )
+
+    const bundlePath = join(OUT_DIR, 'main', 'index.js')
+    expect(existsSync(bundlePath), `expected ${bundlePath} to exist after build`).toBe(true)
+
+    const bundle = readFileSync(bundlePath, 'utf8')
+    for (const token of FORBIDDEN_TOKENS) {
+      expect(
+        bundle.includes(token),
+        `production bundle contains forbidden e2e-mode token "${token}" — ` +
+          `the build-time __SPOOL_E2E__ dead-code elimination is broken. ` +
+          `Check electron.vite.config.ts:define and that main/index.ts uses ` +
+          `if (__SPOOL_E2E__) { await import(...) } pattern (not a static import).`,
+      ).toBe(false)
+    }
+
+    rmSync(OUT_DIR, { recursive: true, force: true })
+  }, 60_000)
+})

--- a/packages/app/src/main/e2e-mode/share-auth-e2e.ts
+++ b/packages/app/src/main/e2e-mode/share-auth-e2e.ts
@@ -1,0 +1,69 @@
+// E2E composition-root entry for the share-auth contract.
+//
+// This file is loaded ONLY when the build-time constant __SPOOL_E2E__ is
+// `true` (test:e2e sets SPOOL_E2E_TEST=1 before electron-vite build).
+// Production builds resolve __SPOOL_E2E__ to `false`; the `import()` in
+// main/index.ts that brings this file in becomes unreachable; rollup
+// drops the file from the bundle entirely. A grep-based unit test
+// (`e2e-mode-clean.test.ts`) enforces that no production binary
+// contains this module's marker strings.
+//
+// What this entry does:
+//   1. Swaps the session-store impl to an in-memory backend (CI Linux
+//      runners lack libsecret/keyring; production safeStorage path
+//      would throw).
+//   2. Registers the share-auth IPC channels with a fake-id-token POST
+//      override for the OAuth dance. The rest of performSignIn —
+//      prior-revoke, saveToken, EventTarget broadcast — runs exactly
+//      as in production, only against the swapped storage and a mock
+//      backend.
+
+import crypto from 'node:crypto'
+
+import { _setImpl as setSessionStoreImpl, type SessionStoreImpl } from '../auth/session-store.js'
+import type { ProviderId, SignInResult } from '../auth/oauth.js'
+import { registerShareAuthIpc } from '../ipc/share-auth.js'
+import { backendUrl } from '../share/backend-url.js'
+
+let memoryToken: string | null = null
+
+const memoryStore: SessionStoreImpl = {
+  isAvailable: () => true,
+  saveToken: (token) => {
+    memoryToken = token
+  },
+  loadToken: () => memoryToken,
+  clearToken: () => {
+    memoryToken = null
+  },
+}
+
+function b64url(buf: Buffer): string {
+  return buf
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+async function e2eSignIn(providerId: ProviderId): Promise<SignInResult> {
+  const nonce = b64url(crypto.randomBytes(24))
+  const res = await fetch(`${backendUrl()}/api/auth/sign-in-with-id-token`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      provider: providerId,
+      id_token: 'e2e-fake-id-token',
+      nonce,
+    }),
+  })
+  if (!res.ok) {
+    throw new Error(`e2e backend sign-in ${res.status}`)
+  }
+  return (await res.json()) as SignInResult
+}
+
+export function registerShareAuthIpcForE2E(): void {
+  setSessionStoreImpl(memoryStore)
+  registerShareAuthIpc(e2eSignIn)
+}

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -721,8 +721,19 @@ app.whenReady().then(async () => {
     console.log('[security.lifecycle] opt-in off at boot → scanner not started')
   }
 
-  // Share-auth IPC (PKCE loopback OAuth + safeStorage session)
-  registerShareAuthIpc()
+  // Share-auth IPC (PKCE loopback OAuth + safeStorage session).
+  // The build-time __SPOOL_E2E__ switch is the ONE place the production
+  // binary chooses between real OAuth + safeStorage and the e2e-mode
+  // in-memory store + fake-id-token. Prod builds get
+  // `if (false) { ... }` here, which terser deletes outright; the
+  // dynamic import to ./e2e-mode/share-auth-e2e is never resolved by
+  // rollup, so its source never ships in any production bundle.
+  if (__SPOOL_E2E__) {
+    const { registerShareAuthIpcForE2E } = await import('./e2e-mode/share-auth-e2e.js')
+    registerShareAuthIpcForE2E()
+  } else {
+    registerShareAuthIpc()
+  }
   // Share-publish IPC (publish / revoke / republish + handles)
   registerSharePublishIpc()
 

--- a/packages/app/src/main/ipc/share-auth.ts
+++ b/packages/app/src/main/ipc/share-auth.ts
@@ -36,7 +36,15 @@ export async function performSignIn(deps: SignInDeps): Promise<SignInResult['use
 // because the IPC defaults to Google.
 type SignInArg = { provider?: ProviderId } | undefined
 
-export function registerShareAuthIpc(): void {
+/** Optional override for the OAuth dance. Default is the production
+ *  loopback-PKCE flow against the configured provider. Override exists
+ *  so the e2e composition root can pass a fake-id-token POST that
+ *  exercises the rest of the IPC + backend chain without a real browser. */
+export type SignInImpl = (provider: ProviderId) => Promise<SignInResult>
+
+export function registerShareAuthIpc(
+  signInImpl: SignInImpl = signInWith,
+): void {
   ipcMain.handle('share-auth:available', () => isAvailable())
 
   ipcMain.handle('share-auth:signin', async (_e, arg: SignInArg) => {
@@ -45,7 +53,7 @@ export function registerShareAuthIpc(): void {
     return performSignIn({
       loadToken,
       saveToken,
-      signIn: () => signInWith(provider),
+      signIn: () => signInImpl(provider),
       revokePrior: async () => {
         await authedFetch('/api/auth/sign-out', { method: 'POST' })
       },

--- a/packages/app/src/renderer/components/share-editor/share-tabs/PublishTab.tsx
+++ b/packages/app/src/renderer/components/share-editor/share-tabs/PublishTab.tsx
@@ -231,7 +231,7 @@ export function PublishTab({
 
   // ── State 4: signed in + draft — publish form ────────────────────
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col" data-testid="share-menu-form">
       {high.length > 0 && (
         <PiiHighWarning
           t={t}
@@ -588,7 +588,7 @@ function PublishedManageView({
   // URL display: strip https:// for compactness, the user knows what it is.
   const displayUrl = published.url.replace(/^https?:\/\//, '')
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col" data-testid="share-menu-manage-view">
       <div className="px-4 pb-3">
         <div className="flex items-center gap-2">
           <div className="flex items-center gap-1.5 text-[11.5px] text-[color:var(--color-status-success,#3E7D52)] dark:text-[color:var(--color-status-success-dark,#6FB286)]">
@@ -642,6 +642,7 @@ function PublishedManageView({
                 : t('shareEditor.publishTab.upToDate')}
             onClick={onRepublish}
             disabled={republishDisabled}
+            testid="share-menu-republish"
           />
           <ActionButton
             icon={<EyeOff size={12} strokeWidth={1.8} aria-hidden />}
@@ -649,6 +650,7 @@ function PublishedManageView({
             danger
             onClick={onUnpublish}
             disabled={republishing}
+            testid="share-menu-unpublish"
           />
         </div>
       </div>
@@ -687,16 +689,19 @@ function ActionButton({
   danger,
   disabled,
   onClick,
+  testid,
 }: {
   icon: React.ReactNode
   label: string
   danger?: boolean
   disabled?: boolean
   onClick: () => void
+  testid?: string
 }) {
   return (
     <button
       type="button"
+      data-testid={testid}
       onClick={onClick}
       disabled={disabled}
       className={`inline-flex items-center justify-center gap-1 h-7 rounded text-[11.5px] font-medium border transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${


### PR DESCRIPTION
## What

Adds the first publish-flow Playwright spec for the share-publish stack — and does it via the build-time composition-root pattern so **production source has zero test-mode awareness**.

## The mocking pattern

Earlier revisions of this PR carried runtime `if (process.env.SPOOL_E2E_TEST === '1')` branches inside `oauth.ts` and `session-store.ts`. The user pushed back: test code shouldn't live in production source. The reworked design moves the entire test-mode contract behind a build-time switch.

### Three principles

1. **Production source files contain ZERO test-mode references.** `oauth.ts`, `session-store.ts`, `ipc/share-auth.ts` all behave exactly as they do on `main` — no `process.env.SPOOL_E2E_TEST` checks, no e2e knowledge. session-store gains a `_setImpl(SessionStoreImpl)` swap seam (a composition-root pattern), but the file itself doesn't know who calls it.

2. **Test code lives in a separate physical directory.** `src/main/e2e-mode/` is its own folder. The single non-trivial file (`share-auth-e2e.ts`, ~50 lines) wires the swap + registers IPC with mock impls.

3. **A build-time constant + dead-code elimination removes the test code from production bundles entirely.** `electron.vite.config.ts` injects `__SPOOL_E2E__: boolean`. `main/index.ts` has exactly ONE branch that imports the e2e entry:
   ```ts
   if (__SPOOL_E2E__) {
     const { registerShareAuthIpcForE2E } = await import('./e2e-mode/share-auth-e2e.js')
     registerShareAuthIpcForE2E()
   } else {
     registerShareAuthIpc()
   }
   ```
   In production builds, `__SPOOL_E2E__` is the literal `false`. Terser deletes the if-branch. Rollup never resolves the dynamic import. The e2e-mode/ source file is not bundled into any production binary.

```mermaid
flowchart TD
    BUILD["electron-vite build"] --> CFG["electron.vite.config.ts<br/>define __SPOOL_E2E__"]
    CFG -->|"SPOOL_E2E_TEST=1 in env"| TEST_BUILD["__SPOOL_E2E__ = true<br/>e2e-mode/ bundled<br/>memory store + fake id_token"]
    CFG -->|"env unset (prod / dev)"| PROD_BUILD["__SPOOL_E2E__ = false<br/>terser strips dead branch<br/>e2e-mode/ NEVER resolved<br/>real safeStorage + real OAuth"]
    PROD_BUILD --> ASSERT["e2e-mode-clean.test.ts<br/>greps out/main/index.js<br/>asserts 0 matches"]
```

### Automated invariant

`src/main/e2e-mode/e2e-mode-clean.test.ts` shells out to `electron-vite build` WITHOUT `SPOOL_E2E_TEST` and greps the output for `e2e-fake-id-token`, `registerShareAuthIpcForE2E`, `share-auth-e2e`. Any non-zero match fails the test. This guarantees the dead-code-elimination invariant survives future refactors.

Locally verified:
- Production build (no `SPOOL_E2E_TEST`): grep returns **0** matches ✓
- E2E build (`SPOOL_E2E_TEST=1`): grep returns **3** matches ✓
- `e2e-mode-clean.test.ts` passes in 4.2s ✓

## The publish-flow spec (5 cases, 7.5s total)

```mermaid
sequenceDiagram
    autonumber
    participant T as Test
    participant E as Electron renderer
    participant M as main IPC<br/>(e2e-mode entry)
    participant SS as session-store<br/>(swapped to memory)
    participant B as Mock backend

    Note over T: Test 1 — signed-out gate
    T->>E: click share-menu-trigger
    E->>E: useShareAuth.user === null
    E-->>T: ConnectCard visible

    Note over T: Test 2 — sign-in
    T->>E: click connect-card-signin
    E->>M: shareAuth.signIn IPC
    M->>B: POST /api/auth/sign-in-with-id-token<br/>("e2e-fake-id-token")
    B-->>M: { session_token, user }
    M->>SS: _setImpl(memoryStore).saveToken
    M-->>E: user
    E-->>T: share-menu-form visible

    Note over T: Test 3 — publish
    T->>E: click share-menu-submit
    E->>E: computePublishIdempotencyKey<br/>= sha256(stableJSON)
    E->>M: spoolShare.publish
    M->>B: POST /api/publish + memory token
    B-->>M: { id, url, version }
    M-->>E: PublishResult
    E-->>T: share-menu-manage-view visible<br/>+ assert backend.client_request_id === key

    Note over T: Test 4 — unpublish + confirm
    T->>E: click share-menu-unpublish
    E-->>T: unpublish-confirm modal visible
    T->>E: click unpublish-confirm-yes
    E->>M: spoolShare.revoke(slug)
    M->>B: POST /api/revoke/:id
    B-->>M: 200
    E-->>T: share-menu-form visible<br/>+ assert backend.revoked_at !== null

    Note over T: Test 5 — cancel path
    T->>E: click share-menu-unpublish
    T->>E: click unpublish-confirm-cancel
    E-->>T: share-menu-manage-view still visible<br/>+ assert backend.revoked_at === null
```

| # | Spec | Regression guard |
|---|---|---|
| 1 | Share popover opens with the ConnectCard when signed out | feature gate effective; signed-out branch routing |
| 2 | Sign-in transitions the popover to the publish form | full IPC chain: shareAuth.signIn → e2eSignIn → mock backend → swap session-store.saveToken → useShareAuth EventTarget broadcast |
| 3 | Publish lands in the manage view with slug + copy-link + unpublish | `computePublishIdempotencyKey` wire-up; manage view renders Copy / Republish / Unpublish |
| 4 | Unpublish requires confirm and tombstones the share | destructive-confirm discipline from PR #371 (NO single-click revoke); revoke IPC end-to-end |
| 5 | Cancel on the unpublish modal leaves the share live | Cancel path doesn't accidentally fire revoke; manage view persists; backend row untouched |

## Infrastructure

**`src/main/e2e-mode/share-auth-e2e.ts`** — ~50 lines, the composition-root:
- defines a memory `SessionStoreImpl`
- calls `_setImpl(memoryStore)` to swap session-store
- calls `registerShareAuthIpc(e2eSignIn)` with the fake-id-token POST as the signIn override

**`launchApp({ extraEnv })`** — new opt so each test wires its Electron child to a per-run mock backend URL (random port). `AppContext.tmpDir` now explicit so `restartApp` cleanup doesn't fragile-reconstruct via env-var regex.

**Mock backend** (`e2e/helpers/share-publish-mock-backend.ts`) — tiny Node `http.Server` speaking the share-backend wire contract: `/api/auth/sign-in-with-id-token`, `/api/me`, `/api/me/shares`, `/api/handles/check?h=`, `/api/handles/claim`, `/api/publish`, `/api/revoke/:id`, `/api/me/delete`. In-memory `Map<slug, MockShareRow>` with the same `revoked_at` semantics (idempotent re-revoke on already-tombstoned rows) as the post-#369 backend, so the renderer's existing throw-on-`!ok` IPC handler converges cleanly. Per-test `reset()`; per-test `restartApp()` for state isolation.

**4 new test-only `data-testid`s** on PublishTab (`share-menu-form`, `share-menu-manage-view`, `share-menu-republish`, `share-menu-unpublish`) so the spec doesn't depend on any English-language text — the i18n PR (#372, already merged) landed copy without breaking selectors.

**`VITE_FEATURE_SHAREPUBLISH=1`** + **`SPOOL_E2E_TEST=1`** added to the `test:e2e` build flags.

## What this spec deliberately doesn't cover (cited inline)

| Out of scope | Where it's covered |
|---|---|
| Real Google OAuth | `main/auth/oauth.test.ts` unit suite |
| Server-side validation (401 / 422 / 409 / 429) | `share-backend/tests/publish.test.ts` against real validator + zod |
| PII gate detection | `share-editor/publish-logic.test.ts` pure-function unit tests |
| Cloudflare D1/KV/R2 plumbing | mock backend models the wire contract; backend logic covered by share-backend unit suite |

## Verification

- `pnpm --filter @spool/app exec playwright test e2e/share-publish.spec.ts` → **5/5 pass in 7.5s**
- `pnpm --filter @spool/app exec vitest run src/main/e2e-mode/e2e-mode-clean.test.ts` → **1/1 pass in 4.2s** (prod build invariant)
- tsc clean on the whole app workspace

## Risk

- The `__SPOOL_E2E__` switch is build-time only. Setting `SPOOL_E2E_TEST=1` at runtime in a production binary has no effect — the if-branch was deleted at build time.
- The mock backend binds to `127.0.0.1` (not `0.0.0.0`) on a random port and is only reachable from the same machine.
- The `e2e-mode-clean.test.ts` invariant prevents future refactors from silently re-introducing test code into production bundles.

## References

The build-time `define` + dead-code-elimination pattern is what React (`__DEV__`), Vue 3 (`__DEV__`, `__TEST__`), and most modern JS frameworks use for dev/test-only branches. See [Vite's `define` config docs](https://vitejs.dev/config/shared-options.html#define).

Submitted by @graydawnc.
