### PR TITLE
feat(share-backend): PATCH /api/me/shares/:id visibility endpoint

### DIFF
--- a/packages/share-backend/functions/api/me/shares/[id].ts
+++ b/packages/share-backend/functions/api/me/shares/[id].ts
@@ -1,0 +1,116 @@
+// PATCH /api/me/shares/:id — owner-scoped visibility change for a live
+// share, without the full republish round-trip. POST /api/publish with
+// override_slug can also change visibility, but it requires the complete
+// snapshot body — which the desktop Shares page doesn't have (rows render
+// from cached metadata only). Listing state is metadata, not content, so
+// it gets a metadata-sized endpoint.
+
+import type {
+  D1Database,
+  KVNamespace,
+  PagesFunction,
+} from '@cloudflare/workers-types'
+
+import { audit } from '../../../../src/audit'
+import { requireUser } from '../../../../src/auth/require'
+import { ApiError, jsonError, jsonOk } from '../../../../src/errors'
+import { isValidSlug } from '../../../../src/publish/slug'
+import { checkRate } from '../../../../src/rate-limit'
+
+type Env = {
+  DB: D1Database
+  SESSIONS: KVNamespace
+  META: KVNamespace
+  RATE: KVNamespace
+}
+
+// Owner-scoped metadata write — same hourly shape as revoke; the bucket
+// caps a leaked-token attacker's D1/KV write loop, nothing more.
+const VISIBILITY_RATE_WINDOW_SEC = 3600
+const VISIBILITY_RATE_MAX = 60
+
+export const onRequestPatch: PagesFunction<Env, 'id'> = async (ctx) => {
+  try {
+    const id = ctx.params.id as string
+    if (!isValidSlug(id)) throw new ApiError('NOT_FOUND')
+    const user = await requireUser(ctx.request, ctx.env)
+
+    const rate = await checkRate(ctx.env.RATE, {
+      bucket: 'share-visibility',
+      key: user.id,
+      windowSec: VISIBILITY_RATE_WINDOW_SEC,
+      max: VISIBILITY_RATE_MAX,
+    })
+    if (!rate.ok) throw new ApiError('TOO_MANY_REQUESTS')
+
+    let body: { visibility?: unknown }
+    try {
+      body = (await ctx.request.json()) as { visibility?: unknown }
+    } catch {
+      throw new ApiError('BAD_REQUEST', 'invalid json')
+    }
+    const visibility = body.visibility
+    if (visibility !== 'unlisted' && visibility !== 'profile-listed') {
+      throw new ApiError(
+        'UNPROCESSABLE',
+        "visibility must be 'unlisted' or 'profile-listed'",
+      )
+    }
+
+    const existing = await ctx.env.DB.prepare(
+      'SELECT visibility, revoked_at FROM published_shares WHERE id=? AND user_id=?',
+    )
+      .bind(id, user.id)
+      .first<{ visibility: string; revoked_at: number | null }>()
+    // Ownership and existence collapse to one 404 — same enumeration
+    // discipline as revoke.
+    if (!existing) throw new ApiError('NOT_FOUND')
+    // Revoked shares are permanent tombstones; their listing state is
+    // meaningless and a write here would desync the frozen audit trail.
+    if (existing.revoked_at !== null) throw new ApiError('GONE')
+    if (existing.visibility === visibility) {
+      // Idempotent — repeat of the current state is a no-op success, so
+      // a retry after a dropped response doesn't surface as an error.
+      return jsonOk({ ok: true, visibility })
+    }
+
+    // Same server-side gate as POST /api/publish: a profile listing
+    // without a live handle has no page to appear on.
+    if (visibility === 'profile-listed') {
+      const h = await ctx.env.DB.prepare(
+        'SELECT handle FROM handles WHERE user_id=? AND released_at IS NULL',
+      )
+        .bind(user.id)
+        .first<{ handle: string }>()
+      if (!h) throw new ApiError('UNPROCESSABLE', 'profile-listed requires a handle')
+    }
+
+    // D1 first (drives /api/me/shares and the /api/profiles listing
+    // query), then the KV meta sidecar (/api/meta/:id). The R2 snapshot
+    // keeps its publish-time `publish.visibility` — no reader renders
+    // it, and rewriting a multi-MB object to flip one cosmetic field
+    // isn't worth the partial-failure surface.
+    await ctx.env.DB.prepare(
+      'UPDATE published_shares SET visibility=? WHERE id=?',
+    )
+      .bind(visibility, id)
+      .run()
+
+    const metaRaw = await ctx.env.META.get(`meta/${id}`)
+    if (metaRaw) {
+      const m = JSON.parse(metaRaw)
+      m.visibility = visibility
+      await ctx.env.META.put(`meta/${id}`, JSON.stringify(m))
+    }
+
+    await audit(ctx.env.DB, ctx.env.RATE, ctx.request, {
+      user_id: user.id,
+      action: 'share.visibility',
+      target_id: id,
+      details: { visibility },
+    })
+    return jsonOk({ ok: true, visibility })
+  } catch (e) {
+    return jsonError(e)
+  }
+}

