### PR TITLE
docs: document the share-publish local dev stack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,11 +36,59 @@ Requires Apple Silicon. The script quits any running Spool instance before repla
 
 ```
 packages/
-  app/      Electron macOS app (React + Vite + Tailwind)
-  core/     Indexing engine (SQLite + FTS5)
-  cli/      CLI interface
-  landing/  spool.pro website
+  app/            Electron macOS app (React + Vite + Tailwind)
+  core/           Indexing engine (SQLite + FTS5)
+  cli/            CLI interface
+  landing/        spool.pro website
+  redact/         Sensitive-data detection shared by app + share surfaces
+  share-kit/      Share templates + snapshot rendering (app + share-web)
+  share-backend/  spool.pro publish API (Cloudflare Pages Functions: D1/KV/R2)
+  share-web/      spool.pro public reader + profile + account pages
 ```
+
+## Share publish: local dev stack
+
+Most contributions never need this — `pnpm dev` runs the app fine without
+it. Set it up only when working on the publish flow (share-backend,
+share-web, or the app's publish surfaces).
+
+The stack is three processes: share-backend (wrangler, :8788), share-web
+(vite, :3002), and the Electron app pointed at the local backend.
+`./scripts/share-dev.sh` boots all three. One-time setup first:
+
+1. **Google OAuth dev clients** — create a "Spool Dev" project in
+   [Google Cloud Console → Credentials](https://console.cloud.google.com/apis/credentials)
+   with TWO OAuth clients (never reuse prod ids):
+   - a **Desktop app** client (the Electron loopback sign-in). Note both
+     the client id and the client secret (download the JSON to find it).
+   - a **Web application** client (share-web sign-in) with
+     `http://localhost:3002/api/auth/google/callback` registered as an
+     authorised redirect URI — without this, web sign-in fails with
+     `redirect_uri_mismatch`.
+
+2. **Two gitignored config files**, one per runtime (wrangler and
+   electron-vite each have their own loader — the values overlap but the
+   files don't):
+   ```bash
+   cp packages/share-backend/.dev.vars.example packages/share-backend/.dev.vars
+   cp packages/app/.env.development.local.example packages/app/.env.development.local
+   ```
+   Fill in the Google ids/secrets per the comments in each file.
+
+3. **Local D1 schema**:
+   ```bash
+   cd packages/share-backend
+   corepack pnpm wrangler d1 migrations apply spool-share-db --local
+   ```
+
+4. **Run it**:
+   ```bash
+   ./scripts/share-dev.sh
+   ```
+
+Sign in with any Google account; data lands in the local D1/KV/R2 under
+`packages/share-backend/.wrangler/state/`. The app keeps its dev library
+in `~/.spool-dev/` as usual.
 
 ## Making changes
 

--- a/packages/share-backend/.dev.vars.example
+++ b/packages/share-backend/.dev.vars.example
@@ -25,9 +25,18 @@
 #   reading the `users` row from the local D1 sqlite file; paste it back
 #   here and restart wrangler dev to admin yourself.
 
+# PUBLIC_BASE_URL
+#   The origin OAuth start/callback bake into the redirect_uri sent to
+#   Google. In dev this MUST be the share-web vite server (the /api/*
+#   proxy origin), not wrangler's own :8788 — and it must match the
+#   redirect URI registered on the web OAuth client, or every web
+#   sign-in 400s with redirect_uri_mismatch. Unset in prod (defaults
+#   to https://spool.pro).
+
 GOOGLE_CLIENT_ID_DESKTOP=
 GOOGLE_CLIENT_ID_WEB=
 GOOGLE_CLIENT_SECRET_WEB=
 SESSION_SIGNING_KEY=
 ABUSE_NOTIFY_EMAIL=dev@localhost
 ADMIN_USER_IDS=
+PUBLIC_BASE_URL=http://localhost:3002

--- a/scripts/share-dev.sh
+++ b/scripts/share-dev.sh
@@ -6,15 +6,18 @@
 #   - share-web      on http://localhost:3002   (vite dev, /api/* proxied to backend)
 #   - Spool app      (electron + vite, env-pinned to talk to local backend)
 #
-# Prerequisites (one-time):
+# Prerequisites (one-time) — full walkthrough in CONTRIBUTING.md
+# ("Share publish: local dev stack"):
 #   1. packages/share-backend/.dev.vars must exist + be filled. Copy from
 #      .dev.vars.example and follow the inline instructions to grab dev
 #      Google OAuth client ids.
-#   2. Apply migrations to local sqlite:
+#   2. packages/app/.env.development.local must exist + be filled. Copy
+#      from .env.development.local.example — electron-vite inlines the
+#      SPOOL_GOOGLE_* values into the main bundle at dev build time, so
+#      no shell exports are needed (exports still work and win).
+#   3. Apply migrations to local sqlite:
 #        cd packages/share-backend
 #        corepack pnpm wrangler d1 migrations apply spool-share-db --local
-#   3. SPOOL_GOOGLE_CLIENT_ID_DESKTOP env exported in your shell (the
-#      desktop OAuth client id from the same Google Console project).
 #
 # Usage:
 #   ./scripts/share-dev.sh
@@ -38,11 +41,25 @@ if [[ ! -f packages/share-backend/.dev.vars ]]; then
   exit 1
 fi
 
-if [[ -z "${SPOOL_GOOGLE_CLIENT_ID_DESKTOP:-}" ]]; then
-  echo "ERROR: SPOOL_GOOGLE_CLIENT_ID_DESKTOP must be exported." >&2
-  echo "       Same value as GOOGLE_CLIENT_ID_DESKTOP in .dev.vars." >&2
-  exit 1
-fi
+# The app's desktop OAuth pair can come from either the shell or
+# packages/app/.env.development.local (electron-vite inlines the file at
+# dev build time; shell exports take precedence in its loader). Check
+# whichever source so a filled env file passes with zero exports.
+app_env=packages/app/.env.development.local
+has_app_var() {
+  # exported and non-empty, or a non-empty assignment in the env file
+  [[ -n "${!1:-}" ]] || { [[ -f "$app_env" ]] && grep -Eq "^$1=.+" "$app_env"; }
+}
+for var in SPOOL_GOOGLE_CLIENT_ID_DESKTOP SPOOL_GOOGLE_CLIENT_SECRET_DESKTOP; do
+  if ! has_app_var "$var"; then
+    echo "ERROR: $var is not set." >&2
+    echo "       Fill it in packages/app/.env.development.local (copy the" >&2
+    echo "       .example next to it) or export it in your shell. It is the" >&2
+    echo "       desktop OAuth client ${var##*_} from the same Google Console" >&2
+    echo "       project as .dev.vars — sign-in fails at runtime without it." >&2
+    exit 1
+  fi
+done
 
 trap 'echo; echo "shutting down share-dev"; kill 0' INT TERM EXIT
 


### PR DESCRIPTION
## What

- **CONTRIBUTING.md**: a new "Share publish: local dev stack" section — the one-time Google Console setup (desktop + web OAuth clients, including the `http://localhost:3002/api/auth/google/callback` redirect-URI registration), the two gitignored config files and why there are two (wrangler and electron-vite each have their own loader), local D1 migrations, and `./scripts/share-dev.sh`. The project-structure tree also gains the four share-era packages (redact, share-kit, share-backend, share-web) it was missing.
- **.dev.vars.example**: adds `PUBLIC_BASE_URL=http://localhost:3002` — OAuth start/callback derive the `redirect_uri` from it, and without the override every dev web sign-in 400s with `redirect_uri_mismatch` against the registered URI.
- **scripts/share-dev.sh**: the precheck now covers `SPOOL_GOOGLE_CLIENT_SECRET_DESKTOP` (the token exchange needs it; previously only the id was checked, so the script booted fine and sign-in failed at runtime) and accepts `packages/app/.env.development.local` as the source for both values — electron-vite inlines that file into the main bundle, so a filled env file needs zero shell exports. Exports still work and take precedence.

## Why

Setting up the stack for the first time today hit four undocumented walls in sequence, each one only diagnosable by reading source. Everything here is the walkthrough that would have made it a five-minute setup.

## Test plan

- `bash -n` clean; precheck verified against a filled env file (passes), a missing var (errors with the file-or-export hint), and shell-export-only (passes)
- Full stack booted end-to-end with this setup today: real Google sign-in on desktop and web, publish, visibility toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)