### PR TITLE
fix(app): derive renderer CSP origins from SPOOL_SHARE_BACKEND

### DIFF
--- a/packages/app/src/main/security/csp.test.ts
+++ b/packages/app/src/main/security/csp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { __cspFixtures } from './csp.js'
+import { __cspFixtures, buildCsp } from './csp.js'
 
 // We don't import installRendererCsp itself in tests — wiring it would
 // require an Electron `session` stub. The string fixtures cover the
@@ -138,6 +138,37 @@ describe('Renderer CSP policy', () => {
         const connect = directives(csp).get('connect-src') ?? []
         expect(connect).toContain('blob:')
       }
+    })
+  })
+
+  describe('SPOOL_SHARE_BACKEND override origin', () => {
+    // The env var swings every main-process API call to another host
+    // (staging, e2e mock, future domain move). The renderer's direct
+    // fetches — avatar <img> loads and api calls — must follow, or CSP
+    // silently blocks them while main works fine and the bug looks
+    // like a broken image with an empty network tab.
+    const origin = 'https://staging.example.dev'
+
+    for (const dev of [true, false]) {
+      const name = dev ? 'dev' : 'prod'
+      it(`${name}: override origin lands in connect-src and img-src`, () => {
+        const dirs = directives(buildCsp({ dev, backendOrigin: origin }))
+        expect(dirs.get('connect-src')).toContain(origin)
+        expect(dirs.get('img-src')).toContain(origin)
+      })
+    }
+
+    it('prod keeps the canonical spool.pro family alongside the override', () => {
+      // Published-share URLs and avatar links keep pointing at
+      // spool.pro even when the API origin is overridden.
+      const connect = directives(buildCsp({ dev: false, backendOrigin: origin })).get('connect-src') ?? []
+      expect(connect).toContain('https://spool.pro')
+      expect(connect).toContain('https://*.spool.pro')
+    })
+
+    it('no override produces the default fixtures exactly', () => {
+      expect(buildCsp({ dev: true })).toBe(DEV_CSP)
+      expect(buildCsp({ dev: false, backendOrigin: null })).toBe(PROD_CSP)
     })
   })
 

--- a/packages/app/src/main/security/csp.ts
+++ b/packages/app/src/main/security/csp.ts
@@ -1,5 +1,7 @@
 import { session as electronSession } from 'electron'
 
