### PR TITLE
feat(share-web): align /me share rows with the desktop Published tab

### DIFF
--- a/packages/share-web/src/components/Chrome.tsx
+++ b/packages/share-web/src/components/Chrome.tsx
@@ -146,6 +146,7 @@ type IconName =
   | 'sun'
   | 'moon'
   | 'google'
+  | 'more-h'
 
 export function Icon({
   name,
@@ -173,6 +174,16 @@ export function Icon({
           <path d="M6 3H3.5A1.5 1.5 0 0 0 2 4.5v8A1.5 1.5 0 0 0 3.5 14h8a1.5 1.5 0 0 0 1.5-1.5V10" />
           <path d="M9.5 2.5H13.5V6.5" />
           <path d="M13 3L7.5 8.5" />
+        </svg>
+      )
+    case 'more-h':
+      // Horizontal ellipsis — the row-actions menu trigger. Filled dots
+      // (not stroked circles) so it reads at 14px.
+      return (
+        <svg {...common} stroke="none" fill="currentColor">
+          <circle cx="3.5" cy="8" r="1.3" />
+          <circle cx="8" cy="8" r="1.3" />
+          <circle cx="12.5" cy="8" r="1.3" />
         </svg>
       )
     case 'link':

--- a/packages/share-web/src/lib/api.ts
+++ b/packages/share-web/src/lib/api.ts
@@ -259,6 +259,49 @@ export async function revokeShare(id: string): Promise<RevokeShareResult> {
   }
 }
 
+export type SetVisibilityResult =
+  | { kind: 'ok' }
+  | { kind: 'unauthenticated' }
+  | { kind: 'not-found' }
+  | { kind: 'gone' }
+  | { kind: 'forbidden' }
+  | { kind: 'needs-handle' }
+  | { kind: 'rate-limited' }
+  | { kind: 'error' }
+
+/** PATCH /api/me/shares/:id — owner-scoped listing toggle. 422 only
+ *  fires for profile-listed without a live handle (the UI gates on the
+ *  handle too, but a release can race), surfaced as `needs-handle`. */
+export async function setShareVisibility(
+  id: string,
+  visibility: 'unlisted' | 'profile-listed',
+): Promise<SetVisibilityResult> {
+  try {
+    const r = await fetch(`/api/me/shares/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      credentials: 'same-origin',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ visibility }),
+    })
+    if (r.status === 200) return { kind: 'ok' }
+    if (r.status === 401) {
+      // Session died between page load and the click — same cache
+      // discipline as fetchMe so the next render redirects cleanly.
+      clearCachedMe()
+      invalidateAuthCache()
+      return { kind: 'unauthenticated' }
+    }
+    if (r.status === 404) return { kind: 'not-found' }
+    if (r.status === 410) return { kind: 'gone' }
+    if (r.status === 403) return { kind: 'forbidden' }
+    if (r.status === 422) return { kind: 'needs-handle' }
+    if (r.status === 429) return { kind: 'rate-limited' }
+    return { kind: 'error' }
+  } catch {
+    return { kind: 'error' }
+  }
+}
+
 export type CheckHandleResult =
   | { kind: 'available' }
   | { kind: 'taken' }

--- a/packages/share-web/src/pages/Me.tsx
+++ b/packages/share-web/src/pages/Me.tsx
@@ -14,6 +14,7 @@ import {
   fetchMe,
   fetchMyShares,
   revokeShare,
+  setShareVisibility,
   scheduleAccountDeletion,
   signOut,
   type MeResponse,
@@ -195,11 +196,17 @@ function renderAvailability(
 function ShareRow({
   row,
   disabled,
+  hasHandle,
   onUnpublishRequest,
+  onToggleVisibility,
 }: {
   row: MeShareRow
   disabled?: boolean
+  /** Whether "List on profile" is offered — requires a live handle
+   *  (the server enforces the same gate). Unlisting is always offered. */
+  hasHandle: boolean
   onUnpublishRequest: (row: MeShareRow) => void
+  onToggleVisibility: (row: MeShareRow) => Promise<{ ok: boolean; reason?: string }>
 }) {
   const [copied, setCopied] = useState(false)
   const revoked = row.revoked_at !== null
@@ -246,39 +253,135 @@ function ShareRow({
             <Icon name={listed ? 'globe' : 'link-2'} size={12} />
           </span>
           <span>published {humanDate(row.published_at)}</span>
-          {revoked && (
-            <>
-              <span className="dot-sep">·</span>
-              <span className="sw-pill revoked">Unpublished</span>
-            </>
-          )}
         </span>
       </a>
-      {!disabled && (
-        <div className="sw-share-actions">
-          <button
-            type="button"
-            className={`sw-icon-btn${copied ? ' ok' : ''}`}
-            onClick={copy}
-            title={copied ? 'Copied' : 'Copy link'}
-            aria-label={copied ? 'Copied' : 'Copy link'}
-          >
-            <Icon name={copied ? 'check' : 'link'} size={14} />
-          </button>
-          {!revoked && (
-            <button
-              type="button"
-              className="sw-icon-btn danger"
-              onClick={() => onUnpublishRequest(row)}
-              title="Unpublish"
-              aria-label="Unpublish"
-            >
-              <Icon name="eye-off" size={14} />
-            </button>
-          )}
-        </div>
+      {/* Row actions live in a single ⋯ menu, mirroring the desktop
+       *  Published row: hover-revealed (always visible on touch — see
+       *  the hover:none media rule), pinned while open. Revoked rows
+       *  get no actions at all — the slug is permanently 410, so Copy
+       *  link would hand out a dead URL. */}
+      {!disabled && !revoked && (
+        <RowMenu
+          copied={copied}
+          listed={listed}
+          canList={hasHandle}
+          onCopy={() => void copy()}
+          onToggleVisibility={() => onToggleVisibility(row)}
+          onUnpublish={() => onUnpublishRequest(row)}
+        />
       )}
     </li>
+  )
+}
+
+function RowMenu({
+  copied,
+  listed,
+  canList,
+  onCopy,
+  onToggleVisibility,
+  onUnpublish,
+}: {
+  copied: boolean
+  listed: boolean
+  canList: boolean
+  onCopy: () => void
+  onToggleVisibility: () => Promise<{ ok: boolean; reason?: string }>
+  onUnpublish: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const rootRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function onDown(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  async function toggleVisibility() {
+    if (busy) return
+    setBusy(true)
+    setErr(null)
+    const r = await onToggleVisibility()
+    setBusy(false)
+    if (r.ok) {
+      setOpen(false)
+    } else {
+      // No toast surface on the web — the failure renders inline in
+      // the open menu and clears when it closes.
+      setErr(r.reason ?? 'Could not change visibility.')
+    }
+  }
+
+  return (
+    <div ref={rootRef} className="sw-rowmenu">
+      <button
+        type="button"
+        className="sw-rowmenu-trigger"
+        onClick={() => {
+          setErr(null)
+          setOpen((v) => !v)
+        }}
+        title="More actions"
+        aria-label="More actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <Icon name="more-h" size={14} />
+      </button>
+      {open && (
+        <div role="menu" className="sw-rowmenu-pop">
+          {/* Copy keeps the menu open so the "Copied" confirmation is
+           *  visible where the click happened; the parent resets the
+           *  copied flag after 1.5s. */}
+          <button type="button" role="menuitem" className={`sw-rowmenu-item${copied ? ' ok' : ''}`} onClick={onCopy}>
+            <Icon name={copied ? 'check' : 'link'} size={13} />
+            {copied ? 'Copied' : 'Copy link'}
+          </button>
+          {/* Icon previews the TARGET state (globe = will appear on the
+           *  profile, link-2 = will go link-only) — same pairing as the
+           *  desktop row menu and the meta-line glyph. */}
+          {(listed || canList) && (
+            <button
+              type="button"
+              role="menuitem"
+              className="sw-rowmenu-item"
+              disabled={busy}
+              onClick={() => void toggleVisibility()}
+            >
+              <Icon name={listed ? 'link-2' : 'globe'} size={13} />
+              {listed ? 'Remove from profile' : 'List on profile'}
+            </button>
+          )}
+          <button
+            type="button"
+            role="menuitem"
+            className="sw-rowmenu-item danger"
+            disabled={busy}
+            onClick={() => {
+              setOpen(false)
+              onUnpublish()
+            }}
+          >
+            <Icon name="eye-off" size={13} />
+            Unpublish
+          </button>
+          {err && <p className="sw-rowmenu-err">{err}</p>}
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -485,6 +588,7 @@ function UnpublishConfirmModal({
 
 export function Me() {
   const [state, setState] = useState<LoadState>({ kind: 'loading' })
+  const [showRevoked, setShowRevoked] = useState(false)
   // Re-entrancy lock on confirmUnpublish: the button is `disabled={busy}`
   // but a double-tap on a slow device can fire onClick twice before React
   // commits the `unpublishBusy: true` write. The ref blocks the second
@@ -519,6 +623,38 @@ export function Me() {
     document.title = 'Your account · spool.pro'
     load()
   }, [load])
+
+  async function onToggleVisibility(row: MeShareRow): Promise<{ ok: boolean; reason?: string }> {
+    const next = row.visibility === 'profile-listed' ? 'unlisted' as const : 'profile-listed' as const
+    const r = await setShareVisibility(row.id, next)
+    if (r.kind === 'ok') {
+      setState((s) => {
+        if (s.kind !== 'ok') return s
+        return {
+          ...s,
+          shares: s.shares.map((x) => (x.id === row.id ? { ...x, visibility: next } : x)),
+        }
+      })
+      return { ok: true }
+    }
+    if (r.kind === 'unauthenticated') {
+      window.location.assign('/sign-in?next=/me')
+      return { ok: true } // navigating away; don't paint an error first
+    }
+    if (r.kind === 'needs-handle') {
+      return { ok: false, reason: 'Claim a handle first — listing needs a profile page.' }
+    }
+    if (r.kind === 'forbidden') {
+      return { ok: false, reason: 'Your account is pending deletion — cancel it first.' }
+    }
+    if (r.kind === 'rate-limited') {
+      return { ok: false, reason: 'Too many changes — wait a minute.' }
+    }
+    if (r.kind === 'gone' || r.kind === 'not-found') {
+      return { ok: false, reason: 'Share not found (already unpublished?).' }
+    }
+    return { ok: false, reason: 'Could not change visibility — try again.' }
+  }
 
   async function onUnpublish(id: string): Promise<{ ok: boolean; reason?: string }> {
     const r = await revokeShare(id)
@@ -611,6 +747,12 @@ export function Me() {
   const { me, shares } = state
   const pendingUntil = me.deletion_pending_until
   const pending = pendingUntil !== null
+  // Live shares stay flat (server order: published_at desc); revoked
+  // history collapses into its own section, newest revoke first.
+  const liveShares = shares.filter((s) => s.revoked_at === null)
+  const revokedShares = shares
+    .filter((s) => s.revoked_at !== null)
+    .sort((a, b) => (b.revoked_at ?? 0) - (a.revoked_at ?? 0))
 
   function openDelete() {
     setState((s) => (s.kind === 'ok' ? { ...s, deleteOpen: true } : s))
@@ -735,25 +877,66 @@ export function Me() {
           <div className="sw-divider" style={{ margin: '24px 0 18px' }} />
           <h2 className="sw-section-label" style={{ marginBottom: 14 }}>
             Your shares
-            {!pending && shares.length > 0 && <span className="count">{shares.length}</span>}
+            {!pending && liveShares.length > 0 && <span className="count">{liveShares.length}</span>}
           </h2>
           {pending ? (
             <p className="sw-empty">
               Hidden while deletion is pending. Cancel deletion to restore the list.
             </p>
-          ) : shares.length === 0 ? (
-            <p className="sw-empty">You haven’t published anything yet.</p>
           ) : (
-            <ul className="sw-list">
-              {shares.map((row) => (
-                <ShareRow
-                  key={row.id}
-                  row={row}
-                  disabled={pending}
-                  onUnpublishRequest={requestUnpublish}
-                />
-              ))}
-            </ul>
+            <>
+              {liveShares.length === 0 && revokedShares.length === 0 ? (
+                <p className="sw-empty">You haven’t published anything yet.</p>
+              ) : (
+                liveShares.length > 0 && (
+                  <ul className="sw-list">
+                    {liveShares.map((row) => (
+                      <ShareRow
+                        key={row.id}
+                        row={row}
+                        disabled={pending}
+                        hasHandle={me.handle !== null}
+                        onUnpublishRequest={requestUnpublish}
+                        onToggleVisibility={onToggleVisibility}
+                      />
+                    ))}
+                  </ul>
+                )
+              )}
+              {/* Revoked shares are history records: collapsed by default
+               *  (they accumulate forever — only account deletion purges
+               *  them) and display-only, mirroring the desktop Published
+               *  tab. The section only exists when there's history. */}
+              {revokedShares.length > 0 && (
+                <div className="sw-collapse">
+                  <button
+                    type="button"
+                    className="sw-collapse-head"
+                    onClick={() => setShowRevoked((v) => !v)}
+                    aria-expanded={showRevoked}
+                  >
+                    <span>Unpublished · {revokedShares.length}</span>
+                    <span className={`sw-collapse-chev${showRevoked ? ' open' : ''}`} aria-hidden>
+                      <Icon name="arrow-right" size={11} />
+                    </span>
+                  </button>
+                  {showRevoked && (
+                    <ul className="sw-list">
+                      {revokedShares.map((row) => (
+                        <ShareRow
+                          key={row.id}
+                          row={row}
+                          disabled={pending}
+                          hasHandle={me.handle !== null}
+                          onUnpublishRequest={requestUnpublish}
+                          onToggleVisibility={onToggleVisibility}
+                        />
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
+            </>
           )}
 
           <p className="sw-signed-in-as">

--- a/packages/share-web/src/styles.css
+++ b/packages/share-web/src/styles.css
@@ -458,7 +458,9 @@ html[data-theme='dark'] .sw-root {
  * as siblings, so their own onClick wins. */
 .sw-share {
   display: flex;
-  align-items: center;
+  /* Top-aligned so the ⋯ trigger pins to the title's first line
+   * (desktop parity) instead of centering against title+meta. */
+  align-items: flex-start;
   gap: 10px;
   padding: 4px 12px;
   margin: 0 -12px;
@@ -506,9 +508,6 @@ html[data-theme='dark'] .sw-root {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.sw-share:hover .sw-share-title {
-  color: var(--accent);
-}
 .sw-share-link:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -540,12 +539,140 @@ html[data-theme='dark'] .sw-root {
   color: var(--muted);
   white-space: nowrap;
 }
-.sw-share-actions {
+/* Row-actions ⋯ menu — mirrors the desktop Published row: a quiet
+ * borderless trigger (not the bordered sw-icon-btn), hover-revealed,
+ * pinned while its menu is open. Touch devices have no hover, so the
+ * trigger is always visible there. */
+.sw-rowmenu-trigger {
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+  flex: 0 0 auto;
+}
+/* One step darker than the row's own hover (card-2), mirroring the
+ * desktop surface → surface2 ladder — card-2 on card-2 was invisible. */
+.sw-rowmenu-trigger:hover,
+.sw-rowmenu-trigger[aria-expanded='true'] {
+  background: var(--border);
+  color: var(--text);
+}
+.sw-rowmenu {
+  position: relative;
+  flex: 0 0 auto;
+  /* Optically center the 24px trigger on the title's first line: the
+   * anchor carries 12px top padding and the 15.5px/1.35 title line is
+   * ~21px tall → 12 + (21 − 24) / 2 ≈ 10px. */
+  margin-top: 10px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.sw-share:hover .sw-rowmenu,
+.sw-share:focus-within .sw-rowmenu,
+.sw-rowmenu:has([aria-expanded='true']) {
+  opacity: 1;
+}
+@media (hover: none) {
+  .sw-rowmenu {
+    opacity: 1;
+  }
+}
+.sw-rowmenu-pop {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  width: max-content;
+  padding: 4px;
+  background: var(--card);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.10);
+  z-index: 30;
+}
+.sw-rowmenu-item {
   display: flex;
   align-items: center;
+  gap: 8px;
+  width: 100%;
+  white-space: nowrap;
+  padding: 7px 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.sw-rowmenu-item svg {
+  color: var(--muted);
+}
+.sw-rowmenu-item:hover {
+  background: var(--card-2);
+}
+.sw-rowmenu-item.danger:hover {
+  background: var(--err-soft);
+  color: var(--err);
+}
+.sw-rowmenu-item.danger:hover svg,
+.sw-rowmenu-item.ok svg {
+  color: inherit;
+}
+.sw-rowmenu-item.ok {
+  color: var(--ok);
+}
+.sw-rowmenu-item:disabled {
+  opacity: 0.5;
+  cursor: progress;
+}
+.sw-rowmenu-err {
+  margin: 4px 6px 4px;
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--err);
+}
+
+/* Collapsed history section — mirrors the desktop Published tab's
+ * "Unpublished · N" header: quiet mono label, chevron rotates open. */
+.sw-collapse {
+  margin-top: 6px;
+}
+.sw-collapse-head {
+  display: inline-flex;
+  align-items: center;
   gap: 6px;
-  flex: 0 0 auto;
-  padding: 8px 0;
+  padding: 8px 0 4px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--faint);
+  transition: color 0.12s;
+}
+.sw-collapse-head:hover {
+  color: var(--text);
+}
+.sw-collapse-chev {
+  display: inline-flex;
+  opacity: 0.5;
+  transition: transform 0.15s, opacity 0.12s;
+}
+.sw-collapse-head:hover .sw-collapse-chev {
+  opacity: 1;
+}
+.sw-collapse-chev.open {
+  transform: rotate(90deg);
 }
 
 /* compact icon buttons */
@@ -589,28 +716,6 @@ html[data-theme='dark'] .sw-root {
   border-color: color-mix(in srgb, var(--err) 55%, transparent);
   color: var(--err);
   background: var(--err-soft);
-}
-
-/* visibility / status pills */
-.sw-pill {
-  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  padding: 2px 7px;
-  border-radius: 5px;
-  border: 1px solid var(--border-strong);
-  color: var(--muted);
-}
-.sw-pill.listed {
-  color: var(--accent);
-  border-color: var(--accent-line);
-  background: var(--accent-soft);
-}
-.sw-pill.revoked {
-  color: var(--err);
-  border-color: color-mix(in srgb, var(--err) 40%, transparent);
 }
 
 /* ── Handle claim ───────────────────────────────────────────── */
@@ -1241,10 +1346,6 @@ html[data-theme='dark'] .sw-modal-overlay {
   .sw-share {
     flex-wrap: wrap;
     gap: 10px;
-  }
-  .sw-share-actions {
-    width: 100%;
-    justify-content: flex-end;
   }
   .reader-canvas {
     padding: 24px 12px 0;


### PR DESCRIPTION
## What

Brings the /me share rows in line with the desktop Shares → Published row design:

- **Row actions collapse into a single hover-revealed ⋯ menu** (pinned while open via `:has([aria-expanded])`; always visible on touch devices, which have no hover): Copy link (in-place "Copied" confirmation), the new **List on profile / Remove from profile** toggle, and Unpublish. The toggle calls the `PATCH /api/me/shares/:id` endpoint shipped in #383 with the same gates as the desktop menu — listing offered only when the account has a live handle, icon previews the target state. Failures render inline in the open menu (the web has no toast surface); 401 clears the auth caches and bounces to /sign-in.
- **Revoked shares move into a collapsed "Unpublished · N" section** that only renders when history exists, and are display-only — the previous Copy link on revoked rows handed out a permanently-410 URL. The per-row red pill goes away; the section header carries the state. Mirrors the desktop decision (revoked history accumulates forever; only account deletion purges it).
- **Title hover no longer recolors** on /me and /@handle, and rows top-align so the ⋯ pins to the title's first line — both matching the desktop row.
- Trigger restyle: quiet borderless 24px button one contrast step above the row hover, replacing the bordered 30px icon buttons. Dead CSS dropped (`.sw-share-actions`, `.sw-pill`).

## Why

The two surfaces show the same data and had drifted into different interaction languages. Two always-visible bare icons also read as ambiguous chrome — the menu names each action.

## Known gap (intentionally out of scope)

`revokeShare` shares the pre-existing un-handled-401 behavior that `setShareVisibility` now fixes; aligning it touches the unpublish confirm-modal flow and belongs in its own change.

## Test plan

- typecheck clean, 69 share-web tests green, production build green
- Verified on the real local stack (wrangler + share-web, real Google session): menu reveal/pin/Esc/outside-click, copy confirmation, list → appears on /@handle, unlist → disappears, no-handle gating, revoked rows collapse into the section with no actions, first-line alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)