--- a/packages/share-backend/tests/_helpers/fakes.ts
+++ b/packages/share-backend/tests/_helpers/fakes.ts
@@ -201,6 +201,11 @@ export function makeDb(state: FakeDbState = emptyState()): {
           const row = state.published_shares.find((s) => s.id === id && s.user_id === uid)
           return (row ? ({ revoked_at: row.revoked_at } as T) : null)
         }
+        if (/^SELECT visibility, revoked_at FROM published_shares WHERE id=\? AND user_id=\?/i.test(sql)) {
+          const [id, uid] = params
+          const row = state.published_shares.find((s) => s.id === id && s.user_id === uid)
+          return (row ? ({ visibility: row.visibility, revoked_at: row.revoked_at } as T) : null)
+        }
         if (/^SELECT 1 FROM published_shares WHERE id=\? AND user_id=\?/i.test(sql)) {
           const [id, uid] = params
           const row = state.published_shares.find((s) => s.id === id && s.user_id === uid)
@@ -424,6 +429,12 @@ export function makeDb(state: FakeDbState = emptyState()): {
           const [revoked_at, id] = params as [number, string]
           const s = state.published_shares.find((x) => x.id === id)
           if (s) s.revoked_at = revoked_at
+          return { success: true, meta: { changes: 1 } }
+        }
+        if (/^UPDATE published_shares SET visibility=\? WHERE id=\?/i.test(sql)) {
+          const [visibility, id] = params as [string, string]
+          const s = state.published_shares.find((x) => x.id === id)
+          if (s) s.visibility = visibility
           return { success: true, meta: { changes: 1 } }
         }
         if (/^UPDATE published_shares SET revoked_at=\? WHERE user_id=\? AND revoked_at IS NULL/i.test(sql)) {

--- a/packages/share-backend/tests/share-visibility.test.ts
+++ b/packages/share-backend/tests/share-visibility.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest'
+import type { KVNamespace } from '@cloudflare/workers-types'
+
+import { onRequestPatch as visibilityPatch } from '../functions/api/me/shares/[id]'
+import type { SessionRecord } from '../src/auth/session'
+import { nanoidSlug } from '../src/publish/slug'
+
+import { invoke } from './_helpers/ctx'
+import { emptyState, makeDb, makeKv, type FakeDbState } from './_helpers/fakes'
+
+const TOKEN = 'v'.repeat(40)
+
+function seedUser(state: FakeDbState, id = 'user-1'): void {
+  state.users.push({
+    id,
+    email: `${id}@example.com`,
+    name: id,
+    avatar_url: null,
+    created_at: Date.now(),
+    last_signin_at: Date.now(),
+    deletion_pending_until: null,
+    deleted_at: null,
+  })
+}
+
+async function seedSession(kv: KVNamespace, token: string, user_id: string): Promise<void> {
+  const now = Date.now()
+  const rec: SessionRecord = {
+    user_id,
+    created: now,
+    exp: now + 30 * 24 * 3600 * 1000,
+    last_seen: now,
+  }
+  await kv.put(`session/${token}`, JSON.stringify(rec), { expirationTtl: 30 * 24 * 3600 })
+}
+
+function seedShare(
+  state: FakeDbState,
+  overrides: Partial<FakeDbState['published_shares'][number]> = {},
+): FakeDbState['published_shares'][number] {
+  const row = {
+    id: nanoidSlug(),
+    user_id: 'user-1',
+    title: 'A nice chat',
+    visibility: 'unlisted',
+    expires_at: null,
+    version: 1,
+    published_at: Date.now(),
+    republished_at: null,
+    revoked_at: null,
+    draft_id: null,
+    client_request_id: null,
+    ...overrides,
+  }
+  state.published_shares.push(row)
+  return row
+}
+
+function envFor(state?: FakeDbState) {
+  const { db, state: s } = makeDb(state ?? emptyState())
+  return {
+    DB: db,
+    SESSIONS: makeKv(),
+    META: makeKv(),
+    RATE: makeKv(),
+    state: s,
+  }
+}
+
+function patchReq(id: string, body: unknown, token: string | null = TOKEN): Request {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    'CF-Connecting-IP': '1.2.3.4',
+  }
+  if (token) headers['authorization'] = `Bearer ${token}`
+  return new Request(`https://spool.pro/api/me/shares/${id}`, {
+    method: 'PATCH',
+    headers,
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+async function setup(over: Parameters<typeof seedShare>[1] = {}, withHandle = true) {
+  const state = emptyState()
+  seedUser(state)
+  if (withHandle) {
+    state.handles.push({ handle: 'alice', user_id: 'user-1', claimed_at: Date.now(), released_at: null })
+  }
+  const share = seedShare(state, over)
+  const env = envFor(state)
+  await seedSession(env.SESSIONS, TOKEN, 'user-1')
+  return { env, share }
+}
+
+describe('PATCH /api/me/shares/:id (visibility)', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    const { env, share } = await setup()
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }, null), env, { id: share.id })
+    expect(res.status).toBe(401)
+  })
+
+  it("404s another user's share without leaking its existence", async () => {
+    const { env, share } = await setup({ user_id: 'user-2' })
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }), env, { id: share.id })
+    expect(res.status).toBe(404)
+    expect(share.visibility).toBe('unlisted')
+  })
+
+  it('404s an invalid slug before touching auth or DB', async () => {
+    const { env } = await setup()
+    const res = await invoke(visibilityPatch, patchReq('!bad slug!', { visibility: 'unlisted' }), env, { id: '!bad slug!' })
+    expect(res.status).toBe(404)
+  })
+
+  it('410s a revoked share — tombstones are immutable', async () => {
+    const { env, share } = await setup({ revoked_at: Date.now() - 1000 })
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }), env, { id: share.id })
+    expect(res.status).toBe(410)
+    expect(share.visibility).toBe('unlisted')
+  })
+
+  it('422s an unknown visibility value', async () => {
+    const { env, share } = await setup()
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'public' }), env, { id: share.id })
+    expect(res.status).toBe(422)
+  })
+
+  it('400s malformed json', async () => {
+    const { env, share } = await setup()
+    const res = await invoke(visibilityPatch, patchReq(share.id, '{not json'), env, { id: share.id })
+    expect(res.status).toBe(400)
+  })
+
+  it('422s profile-listed when the user has no live handle — same gate as publish', async () => {
+    const { env, share } = await setup({}, /* withHandle */ false)
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }), env, { id: share.id })
+    expect(res.status).toBe(422)
+    expect(share.visibility).toBe('unlisted')
+  })
+
+  it('allows unlisting even without a handle', async () => {
+    const { env, share } = await setup({ visibility: 'profile-listed' }, /* withHandle */ false)
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'unlisted' }), env, { id: share.id })
+    expect(res.status).toBe(200)
+    expect(share.visibility).toBe('unlisted')
+  })
+
+  it('lists a share: updates D1, the KV meta sidecar, and writes an audit row', async () => {
+    const { env, share } = await setup()
+    await env.META.put(`meta/${share.id}`, JSON.stringify({
+      owner: 'user-1',
+      title: share.title,
+      visibility: 'unlisted',
+      expires_at: null,
+      revoked_at: null,
+      version: 1,
+    }))
+
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }), env, { id: share.id })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ ok: true, visibility: 'profile-listed' })
+
+    expect(share.visibility).toBe('profile-listed')
+    const meta = JSON.parse((await env.META.get(`meta/${share.id}`)) as string)
+    expect(meta.visibility).toBe('profile-listed')
+    // Untouched meta fields survive the read-modify-write.
+    expect(meta.title).toBe(share.title)
+    expect(meta.version).toBe(1)
+
+    const auditRow = env.state.audit.find((a) => a.action === 'share.visibility')
+    expect(auditRow).toBeTruthy()
+    expect(auditRow?.target_id).toBe(share.id)
+  })
+
+  it('no-ops idempotently when the visibility already matches', async () => {
+    const { env, share } = await setup({ visibility: 'profile-listed' })
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }), env, { id: share.id })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ ok: true, visibility: 'profile-listed' })
+    // No audit row for a no-op.
+    expect(env.state.audit.some((a) => a.action === 'share.visibility')).toBe(false)
+  })
+
+  it('survives a missing KV meta row (D1 stays the source of truth)', async () => {
+    const { env, share } = await setup()
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }), env, { id: share.id })
+    expect(res.status).toBe(200)
+    expect(share.visibility).toBe('profile-listed')
+  })
+
+  it('429s past the hourly per-user cap', async () => {
+    const { env, share } = await setup()
+    for (let i = 0; i < 60; i++) {
+      const flip = i % 2 === 0 ? 'profile-listed' : 'unlisted'
+      const r = await invoke(visibilityPatch, patchReq(share.id, { visibility: flip }), env, { id: share.id })
+      expect(r.status).toBe(200)
+    }
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }), env, { id: share.id })
+    expect(res.status).toBe(429)
+  })
+})


