### PR TITLE
chore(share-editor): sentence-case panel section labels

### DIFF
--- a/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
+++ b/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
@@ -111,7 +111,7 @@ export function ControlPanel({ convo, opts, setOpts }: Props) {
       <div className="flex-1 min-h-0 overflow-y-auto scrollbar-none">
       <div className="px-4 pt-3 pb-4">
         <div className="flex items-baseline justify-between mb-3">
-          <div className="text-[11px] font-medium tracking-[0.08em] uppercase text-warm-muted dark:text-dark-muted leading-none">
+          <div className="text-[11px] font-medium tracking-[0.08em] text-warm-muted dark:text-dark-muted leading-none">
             {t('shareEditorPanel.section_template')}
           </div>
           <div className="text-[11px] text-warm-faint dark:text-dark-muted leading-none">
@@ -750,7 +750,7 @@ function PrivacyView({
        *  always has the master control + leak-count in view. */}
       <div className="flex-none px-4 pt-3">
         <div className="flex items-center justify-between mb-3 gap-2">
-          <div className="text-[11px] font-medium tracking-[0.08em] uppercase text-warm-muted dark:text-dark-muted leading-none">
+          <div className="text-[11px] font-medium tracking-[0.08em] text-warm-muted dark:text-dark-muted leading-none">
             {t('shareEditorPanel.section_redactions')}
           </div>
           <div className="flex items-center gap-2 min-w-0">
@@ -826,7 +826,7 @@ function Section({ label, hint, children }: { label: string; hint?: string; chil
   return (
     <div className="px-4 pt-1.5 pb-4">
       <div className="flex items-baseline justify-between mb-3">
-        <div className="text-[11px] font-medium tracking-[0.08em] uppercase text-warm-muted dark:text-dark-muted leading-none">
+        <div className="text-[11px] font-medium tracking-[0.08em] text-warm-muted dark:text-dark-muted leading-none">
           {label}
         </div>
         {hint && <div className="text-[11px] text-warm-faint dark:text-dark-muted leading-none">{hint}</div>}
@@ -857,7 +857,7 @@ function Collapsible({
         aria-expanded={open}
         className="w-full text-left px-4 pt-2 pb-3.5 flex items-center justify-between hover:bg-warm-surface2/60 dark:hover:bg-dark-surface2/60 transition-colors"
       >
-        <span className="text-[11px] font-medium tracking-[0.08em] uppercase text-warm-muted dark:text-dark-muted">
+        <span className="text-[11px] font-medium tracking-[0.08em] text-warm-muted dark:text-dark-muted">
           {label}
         </span>
         <span className="flex items-center gap-2.5">

--- a/packages/app/src/renderer/components/share-editor/TurnSelector.tsx
+++ b/packages/app/src/renderer/components/share-editor/TurnSelector.tsx
@@ -116,7 +116,7 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
   return (
     <div className="flex flex-col min-h-0 flex-1">
       <div className="flex items-center justify-between px-4 pt-3 pb-2">
-        <span className="text-[10px] uppercase tracking-wider font-medium text-warm-faint dark:text-dark-faint">
+        <span className="text-[10px] tracking-wider font-medium text-warm-faint dark:text-dark-faint">
           {t('shareEditorPanel.turnSelector_header', { kept: visibleKept, total: visibleTotal })}
         </span>
         <span className="flex items-center gap-0.5">


### PR DESCRIPTION
## What

The share editor's panel section headers — Template, Paper, Typeface, Colorway, More options, Messages N of M (Messages tab), and Redactions (Privacy tab) — now render in sentence case instead of all caps. The `uppercase` class is removed from the five label sites in `ControlPanel` and `TurnSelector`; the underlying i18n strings were already sentence-cased, so no locale changes are needed.

## Why

Library Home section labels (Pinned, Today, …) already use sentence case with the same 11px/0.08em-tracking treatment — the share editor was the remaining surface still shouting its section titles. This aligns both surfaces with the established label convention.

## Test plan

- CSS-class-only change; the rendered DOM text was already sentence case, so no test or i18n string referenced the uppercase form.
- share-editor e2e suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)