### PR TITLE
fix(app): localize ShareMenu trigger and tab labels

### DIFF
--- a/packages/app/src/renderer/components/share-editor/ShareMenu.tsx
+++ b/packages/app/src/renderer/components/share-editor/ShareMenu.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ChevronDown } from 'lucide-react'
 import type { Conversation, EditorOpts } from '@spool/share-kit'
 import { useHotkeys } from '../../hooks/useHotkeys.js'
@@ -76,6 +77,7 @@ export function ShareMenu({
   exporting,
   onExport,
 }: Props) {
+  const { t } = useTranslation()
   const lookupLoading = published === undefined
   // When the publish surface is flag-gated off, the popover collapses
   // to just the Export tab — no tab strip, no "Publish" entry to imply
@@ -188,14 +190,14 @@ export function ShareMenu({
         aria-expanded={open}
         className="inline-flex items-center gap-1.5 h-6 px-2 rounded text-[13px] font-medium text-white bg-accent dark:bg-accent-dark hover:opacity-90 transition-opacity"
       >
-        <span>Share</span>
+        <span>{t('shareEditor.shareMenu.trigger')}</span>
         <ChevronDown size={12} strokeWidth={1.75} aria-hidden />
       </button>
 
       {open && (
         <div
           role="dialog"
-          aria-label="Share"
+          aria-label={t('shareEditor.shareMenu.popover_aria')}
           data-testid="share-menu-popover"
           className="absolute right-0 top-full mt-1.5 w-[380px] rounded-[10px] bg-warm-bg dark:bg-dark-bg border border-warm-border dark:border-dark-border shadow-xl z-20 flex flex-col overflow-hidden"
         >
@@ -206,7 +208,7 @@ export function ShareMenu({
           {publishEnabled && (
             <div
               role="tablist"
-              aria-label="Share surface"
+              aria-label={t('shareEditor.shareMenu.tablist_aria')}
               className="m-3 p-1 flex gap-1 rounded-md bg-warm-surface dark:bg-dark-surface"
             >
               {(['publish', 'export'] as const).map((id) => {
@@ -231,7 +233,9 @@ export function ShareMenu({
                         : 'text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text border-transparent'
                     }`}
                   >
-                    {id === 'publish' ? 'Publish' : 'Export'}
+                    {id === 'publish'
+                      ? t('shareEditor.shareMenu.tab_publish')
+                      : t('shareEditor.shareMenu.tab_export')}
                   </button>
                 )
               })}

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -585,6 +585,13 @@
     "privacy_show": "Anzeigen",
     "privacy_header": "Sensible Daten gefunden",
     "privacy_help": "Wählen Sie vor dem Export, was geschwärzt wird.",
+    "shareMenu": {
+      "trigger": "Teilen",
+      "tab_publish": "Veröffentlichen",
+      "tab_export": "Exportieren",
+      "popover_aria": "Teilen",
+      "tablist_aria": "Freigabeart"
+    },
     "publishTab": {
       "visibility_legend": "Sichtbarkeit",
       "visibility_link_title": "Nur Link",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -585,6 +585,13 @@
     "privacy_show": "Show",
     "privacy_header": "Sensitive data found",
     "privacy_help": "Choose what to mask before exporting.",
+    "shareMenu": {
+      "trigger": "Share",
+      "tab_publish": "Publish",
+      "tab_export": "Export",
+      "popover_aria": "Share",
+      "tablist_aria": "Share surface"
+    },
     "publishTab": {
       "visibility_legend": "Visibility",
       "visibility_link_title": "Link only",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -585,6 +585,13 @@
     "privacy_show": "Afficher",
     "privacy_header": "Données sensibles détectées",
     "privacy_help": "Choisissez ce qu'il faut masquer avant l'export.",
+    "shareMenu": {
+      "trigger": "Partager",
+      "tab_publish": "Publier",
+      "tab_export": "Exporter",
+      "popover_aria": "Partager",
+      "tablist_aria": "Mode de partage"
+    },
     "publishTab": {
       "visibility_legend": "Visibilité",
       "visibility_link_title": "Lien uniquement",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -556,6 +556,13 @@
     "privacy_show": "表示",
     "privacy_header": "機密データを検出",
     "privacy_help": "エクスポート前にマスクする項目を選択してください。",
+    "shareMenu": {
+      "trigger": "共有",
+      "tab_publish": "公開",
+      "tab_export": "エクスポート",
+      "popover_aria": "共有",
+      "tablist_aria": "共有方法"
+    },
     "publishTab": {
       "visibility_legend": "公開範囲",
       "visibility_link_title": "リンクのみ",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -556,6 +556,13 @@
     "privacy_show": "표시",
     "privacy_header": "민감한 데이터 감지됨",
     "privacy_help": "내보내기 전에 가릴 항목을 선택하세요.",
+    "shareMenu": {
+      "trigger": "공유",
+      "tab_publish": "게시",
+      "tab_export": "내보내기",
+      "popover_aria": "공유",
+      "tablist_aria": "공유 방식"
+    },
     "publishTab": {
       "visibility_legend": "공개 범위",
       "visibility_link_title": "링크만",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -556,6 +556,13 @@
     "privacy_show": "显示",
     "privacy_header": "发现敏感内容",
     "privacy_help": "导出前选择要脱敏的内容。",
+    "shareMenu": {
+      "trigger": "分享",
+      "tab_publish": "发布",
+      "tab_export": "导出",
+      "popover_aria": "分享",
+      "tablist_aria": "分享方式"
+    },
     "publishTab": {
       "visibility_legend": "可见性",
       "visibility_link_title": "仅链接",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -556,6 +556,13 @@
     "privacy_show": "顯示",
     "privacy_header": "偵測到敏感內容",
     "privacy_help": "匯出前選擇要脫敏的內容。",
+    "shareMenu": {
+      "trigger": "分享",
+      "tab_publish": "發布",
+      "tab_export": "匯出",
+      "popover_aria": "分享",
+      "tablist_aria": "分享方式"
+    },
     "publishTab": {
       "visibility_legend": "可見性",
       "visibility_link_title": "僅連結",


### PR DESCRIPTION
## What

Routes the last hardcoded English strings in the share-publish surfaces through `t()`: the **Share** trigger button, the **Publish / Export** tab labels, and the popover/tablist aria-labels in `ShareMenu`. Adds `shareEditor.shareMenu.*` (5 keys) to all 7 locales, reusing each locale's established Publish/Export terminology from the existing `publishTab`/`export` keys.

## Why

The #372 i18n pass covered PublishTab, UnpublishConfirmModal, and ConnectCard but missed the menu shell itself — the most visible string of the whole surface. A German user saw a fully localized publish form behind an English "Share" button.

## Test plan

- `locales.test.ts` enforces 7-locale key parity (17 tests green)
- Existing share-publish e2e uses data-testid selectors only, unaffected by copy changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)