### PR TITLE
fix(share): OG image renders CJK glyphs

### DIFF
--- a/packages/share-backend/src/publish/og.ts
+++ b/packages/share-backend/src/publish/og.ts
@@ -1,4 +1,4 @@
-import { ImageResponse } from 'workers-og'
+import { ImageResponse, loadGoogleFont } from 'workers-og'
 
 export type SnapshotForOg = {
   conversation: { title: string }
@@ -19,8 +19,15 @@ export function escapeHtml(s: string): string {
   })
 }
 
+// 140-char truncation kept in one place so the same string drives both
+// the rendered title and the font-subset fetch — otherwise a long title
+// would load glyphs we never paint.
+export function clampTitle(raw: string): string {
+  return escapeHtml(raw).slice(0, 140)
+}
+
 export function buildOgHtml(snap: SnapshotForOg): string {
-  const title = escapeHtml(snap.conversation.title).slice(0, 140)
+  const title = clampTitle(snap.conversation.title)
   const template = escapeHtml(snap.editor_opts.template)
   const date = new Date(snap.publish.published_at).toLocaleDateString()
   // Satori (inside workers-og) is strict about layout: every div that
@@ -33,8 +40,14 @@ export function buildOgHtml(snap: SnapshotForOg): string {
   // way a browser would — flex column children collapse to content width
   // instead. Hard-code the 1200×630 dimensions so the cream paper fills
   // the whole OG image rather than leaving a grey gutter on the right.
+  //
+  // Font-family chain: Inter → Noto Sans SC → system-ui. Satori walks
+  // the chain per glyph, so Latin chars resolve to Inter and CJK chars
+  // fall through to Noto Sans SC. Without Noto Sans SC in the loaded
+  // fonts list, CJK glyphs render as black "NO GLYPH" placeholder
+  // boxes (the Satori default for unmapped codepoints).
   return (
-    `<div style="display:flex;flex-direction:column;justify-content:space-between;width:1200px;height:630px;padding:60px;background:#FAF7F0;font-family:Inter,system-ui,sans-serif">` +
+    `<div style="display:flex;flex-direction:column;justify-content:space-between;width:1200px;height:630px;padding:60px;background:#FAF7F0;font-family:Inter,'Noto Sans SC',system-ui,sans-serif">` +
     `<div style="display:flex;font-size:28px;color:#C85A00;letter-spacing:0.12em;text-transform:uppercase">spool · share</div>` +
     `<div style="display:flex;font-size:64px;color:#141410;line-height:1.15;font-weight:500">${title}</div>` +
     `<div style="display:flex;font-size:22px;color:#6b6857">${template} · ${date}</div>` +
@@ -42,8 +55,40 @@ export function buildOgHtml(snap: SnapshotForOg): string {
   )
 }
 
+/** Collect every distinct character that the OG image will paint, so
+ *  Google Fonts' `text=` subset endpoint returns only the glyphs we
+ *  actually need (a few KB per request) instead of the full ~3 MB CJK
+ *  blob. Satori looks up each codepoint independently, so the order
+ *  doesn't matter — we just need the set. */
+function uniqueCharsFor(snap: SnapshotForOg): string {
+  const title = clampTitle(snap.conversation.title)
+  const template = escapeHtml(snap.editor_opts.template)
+  const date = new Date(snap.publish.published_at).toLocaleDateString()
+  const wordmark = 'SPOOL · SHARE'
+  const all = `${title}${template}${date}${wordmark}`
+  return Array.from(new Set(all)).join('')
+}
+
 export async function renderOgPng(snap: SnapshotForOg): Promise<ArrayBuffer> {
   const html = buildOgHtml(snap)
-  const res = new ImageResponse(html, { width: 1200, height: 630 })
+  const text = uniqueCharsFor(snap)
+  // Load font subsets in parallel. Both failures degrade gracefully:
+  // Satori still renders with whichever subset arrived (and shows
+  // "NO GLYPH" boxes for the missing script — same as the pre-fix
+  // behaviour). Worst case: Google Fonts is down, we get an OG image
+  // that says "Shared conversation" in default sans with no glyphs.
+  const [inter, cjk] = await Promise.all([
+    loadGoogleFont({ family: 'Inter', weight: 500, text }).catch(() => null),
+    loadGoogleFont({ family: 'Noto Sans SC', weight: 500, text }).catch(() => null),
+  ])
+  const fonts: { name: string; data: ArrayBuffer; weight: 500; style: 'normal' }[] = []
+  if (inter) fonts.push({ name: 'Inter', data: inter, weight: 500, style: 'normal' })
+  if (cjk) fonts.push({ name: 'Noto Sans SC', data: cjk, weight: 500, style: 'normal' })
+
+  const res = new ImageResponse(html, {
+    width: 1200,
+    height: 630,
+    ...(fonts.length > 0 ? { fonts } : {}),
+  })
   return res.arrayBuffer()
 }

--- a/packages/share-backend/tests/og.test.ts
+++ b/packages/share-backend/tests/og.test.ts
@@ -18,6 +18,12 @@ vi.mock('workers-og', () => ({
       },
     }
   }),
+  // Tests don't exercise the Google Fonts network — stub to a tiny
+  // ArrayBuffer so renderOgPng's font-load path completes without
+  // actually fetching. The real subset-fetch is exercised in prod.
+  loadGoogleFont: vi
+    .fn()
+    .mockImplementation(() => Promise.resolve(new Uint8Array([0]).buffer)),
 }))
 
 const TOKEN = 'p'.repeat(40)

