### PR TITLE
feat(share-web): /me + /@handle polish — modals, SWR header, row redesign

### DIFF
--- a/packages/share-web/src/components/Chrome.tsx
+++ b/packages/share-web/src/components/Chrome.tsx
@@ -10,7 +10,29 @@
 
 import { useCallback, useEffect, useState, type ReactNode } from 'react'
 
-export type AuthState = 'out' | { name: string | null; src: string | null }
+import { fetchMe } from '../lib/api'
+import {
+  type AuthIdentity,
+  getCachedAuth,
+  setCachedAuth,
+} from '../lib/auth-cache'
+import { readCachedMe } from '../lib/me-cache'
+
+export type AuthState = AuthIdentity | 'auto'
+
+async function resolveAuthState(): Promise<AuthIdentity> {
+  const existing = getCachedAuth()
+  if (existing) return existing
+  const p = (async () => {
+    const r = await fetchMe()
+    if (r.kind === 'ok') {
+      return { name: r.me.name, src: r.me.avatar_url } as AuthIdentity
+    }
+    return 'out' as AuthIdentity
+  })()
+  setCachedAuth(p)
+  return p
+}
 
 const THEME_KEY = 'spool.share-web.theme'
 
@@ -111,6 +133,7 @@ export function Avatar({
 type IconName =
   | 'external'
   | 'link'
+  | 'link-2'
   | 'check'
   | 'check-circle'
   | 'alert'
@@ -118,6 +141,7 @@ type IconName =
   | 'arrow-right'
   | 'clock'
   | 'eye-off'
+  | 'globe'
   | 'lock'
   | 'sun'
   | 'moon'
@@ -156,6 +180,26 @@ export function Icon({
         <svg {...common}>
           <path d="M6.5 9.5a2.5 2.5 0 0 0 3.6.1l2-2a2.55 2.55 0 0 0-3.6-3.6l-1.1 1.1" />
           <path d="M9.5 6.5a2.5 2.5 0 0 0-3.6-.1l-2 2a2.55 2.55 0 0 0 3.6 3.6l1.1-1.1" />
+        </svg>
+      )
+    case 'link-2':
+      // Lucide-style link-2: straight chain — distinct from the curvy
+      // `link` glyph used by the copy-link button, so a meta-line
+      // visibility marker (link-only share) doesn't read as the same
+      // affordance as the copy action sitting next to it.
+      return (
+        <svg {...common}>
+          <path d="M5 8h6" />
+          <path d="M5.5 4.5h-2A2.5 2.5 0 0 0 1 7v2a2.5 2.5 0 0 0 2.5 2.5h2" />
+          <path d="M10.5 4.5h2A2.5 2.5 0 0 1 15 7v2a2.5 2.5 0 0 1-2.5 2.5h-2" />
+        </svg>
+      )
+    case 'globe':
+      return (
+        <svg {...common}>
+          <circle cx="8" cy="8" r="6" />
+          <path d="M2 8h12" />
+          <path d="M8 2c1.7 2 2.6 4 2.6 6S9.7 14 8 14c-1.7 0-2.6-2-2.6-6S6.3 2 8 2z" />
         </svg>
       )
     case 'check':
@@ -271,21 +315,44 @@ export function ThemeToggle() {
   )
 }
 
-export function Header({ auth = 'out' as AuthState }: { auth?: AuthState }) {
+export function Header({ auth = 'auto' as AuthState }: { auth?: AuthState }) {
+  // 'auto' = SWR pattern: first frame paints from the localStorage
+  // cache, background fetchMe revalidates and rewrites. 'out' or an
+  // explicit object lets a page short-circuit (SignIn knows the user
+  // is unauthenticated by definition).
+  const [resolved, setResolved] = useState<AuthState>(() => {
+    if (auth !== 'auto') return auth
+    const cached = readCachedMe()
+    return cached
+      ? ({ name: cached.name, src: cached.avatar_url } as AuthState)
+      : 'out'
+  })
+
+  useEffect(() => {
+    if (auth !== 'auto') return
+    let alive = true
+    resolveAuthState().then((next) => {
+      if (alive) setResolved(next)
+    })
+    return () => {
+      alive = false
+    }
+  }, [auth])
+
   return (
     <header className="sw-header">
-      <a href="/" aria-label="Spool home">
+      <a href="https://spool.pro/" aria-label="Spool home">
         <Wordmark />
       </a>
       <div className="sw-header-right">
         <ThemeToggle />
-        {auth === 'out' ? (
+        {resolved === 'out' || resolved === 'auto' ? (
           <a className="sw-signin-link" href="/sign-in">
             Sign in
           </a>
         ) : (
           <a href="/me" title="Your account" style={{ display: 'inline-flex' }}>
-            <Avatar src={auth.src} name={auth.name} size={30} />
+            <Avatar src={resolved.src} name={resolved.name} size={30} />
           </a>
         )}
       </div>

--- a/packages/share-web/src/lib/api-cache.test.ts
+++ b/packages/share-web/src/lib/api-cache.test.ts
@@ -1,0 +1,117 @@
+// Asserts the cache side-effects baked into api.ts (`fetchMe` writes
+// on 200, clears on 401; `signOut` always clears) AND the auth-promise
+// memo invalidation that keeps the Header from painting a stale
+// signed-in state after sign-out.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchMe, signOut } from './api'
+import { getCachedAuth, setCachedAuth } from './auth-cache'
+import { readCachedMe, writeCachedMe } from './me-cache'
+
+function makeStorage(): Storage {
+  const data = new Map<string, string>()
+  return {
+    get length() {
+      return data.size
+    },
+    clear: () => data.clear(),
+    getItem: (k) => data.get(k) ?? null,
+    key: (i) => Array.from(data.keys())[i] ?? null,
+    removeItem: (k) => {
+      data.delete(k)
+    },
+    setItem: (k, v) => {
+      data.set(k, v)
+    },
+  }
+}
+
+function mockFetchOnce(status: number, body: unknown = {}): void {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    }),
+  )
+}
+
+describe('api.ts cache side-effects', () => {
+  let original: Storage | undefined
+  beforeEach(() => {
+    original = globalThis.localStorage
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: makeStorage(),
+      configurable: true,
+    })
+    // Reset the in-memory auth memo between tests so we observe the
+    // intended state, not a leftover from a previous it().
+    setCachedAuth(Promise.resolve('out'))
+    setCachedAuth(null as unknown as Promise<never>) // wipe via re-set
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (original) {
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: original,
+        configurable: true,
+      })
+    }
+  })
+
+  it('fetchMe 200 writes the public-identity slice into me-cache', async () => {
+    mockFetchOnce(200, {
+      id: 'u1',
+      email: 'alice@example.com',
+      name: 'Alice',
+      avatar_url: 'https://x/a.png',
+      handle: 'alice',
+      deletion_pending_until: null,
+    })
+    const r = await fetchMe()
+    expect(r.kind).toBe('ok')
+    expect(readCachedMe()).toEqual({ name: 'Alice', avatar_url: 'https://x/a.png' })
+  })
+
+  it('fetchMe 401 clears the cache + invalidates the auth memo', async () => {
+    // Seed both layers as if we were previously signed in.
+    writeCachedMe({ name: 'Alice', avatar_url: 'x.png' })
+    setCachedAuth(Promise.resolve({ name: 'Alice', src: 'x.png' }))
+
+    mockFetchOnce(401, { error: 'UNAUTHENTICATED' })
+    const r = await fetchMe()
+    expect(r.kind).toBe('unauthenticated')
+    expect(readCachedMe()).toBeNull()
+    expect(getCachedAuth()).toBeNull()
+  })
+
+  it('fetchMe 403 (deletion pending) does NOT clear — user can still see the recovery surface', async () => {
+    writeCachedMe({ name: 'Alice', avatar_url: 'x.png' })
+    mockFetchOnce(403, { error: 'FORBIDDEN' })
+    const r = await fetchMe()
+    expect(r.kind).toBe('forbidden')
+    expect(readCachedMe()).toEqual({ name: 'Alice', avatar_url: 'x.png' })
+  })
+
+  it('signOut clears me-cache + auth memo even when the network call fails', async () => {
+    writeCachedMe({ name: 'Alice', avatar_url: 'x.png' })
+    setCachedAuth(Promise.resolve({ name: 'Alice', src: 'x.png' }))
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('offline'))
+
+    const ok = await signOut()
+    expect(ok).toBe(false)
+    expect(readCachedMe()).toBeNull()
+    expect(getCachedAuth()).toBeNull()
+  })
+
+  it('signOut 200 also clears local state', async () => {
+    writeCachedMe({ name: 'Alice', avatar_url: 'x.png' })
+    setCachedAuth(Promise.resolve({ name: 'Alice', src: 'x.png' }))
+    mockFetchOnce(200, { ok: true })
+
+    const ok = await signOut()
+    expect(ok).toBe(true)
+    expect(readCachedMe()).toBeNull()
+    expect(getCachedAuth()).toBeNull()
+  })
+})

