### PR TITLE
feat(share-web): real Terms and Privacy pages

### DIFF
--- a/packages/share-web/public/_headers
+++ b/packages/share-web/public/_headers
@@ -17,3 +17,13 @@
 
 /sign-in
   Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://spool.pro https://lh3.googleusercontent.com; font-src 'self' data:; connect-src 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'
+
+# Legal pages are the one surface we WANT indexable (and Google's OAuth
+# brand verification fetches the privacy URL) — drop the site default.
+/terms
+  ! X-Robots-Tag
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; form-action 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'
+
+/privacy
+  ! X-Robots-Tag
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; form-action 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'

--- a/packages/share-web/src/App.tsx
+++ b/packages/share-web/src/App.tsx
@@ -2,9 +2,11 @@ import { useMemo } from 'react'
 
 import { routeFor } from './lib/route'
 import { Me } from './pages/Me'
+import { Privacy } from './pages/Privacy'
 import { Profile } from './pages/Profile'
 import { Reader } from './pages/Reader'
 import { SignIn } from './pages/SignIn'
+import { Terms } from './pages/Terms'
 import { Tombstone } from './pages/Tombstone'
 
 export function App() {
@@ -17,5 +19,7 @@ export function App() {
   if (route.kind === 'profile') return <Profile handle={route.handle} />
   if (route.kind === 'me') return <Me />
   if (route.kind === 'sign-in') return <SignIn next={route.next} />
+  if (route.kind === 'terms') return <Terms />
+  if (route.kind === 'privacy') return <Privacy />
   return <Tombstone reason="not-found" />
 }

--- a/packages/share-web/src/components/Chrome.tsx
+++ b/packages/share-web/src/components/Chrome.tsx
@@ -372,15 +372,11 @@ export function Header({ auth = 'auto' as AuthState }: { auth?: AuthState }) {
 }
 
 /**
- * Footer is now report-only. The previous "Learn about Spool · Terms ·
- * Privacy" row was dropped because Terms / Privacy never had real copy
- * — the placeholder routes 404'd, and a misleading link is worse than
- * no link. The Learn-about-Spool link is redundant with the Wordmark
- * in the header (both link to the landing site).
- *
- * Only Reader still mounts a footer, exclusively to surface the
- * report-share path. Pages that call `<Footer />` without a report
- * prop render nothing.
+ * Footer carries the legal links (real pages as of the GA prep — the
+ * pre-#378 placeholders 404'd and were dropped) plus, on Reader pages,
+ * the report-share path. The Learn-about-Spool link stays gone: it is
+ * redundant with the Wordmark in the header (both link to the landing
+ * site).
  */
 export function Footer({
   report,
@@ -389,12 +385,19 @@ export function Footer({
   report?: boolean
   reportHref?: string
 }) {
-  if (!report || !reportHref) return null
   return (
     <footer className="sw-footer">
-      <a href={reportHref} rel="nofollow">
-        Report this share
-      </a>
+      {report && reportHref && (
+        <>
+          <a href={reportHref} rel="nofollow">
+            Report this share
+          </a>
+          <span className="sep">·</span>
+        </>
+      )}
+      <a href="/terms">Terms</a>
+      <span className="sep">·</span>
+      <a href="/privacy">Privacy</a>
     </footer>
   )
 }

--- a/packages/share-web/src/lib/route.test.ts
+++ b/packages/share-web/src/lib/route.test.ts
@@ -33,6 +33,15 @@ describe('routeFor', () => {
     expect(routeFor('/me')).toEqual({ kind: 'me' })
   })
 
+  it('matches /terms and /privacy as legal pages', () => {
+    expect(routeFor('/terms')).toEqual({ kind: 'terms' })
+    expect(routeFor('/privacy')).toEqual({ kind: 'privacy' })
+    // Trailing slashes normalize like every other route.
+    expect(routeFor('/terms/')).toEqual({ kind: 'terms' })
+    // Subpaths are not legal pages.
+    expect(routeFor('/terms/extra').kind).toBe('tombstone')
+  })
+
   it('matches /@<handle> as profile', () => {
     expect(routeFor('/@alice')).toEqual({ kind: 'profile', handle: 'alice' })
   })

--- a/packages/share-web/src/lib/route.ts
+++ b/packages/share-web/src/lib/route.ts
@@ -11,6 +11,8 @@ export type Route =
   | { kind: 'profile'; handle: string }
   | { kind: 'me' }
   | { kind: 'sign-in'; next: string }
+  | { kind: 'terms' }
+  | { kind: 'privacy' }
   | { kind: 'tombstone'; reason: 'not-found' }
 
 // Slugs are nanoid(21) — URL-safe base64 alphabet
@@ -42,6 +44,10 @@ export function routeFor(pathname: string, search: string = ''): Route {
 
   // Me: /me
   if (path === '/me') return { kind: 'me' }
+
+  // Legal: /terms, /privacy
+  if (path === '/terms') return { kind: 'terms' }
+  if (path === '/privacy') return { kind: 'privacy' }
 
   // Sign-in: /sign-in?next=<safe>
   if (path === '/sign-in') {

--- a/packages/share-web/src/pages/Privacy.tsx
+++ b/packages/share-web/src/pages/Privacy.tsx
@@ -1,0 +1,173 @@
+// Privacy policy — static legal page. Every factual claim below is
+// grounded in the codebase; if behavior changes (new processor, new
+// data category, different retention), this page MUST change in the
+// same PR. Structure informed by the Basecamp open-source policies
+// (CC BY 4.0) and Obsidian's summary-first layout.
+
+import { useEffect } from 'react'
+
+import { Footer, Header, Page } from '../components/Chrome'
+
+const LAST_UPDATED = 'June 12, 2026'
+
+export function Privacy() {
+  useEffect(() => {
+    document.title = 'Privacy · spool.pro'
+  }, [])
+
+  return (
+    <Page>
+      <Header auth="out" />
+      <main className="sw-main">
+        <article className="sw-card w-600 sw-legal">
+          <p className="sw-eyebrow">spool.pro</p>
+          <h1 className="sw-title">Privacy policy</h1>
+          <p className="sw-legal-date">Last updated: {LAST_UPDATED}</p>
+
+          <div className="sw-legal-summary">
+            <p>The short version:</p>
+            <ul>
+              <li>
+                The Spool desktop app is local-first. Your session library
+                never leaves your machine — the only thing that ever
+                reaches our servers is a snapshot you explicitly publish.
+              </li>
+              <li>
+                spool.pro runs no analytics, no trackers, no ads, and no
+                third-party cookies.
+              </li>
+              <li>
+                Unpublishing a share or deleting your account actually
+                deletes the data.
+              </li>
+            </ul>
+          </div>
+
+          <h2>Who we are</h2>
+          <p>
+            spool.pro is the publishing service for{' '}
+            <a href="https://spool.pro">Spool</a>, an open-source desktop
+            app for browsing and sharing AI coding sessions. For anything
+            in this policy, contact us at{' '}
+            <a href="mailto:hello@spool.pro">hello@spool.pro</a>.
+          </p>
+
+          <h2>What we collect</h2>
+          <p>
+            <strong>Account.</strong> You sign in with Google. We request
+            the <code>openid</code>, <code>email</code>, and{' '}
+            <code>profile</code> scopes and use them for exactly one
+            thing: signing you in and identifying your account. From
+            those we store your email address, your name, and the URL of
+            your Google profile picture. We never see your Google
+            password and we request no access to any other Google data.
+          </p>
+          <p>
+            <strong>Profile, if you set one up.</strong> A handle, an
+            optional display name, and an optional uploaded avatar.
+            These are public on your profile page.
+          </p>
+          <p>
+            <strong>Content you publish.</strong> When you click Publish
+            in the desktop app, the snapshot you composed — and nothing
+            else from your library — is uploaded and stored so it can be
+            served at its share link.
+          </p>
+          <p>
+            <strong>Operational data.</strong> A session cookie keeps you
+            signed in (30 days, sliding, capped at 90). Security-relevant
+            actions (sign-in, publish, unpublish) are recorded in an
+            audit log together with a salted hash of your IP address and
+            browser user-agent — the salt rotates daily and the hash
+            cannot be reversed back to your IP. Rate-limit counters exist
+            briefly to keep abuse in check.
+          </p>
+          <p>
+            <strong>What we don't collect:</strong> no analytics, no
+            behavioral tracking, no advertising identifiers, no
+            third-party cookies. The desktop app sends no telemetry, and
+            your local session library is never uploaded.
+          </p>
+
+          <h2>How we use it</h2>
+          <p>
+            To operate the service you asked for (signing you in, hosting
+            your shares, showing your profile — in GDPR terms, performance
+            of a contract) and to keep the service safe (rate limiting and
+            audit logging — our legitimate interest in preventing abuse).
+            That's the whole list.
+          </p>
+
+          <h2>Who we share it with</h2>
+          <p>
+            Two infrastructure providers, and nobody else:{' '}
+            <strong>Cloudflare</strong> hosts the service and stores all
+            data (Pages, D1, KV, R2), and <strong>Google</strong> handles
+            sign-in; unless you upload a custom avatar, your profile
+            picture is served from Google's CDN. We do not sell or share
+            your personal information, in the everyday sense or in the
+            CCPA sense.
+          </p>
+
+          <h2>Published content is public</h2>
+          <p>
+            That's the point of publishing. A link-only share is visible
+            to anyone who has the URL; a share listed on your profile is
+            visible to anyone who visits it. Third parties — search
+            engines, social-media link previews — may make their own
+            copies, and those copies can outlive an unpublish. Treat
+            publishing as you would posting publicly anywhere.
+          </p>
+
+          <h2>Retention and deletion</h2>
+          <p>
+            <strong>Unpublishing a share is immediate and permanent.</strong>{' '}
+            The link stops working within seconds and the stored snapshot
+            is deleted; the same link can never be brought back.
+          </p>
+          <p>
+            <strong>Deleting your account</strong> starts a 24-hour grace
+            window (so a mistaken click can be undone), after which every
+            share is unpublished and its content deleted, your handle is
+            released, and your account record is stripped of personal
+            information. Residual copies in our infrastructure provider's
+            automatic backups expire within 30 days.
+          </p>
+
+          <h2>Your rights</h2>
+          <p>
+            Everything is self-service. You can see and change everything
+            we store about you from <a href="/me">your account page</a>,
+            and delete all of it with the delete-account flow — no email
+            required, no questions asked. You already hold a complete
+            copy of anything you've published: you composed it locally in
+            the app, and every live share serves its full content at its
+            link. For privacy questions or anything you can't do from the
+            account page, write to{' '}
+            <a href="mailto:hello@spool.pro">hello@spool.pro</a>.
+          </p>
+
+          <h2>Children</h2>
+          <p>
+            spool.pro is not directed at children under 13 and we don't
+            knowingly collect their data.
+          </p>
+
+          <h2>Changes</h2>
+          <p>
+            When this policy changes we'll update it here and adjust the
+            date at the top. If a change meaningfully affects what we
+            collect or how we use it, we'll say so on the site before it
+            takes effect.
+          </p>
+
+          <p className="sw-legal-credit">
+            Structure adapted from the Basecamp open-source policies
+            (CC BY 4.0).
+          </p>
+        </article>
+      </main>
+      <Footer />
+    </Page>
+  )
+}

--- a/packages/share-web/src/pages/SignIn.tsx
+++ b/packages/share-web/src/pages/SignIn.tsx
@@ -126,6 +126,10 @@ export function SignIn({ next }: Props) {
               name, and picture.
             </span>
           </div>
+          <p className="sw-signin-legal">
+            By signing in you agree to the <a href="/terms">Terms</a> and{' '}
+            <a href="/privacy">Privacy policy</a>.
+          </p>
         </div>
       </main>
       <Footer />

--- a/packages/share-web/src/pages/Terms.tsx
+++ b/packages/share-web/src/pages/Terms.tsx
@@ -1,0 +1,137 @@
+// Terms of service — static legal page, deliberately minimal: the
+// service is free, so there are no billing/refund clauses, and we
+// self-identify as the service rather than a named legal entity. The
+// load-bearing parts are content ownership/responsibility and the use
+// restrictions the report flow points at. Structure informed by the
+// Basecamp open-source policies (CC BY 4.0).
+
+import { useEffect } from 'react'
+
+import { Footer, Header, Page } from '../components/Chrome'
+
+const LAST_UPDATED = 'June 12, 2026'
+
+export function Terms() {
+  useEffect(() => {
+    document.title = 'Terms · spool.pro'
+  }, [])
+
+  return (
+    <Page>
+      <Header auth="out" />
+      <main className="sw-main">
+        <article className="sw-card w-600 sw-legal">
+          <p className="sw-eyebrow">spool.pro</p>
+          <h1 className="sw-title">Terms of service</h1>
+          <p className="sw-legal-date">Last updated: {LAST_UPDATED}</p>
+
+          <p>
+            These terms cover spool.pro, the publishing service for the
+            Spool desktop app. By creating an account or publishing a
+            share you agree to them. The short version: your content is
+            yours, don't use the service to hurt people, and we provide
+            it as-is.
+          </p>
+
+          <h2>The service</h2>
+          <p>
+            spool.pro hosts conversation snapshots you explicitly publish
+            from the Spool app and serves them at public links, optionally
+            listed on a public profile page. The service is currently
+            free. We work hard to keep it fast and available, but it is
+            provided <strong>as is</strong>, without warranties of any
+            kind, and we may change or discontinue features — if we ever
+            discontinue the service itself, we'll give you notice and
+            time to take your content elsewhere.
+          </p>
+
+          <h2>Your account</h2>
+          <p>
+            You sign in with Google and are responsible for activity that
+            happens under your account. You can delete your account at any
+            time from <a href="/me">your account page</a>; deletion is
+            described in the <a href="/privacy">privacy policy</a>.
+          </p>
+
+          <h2>Your content</h2>
+          <p>
+            What you publish stays yours. You grant us the non-exclusive
+            license needed to operate the service — to store, copy,
+            display, and distribute your published shares at their links,
+            on your profile if listed, and in previews such as
+            social-media cards. This license ends for a share when you
+            unpublish it, except where the privacy policy describes
+            residual copies.
+          </p>
+          <p>
+            You are responsible for what you publish. Conversations can
+            contain things you didn't write — other people's words, AI
+            output, pasted code, credentials, personal data. Publishing
+            makes all of it public, and by publishing you confirm you
+            have the right to do that.
+          </p>
+          <p>
+            <strong>Unpublishing is permanent.</strong> The link dies
+            within seconds and can never be revived; republishing the
+            same draft produces a new link. Copies made by third parties
+            while a share was live (search engines, link previews) are
+            outside our control.
+          </p>
+
+          <h2>Use restrictions</h2>
+          <p>You may not use spool.pro to publish or do any of the following:</p>
+          <ul>
+            <li>content that is illegal or that you don't have the right to share</li>
+            <li>other people's personal or private information (doxxing)</li>
+            <li>malware, phishing, or content designed to deceive or harm</li>
+            <li>harassment, threats, or incitement</li>
+            <li>spam, or bulk publishing for SEO or promotional schemes</li>
+            <li>
+              anything that disrupts the service — probing or breaking
+              security and rate limits, scraping accounts, automated
+              abuse
+            </li>
+          </ul>
+          <p>
+            Every published share carries a report link. You can also
+            reach us at{' '}
+            <a href="mailto:abuse@spool.pro">abuse@spool.pro</a>.
+          </p>
+
+          <h2>Removal and termination</h2>
+          <p>
+            We may remove content or suspend accounts that violate these
+            terms — where practical we'll tell you why. Nothing here
+            limits your ability to walk away: your account and everything
+            in it can be deleted by you, at any time, for any reason.
+          </p>
+
+          <h2>Liability</h2>
+          <p>
+            To the maximum extent permitted by law, we are not liable for
+            indirect, incidental, or consequential damages arising from
+            your use of the service, and our total liability for any
+            claim is limited to the amount you've paid us to use
+            spool.pro in the past twelve months — which, for a free
+            service, is zero.
+          </p>
+
+          <h2>Changes</h2>
+          <p>
+            We may update these terms as the service evolves. The date at
+            the top reflects the latest revision; material changes will
+            be announced on the site before they take effect. Using the
+            service after a change takes effect means you accept the
+            revised terms.
+          </p>
+
+          <p className="sw-legal-credit">
+            Structure adapted from the Basecamp open-source policies
+            (CC BY 4.0).
+          </p>
+        </article>
+      </main>
+      <Footer />
+    </Page>
+  )
+}

--- a/packages/share-web/src/styles.css
+++ b/packages/share-web/src/styles.css
@@ -239,6 +239,80 @@ html[data-theme='dark'] .sw-root {
   max-width: 480px;
 }
 
+/* ── Legal pages (terms / privacy) ─────────────────────────── */
+.sw-legal {
+  font-size: 14px;
+  line-height: 1.65;
+}
+.sw-legal h1 {
+  margin: 6px 0 0;
+}
+.sw-legal h2 {
+  margin: 28px 0 8px;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+.sw-legal p {
+  margin: 0 0 12px;
+  color: var(--text);
+}
+.sw-legal ul {
+  margin: 0 0 12px;
+  padding-left: 20px;
+}
+.sw-legal li {
+  margin: 4px 0;
+}
+.sw-legal a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.sw-legal code {
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12.5px;
+  background: var(--card-2);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+.sw-legal-date {
+  margin: 10px 0 22px;
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  color: var(--muted);
+}
+.sw-legal-summary {
+  margin: 0 0 24px;
+}
+.sw-legal-summary p {
+  margin: 0 0 6px;
+  font-weight: 600;
+}
+.sw-legal-summary ul {
+  margin: 0;
+}
+.sw-legal-credit {
+  margin-top: 30px;
+  font-size: 11.5px;
+  color: var(--faint);
+}
+.sw-signin-legal {
+  margin: 14px 0 0;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--faint);
+}
+.sw-signin-legal a {
+  color: var(--muted);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.sw-signin-legal a:hover {
+  color: var(--accent);
+}
+
 /* ── Eyebrows / mastheads ───────────────────────────────────── */
 .sw-eyebrow {
   font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;


### PR DESCRIPTION
## What

- **/privacy** — written from the codebase's actual behavior, summary-first: local-first stance (library never uploaded; only explicit publishes leave the machine), the Google OAuth scopes statement (`openid`/`email`/`profile`, used for sign-in only — required wording for Google's brand verification), what is and isn't collected (no analytics/trackers/ads; session cookie 30d sliding/90d cap; daily-salted irreversible IP/UA hashes in the audit log), Cloudflare + Google as the only processors, public-content caveats, permanent unpublish, 24h deletion grace + hard cascade, 30-day infrastructure-backup expiry, self-service rights via /me.
- **/terms** — deliberately minimal for a free service: as-is provision (with a wind-down notice promise), content ownership + the hosting/display license, publisher responsibility (conversations can contain third-party / AI content), permanent-unpublish semantics, six use restrictions that the Reader's report link and abuse@spool.pro anchor to, removal/termination, the paid-us-zero liability cap. No billing clauses, no governing-law clause; the operator self-identifies as spool.pro.
- Footer renders **Terms · Privacy** site-wide again (Reader keeps Report this share in front) — undoing the #378 placeholder removal with real pages.
- **/sign-in** gains the customary "By signing in you agree to…" line.
- **_headers**: `/terms` + `/privacy` drop the site-wide `X-Robots-Tag: noindex` (the one surface we want indexable; Google's verification fetches the privacy URL) and get the static-page CSP.

Both documents credit "Structure adapted from the Basecamp open-source policies (CC BY 4.0)" in-page.

## Post-merge ops (GA checklist)

- Create the `hello@spool.pro` and `abuse@spool.pro` routes in Cloudflare Email Routing.
- In Google Cloud Console → OAuth consent screen (Branding), set the Privacy Policy and Terms URLs to `https://spool.pro/privacy` / `https://spool.pro/terms` so the consent screen links them, and run brand verification.

## Test plan

- Route tests cover /terms, /privacy, trailing-slash normalization, and subpath → tombstone (70 share-web tests green); typecheck + production build green.
- Review pass verified the policy text against code: session TTLs (session.ts), daily-salted hashes (audit.ts), 24h grace (me/delete.ts). SPA fallback for the new paths uses the same mechanism as /me and /sign-in.
- Content reviewed locally on the dev server, including dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)