### PR TITLE
feat(app): list/unlist published shares from the row menu

### DIFF
--- a/packages/app/e2e/helpers/share-publish-mock-backend.ts
+++ b/packages/app/e2e/helpers/share-publish-mock-backend.ts
@@ -314,6 +314,26 @@ async function routeRequest(
     })
   }
 
+  // PATCH /api/me/shares/:id — visibility change. Mirrors the real
+  // handler's gates: 404 unknown, 410 revoked, 422 bad value or
+  // profile-listed without a handle.
+  const visMatch = method === 'PATCH' && url.pathname.match(/^\/api\/me\/shares\/([\w-]+)$/)
+  if (visMatch) {
+    const id = visMatch[1] as string
+    const row = state.shares.get(id)
+    if (!row) return json(res, 404, { detail: 'not found' })
+    if (row.revoked_at !== null) return json(res, 410, { detail: 'gone' })
+    const body = JSON.parse(await readBody(req)) as { visibility?: string }
+    if (body.visibility !== 'unlisted' && body.visibility !== 'profile-listed') {
+      return json(res, 422, { detail: 'invalid visibility' })
+    }
+    if (body.visibility === 'profile-listed' && !state.user.handle) {
+      return json(res, 422, { detail: 'profile-listed requires a handle' })
+    }
+    state.shares.set(id, { ...row, visibility: body.visibility })
+    return json(res, 200, { ok: true, visibility: body.visibility })
+  }
+
   // POST /api/revoke/:id
   const revokeMatch = method === 'POST' && url.pathname.match(/^\/api\/revoke\/([\w-]+)$/)
   if (revokeMatch) {

--- a/packages/app/e2e/share-publish.spec.ts
+++ b/packages/app/e2e/share-publish.spec.ts
@@ -285,12 +285,50 @@ test('Published tab lists a live share with open/copy/unpublish affordances', as
   await expect(
     window.getByRole('menuitem', { name: en.shares.publishedTab.action_unpublish }),
   ).toBeVisible()
+  // No handle on the mock user → no "List on profile" item (the server
+  // would 422 it; the menu doesn't offer what can't succeed).
+  await expect(
+    window.getByRole('menuitem', { name: en.shares.publishedTab.action_listOnProfile }),
+  ).toHaveCount(0)
   await window.keyboard.press('Escape')
   // Live row — no stale banner, no revoked styling.
   await expect(row).not.toHaveAttribute('data-revoked', '')
   await expect(
     window.locator('[data-testid="published-stale-banner"]'),
   ).toBeHidden()
+})
+
+test('Row menu lists a share on the profile and back', async () => {
+  const { window } = ctx
+  // Handle must exist before sign-in so /api/me carries it — listing
+  // is gated on it at both the menu and the backend.
+  mock.state.user.handle = 'e2e-user'
+  await signInAndPublish(window)
+
+  await window.keyboard.press('Escape')
+  await window.locator('[data-testid="share-editor-back"]').click()
+  await navigateToShares(window)
+  await window.locator('[data-testid="shares-tab-published"]').click()
+
+  const row = window.locator('[data-testid="published-row"]')
+  await expect(row).toBeVisible({ timeout: 5_000 })
+  // Starts link-only.
+  await expect(row.getByLabel(en.shares.publishedTab.vis_unlisted)).toBeVisible()
+
+  // List it.
+  await row.hover()
+  await row.getByLabel(en.common.moreActions).click()
+  await window.getByRole('menuitem', { name: en.shares.publishedTab.action_listOnProfile }).click()
+  await expect(row.getByLabel(en.shares.publishedTab.vis_listed)).toBeVisible({ timeout: 5_000 })
+  const [share] = Array.from(mock.state.shares.values())
+  expect(share!.visibility).toBe('profile-listed')
+
+  // And back.
+  await row.hover()
+  await row.getByLabel(en.common.moreActions).click()
+  await window.getByRole('menuitem', { name: en.shares.publishedTab.action_unlistFromProfile }).click()
+  await expect(row.getByLabel(en.shares.publishedTab.vis_unlisted)).toBeVisible({ timeout: 5_000 })
+  expect(Array.from(mock.state.shares.values())[0]!.visibility).toBe('unlisted')
 })
 
 test('Revoked shares collapse into the Unpublished section, display-only', async () => {

--- a/packages/app/src/main/ipc/share-publish.ts
+++ b/packages/app/src/main/ipc/share-publish.ts
@@ -17,6 +17,8 @@ import type {
   HandleCheckResponse,
   HandleClaimResponse,
   ScheduleDeleteResponse,
+  SetVisibilityResult,
+  Visibility,
 } from '../../shared/share-publish.js'
 
 async function readBody(res: Response): Promise<Record<string, unknown>> {
@@ -97,6 +99,28 @@ export function registerSharePublishIpc(): void {
     }
     return { ok: true }
   })
+
+  ipcMain.handle(
+    'share-publish:set-visibility',
+    async (_e, id: string, visibility: Visibility): Promise<SetVisibilityResult> => {
+      const r = await authedFetch(`/api/me/shares/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ visibility }),
+      })
+      const json = await readBody(r)
+      if (!r.ok) {
+        const error: PublishErrorBody = {
+          error: typeof json['error'] === 'string' ? (json['error'] as string) : `HTTP_${r.status}`,
+        }
+        if (typeof json['detail'] === 'string') error.detail = json['detail'] as string
+        return { ok: false, status: r.status, error }
+      }
+      // No local cache write here — the renderer follows up with a
+      // myShares refresh (guarded by its mutation generation), which
+      // reconciles the cache through the normal replaceAll path.
+      return { ok: true, visibility }
+    },
+  )
 
   ipcMain.handle(
     'share-publish:get-published-by-draft',

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -60,6 +60,8 @@ import type {
   HandleCheckResponse,
   HandleClaimResponse,
   ScheduleDeleteResponse,
+  SetVisibilityResult,
+  Visibility,
 } from '../shared/share-publish.js'
 
 export interface AgentInfo {
@@ -399,6 +401,8 @@ const spoolShare = {
     ipcRenderer.invoke('share-publish:publish', body),
   revoke: (id: string): Promise<{ ok: true }> =>
     ipcRenderer.invoke('share-publish:revoke', id),
+  setVisibility: (id: string, visibility: Visibility): Promise<SetVisibilityResult> =>
+    ipcRenderer.invoke('share-publish:set-visibility', id, visibility),
   myShares: (): Promise<MySharesResponse> =>
     ipcRenderer.invoke('share-publish:my-shares'),
   claimHandle: (handle: string): Promise<HandleClaimResponse> =>

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -361,6 +361,36 @@ function PublishedList() {
     window.open(sharePublicUrl(it.id), '_blank', 'noopener,noreferrer')
   }
 
+  // List/unlist toggle. Reuses `busyId` so the row shows the trigger
+  // spinner and other rows' destructive controls lock, same as revoke.
+  // refresh() reconciles the cache; noteLocalMutation() keeps a racing
+  // focus-refresh from stomping the change in between.
+  const onToggleVisibility = async (it: PublishedShareCacheItem) => {
+    if (busyId) return
+    const next = it.visibility === 'profile-listed' ? 'unlisted' as const : 'profile-listed' as const
+    setBusyId(it.id)
+    noteLocalMutation()
+    try {
+      const res = await window.spoolShare.setVisibility(it.id, next)
+      if (!res.ok) {
+        toast.error(
+          t('shares.publishedTab.visibilityError'),
+          res.error.detail ? { description: res.error.detail } : undefined,
+        )
+        return
+      }
+      toast.success(next === 'profile-listed'
+        ? t('shares.publishedTab.visibilityListedToast')
+        : t('shares.publishedTab.visibilityUnlistedToast'))
+      await refresh()
+    } catch (err) {
+      console.error('Set visibility failed:', err)
+      toast.error(t('shares.publishedTab.visibilityError'))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
   const requestUnpublish = (it: PublishedShareCacheItem) => {
     // Don't open a second confirm while one is in flight. The button
     // is also visually disabled across all rows when `busyId !== null`,
@@ -415,8 +445,13 @@ function PublishedList() {
               // the spinner via `busy`; other locked rows just appear
               // disabled.
               locked={busyId !== null && busyId !== it.id}
+              // Listing requires a live handle (the server enforces the
+              // same gate); unlisting is always allowed, so an
+              // already-listed share keeps its toggle regardless.
+              canList={user?.handle != null}
               onCopy={() => void onCopy(it)}
               onView={() => onView(it)}
+              onToggleVisibility={() => void onToggleVisibility(it)}
               onUnpublish={() => requestUnpublish(it)}
             />
           ))}
@@ -533,8 +568,10 @@ function PublishedRow({
   item,
   busy,
   locked = false,
+  canList,
   onCopy,
   onView,
+  onToggleVisibility,
   onUnpublish,
 }: {
   item: PublishedShareCacheItem
@@ -544,11 +581,16 @@ function PublishedRow({
    *  no-op behind the modal. The active row uses `busy` instead and
    *  shows its own spinner. */
   locked?: boolean
+  /** Whether "List on profile" is offered — requires a live handle.
+   *  Unlisting an already-listed share is offered regardless. */
+  canList: boolean
   onCopy: () => void
   onView: () => void
+  onToggleVisibility: () => void
   onUnpublish: () => void
 }) {
   const { t } = useTranslation()
+  const listed = item.visibility === 'profile-listed'
   const title = item.title || t('common.untitled')
   const publishedLabel = rowDateLabel(item.published_at)
   const expiresLabel = item.expires_at !== null
@@ -564,14 +606,14 @@ function PublishedRow({
   return (
     <li
       data-testid="published-row"
-      className="group flex items-center gap-3 rounded-[7px] pr-3 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors duration-75"
+      className="group flex items-start gap-3 rounded-[7px] pr-3 py-2.5 hover:bg-warm-surface dark:hover:bg-dark-surface transition-colors duration-75"
     >
       <button
         type="button"
         data-testid="published-row-open"
         onClick={onView}
         aria-label={t('shares.publishedTab.row_open_aria', { title })}
-        className="flex-1 min-w-0 text-left pl-3 py-2.5 cursor-default focus:outline-none"
+        className="flex-1 min-w-0 text-left pl-3 cursor-default focus:outline-none"
       >
         <span
           title={title}
@@ -580,7 +622,7 @@ function PublishedRow({
           {title}
         </span>
         <span className="mt-0.5 flex items-center gap-2 text-[11px] text-warm-faint dark:text-dark-muted">
-          <VisIcon listed={item.visibility === 'profile-listed'} />
+          <VisIcon listed={listed} />
           <span>{t('shares.publishedTab.publishedOn', { when: publishedLabel })}</span>
           {expiresLabel && (
             <>
@@ -595,11 +637,14 @@ function PublishedRow({
        *  hover-reveal, and open-menu persistence all mirror SessionRow.
        *  The destructive Unpublish still escalates to its confirm
        *  modal. */}
+      {/* `items-start` + `-mt-0.5` pins the trigger to the title's first
+       *  line instead of the row's vertical center — same optical
+       *  alignment as SessionRow's action group. */}
       <span
         className={
           busy
-            ? 'flex-none opacity-70 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity'
-            : 'flex-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 group-has-[[aria-expanded=true]]:opacity-100 transition-opacity'
+            ? 'flex-none -mt-0.5 opacity-70 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity'
+            : 'flex-none -mt-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 group-has-[[aria-expanded=true]]:opacity-100 transition-opacity'
         }
       >
         <Menu
@@ -625,6 +670,19 @@ function PublishedRow({
               icon: <LinkIcon size={14} strokeWidth={1.6} aria-hidden />,
               onSelect: onCopy,
             },
+            // Icon previews the TARGET state (globe = will appear on
+            // the profile, link-2 = will go link-only), matching the
+            // meta-line glyph the row lands on after the toggle.
+            ...(listed || canList ? [{
+              label: listed
+                ? t('shares.publishedTab.action_unlistFromProfile')
+                : t('shares.publishedTab.action_listOnProfile'),
+              icon: listed
+                ? <Link2 size={14} strokeWidth={1.6} aria-hidden />
+                : <Globe size={14} strokeWidth={1.6} aria-hidden />,
+              onSelect: onToggleVisibility,
+              disabled: busy || locked,
+            }] : []),
             {
               label: busy
                 ? t('shares.publishedTab.action_unpublishing')

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -535,6 +535,11 @@
       "row_open_aria": "{{title}} öffnen",
       "section_unpublished": "Zurückgezogen",
       "action_copyLink": "Link kopieren",
+      "action_listOnProfile": "Auf Profil listen",
+      "action_unlistFromProfile": "Vom Profil entfernen",
+      "visibilityListedToast": "Auf deinem Profil gelistet",
+      "visibilityUnlistedToast": "Von deinem Profil entfernt",
+      "visibilityError": "Sichtbarkeit konnte nicht geändert werden",
       "action_unpublish": "Zurückziehen",
       "action_unpublishing": "Ziehe zurück"
     }

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -535,6 +535,11 @@
       "row_open_aria": "Open {{title}}",
       "section_unpublished": "Unpublished",
       "action_copyLink": "Copy link",
+      "action_listOnProfile": "List on profile",
+      "action_unlistFromProfile": "Remove from profile",
+      "visibilityListedToast": "Listed on your profile",
+      "visibilityUnlistedToast": "Removed from your profile",
+      "visibilityError": "Couldn't change visibility",
       "action_unpublish": "Unpublish",
       "action_unpublishing": "Unpublishing"
     }

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -535,6 +535,11 @@
       "row_open_aria": "Ouvrir {{title}}",
       "section_unpublished": "Dépubliés",
       "action_copyLink": "Copier le lien",
+      "action_listOnProfile": "Afficher sur le profil",
+      "action_unlistFromProfile": "Retirer du profil",
+      "visibilityListedToast": "Affiché sur votre profil",
+      "visibilityUnlistedToast": "Retiré de votre profil",
+      "visibilityError": "Impossible de modifier la visibilité",
       "action_unpublish": "Dépublier",
       "action_unpublishing": "Dépublication"
     }

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -506,6 +506,11 @@
       "row_open_aria": "{{title}} を開く",
       "section_unpublished": "公開停止",
       "action_copyLink": "リンクをコピー",
+      "action_listOnProfile": "プロフィールに掲載",
+      "action_unlistFromProfile": "プロフィールから外す",
+      "visibilityListedToast": "プロフィールに掲載しました",
+      "visibilityUnlistedToast": "プロフィールから外しました",
+      "visibilityError": "公開範囲を変更できませんでした",
       "action_unpublish": "公開を取り消す",
       "action_unpublishing": "取り消し中"
     }

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -506,6 +506,11 @@
       "row_open_aria": "{{title}} 열기",
       "section_unpublished": "게시 취소됨",
       "action_copyLink": "링크 복사",
+      "action_listOnProfile": "프로필에 게시",
+      "action_unlistFromProfile": "프로필에서 제거",
+      "visibilityListedToast": "프로필에 게시했습니다",
+      "visibilityUnlistedToast": "프로필에서 제거했습니다",
+      "visibilityError": "공개 범위를 변경하지 못했습니다",
       "action_unpublish": "게시 취소",
       "action_unpublishing": "취소 중"
     }

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -506,6 +506,11 @@
       "row_open_aria": "打开 {{title}}",
       "section_unpublished": "已取消发布",
       "action_copyLink": "复制链接",
+      "action_listOnProfile": "在个人主页展示",
+      "action_unlistFromProfile": "从个人主页移除",
+      "visibilityListedToast": "已在个人主页展示",
+      "visibilityUnlistedToast": "已从个人主页移除",
+      "visibilityError": "无法更改可见性",
       "action_unpublish": "取消发布",
       "action_unpublishing": "取消发布中"
     }

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -506,6 +506,11 @@
       "row_open_aria": "開啟 {{title}}",
       "section_unpublished": "已取消發布",
       "action_copyLink": "複製連結",
+      "action_listOnProfile": "在個人主頁展示",
+      "action_unlistFromProfile": "從個人主頁移除",
+      "visibilityListedToast": "已在個人主頁展示",
+      "visibilityUnlistedToast": "已從個人主頁移除",
+      "visibilityError": "無法變更可見性",
       "action_unpublish": "取消發布",
       "action_unpublishing": "取消發布中"
     }

--- a/packages/app/src/shared/share-publish.ts
+++ b/packages/app/src/shared/share-publish.ts
@@ -115,6 +115,13 @@ export type PublishResult =
     }
   | { ok: false; status: number; error: PublishErrorBody }
 
+/** Result of PATCH /api/me/shares/:id — listing state is metadata, so
+ *  errors come back as data (the renderer shows a toast) instead of a
+ *  thrown IPC error. */
+export type SetVisibilityResult =
+  | { ok: true; visibility: Visibility }
+  | { ok: false; status: number; error: PublishErrorBody }
+
 export interface MyShare {
   id: string
   title: string

--- a/packages/share-backend/functions/api/me/shares/[id].ts
+++ b/packages/share-backend/functions/api/me/shares/[id].ts
@@ -1,0 +1,116 @@
+// PATCH /api/me/shares/:id — owner-scoped visibility change for a live
+// share, without the full republish round-trip. POST /api/publish with
+// override_slug can also change visibility, but it requires the complete
+// snapshot body — which the desktop Shares page doesn't have (rows render
+// from cached metadata only). Listing state is metadata, not content, so
+// it gets a metadata-sized endpoint.
+
+import type {
+  D1Database,
+  KVNamespace,
+  PagesFunction,
+} from '@cloudflare/workers-types'
+
+import { audit } from '../../../../src/audit'
+import { requireUser } from '../../../../src/auth/require'
+import { ApiError, jsonError, jsonOk } from '../../../../src/errors'
+import { isValidSlug } from '../../../../src/publish/slug'
+import { checkRate } from '../../../../src/rate-limit'
+
+type Env = {
+  DB: D1Database
+  SESSIONS: KVNamespace
+  META: KVNamespace
+  RATE: KVNamespace
+}
+
+// Owner-scoped metadata write — same hourly shape as revoke; the bucket
+// caps a leaked-token attacker's D1/KV write loop, nothing more.
+const VISIBILITY_RATE_WINDOW_SEC = 3600
+const VISIBILITY_RATE_MAX = 60
+
+export const onRequestPatch: PagesFunction<Env, 'id'> = async (ctx) => {
+  try {
+    const id = ctx.params.id as string
+    if (!isValidSlug(id)) throw new ApiError('NOT_FOUND')
+    const user = await requireUser(ctx.request, ctx.env)
+
+    const rate = await checkRate(ctx.env.RATE, {
+      bucket: 'share-visibility',
+      key: user.id,
+      windowSec: VISIBILITY_RATE_WINDOW_SEC,
+      max: VISIBILITY_RATE_MAX,
+    })
+    if (!rate.ok) throw new ApiError('TOO_MANY_REQUESTS')
+
+    let body: { visibility?: unknown }
+    try {
+      body = (await ctx.request.json()) as { visibility?: unknown }
+    } catch {
+      throw new ApiError('BAD_REQUEST', 'invalid json')
+    }
+    const visibility = body.visibility
+    if (visibility !== 'unlisted' && visibility !== 'profile-listed') {
+      throw new ApiError(
+        'UNPROCESSABLE',
+        "visibility must be 'unlisted' or 'profile-listed'",
+      )
+    }
+
+    const existing = await ctx.env.DB.prepare(
+      'SELECT visibility, revoked_at FROM published_shares WHERE id=? AND user_id=?',
+    )
+      .bind(id, user.id)
+      .first<{ visibility: string; revoked_at: number | null }>()
+    // Ownership and existence collapse to one 404 — same enumeration
+    // discipline as revoke.
+    if (!existing) throw new ApiError('NOT_FOUND')
+    // Revoked shares are permanent tombstones; their listing state is
+    // meaningless and a write here would desync the frozen audit trail.
+    if (existing.revoked_at !== null) throw new ApiError('GONE')
+    if (existing.visibility === visibility) {
+      // Idempotent — repeat of the current state is a no-op success, so
+      // a retry after a dropped response doesn't surface as an error.
+      return jsonOk({ ok: true, visibility })
+    }
+
+    // Same server-side gate as POST /api/publish: a profile listing
+    // without a live handle has no page to appear on.
+    if (visibility === 'profile-listed') {
+      const h = await ctx.env.DB.prepare(
+        'SELECT handle FROM handles WHERE user_id=? AND released_at IS NULL',
+      )
+        .bind(user.id)
+        .first<{ handle: string }>()
+      if (!h) throw new ApiError('UNPROCESSABLE', 'profile-listed requires a handle')
+    }
+
+    // D1 first (drives /api/me/shares and the /api/profiles listing
+    // query), then the KV meta sidecar (/api/meta/:id). The R2 snapshot
+    // keeps its publish-time `publish.visibility` — no reader renders
+    // it, and rewriting a multi-MB object to flip one cosmetic field
+    // isn't worth the partial-failure surface.
+    await ctx.env.DB.prepare(
+      'UPDATE published_shares SET visibility=? WHERE id=?',
+    )
+      .bind(visibility, id)
+      .run()
+
+    const metaRaw = await ctx.env.META.get(`meta/${id}`)
+    if (metaRaw) {
+      const m = JSON.parse(metaRaw)
+      m.visibility = visibility
+      await ctx.env.META.put(`meta/${id}`, JSON.stringify(m))
+    }
+
+    await audit(ctx.env.DB, ctx.env.RATE, ctx.request, {
+      user_id: user.id,
+      action: 'share.visibility',
+      target_id: id,
+      details: { visibility },
+    })
+    return jsonOk({ ok: true, visibility })
+  } catch (e) {
+    return jsonError(e)
+  }
+}

--- a/packages/share-backend/tests/_helpers/fakes.ts
+++ b/packages/share-backend/tests/_helpers/fakes.ts
@@ -201,6 +201,11 @@ export function makeDb(state: FakeDbState = emptyState()): {
           const row = state.published_shares.find((s) => s.id === id && s.user_id === uid)
           return (row ? ({ revoked_at: row.revoked_at } as T) : null)
         }
+        if (/^SELECT visibility, revoked_at FROM published_shares WHERE id=\? AND user_id=\?/i.test(sql)) {
+          const [id, uid] = params
+          const row = state.published_shares.find((s) => s.id === id && s.user_id === uid)
+          return (row ? ({ visibility: row.visibility, revoked_at: row.revoked_at } as T) : null)
+        }
         if (/^SELECT 1 FROM published_shares WHERE id=\? AND user_id=\?/i.test(sql)) {
           const [id, uid] = params
           const row = state.published_shares.find((s) => s.id === id && s.user_id === uid)
@@ -424,6 +429,12 @@ export function makeDb(state: FakeDbState = emptyState()): {
           const [revoked_at, id] = params as [number, string]
           const s = state.published_shares.find((x) => x.id === id)
           if (s) s.revoked_at = revoked_at
+          return { success: true, meta: { changes: 1 } }
+        }
+        if (/^UPDATE published_shares SET visibility=\? WHERE id=\?/i.test(sql)) {
+          const [visibility, id] = params as [string, string]
+          const s = state.published_shares.find((x) => x.id === id)
+          if (s) s.visibility = visibility
           return { success: true, meta: { changes: 1 } }
         }
         if (/^UPDATE published_shares SET revoked_at=\? WHERE user_id=\? AND revoked_at IS NULL/i.test(sql)) {

--- a/packages/share-backend/tests/share-visibility.test.ts
+++ b/packages/share-backend/tests/share-visibility.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest'
+import type { KVNamespace } from '@cloudflare/workers-types'
+
+import { onRequestPatch as visibilityPatch } from '../functions/api/me/shares/[id]'
+import type { SessionRecord } from '../src/auth/session'
+import { nanoidSlug } from '../src/publish/slug'
+
+import { invoke } from './_helpers/ctx'
+import { emptyState, makeDb, makeKv, type FakeDbState } from './_helpers/fakes'
+
+const TOKEN = 'v'.repeat(40)
+
+function seedUser(state: FakeDbState, id = 'user-1'): void {
+  state.users.push({
+    id,
+    email: `${id}@example.com`,
+    name: id,
+    avatar_url: null,
+    created_at: Date.now(),
+    last_signin_at: Date.now(),
+    deletion_pending_until: null,
+    deleted_at: null,
+  })
+}
+
+async function seedSession(kv: KVNamespace, token: string, user_id: string): Promise<void> {
+  const now = Date.now()
+  const rec: SessionRecord = {
+    user_id,
+    created: now,
+    exp: now + 30 * 24 * 3600 * 1000,
+    last_seen: now,
+  }
+  await kv.put(`session/${token}`, JSON.stringify(rec), { expirationTtl: 30 * 24 * 3600 })
+}
+
+function seedShare(
+  state: FakeDbState,
+  overrides: Partial<FakeDbState['published_shares'][number]> = {},
+): FakeDbState['published_shares'][number] {
+  const row = {
+    id: nanoidSlug(),
+    user_id: 'user-1',
+    title: 'A nice chat',
+    visibility: 'unlisted',
+    expires_at: null,
+    version: 1,
+    published_at: Date.now(),
+    republished_at: null,
+    revoked_at: null,
+    draft_id: null,
+    client_request_id: null,
+    ...overrides,
+  }
+  state.published_shares.push(row)
+  return row
+}
+
+function envFor(state?: FakeDbState) {
+  const { db, state: s } = makeDb(state ?? emptyState())
+  return {
+    DB: db,
+    SESSIONS: makeKv(),
+    META: makeKv(),
+    RATE: makeKv(),
+    state: s,
+  }
+}
+
+function patchReq(id: string, body: unknown, token: string | null = TOKEN): Request {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    'CF-Connecting-IP': '1.2.3.4',
+  }
+  if (token) headers['authorization'] = `Bearer ${token}`
+  return new Request(`https://spool.pro/api/me/shares/${id}`, {
+    method: 'PATCH',
+    headers,
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+async function setup(over: Parameters<typeof seedShare>[1] = {}, withHandle = true) {
+  const state = emptyState()
+  seedUser(state)
+  if (withHandle) {
+    state.handles.push({ handle: 'alice', user_id: 'user-1', claimed_at: Date.now(), released_at: null })
+  }
+  const share = seedShare(state, over)
+  const env = envFor(state)
+  await seedSession(env.SESSIONS, TOKEN, 'user-1')
+  return { env, share }
+}
+
+describe('PATCH /api/me/shares/:id (visibility)', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    const { env, share } = await setup()
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }, null), env, { id: share.id })
+    expect(res.status).toBe(401)
+  })
+
+  it("404s another user's share without leaking its existence", async () => {
+    const { env, share } = await setup({ user_id: 'user-2' })
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }), env, { id: share.id })
+    expect(res.status).toBe(404)
+    expect(share.visibility).toBe('unlisted')
+  })
+
+  it('404s an invalid slug before touching auth or DB', async () => {
+    const { env } = await setup()
+    const res = await invoke(visibilityPatch, patchReq('!bad slug!', { visibility: 'unlisted' }), env, { id: '!bad slug!' })
+    expect(res.status).toBe(404)
+  })
+
+  it('410s a revoked share — tombstones are immutable', async () => {
+    const { env, share } = await setup({ revoked_at: Date.now() - 1000 })
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }), env, { id: share.id })
+    expect(res.status).toBe(410)
+    expect(share.visibility).toBe('unlisted')
+  })
+
+  it('422s an unknown visibility value', async () => {
+    const { env, share } = await setup()
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'public' }), env, { id: share.id })
+    expect(res.status).toBe(422)
+  })
+
+  it('400s malformed json', async () => {
+    const { env, share } = await setup()
+    const res = await invoke(visibilityPatch, patchReq(share.id, '{not json'), env, { id: share.id })
+    expect(res.status).toBe(400)
+  })
+
+  it('422s profile-listed when the user has no live handle — same gate as publish', async () => {
+    const { env, share } = await setup({}, /* withHandle */ false)
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }), env, { id: share.id })
+    expect(res.status).toBe(422)
+    expect(share.visibility).toBe('unlisted')
+  })
+
+  it('allows unlisting even without a handle', async () => {
+    const { env, share } = await setup({ visibility: 'profile-listed' }, /* withHandle */ false)
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'unlisted' }), env, { id: share.id })
+    expect(res.status).toBe(200)
+    expect(share.visibility).toBe('unlisted')
+  })
+
+  it('lists a share: updates D1, the KV meta sidecar, and writes an audit row', async () => {
+    const { env, share } = await setup()
+    await env.META.put(`meta/${share.id}`, JSON.stringify({
+      owner: 'user-1',
+      title: share.title,
+      visibility: 'unlisted',
+      expires_at: null,
+      revoked_at: null,
+      version: 1,
+    }))
+
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }), env, { id: share.id })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ ok: true, visibility: 'profile-listed' })
+
+    expect(share.visibility).toBe('profile-listed')
+    const meta = JSON.parse((await env.META.get(`meta/${share.id}`)) as string)
+    expect(meta.visibility).toBe('profile-listed')
+    // Untouched meta fields survive the read-modify-write.
+    expect(meta.title).toBe(share.title)
+    expect(meta.version).toBe(1)
+
+    const auditRow = env.state.audit.find((a) => a.action === 'share.visibility')
+    expect(auditRow).toBeTruthy()
+    expect(auditRow?.target_id).toBe(share.id)
+  })
+
+  it('no-ops idempotently when the visibility already matches', async () => {
+    const { env, share } = await setup({ visibility: 'profile-listed' })
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }), env, { id: share.id })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ ok: true, visibility: 'profile-listed' })
+    // No audit row for a no-op.
+    expect(env.state.audit.some((a) => a.action === 'share.visibility')).toBe(false)
+  })
+
+  it('survives a missing KV meta row (D1 stays the source of truth)', async () => {
+    const { env, share } = await setup()
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }), env, { id: share.id })
+    expect(res.status).toBe(200)
+    expect(share.visibility).toBe('profile-listed')
+  })
+
+  it('429s past the hourly per-user cap', async () => {
+    const { env, share } = await setup()
+    for (let i = 0; i < 60; i++) {
+      const flip = i % 2 === 0 ? 'profile-listed' : 'unlisted'
+      const r = await invoke(visibilityPatch, patchReq(share.id, { visibility: flip }), env, { id: share.id })
+      expect(r.status).toBe(200)
+    }
+    const res = await invoke(visibilityPatch, patchReq(share.id, { visibility: 'profile-listed' }), env, { id: share.id })
+    expect(res.status).toBe(429)
+  })
+})


