### PR TITLE
ci: run share-backend and share-web suites in the unit job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,6 +46,10 @@ jobs:
       - run: pnpm --filter @spool-lab/cli test
       - run: pnpm --filter @spool/share-kit build
       - run: pnpm --filter @spool/share-kit test
+      - run: pnpm --filter @spool/share-backend typecheck
+      - run: pnpm --filter @spool/share-backend test
+      - run: pnpm --filter @spool/share-web typecheck
+      - run: pnpm --filter @spool/share-web test
       - run: pnpm --filter @spool/app test
 
   e2e:

--- a/packages/share-backend/functions/_scheduled/deletion-worker.ts
+++ b/packages/share-backend/functions/_scheduled/deletion-worker.ts
@@ -154,7 +154,10 @@ async function deleteAvatarPrefix(env: DeletionEnv, userId: string): Promise<voi
   const prefix = `avatars/${userId}/`
   let cursor: string | undefined
   for (let page = 0; page < 32; page++) {
-    const listing = await env.AVATARS.list({ prefix, limit: 1000, cursor })
+    // Conditional spread instead of `cursor` directly: with
+    // exactOptionalPropertyTypes, R2ListOptions doesn't accept an
+    // explicit `cursor: undefined`.
+    const listing = await env.AVATARS.list({ prefix, limit: 1000, ...(cursor ? { cursor } : {}) })
     await Promise.all(
       listing.objects.map((o) => env.AVATARS.delete(o.key).catch(() => undefined)),
     )


### PR DESCRIPTION
## What

Adds four lines to the unit job: typecheck + test for `@spool/share-backend` (238 tests) and `@spool/share-web` (70 tests).

share-backend's typecheck had one pre-existing error keeping it red: the deletion worker passed an explicit `cursor: undefined` into `R2ListOptions`, which `exactOptionalPropertyTypes` rejects. Fixed with a conditional spread — no behavior change.

## Why

The unit job covered redact/core/cli/share-kit/app but never the two share packages — flagged in the 2026-06-10 launch-readiness audit as the sole CI blocker and not fixed since. Every share-backend PR merged this week carried a green check that never executed its tests; auth, rate-limiting, and deletion-cascade regressions would ship silently. Closing this is a GA precondition.

## Test plan

All four new CI commands run locally exactly as CI will: both typechecks clean, 238 + 70 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)