--- a/packages/share-backend/tests/publish.test.ts
+++ b/packages/share-backend/tests/publish.test.ts
@@ -11,13 +11,17 @@ import { invoke } from './_helpers/ctx'
 import { emptyState, makeDb, makeKv, makeR2, type FakeDbState } from './_helpers/fakes'
 
 // Mock workers-og so publish.ts (which imports renderOgPng → workers-og)
-// can be exercised in node without loading Satori/wasm.
+// can be exercised in node without loading Satori/wasm or fetching
+// font subsets from Google Fonts.
 vi.mock('workers-og', () => ({
   ImageResponse: vi.fn().mockImplementation(() => ({
     async arrayBuffer() {
       return new Uint8Array([137, 80, 78, 71]).buffer
     },
   })),
+  loadGoogleFont: vi
+    .fn()
+    .mockImplementation(() => Promise.resolve(new Uint8Array([0]).buffer)),
 }))
 
 const TOKEN = 'p'.repeat(40)


### PR DESCRIPTION
## Summary

Titles containing Chinese / Japanese / Korean characters rendered as black \"NO GLYPH\" placeholder boxes on the `/api/og/<id>.png` social-card preview. `workers-og` (the Satori wrapper used for OG rendering) bundles only Inter — any codepoint outside Inter's Latin / Greek / Cyrillic coverage hit Satori's fallback glyph.

## Fix

`renderOgPng` now loads two font subsets in parallel via `loadGoogleFont`:

- **Inter** at weight 500 — covers the Latin portion (wordmark, template name, date)
- **Noto Sans SC** at weight 500 — covers CJK Unified Ideographs

Both calls pass `text=<glyphs we actually paint>` so Google Fonts returns only the codepoints in the current title plus the static \"SPOOL · SHARE\" wordmark and date string — typically a few KB per render instead of the full ~3 MB CJK blob.

`buildOgHtml` declares `font-family: Inter, 'Noto Sans SC', system-ui, sans-serif`. Satori walks the chain per codepoint, so Latin chars resolve to Inter and the rest fall through to Noto Sans SC.

Both font loads degrade gracefully: a Google Fonts outage leaves the OG image rendering with whichever subset arrived — worst case is the pre-fix behaviour with NO GLYPH boxes, never a 500.

## Tests

`workers-og` mocks in `og.test.ts` and `publish.test.ts` now stub `loadGoogleFont` to a 1-byte `ArrayBuffer` so the suites keep running without hitting the network.

- `pnpm --filter @spool/share-backend test` — 220 / 220

## Manual verification

Published a new share with a Chinese title via the desktop app; fetched `/api/og/<id>.png` from the running wrangler instance and confirmed the title renders as Chinese characters rather than the placeholder blocks.

Submitter: @graydawnc

🤖 Generated with [Claude Code](https://claude.com/claude-code)