### PR TITLE
chore(share-web): drop placeholder Terms / Privacy / Learn-more footer

### DIFF
--- a/packages/share-web/src/components/Chrome.tsx
+++ b/packages/share-web/src/components/Chrome.tsx
@@ -360,6 +360,17 @@ export function Header({ auth = 'auto' as AuthState }: { auth?: AuthState }) {
   )
 }
 
+/**
+ * Footer is now report-only. The previous "Learn about Spool · Terms ·
+ * Privacy" row was dropped because Terms / Privacy never had real copy
+ * — the placeholder routes 404'd, and a misleading link is worse than
+ * no link. The Learn-about-Spool link is redundant with the Wordmark
+ * in the header (both link to the landing site).
+ *
+ * Only Reader still mounts a footer, exclusively to surface the
+ * report-share path. Pages that call `<Footer />` without a report
+ * prop render nothing.
+ */
 export function Footer({
   report,
   reportHref,
@@ -367,21 +378,12 @@ export function Footer({
   report?: boolean
   reportHref?: string
 }) {
+  if (!report || !reportHref) return null
   return (
     <footer className="sw-footer">
-      {report && reportHref && (
-        <>
-          <a href={reportHref} rel="nofollow">
-            Report this share
-          </a>
-          <span className="sep">·</span>
-        </>
-      )}
-      <a href="https://spool.pro">Learn about Spool</a>
-      <span className="sep">·</span>
-      <a href="/terms">Terms</a>
-      <span className="sep">·</span>
-      <a href="/privacy">Privacy</a>
+      <a href={reportHref} rel="nofollow">
+        Report this share
+      </a>
     </footer>
   )
 }

--- a/packages/share-web/src/styles.css
+++ b/packages/share-web/src/styles.css
@@ -182,7 +182,6 @@ html[data-theme='dark'] .sw-root {
   gap: 0;
   padding: 28px 16px 30px;
   background: var(--bg);
-  border-top: 1px solid var(--border);
   font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
   letter-spacing: 0.04em;


### PR DESCRIPTION
## Summary

The share-web footer rendered \"Learn about Spool · Terms · Privacy\" on every page, but `/terms` and `/privacy` never had real copy — both routes 404'd through the SPA tombstone fallback. Pointing at empty placeholder pages is worse than no link at all, and \"Learn about Spool\" duplicates the Wordmark in the header.

## Changes

- `Footer` is now report-only. When a `reportHref` is passed (Reader mounts it this way for the abuse / DMCA path), it renders a single \"Report this share\" link. Without that prop, the component returns null.
- Pages that mount `<Footer />` without props (Tombstone / Me / SignIn / Profile / Reader's loading + error states) now render nothing for the footer slot — no call-site changes needed.

## Test plan

- `pnpm --filter @spool/share-web typecheck` — clean
- `pnpm --filter @spool/share-web exec vitest run` — 70 / 70

## Removes the follow-up

Originally tracked in the share follow-ups memo as \"prepare real /terms and /privacy content\". Removing the placeholder links lets us defer real legal copy until the feature is GA'd without leaving a misleading link in the dev surface.

Submitter: @graydawnc

🤖 Generated with [Claude Code](https://claude.com/claude-code)