--- a/packages/share-web/src/lib/api.ts
+++ b/packages/share-web/src/lib/api.ts
@@ -4,6 +4,9 @@
 
 import type { Snapshot } from '@spool/share-kit'
 
+import { invalidateAuthCache } from './auth-cache'
+import { clearCachedMe, writeCachedMe } from './me-cache'
+
 export type SnapshotFetchResult =
   | { kind: 'ok'; snapshot: Snapshot }
   | { kind: 'gone'; reason: 'revoked' | 'expired'; at: number }
@@ -121,8 +124,23 @@ export async function fetchMe(): Promise<MeFetchResult> {
       headers: { accept: 'application/json' },
       credentials: 'same-origin',
     })
-    if (r.status === 200) return { kind: 'ok', me: (await r.json()) as MeResponse }
-    if (r.status === 401) return { kind: 'unauthenticated' }
+    if (r.status === 200) {
+      const me = (await r.json()) as MeResponse
+      // Write the public-identity slice into the SWR cache so the next
+      // page mount can paint the avatar before the round trip lands.
+      writeCachedMe({ name: me.name, avatar_url: me.avatar_url })
+      return { kind: 'ok', me }
+    }
+    if (r.status === 401) {
+      // Cookie expired / signed out from another tab — drop both the
+      // localStorage avatar cache AND the in-memory auth promise so the
+      // next Header mount doesn't paint stale identity.
+      clearCachedMe()
+      invalidateAuthCache()
+      return { kind: 'unauthenticated' }
+    }
+    // 403 = deletion-pending account; leave the cache alone, the user
+    // is still effectively signed in for the recovery surface.
     if (r.status === 403) return { kind: 'forbidden' }
     return { kind: 'error' }
   } catch {
@@ -229,6 +247,11 @@ export async function claimHandle(handle: string): Promise<
 }
 
 export async function signOut(): Promise<boolean> {
+  // Always drop the local identity cache, even if the network call
+  // fails — the user's intent is "log me out of this device" and a
+  // stale cached avatar is the wrong signal.
+  clearCachedMe()
+  invalidateAuthCache()
   try {
     const r = await fetch('/api/auth/sign-out', {
       method: 'POST',

--- a/packages/share-web/src/lib/auth-cache.ts
+++ b/packages/share-web/src/lib/auth-cache.ts
@@ -1,0 +1,26 @@
+// Primitive state holder for the cross-Header auth memo. No imports
+// from `api.ts` so `api.ts` can call `invalidateAuthCache()` on
+// sign-out / 401 without creating a circular module graph. The
+// `resolveAuthState` wrapper that actually calls `fetchMe` lives in
+// `components/Chrome.tsx`.
+
+export type AuthIdentity =
+  | 'out'
+  | { name: string | null; src: string | null }
+
+let cached: Promise<AuthIdentity> | null = null
+
+export function getCachedAuth(): Promise<AuthIdentity> | null {
+  return cached
+}
+
+export function setCachedAuth(p: Promise<AuthIdentity>): void {
+  cached = p
+}
+
+/** Drop the in-flight / resolved auth memo. Called from `api.ts`'s
+ *  `signOut` and from `fetchMe`'s 401 path so the next Header mount
+ *  refetches `/api/me` instead of resolving against the stale promise. */
+export function invalidateAuthCache(): void {
+  cached = null
+}

--- a/packages/share-web/src/lib/dates.test.ts
+++ b/packages/share-web/src/lib/dates.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import { humanDate, humanDateTime, relativeDate } from './dates'
+
+describe('humanDate', () => {
+  it('formats a valid timestamp as Mon DD, YYYY', () => {
+    // 2026-06-04 12:00 UTC — toLocaleDateString uses the host timezone,
+    // so we accept any "Jun" date in the same week to avoid TZ flake.
+    const ts = Date.UTC(2026, 5, 4, 12, 0, 0)
+    expect(humanDate(ts)).toMatch(/^Jun \d, 2026$/)
+  })
+
+  it('returns "" for NaN — guards against Invalid Date leaking to UI', () => {
+    expect(humanDate(Number.NaN)).toBe('')
+  })
+
+  it('returns "" for Infinity', () => {
+    expect(humanDate(Number.POSITIVE_INFINITY)).toBe('')
+    expect(humanDate(Number.NEGATIVE_INFINITY)).toBe('')
+  })
+})
+
+describe('humanDateTime', () => {
+  it('returns "" for NaN', () => {
+    expect(humanDateTime(Number.NaN)).toBe('')
+  })
+
+  it('emits a Jun date + time for a valid timestamp', () => {
+    const ts = Date.UTC(2026, 5, 4, 12, 0, 0)
+    // Substring-match: TZ varies, but "Jun" and "2026" must appear.
+    const out = humanDateTime(ts)
+    expect(out).toMatch(/Jun.*2026/)
+  })
+})
+
+describe('relativeDate', () => {
+  // Pin "now" so the test doesn't drift with the wall clock.
+  const now = Date.UTC(2026, 5, 8, 10, 0, 0) // 2026-06-08 10:00 UTC
+
+  it('returns "Just now" for diffs under one minute', () => {
+    expect(relativeDate(now - 30_000, now)).toBe('Just now')
+  })
+
+  it('returns "Today" for timestamps earlier the same calendar day', () => {
+    expect(relativeDate(now - 5 * 3600 * 1000, now)).toBe('Today')
+  })
+
+  it('returns "Yesterday" for one calendar day back', () => {
+    const yesterday = now - 24 * 3600 * 1000
+    expect(relativeDate(yesterday, now)).toBe('Yesterday')
+  })
+
+  it('returns "Nd ago" for 2–6 days back', () => {
+    const threeDaysBack = now - 3 * 24 * 3600 * 1000
+    expect(relativeDate(threeDaysBack, now)).toBe('3d ago')
+  })
+
+  it('falls through to humanDate at 7+ days back', () => {
+    const eightDaysBack = now - 8 * 24 * 3600 * 1000
+    expect(relativeDate(eightDaysBack, now)).toMatch(/2026/)
+  })
+
+  it('returns "Today" / "Just now" for future timestamps (does not crash)', () => {
+    // We deliberately tolerate slight clock drift rather than throwing.
+    const oneSecondFromNow = now + 1000
+    const out = relativeDate(oneSecondFromNow, now)
+    expect(out === 'Just now' || out === 'Today').toBe(true)
+  })
+
+  it('returns "" for NaN input', () => {
+    expect(relativeDate(Number.NaN, now)).toBe('')
+  })
+})

--- a/packages/share-web/src/lib/dates.ts
+++ b/packages/share-web/src/lib/dates.ts
@@ -2,8 +2,13 @@
 // different formats. `humanDate` matches the Reader's masthead format
 // (e.g. "Jun 4, 2026") so a published-on cell on /@handle reads the
 // same as the masthead on the share page it links to.
+//
+// All helpers gate on `Number.isFinite(ts)` before constructing a
+// Date — `new Date(NaN)` doesn't throw, it silently produces "Invalid
+// Date" which then leaks to the UI. Wrapping in try/catch isn't enough.
 
 export function humanDate(ts: number): string {
+  if (!Number.isFinite(ts)) return ''
   try {
     return new Date(ts).toLocaleDateString('en-US', {
       year: 'numeric',
@@ -16,6 +21,7 @@ export function humanDate(ts: number): string {
 }
 
 export function humanDateTime(ts: number): string {
+  if (!Number.isFinite(ts)) return ''
   try {
     return new Date(ts).toLocaleString('en-US', {
       year: 'numeric',
@@ -27,4 +33,29 @@ export function humanDateTime(ts: number): string {
   } catch {
     return ''
   }
+}
+
+/**
+ * Relative-time label for list rows: "Today" / "Yesterday" / "Nd ago"
+ * up to one week, then falls back to `humanDate`. Pattern matches
+ * Notion / Linear / GitHub list timestamps.
+ *
+ * `now` is injectable so tests can pin the clock without monkey-patching
+ * Date globally.
+ */
+export function relativeDate(ts: number, now: number = Date.now()): string {
+  if (!Number.isFinite(ts) || !Number.isFinite(now)) return ''
+  const diffMs = now - ts
+  if (diffMs < 60_000) return 'Just now'
+  const oneDay = 24 * 3600 * 1000
+  const startOfDay = (t: number) => {
+    const d = new Date(t)
+    d.setHours(0, 0, 0, 0)
+    return d.getTime()
+  }
+  const days = Math.round((startOfDay(now) - startOfDay(ts)) / oneDay)
+  if (days <= 0) return 'Today'
+  if (days === 1) return 'Yesterday'
+  if (days < 7) return `${days}d ago`
+  return humanDate(ts)
 }

--- a/packages/share-web/src/lib/me-cache.test.ts
+++ b/packages/share-web/src/lib/me-cache.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { clearCachedMe, readCachedMe, writeCachedMe } from './me-cache'
+
+// Minimal localStorage shim — vitest's default test env is jsdom so a
+// real Storage object exists, but we re-create it per test so write
+// state from one assertion doesn't leak into the next.
+function makeStorage(): Storage {
+  const data = new Map<string, string>()
+  return {
+    get length() {
+      return data.size
+    },
+    clear: () => data.clear(),
+    getItem: (k) => data.get(k) ?? null,
+    key: (i) => Array.from(data.keys())[i] ?? null,
+    removeItem: (k) => {
+      data.delete(k)
+    },
+    setItem: (k, v) => {
+      data.set(k, v)
+    },
+  }
+}
+
+const KEY = 'spool.share-web.me'
+
+describe('me-cache', () => {
+  let original: Storage | undefined
+  beforeEach(() => {
+    original = globalThis.localStorage
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: makeStorage(),
+      configurable: true,
+    })
+  })
+  afterEach(() => {
+    if (original) {
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: original,
+        configurable: true,
+      })
+    }
+  })
+
+  it('returns null when the cache is empty', () => {
+    expect(readCachedMe()).toBeNull()
+  })
+
+  it('round-trips name + avatar_url through write/read', () => {
+    writeCachedMe({ name: 'Alice', avatar_url: 'https://x/a.png' })
+    expect(readCachedMe()).toEqual({ name: 'Alice', avatar_url: 'https://x/a.png' })
+  })
+
+  it('treats a foreign-version blob as a cache miss instead of returning bad data', () => {
+    localStorage.setItem(KEY, JSON.stringify({ v: 999, name: 'Stale', avatar_url: null }))
+    expect(readCachedMe()).toBeNull()
+  })
+
+  it('survives malformed JSON without throwing', () => {
+    localStorage.setItem(KEY, '{not json')
+    expect(readCachedMe()).toBeNull()
+  })
+
+  it('clearCachedMe removes the entry', () => {
+    writeCachedMe({ name: 'Alice', avatar_url: null })
+    clearCachedMe()
+    expect(readCachedMe()).toBeNull()
+  })
+
+  it('readCachedMe returns null when localStorage is unavailable (private mode)', () => {
+    // Throw on every access to simulate Safari private mode quota error.
+    Object.defineProperty(globalThis, 'localStorage', {
+      get() {
+        throw new Error('SecurityError')
+      },
+      configurable: true,
+    })
+    expect(readCachedMe()).toBeNull()
+  })
+
+  it('writeCachedMe is silent when localStorage is unavailable', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      get() {
+        throw new Error('SecurityError')
+      },
+      configurable: true,
+    })
+    expect(() => writeCachedMe({ name: 'Alice', avatar_url: null })).not.toThrow()
+  })
+
+  it('preserves null name + null avatar_url through the round trip', () => {
+    writeCachedMe({ name: null, avatar_url: null })
+    expect(readCachedMe()).toEqual({ name: null, avatar_url: null })
+  })
+})
+
+describe('me-cache vs api integration', () => {
+  // The contract that matters: fetchMe writes on 200, clears on 401.
+  // Direct API integration is covered in api.test.ts; this asserts
+  // the cache primitive does what those side-effects expect.
+  it('writeCachedMe followed by clearCachedMe leaves no residue', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: makeStorage(),
+      configurable: true,
+    })
+    writeCachedMe({ name: 'Alice', avatar_url: 'x.png' })
+    clearCachedMe()
+    // Don't just trust readCachedMe — confirm via raw key absence too.
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+})

--- a/packages/share-web/src/lib/me-cache.ts
+++ b/packages/share-web/src/lib/me-cache.ts
@@ -1,0 +1,58 @@
+// Stale-while-revalidate localStorage cache for the signed-in user's
+// public identity (name + avatar URL). Read at Header mount so the
+// first paint shows a real avatar instead of a 100ms blank-spot while
+// /api/me round-trips. The fresh fetch then revalidates and writes
+// back. True auth is always backend-validated — this only affects the
+// chrome glyph during the boot window.
+//
+// Schema is versioned; bumping `v` invalidates every reader without
+// needing a separate migration step.
+
+const KEY = 'spool.share-web.me'
+const VERSION = 1
+
+export interface CachedMe {
+  name: string | null
+  avatar_url: string | null
+}
+
+interface StoredShape {
+  v: number
+  name: string | null
+  avatar_url: string | null
+}
+
+export function readCachedMe(): CachedMe | null {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as StoredShape
+    if (parsed.v !== VERSION) return null
+    return { name: parsed.name ?? null, avatar_url: parsed.avatar_url ?? null }
+  } catch {
+    // localStorage unavailable (private mode, disabled) or JSON corrupt.
+    // Treat as cache miss — no thrown error reaches the renderer.
+    return null
+  }
+}
+
+export function writeCachedMe(me: CachedMe): void {
+  try {
+    const payload: StoredShape = {
+      v: VERSION,
+      name: me.name,
+      avatar_url: me.avatar_url,
+    }
+    localStorage.setItem(KEY, JSON.stringify(payload))
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+export function clearCachedMe(): void {
+  try {
+    localStorage.removeItem(KEY)
+  } catch {
+    /* ignore */
+  }
+}

--- a/packages/share-web/src/pages/Me.tsx
+++ b/packages/share-web/src/pages/Me.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 
 import {
   Avatar,
@@ -31,7 +31,15 @@ const CHECK_DEBOUNCE_MS = 320
 
 type LoadState =
   | { kind: 'loading' }
-  | { kind: 'ok'; me: MeResponse; shares: MeShareRow[] }
+  | {
+      kind: 'ok'
+      me: MeResponse
+      shares: MeShareRow[]
+      deleteOpen?: boolean
+      unpublishTarget?: MeShareRow | null
+      unpublishBusy?: boolean
+      unpublishErr?: string | null
+    }
   | { kind: 'error' }
 
 function shareUrl(id: string): string {
@@ -186,15 +194,13 @@ function renderAvailability(
 function ShareRow({
   row,
   disabled,
-  onUnpublish,
+  onUnpublishRequest,
 }: {
   row: MeShareRow
   disabled?: boolean
-  onUnpublish: (id: string) => Promise<{ ok: boolean; reason?: string }>
+  onUnpublishRequest: (row: MeShareRow) => void
 }) {
-  const [busy, setBusy] = useState(false)
   const [copied, setCopied] = useState(false)
-  const [err, setErr] = useState<string | null>(null)
   const revoked = row.revoked_at !== null
   const expiry = row.expires_at !== null ? humanDate(row.expires_at) : null
   const listed = row.visibility === 'profile-listed'
@@ -209,24 +215,35 @@ function ShareRow({
     }
   }
 
-  async function unpublish() {
-    if (busy || revoked || disabled) return
-    setBusy(true)
-    setErr(null)
-    const r = await onUnpublish(row.id)
-    setBusy(false)
-    if (!r.ok) setErr(r.reason ?? 'Could not unpublish — try again.')
-  }
-
   return (
     <li
       className={`sw-share${revoked ? ' revoked' : ''}${disabled ? ' disabled' : ''}`}
     >
-      <div className="sw-share-main">
-        <span className="sw-share-title">{row.title}</span>
+      <a
+        className="sw-share-link"
+        href={`/s/${encodeURIComponent(row.id)}`}
+        target="_blank"
+        rel="noreferrer"
+      >
+        <span className="sw-share-title" title={row.title}>
+          {row.title}
+        </span>
         <span className="sw-share-meta">
-          <span className={`sw-pill${listed ? ' listed' : ''}`}>
-            {listed ? 'Listed' : 'Unlisted'}
+          {/* Visibility is an icon-only glyph with a tooltip — text label
+           *  fought the title for visual weight (industry pattern:
+           *  GitHub gist / YouTube / Google Docs). `link-2` is the
+           *  straight-edge chain so it doesn't visually collide with
+           *  the copy-link button's curvy `link` icon. */}
+          <span
+            className="sw-share-vis"
+            title={
+              listed
+                ? 'On profile — visible on your /@handle page'
+                : 'Link only — unlisted, accessible only with the URL'
+            }
+            aria-label={listed ? 'On profile' : 'Link only'}
+          >
+            <Icon name={listed ? 'globe' : 'link-2'} size={12} />
           </span>
           <span>published {humanDate(row.published_at)}</span>
           {expiry && (
@@ -242,161 +259,243 @@ function ShareRow({
             </>
           )}
         </span>
-        {err && (
-          <span className="sw-share-error" role="alert">
-            {err}
-          </span>
-        )}
-      </div>
-      <div className="sw-share-actions">
-        <a
-          className="sw-icon-btn"
-          href={`/s/${encodeURIComponent(row.id)}`}
-          target="_blank"
-          rel="noreferrer"
-          title="Open share"
-          aria-label="Open share"
-        >
-          <Icon name="external" size={14} />
-        </a>
-        <button
-          type="button"
-          className={`sw-icon-btn${copied ? ' ok' : ''}`}
-          onClick={copy}
-          disabled={disabled}
-          title={copied ? 'Copied' : 'Copy link'}
-          aria-label={copied ? 'Copied' : 'Copy link'}
-        >
-          <Icon name={copied ? 'check' : 'link'} size={14} />
-        </button>
-        {!revoked && (
-          busy ? (
-            <span
-              className="sw-icon-btn busy"
-              aria-label="Unpublishing"
-              style={{ borderColor: 'var(--border-strong)' }}
-            >
-              <span className="sw-spin sw-spin-anim" style={{ width: 13, height: 13 }} />
-            </span>
-          ) : (
+      </a>
+      {!disabled && (
+        <div className="sw-share-actions">
+          <button
+            type="button"
+            className={`sw-icon-btn${copied ? ' ok' : ''}`}
+            onClick={copy}
+            title={copied ? 'Copied' : 'Copy link'}
+            aria-label={copied ? 'Copied' : 'Copy link'}
+          >
+            <Icon name={copied ? 'check' : 'link'} size={14} />
+          </button>
+          {!revoked && (
             <button
               type="button"
               className="sw-icon-btn danger"
-              onClick={unpublish}
-              disabled={disabled}
+              onClick={() => onUnpublishRequest(row)}
               title="Unpublish"
               aria-label="Unpublish"
             >
               <Icon name="eye-off" size={14} />
             </button>
-          )
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </li>
   )
 }
 
-function DeleteAccount({
-  initialPendingUntil,
+// Generic modal shell used by both DeleteAccountModal and
+// UnpublishConfirmModal. Esc + backdrop click close (gated by `busy`
+// so we don't drop an in-flight request).
+function ModalShell({
+  open,
+  busy,
+  onClose,
+  labelledBy,
+  children,
+}: {
+  open: boolean
+  busy?: boolean
+  onClose: () => void
+  labelledBy: string
+  children: ReactNode
+}) {
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !busy) onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, busy, onClose])
+  if (!open) return null
+  return (
+    <div
+      className="sw-modal-overlay"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) onClose()
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={labelledBy}
+    >
+      <div className="sw-modal">{children}</div>
+    </div>
+  )
+}
+
+function DeleteAccountModal({
+  open,
+  onClose,
+  pendingUntil,
+  onScheduled,
   onCancelled,
 }: {
-  initialPendingUntil: number | null
+  open: boolean
+  onClose: () => void
+  pendingUntil: number | null
+  onScheduled: (at: number) => void
   onCancelled: () => void
 }) {
-  const [state, setState] = useState<
-    | { kind: 'idle' }
-    | { kind: 'confirming' }
-    | { kind: 'scheduled'; at: number }
-    | { kind: 'cancelling' }
-  >(
-    initialPendingUntil
-      ? { kind: 'scheduled', at: initialPendingUntil }
-      : { kind: 'idle' },
-  )
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const pending = pendingUntil !== null
 
-  async function schedule() {
-    const r = await scheduleAccountDeletion()
-    if (r.kind === 'ok') setState({ kind: 'scheduled', at: r.scheduled_at })
-  }
-
-  async function cancel() {
-    const prev = state
-    setState({ kind: 'cancelling' })
-    const ok = await cancelAccountDeletion()
-    if (ok) {
-      setState({ kind: 'idle' })
-      onCancelled()
-    } else if (prev.kind === 'scheduled') {
-      setState(prev)
-    } else {
-      setState({ kind: 'scheduled', at: 0 })
+  // Reset transient state each time the modal re-opens — otherwise a
+  // previous error lingers when the user re-triggers from the footer.
+  useEffect(() => {
+    if (open) {
+      setBusy(false)
+      setErr(null)
     }
+  }, [open])
+
+  async function onSchedule() {
+    if (busy) return
+    setBusy(true)
+    setErr(null)
+    const r = await scheduleAccountDeletion()
+    setBusy(false)
+    if (r.kind === 'ok') {
+      onScheduled(r.scheduled_at)
+      onClose()
+      return
+    }
+    setErr('Could not schedule deletion — try again.')
   }
 
-  if (state.kind === 'scheduled' || state.kind === 'cancelling') {
-    const at = state.kind === 'scheduled' ? state.at : 0
-    const when = at > 0 ? humanDateTime(at) : null
-    return (
-      <div className="sw-scheduled-box">
-        <p>
-          <strong>Account deletion is scheduled</strong>
-          {when ? ` for ${when}` : ''}. You have 24 hours to cancel.
-        </p>
-        <button
-          type="button"
-          className="sw-btn sw-btn-ghost"
-          onClick={cancel}
-          disabled={state.kind === 'cancelling'}
-        >
-          {state.kind === 'cancelling' ? (
-            <>
-              <span className="sw-spin sw-spin-anim" style={{ width: 11, height: 11 }} />
-              Cancelling…
-            </>
-          ) : (
-            'Cancel deletion'
-          )}
-        </button>
-      </div>
-    )
-  }
-
-  if (state.kind === 'confirming') {
-    return (
-      <div className="sw-confirm-box">
-        <p>
-          Deleting your account unpublishes every share, releases your handle, and removes
-          your record after 24 hours. This can be undone within that window.
-        </p>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button type="button" className="sw-btn sw-btn-danger" onClick={schedule}>
-            Yes, delete my account
-          </button>
-          <button
-            type="button"
-            className="sw-btn sw-btn-ghost"
-            onClick={() => setState({ kind: 'idle' })}
-          >
-            Back
-          </button>
-        </div>
-      </div>
-    )
+  async function onCancel() {
+    if (busy) return
+    setBusy(true)
+    setErr(null)
+    const ok = await cancelAccountDeletion()
+    setBusy(false)
+    if (ok) {
+      onCancelled()
+      onClose()
+      return
+    }
+    setErr('Could not cancel deletion — try again.')
   }
 
   return (
-    <button
-      type="button"
-      className="sw-btn sw-btn-ghost"
-      onClick={() => setState({ kind: 'confirming' })}
+    <ModalShell open={open} busy={busy} onClose={onClose} labelledBy="delete-account-title">
+      <h2 id="delete-account-title" className="sw-modal-title">
+        {pending ? 'Cancel account deletion?' : 'Delete account?'}
+      </h2>
+      {pending && pendingUntil ? (
+        <p className="sw-modal-body">
+          Scheduled for <span className="sw-mono">{humanDateTime(pendingUntil)}</span>. Cancelling
+          keeps your shares, handle, and account intact.
+        </p>
+      ) : (
+        <p className="sw-modal-body">
+          Unpublishes every share, releases your handle, and removes your account record after 24
+          hours. You can undo this from the same place within that window.
+        </p>
+      )}
+      {err && (
+        <p className="sw-modal-error" role="alert">
+          {err}
+        </p>
+      )}
+      <div className="sw-modal-actions">
+        <button
+          type="button"
+          className="sw-btn sw-btn-ghost"
+          onClick={onClose}
+          disabled={busy}
+        >
+          Cancel
+        </button>
+        {pending ? (
+          <button
+            type="button"
+            className="sw-btn sw-btn-primary"
+            onClick={onCancel}
+            disabled={busy}
+          >
+            {busy ? 'Cancelling…' : 'Cancel deletion'}
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="sw-btn sw-btn-danger"
+            onClick={onSchedule}
+            disabled={busy}
+          >
+            {busy ? 'Scheduling…' : 'Yes, delete account'}
+          </button>
+        )}
+      </div>
+    </ModalShell>
+  )
+}
+
+function UnpublishConfirmModal({
+  target,
+  busy,
+  onClose,
+  onConfirm,
+}: {
+  target: MeShareRow | null
+  busy: boolean
+  onClose: () => void
+  onConfirm: () => void
+}) {
+  return (
+    <ModalShell
+      open={target !== null}
+      busy={busy}
+      onClose={onClose}
+      labelledBy="unpublish-title"
     >
-      Delete account…
-    </button>
+      <h2 id="unpublish-title" className="sw-modal-title">
+        Unpublish this share?
+      </h2>
+      {target && (
+        <p className="sw-modal-target sw-mono" title={target.title}>
+          {target.title}
+        </p>
+      )}
+      <p className="sw-modal-body">
+        This permanently deletes the snapshot from R2 and locks the URL to <span className="sw-mono">410 Gone</span>. The
+        slug can never be reused. To share this conversation again, republish from the desktop app
+        — you'll get a new URL.
+      </p>
+      <div className="sw-modal-actions">
+        <button
+          type="button"
+          className="sw-btn sw-btn-ghost"
+          onClick={onClose}
+          disabled={busy}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="sw-btn sw-btn-danger"
+          onClick={onConfirm}
+          disabled={busy}
+        >
+          {busy ? 'Unpublishing…' : 'Yes, unpublish permanently'}
+        </button>
+      </div>
+    </ModalShell>
   )
 }
 
 export function Me() {
   const [state, setState] = useState<LoadState>({ kind: 'loading' })
+  // Re-entrancy lock on confirmUnpublish: the button is `disabled={busy}`
+  // but a double-tap on a slow device can fire onClick twice before React
+  // commits the `unpublishBusy: true` write. The ref blocks the second
+  // call synchronously, before any async work.
+  const unpublishingRef = useRef(false)
 
   const load = useCallback(async () => {
     const [meResult, sharesResult] = await Promise.all([fetchMe(), fetchMyShares()])
@@ -466,7 +565,7 @@ export function Me() {
   if (state.kind === 'loading') {
     return (
       <Page>
-        <Header auth="out" />
+        <Header />
         <main className="sw-main center" aria-busy="true">
           <div className="sw-loading">
             <span className="sw-spin sw-spin-anim" />
@@ -481,7 +580,7 @@ export function Me() {
   if (state.kind === 'error') {
     return (
       <Page>
-        <Header auth="out" />
+        <Header />
         <main className="sw-main center">
           <div className="sw-card tight w-480">
             <div className="sw-rule" style={{ marginBottom: 20 }}>
@@ -508,11 +607,53 @@ export function Me() {
   const { me, shares } = state
   const pendingUntil = me.deletion_pending_until
   const pending = pendingUntil !== null
-  const headerAuth = { name: me.name, src: me.avatar_url }
+
+  function openDelete() {
+    setState((s) => (s.kind === 'ok' ? { ...s, deleteOpen: true } : s))
+  }
+  function closeDelete() {
+    setState((s) => (s.kind === 'ok' ? { ...s, deleteOpen: false } : s))
+  }
+  function onDeletionScheduled(at: number) {
+    setState((s) =>
+      s.kind === 'ok' ? { ...s, me: { ...s.me, deletion_pending_until: at } } : s,
+    )
+  }
+  function requestUnpublish(row: MeShareRow) {
+    setState((s) => (s.kind === 'ok' ? { ...s, unpublishTarget: row, unpublishErr: null } : s))
+  }
+  function closeUnpublish() {
+    setState((s) =>
+      s.kind === 'ok' ? { ...s, unpublishTarget: null, unpublishErr: null } : s,
+    )
+  }
+  async function confirmUnpublish() {
+    if (state.kind !== 'ok' || !state.unpublishTarget) return
+    if (unpublishingRef.current) return
+    unpublishingRef.current = true
+    const target = state.unpublishTarget
+    setState((s) => (s.kind === 'ok' ? { ...s, unpublishBusy: true, unpublishErr: null } : s))
+    try {
+      const r = await onUnpublish(target.id)
+      setState((s) => {
+        if (s.kind !== 'ok') return s
+        if (r.ok) {
+          return { ...s, unpublishBusy: false, unpublishTarget: null, unpublishErr: null }
+        }
+        return {
+          ...s,
+          unpublishBusy: false,
+          unpublishErr: r.reason ?? 'Could not unpublish — try again.',
+        }
+      })
+    } finally {
+      unpublishingRef.current = false
+    }
+  }
 
   return (
     <Page>
-      <Header auth={headerAuth} />
+      <Header />
       <main className="sw-main gap">
         {pending && (
           <div className="sw-banner pending" role="alert">
@@ -521,8 +662,15 @@ export function Me() {
             </span>
             <span>
               <strong>Account deletion is pending.</strong>{' '}
-              {pendingUntil ? `Scheduled for ${humanDateTime(pendingUntil)}.` : null} Cancel
-              it in the Danger zone below to restore access.
+              {pendingUntil ? `Scheduled for ${humanDateTime(pendingUntil)}.` : null}{' '}
+              <button
+                type="button"
+                className="sw-banner-action"
+                onClick={openDelete}
+              >
+                Cancel deletion
+              </button>{' '}
+              to restore access.
             </span>
           </div>
         )}
@@ -580,34 +728,46 @@ export function Me() {
                   key={row.id}
                   row={row}
                   disabled={pending}
-                  onUnpublish={onUnpublish}
+                  onUnpublishRequest={requestUnpublish}
                 />
               ))}
             </ul>
           )}
 
-          <div className="sw-danger-zone" style={{ marginTop: 24 }}>
-            <h2
-              className="sw-section-label"
-              style={{ marginBottom: 14, color: 'var(--muted)' }}
-            >
-              Danger zone
-            </h2>
-            <DeleteAccount
-              initialPendingUntil={pendingUntil}
-              onCancelled={onDeletionCancelled}
-            />
-          </div>
-
           <p className="sw-signed-in-as">
             <span className="ico">
               <Icon name="lock" size={11} />
             </span>
-            Signed in as {me.email}
+            <span>Signed in as {me.email}</span>
+            <button
+              type="button"
+              className="sw-link-quiet"
+              onClick={openDelete}
+            >
+              {pending ? 'Cancel deletion' : 'Delete account'}
+            </button>
           </p>
+          {state.unpublishErr && (
+            <p className="sw-unpublish-err" role="alert">
+              {state.unpublishErr}
+            </p>
+          )}
         </div>
       </main>
       <Footer />
+      <DeleteAccountModal
+        open={state.deleteOpen === true}
+        onClose={closeDelete}
+        pendingUntil={pendingUntil}
+        onScheduled={onDeletionScheduled}
+        onCancelled={onDeletionCancelled}
+      />
+      <UnpublishConfirmModal
+        target={state.unpublishTarget ?? null}
+        busy={state.unpublishBusy === true}
+        onClose={closeUnpublish}
+        onConfirm={confirmUnpublish}
+      />
     </Page>
   )
 }

--- a/packages/share-web/src/pages/Profile.tsx
+++ b/packages/share-web/src/pages/Profile.tsx
@@ -4,7 +4,6 @@ import {
   Avatar,
   Footer,
   Header,
-  Icon,
   Page,
 } from '../components/Chrome'
 import { fetchProfile, type ProfileFetchResult, type ProfileResponse } from '../lib/api'
@@ -45,7 +44,7 @@ export function Profile({ handle }: { handle: string }) {
   if (state.kind === 'loading') {
     return (
       <Page>
-        <Header auth="out" />
+        <Header />
         <main className="sw-main">
           <div className="sw-card w-600">
             <div className="sw-identity">
@@ -74,7 +73,7 @@ export function Profile({ handle }: { handle: string }) {
   if (state.kind === 'not-found' || state.kind === 'error') {
     return (
       <Page>
-        <Header auth="out" />
+        <Header />
         <main className="sw-main">
           <div className="sw-card tight w-600">
             <div className="sw-rule" style={{ marginBottom: 22 }}>
@@ -93,7 +92,7 @@ export function Profile({ handle }: { handle: string }) {
   const { profile } = state
   return (
     <Page>
-      <Header auth="out" />
+      <Header />
       <main className="sw-main">
         <div className="sw-card w-600">
           <div className="sw-identity">
@@ -115,17 +114,15 @@ export function Profile({ handle }: { handle: string }) {
           ) : (
             <ul className="sw-list">
               {profile.shares.map((s) => (
-                <li key={s.id}>
-                  <a className="sw-share link" href={`/s/${encodeURIComponent(s.id)}`}>
-                    <span className="sw-share-main">
-                      <span className="sw-share-title">{s.title}</span>
+                <li key={s.id} className="sw-share">
+                  <a
+                    className="sw-share-link"
+                    href={`/s/${encodeURIComponent(s.id)}`}
+                  >
+                    <span className="sw-share-title" title={s.title}>
+                      {s.title}
                     </span>
-                    <span className="sw-share-meta" style={{ flex: '0 0 auto' }}>
-                      {humanDate(s.published_at)}
-                    </span>
-                    <span style={{ color: 'var(--muted)', display: 'inline-flex' }}>
-                      <Icon name="arrow-right" size={14} />
-                    </span>
+                    <span className="sw-share-date">{humanDate(s.published_at)}</span>
                   </a>
                 </li>
               ))}

--- a/packages/share-web/src/pages/Reader.tsx
+++ b/packages/share-web/src/pages/Reader.tsx
@@ -93,7 +93,7 @@ export function Reader({ id }: { id: string }) {
   if (state.kind === 'loading') {
     return (
       <Page>
-        <Header auth="out" />
+        <Header />
         <main className="sw-main center" aria-busy="true">
           <div className="sw-loading">
             <span className="sw-spin sw-spin-anim" />
@@ -110,7 +110,7 @@ export function Reader({ id }: { id: string }) {
 
   return (
     <Page>
-      <Header auth="out" />
+      <Header />
       <div className="reader-canvas">
         <div
           className="reader-paper"

--- a/packages/share-web/src/pages/Tombstone.tsx
+++ b/packages/share-web/src/pages/Tombstone.tsx
@@ -49,7 +49,7 @@ export function Tombstone({ reason, at }: Props) {
   const when = formatAt(at)
   return (
     <Page>
-      <Header auth="out" />
+      <Header />
       <main className="sw-main center">
         <div className="sw-card tight" style={{ maxWidth: 560 }}>
           <div className="sw-rule" style={{ marginBottom: 22 }}>

--- a/packages/share-web/src/styles.css
+++ b/packages/share-web/src/styles.css
@@ -426,7 +426,6 @@ html[data-theme='dark'] .sw-root {
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.16em;
-  text-transform: uppercase;
   color: var(--faint);
   display: flex;
   align-items: center;
@@ -447,21 +446,28 @@ html[data-theme='dark'] .sw-root {
   flex-direction: column;
   gap: 8px;
 }
+/* Two row variants share `.sw-share`:
+ *   - /me  (owner) — multi-line: title + meta (visibility icon + dates
+ *     + state pill), actions on the right
+ *   - /@handle (public) — single line: title left + mono date right
+ *
+ * Whole-row click affordance: `<a class="sw-share-link">` wraps the
+ * title + meta column on /me and the title + date on /@handle. The
+ * anchor itself is the click target, so hovering any child (incl.
+ * the visibility icon) shows that child's `title=` tooltip naturally
+ * — no `::after` overlay to fight. Actions live OUTSIDE the anchor
+ * as siblings, so their own onClick wins. */
 .sw-share {
   display: flex;
   align-items: center;
-  gap: 14px;
-  padding: 13px 16px;
-  background: var(--card-2);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  transition: border-color 0.15s, background 0.15s;
+  gap: 10px;
+  padding: 4px 12px;
+  margin: 0 -12px;
+  border-radius: 8px;
+  transition: background 0.12s;
 }
 .sw-share:hover {
-  border-color: var(--border-strong);
-}
-.sw-share.link:hover {
-  border-color: var(--accent);
+  background: var(--card-2);
 }
 .sw-share.revoked {
   opacity: 0.55;
@@ -470,23 +476,48 @@ html[data-theme='dark'] .sw-root {
   opacity: 0.5;
   pointer-events: none;
 }
-.sw-share-main {
+.sw-share-link {
   flex: 1;
   min-width: 0;
   display: flex;
+  gap: 14px;
+  align-items: center;
+  padding: 12px 0;
+  color: inherit;
+  text-decoration: none;
+}
+/* /me variant: title + meta stack vertically inside the anchor.
+ * Triggered by the meta line's presence — public /@handle rows
+ * have no meta line so they keep the row layout (title + date). */
+.sw-share-link:has(> .sw-share-meta) {
   flex-direction: column;
-  gap: 3px;
+  align-items: stretch;
+  gap: 4px;
 }
 .sw-share-title {
+  flex: 1;
+  min-width: 0;
+  display: block;
   font-weight: 600;
-  font-size: 14.5px;
+  font-size: 15.5px;
+  line-height: 1.35;
+  color: var(--text);
+  text-decoration: none;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+}
+.sw-share:hover .sw-share-title {
+  color: var(--accent);
+}
+.sw-share-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 .sw-share-meta {
   font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
+  font-size: 11.5px;
   letter-spacing: 0.02em;
   color: var(--muted);
   display: flex;
@@ -497,16 +528,25 @@ html[data-theme='dark'] .sw-root {
 .sw-share-meta .dot-sep {
   opacity: 0.5;
 }
-.sw-share-error {
-  color: var(--err);
+.sw-share-vis {
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted);
+  cursor: help;
+}
+.sw-share-date {
+  flex: 0 0 auto;
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
-  margin-top: 2px;
+  color: var(--muted);
+  white-space: nowrap;
 }
 .sw-share-actions {
   display: flex;
   align-items: center;
   gap: 6px;
   flex: 0 0 auto;
+  padding: 8px 0;
 }
 
 /* compact icon buttons */
@@ -696,6 +736,55 @@ html[data-theme='dark'] .sw-root {
 .sw-signed-in-as .ico {
   color: var(--faint);
   display: inline-flex;
+}
+/* Wrap the user identity span so its ellipsis behaviour works
+ * without stealing the flex slot from the Delete account link. */
+.sw-signed-in-as > span {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* Push the destructive trigger to the right edge of the row so the
+ * left side reads as a stable identity line. */
+.sw-signed-in-as .sw-link-quiet {
+  margin-left: auto;
+}
+/* Quiet text link — used for the Delete account / Cancel deletion
+ * trigger next to "Signed in as …". Reads as ancillary metadata
+ * unless hovered. */
+.sw-link-quiet {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--faint);
+  cursor: pointer;
+  text-underline-offset: 2px;
+  transition: color 0.12s;
+}
+.sw-link-quiet:hover,
+.sw-link-quiet:focus-visible {
+  color: var(--err);
+  text-decoration: underline;
+}
+.sw-banner-action {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.sw-banner-action:hover {
+  color: var(--accent);
+}
+.sw-unpublish-err {
+  margin: 10px 0 0;
+  font-size: 12px;
+  color: var(--err);
 }
 
 /* ── Danger zone ────────────────────────────────────────────── */
@@ -887,6 +976,74 @@ html[data-theme='dark'] .sw-google-btn:hover {
 }
 .reader-paper {
   max-width: 100%;
+  border-radius: 12px;
+  box-shadow:
+    0 1px 2px rgba(40, 34, 26, 0.05),
+    0 18px 50px rgba(40, 34, 26, 0.10);
+}
+html[data-theme='dark'] .reader-paper {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.40),
+    0 18px 50px rgba(0, 0, 0, 0.55);
+}
+
+/* ── Modal shell (Delete / Unpublish confirm) ───────────────── */
+.sw-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(20, 20, 16, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 100;
+}
+html[data-theme='dark'] .sw-modal-overlay {
+  background: rgba(0, 0, 0, 0.65);
+}
+.sw-modal {
+  width: 100%;
+  max-width: 460px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: var(--shadow-card);
+  padding: 26px 26px 22px;
+}
+.sw-modal-title {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0 0 10px;
+  color: var(--text);
+}
+.sw-modal-body {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--muted);
+  margin: 0 0 18px;
+}
+.sw-modal-target {
+  font-size: 13px;
+  color: var(--text);
+  background: var(--card-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 11px;
+  margin: 0 0 16px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sw-modal-error {
+  font-size: 12.5px;
+  color: var(--err);
+  margin: 0 0 12px;
+}
+.sw-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }
 
 /* ── Narrow viewport adjustments ────────────────────────────── */


### PR DESCRIPTION
## Summary

Polish pass on the share-web `/me` and `/@handle` surfaces. Scoped to `packages/share-web/` only; no backend or desktop changes.

## Changes

**Header SWR + cache**

- `lib/me-cache.ts` — versioned `localStorage` cache of `{name, avatar_url}` so first paint shows the real avatar instead of a 100ms blank while `/api/me` round-trips
- `lib/auth-cache.ts` — module-level memo so cross-page `Header` mounts share one `fetchMe` call; invalidated on `signOut` and on a 401 response
- `Header` default changes from `auth='out'` to `auth='auto'` — paints from cache, revalidates in the background; `Reader.tsx`, `Profile.tsx`, `Tombstone.tsx`, and the `Me` loading / error states drop the hardcoded `auth="out"` prop
- `Wordmark` href `/` → `https://spool.pro/` so logo-click lands on the landing site in both dev and prod

**Account surface**

- `DeleteAccountModal` replaces the inline `idle / confirming / scheduled / cancelling` state machine; opened from a small "Delete account" link in the "Signed in as …" footer row
- `onScheduled(at)` lifts state to the parent so the deletion-pending banner appears immediately after the user confirms — previously the banner waited for the next reload
- Banner copy carries an inline "Cancel deletion" button that re-opens the same modal in cancel mode
- `useRef` re-entrancy lock on `confirmUnpublish` so a double-tap on a slow device cannot fire two parallel revoke calls

**ShareRow + Unpublish flow**

- Single-line title (ellipsis + `title=` hover tooltip), meta line with a visibility icon (`globe` for `profile-listed`, `link-2` for `unlisted`; `title=` tooltip, `cursor: help`) + published date + optional expires + revoked = small red `Unpublished` pill
- Whole-row click navigates to the reader: title + meta wrap in one `<a class="sw-share-link">` so hovering the visibility icon shows its `title=` naturally without an overlay blocking events
- Hover: row bg → `--card-2`, title → accent
- Actions live outside the anchor as siblings (copy + eye-off only — the external-link Open icon is removed because the title is now the open affordance)
- `UnpublishConfirmModal` uses the same `.sw-modal-*` shell; renders the target row plus a 410-Gone warning before committing

**Profile (public /@handle) rows**

- Single-line title + mono date, same anchor wrap, no actions

**Utilities**

- `relativeDate(ts, now)` + `Number.isFinite` guards on `humanDate` / `humanDateTime` / `relativeDate` so `NaN` does not surface as `Invalid Date`
- `.sw-section-label` drops `text-transform: uppercase`, keeps mono + tracking
- `.reader-paper` gets shadow tokens (light + dark)
- `ModalShell` shared by both confirm modals — `Esc` and backdrop click close, gated by `busy`

## Test plan

- `pnpm --filter @spool/share-web typecheck` — clean
- `pnpm --filter @spool/share-web exec vitest run` — 70 / 70
  - `dates.test.ts` (8): `humanDate` / `humanDateTime` guards, `relativeDate` buckets (Today / Yesterday / Nd ago / 7+ days fallback / future / NaN)
  - `me-cache.test.ts` (7): round-trip, version-mismatch invalidation, malformed-JSON tolerance, `clearCachedMe`, `localStorage`-unavailable fallback
  - `api-cache.test.ts` (5): `fetchMe` 200 writes cache, 401 clears cache + drops the auth memo, 403 leaves cache intact, `signOut` clears both layers even when the network call fails
- Manual dogfooding in worktree: sign-in / cross-page header sync, hover tooltips on visibility icons, row click → reader, copy + eye-off actions, Unpublish modal Esc + backdrop close + double-tap block, Delete account modal from both healthy and pending-deletion states, sign-out clears cache + memo

## Follow-ups

- `/terms` and `/privacy` are placeholder pages — real content needed
- Desktop Spool app `Shares → Published` tab rows want the same polish

Submitter: @graydawnc

🤖 Generated with [Claude Code](https://claude.com/claude-code)