### PR DESCRIPTION
## What

The Published row's ⋯ menu gains a visibility toggle — **List on profile / Remove from profile** — wired through a new `share-publish:set-visibility` IPC to the backend's PATCH endpoint (previous PR in this stack).

- The item is offered only when the account has a handle (the server enforces the same gate; the menu doesn't offer what can't succeed). Unlisting an already-listed share is always offered, so a handle release doesn't strand a listed share.
- The item's icon previews the **target** state (globe = will appear on the profile, link-2 = will go link-only), matching the meta-line glyph the row lands on after the toggle.
- The toggle reuses the row's busy/lock discipline (trigger spinner, other rows' destructive controls locked) and reconciles through the normal myShares refresh, guarded by the hook's mutation generation so a racing focus-refresh can't stomp the change. Errors come back as data and surface as a toast with the server's detail.
- Also nudges the ⋯ trigger to align with the title's first line (items-start + -mt-0.5), matching SessionRow's action-group alignment.

i18n: 5 new keys across all 7 locales, reusing each locale's established visibility terminology from publishTab.

## Why

Listing state is the one piece of share metadata users revisit after publishing ("actually, put this on my page" / "take it off"). Until now that required reopening the draft in the editor and republishing — or wasn't possible at all when the local draft was gone.

## Test plan

- New e2e drives the toggle both ways through the menu against the mock backend's new PATCH route, asserting the meta-line glyph and mock state after each flip; the live-row spec now also asserts the item is absent for handle-less accounts. share-publish suite 11/11.
- Locale parity green; typecheck clean.
- Manually verified end-to-end on the real local stack (wrangler + share-web + app, real Google OAuth): list → appears on /@handle, unlist → disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)