### PR DESCRIPTION
## What

Adds `PATCH /api/me/shares/:id` with body `{ visibility: 'unlisted' | 'profile-listed' }` — an owner-scoped, metadata-sized way to change a live share's listing state.

Guard chain mirrors publish/revoke: bearer auth → per-user hourly rate bucket → slug validation and ownership collapsed into 404 (no existence leak) → revoked tombstones immutable (410) → 422 on unknown values → the same profile-listed-requires-handle gate publish enforces server-side → idempotent 200 no-op when the value already matches (a dropped-response retry doesn't surface as an error). Writes D1 first (drives /api/me/shares and the profile listing query), then the KV meta sidecar. The R2 snapshot keeps its publish-time `publish.visibility` — no reader renders it, and rewriting a multi-MB object to flip one cosmetic field isn't worth the partial-failure surface.

## Why

Changing visibility previously required a full republish (`POST /api/publish` + `override_slug`), which needs the complete snapshot body. The desktop Shares page renders rows from cached metadata only, so it had no way to offer a list/unlist action — the consumer lands in the follow-up app PR.

## Test plan

12 new tests in `share-visibility.test.ts`: 401 / non-owner 404 / bad slug 404 / revoked 410 / bad value 422 / malformed json 400 / no-handle 422 / unlist-without-handle allowed / D1+KV+audit on success / idempotent no-op without audit / missing-KV tolerance / 429 past the hourly cap. Full share-backend suite green (252).

🤖 Generated with [Claude Code](https://claude.com/claude-code)