+import { backendUrl, DEFAULT_BACKEND } from '../share/backend-url.js'
+
 /**
  * Inject a `Content-Security-Policy` response header on every renderer
  * response from the default session. Industry pattern (Linear / Notion
@@ -66,34 +68,63 @@ const OBJECT_ALLOW = "'self' blob: chrome-extension:"
 // fetch" and the save dialog never gets bytes.
 const CONNECT_BLOB = 'blob:'
 
-const DEV_CSP = [
-  "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-  "style-src 'self' 'unsafe-inline'",
-  "font-src 'self' data:",
-  `img-src ${IMG_ALLOW_DEV}`,
-  `connect-src 'self' ${CONNECT_BLOB} http://localhost:8788 http://localhost:5173 ws://localhost:5173 ws://127.0.0.1:5173`,
-  `frame-src ${FRAME_ALLOW}`,
-  `object-src ${OBJECT_ALLOW}`,
-  "frame-ancestors 'none'",
-  "base-uri 'self'",
-].join('; ')
+// `SPOOL_SHARE_BACKEND` redirects every main-process API call to a
+// different backend (staging, local mock, future domain move) — the
+// renderer's direct fetches (avatars in img-src, api calls in
+// connect-src) must follow the same override or they silently 404
+// behind CSP while main happily talks to the new host. The canonical
+// spool.pro family stays in the prod allow-list unconditionally:
+// published-share URLs and avatar links keep pointing there even when
+// the API origin is overridden.
+function overrideBackendOrigin(): string | null {
+  try {
+    // Compare normalized origins, not raw strings — an override of
+    // `https://spool.pro/` (trailing slash) is still the default and
+    // must not duplicate the origin in the policy.
+    const origin = new URL(backendUrl()).origin
+    return origin === new URL(DEFAULT_BACKEND).origin ? null : origin
+  } catch {
+    // Malformed override — main's fetches will fail loudly on their
+    // own; don't let CSP construction crash the app over it.
+    return null
+  }
+}
 
-const PROD_CSP = [
-  "default-src 'self'",
-  // Inline styles only — no inline scripts in the production bundle.
-  // `unsafe-eval` is required by `vite-plugin-react`'s dev fast-refresh
-  // but the prod build strips that out.
-  "script-src 'self'",
-  "style-src 'self' 'unsafe-inline'",
-  "font-src 'self' data:",
-  `img-src ${IMG_ALLOW_PROD}`,
-  `connect-src 'self' ${CONNECT_BLOB} https://spool.pro https://*.spool.pro`,
-  `frame-src ${FRAME_ALLOW}`,
-  `object-src ${OBJECT_ALLOW}`,
-  "frame-ancestors 'none'",
-  "base-uri 'self'",
-].join('; ')
+export function buildCsp(opts: { dev: boolean; backendOrigin?: string | null }): string {
+  const extra = opts.backendOrigin ? ` ${opts.backendOrigin}` : ''
+  if (opts.dev) {
+    return [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "font-src 'self' data:",
+      `img-src ${IMG_ALLOW_DEV}${extra}`,
+      `connect-src 'self' ${CONNECT_BLOB} http://localhost:8788 http://localhost:5173 ws://localhost:5173 ws://127.0.0.1:5173${extra}`,
+      `frame-src ${FRAME_ALLOW}`,
+      `object-src ${OBJECT_ALLOW}`,
+      "frame-ancestors 'none'",
+      "base-uri 'self'",
+    ].join('; ')
+  }
+  return [
+    "default-src 'self'",
+    // Inline styles only — no inline scripts in the production bundle.
+    // `unsafe-eval` is required by `vite-plugin-react`'s dev fast-refresh
+    // but the prod build strips that out.
+    "script-src 'self'",
+    "style-src 'self' 'unsafe-inline'",
+    "font-src 'self' data:",
+    `img-src ${IMG_ALLOW_PROD}${extra}`,
+    `connect-src 'self' ${CONNECT_BLOB} https://spool.pro https://*.spool.pro${extra}`,
+    `frame-src ${FRAME_ALLOW}`,
+    `object-src ${OBJECT_ALLOW}`,
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+  ].join('; ')
+}
+
+const DEV_CSP = buildCsp({ dev: true })
+const PROD_CSP = buildCsp({ dev: false })
 
 export function installRendererCsp(opts: { dev: boolean }): void {
   // Diagnostic escape hatch: setting SPOOL_DISABLE_CSP=1 skips the
@@ -101,7 +132,7 @@ export function installRendererCsp(opts: { dev: boolean }): void {
   // surface. Kept inside the module rather than at the call site so a
   // future Labs toggle could flip it via the renderer too.
   if (process.env['SPOOL_DISABLE_CSP'] === '1') return
-  const policy = opts.dev ? DEV_CSP : PROD_CSP
+  const policy = buildCsp({ dev: opts.dev, backendOrigin: overrideBackendOrigin() })
   electronSession.defaultSession.webRequest.onHeadersReceived(
     (details, callback) => {
       // Only inject CSP into responses for the documents we actually

--- a/packages/app/src/renderer/components/share-editor/ShareMenu.tsx
+++ b/packages/app/src/renderer/components/share-editor/ShareMenu.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ChevronDown } from 'lucide-react'
 import type { Conversation, EditorOpts } from '@spool/share-kit'
 import { useHotkeys } from '../../hooks/useHotkeys.js'
@@ -76,6 +77,7 @@ export function ShareMenu({
   exporting,
   onExport,
 }: Props) {
+  const { t } = useTranslation()
   const lookupLoading = published === undefined
   // When the publish surface is flag-gated off, the popover collapses
   // to just the Export tab — no tab strip, no "Publish" entry to imply
@@ -188,14 +190,14 @@ export function ShareMenu({
         aria-expanded={open}
         className="inline-flex items-center gap-1.5 h-6 px-2 rounded text-[13px] font-medium text-white bg-accent dark:bg-accent-dark hover:opacity-90 transition-opacity"
       >
-        <span>Share</span>
+        <span>{t('shareEditor.shareMenu.trigger')}</span>
         <ChevronDown size={12} strokeWidth={1.75} aria-hidden />
       </button>
 
       {open && (
         <div
           role="dialog"
-          aria-label="Share"
+          aria-label={t('shareEditor.shareMenu.popover_aria')}
           data-testid="share-menu-popover"
           className="absolute right-0 top-full mt-1.5 w-[380px] rounded-[10px] bg-warm-bg dark:bg-dark-bg border border-warm-border dark:border-dark-border shadow-xl z-20 flex flex-col overflow-hidden"
         >
@@ -206,7 +208,7 @@ export function ShareMenu({
           {publishEnabled && (
             <div
               role="tablist"
-              aria-label="Share surface"
+              aria-label={t('shareEditor.shareMenu.tablist_aria')}
               className="m-3 p-1 flex gap-1 rounded-md bg-warm-surface dark:bg-dark-surface"
             >
               {(['publish', 'export'] as const).map((id) => {
@@ -231,7 +233,9 @@ export function ShareMenu({
                         : 'text-warm-muted dark:text-dark-muted hover:text-warm-text dark:hover:text-dark-text border-transparent'
                     }`}
                   >
-                    {id === 'publish' ? 'Publish' : 'Export'}
+                    {id === 'publish'
+                      ? t('shareEditor.shareMenu.tab_publish')
+                      : t('shareEditor.shareMenu.tab_export')}
                   </button>
                 )
               })}

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -585,6 +585,13 @@
     "privacy_show": "Anzeigen",
     "privacy_header": "Sensible Daten gefunden",
     "privacy_help": "Wählen Sie vor dem Export, was geschwärzt wird.",
+    "shareMenu": {
+      "trigger": "Teilen",
+      "tab_publish": "Veröffentlichen",
+      "tab_export": "Exportieren",
+      "popover_aria": "Teilen",
+      "tablist_aria": "Freigabeart"
+    },
     "publishTab": {
       "visibility_legend": "Sichtbarkeit",
       "visibility_link_title": "Nur Link",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -585,6 +585,13 @@
     "privacy_show": "Show",
     "privacy_header": "Sensitive data found",
     "privacy_help": "Choose what to mask before exporting.",
+    "shareMenu": {
+      "trigger": "Share",
+      "tab_publish": "Publish",
+      "tab_export": "Export",
+      "popover_aria": "Share",
+      "tablist_aria": "Share surface"
+    },
     "publishTab": {
       "visibility_legend": "Visibility",
       "visibility_link_title": "Link only",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -585,6 +585,13 @@
     "privacy_show": "Afficher",
     "privacy_header": "Données sensibles détectées",
     "privacy_help": "Choisissez ce qu'il faut masquer avant l'export.",
+    "shareMenu": {
+      "trigger": "Partager",
+      "tab_publish": "Publier",
+      "tab_export": "Exporter",
+      "popover_aria": "Partager",
+      "tablist_aria": "Mode de partage"
+    },
     "publishTab": {
       "visibility_legend": "Visibilité",
       "visibility_link_title": "Lien uniquement",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -556,6 +556,13 @@
     "privacy_show": "表示",
     "privacy_header": "機密データを検出",
     "privacy_help": "エクスポート前にマスクする項目を選択してください。",
+    "shareMenu": {
+      "trigger": "共有",
+      "tab_publish": "公開",
+      "tab_export": "エクスポート",
+      "popover_aria": "共有",
+      "tablist_aria": "共有方法"
+    },
     "publishTab": {
       "visibility_legend": "公開範囲",
       "visibility_link_title": "リンクのみ",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -556,6 +556,13 @@
     "privacy_show": "표시",
     "privacy_header": "민감한 데이터 감지됨",
     "privacy_help": "내보내기 전에 가릴 항목을 선택하세요.",
+    "shareMenu": {
+      "trigger": "공유",
+      "tab_publish": "게시",
+      "tab_export": "내보내기",
+      "popover_aria": "공유",
+      "tablist_aria": "공유 방식"
+    },
     "publishTab": {
       "visibility_legend": "공개 범위",
       "visibility_link_title": "링크만",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -556,6 +556,13 @@
     "privacy_show": "显示",
     "privacy_header": "发现敏感内容",
     "privacy_help": "导出前选择要脱敏的内容。",
+    "shareMenu": {
+      "trigger": "分享",
+      "tab_publish": "发布",
+      "tab_export": "导出",
+      "popover_aria": "分享",
+      "tablist_aria": "分享方式"
+    },
     "publishTab": {
       "visibility_legend": "可见性",
       "visibility_link_title": "仅链接",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -556,6 +556,13 @@
     "privacy_show": "顯示",
     "privacy_header": "偵測到敏感內容",
     "privacy_help": "匯出前選擇要脫敏的內容。",
+    "shareMenu": {
+      "trigger": "分享",
+      "tab_publish": "發布",
+      "tab_export": "匯出",
+      "popover_aria": "分享",
+      "tablist_aria": "分享方式"
+    },
     "publishTab": {
       "visibility_legend": "可見性",
       "visibility_link_title": "僅連結",


### PR DESCRIPTION
## What

Refactors the renderer CSP into a `buildCsp()` builder and appends the `SPOOL_SHARE_BACKEND` override origin (when set) to `connect-src` and `img-src` in both dev and prod profiles. Origins are compared after `URL.origin` normalization so a trailing-slash spelling of the default doesn't duplicate entries. The canonical `spool.pro` family stays in the prod allow-list unconditionally — published-share URLs and avatar links keep pointing there even when the API origin is overridden.

## Why

Main-process fetches follow `SPOOL_SHARE_BACKEND`, but the renderer's direct fetches (user-avatar `<img>` loads from `/api/avatars/<id>`, renderer-side API calls) were pinned to the hardcoded `spool.pro` family. Pointing the app at staging or a local mock made those requests silently disappear behind CSP — broken image, empty network tab, no console hint. Found in the pre-GA launch audit.

## Test plan

- 4 new cases in `csp.test.ts`: override origin lands in connect-src/img-src (both profiles), spool.pro family retained alongside the override, no-override output is byte-identical to the previous fixtures (19 tests green)
- Publish e2e runs the app with `SPOOL_SHARE_BACKEND` pointed at the in-process mock — exercises the override path on every run

🤖 Generated with [Claude Code](https://claude.com/claude-code)