### PR TITLE
chore: vendor the spool-pro-router dispatcher; share-web deploy scripts

### DIFF
--- a/packages/share-web/package.json
+++ b/packages/share-web/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite --port 3002",
     "build": "vite build",
+    "deploy:staging": "vite build && wrangler pages deploy dist --project-name spool-share-web-staging",
+    "deploy:prod": "vite build && wrangler pages deploy dist --project-name spool-share-web",
     "preview": "vite preview --port 3002",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -29,6 +31,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "typescript": "^5.7.3",
     "vite": "^6.3.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "wrangler": "^4.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,6 +426,21 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      wrangler:
+        specifier: ^4.0.0
+        version: 4.90.0(@cloudflare/workers-types@4.20260511.1)
+
+  workers/spool-pro-router:
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260101.0
+        version: 4.20260511.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      wrangler:
+        specifier: ^4.0.0
+        version: 4.90.0(@cloudflare/workers-types@4.20260511.1)
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "packages/*"
+  - "workers/*"

--- a/workers/spool-pro-router/package.json
+++ b/workers/spool-pro-router/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "spool-pro-router",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "deploy:staging": "wrangler deploy --env staging",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260101.0",
+    "typescript": "^5.9.3",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/workers/spool-pro-router/src/worker.ts
+++ b/workers/spool-pro-router/src/worker.ts
@@ -1,0 +1,57 @@
+// spool-pro-router — single Worker bound to spool.pro/* that forwards
+// each path to the right pages.dev origin so users only ever see one
+// domain. Internal Cloudflare resource names (spool-share-web,
+// spool-share-backend, spool-landing) are unchanged.
+//
+// Every response carries `x-spool-route: landing|web|backend` so
+// misrouting is visible from `curl -I` alone (the launch runbook's §5
+// URL probes assert on it).
+
+type Env = {
+  ORIGIN_BACKEND: string // e.g. "spool-share-backend.pages.dev"
+  ORIGIN_WEB: string // e.g. "spool-share-web.pages.dev"
+  ORIGIN_LANDING: string // e.g. "spool-landing.pages.dev"
+}
+
+export function routeFor(pathname: string): 'backend' | 'web' | 'landing' {
+  if (pathname.startsWith('/api/')) return 'backend'
+  if (
+    pathname.startsWith('/s/') ||
+    pathname.startsWith('/@') ||
+    pathname === '/me' ||
+    pathname === '/sign-in' ||
+    pathname === '/terms' || // legal pages (#389)
+    pathname === '/privacy'
+  ) {
+    return 'web'
+  }
+  return 'landing'
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url)
+    const route = routeFor(url.pathname)
+    const origin =
+      route === 'backend'
+        ? env.ORIGIN_BACKEND
+        : route === 'web'
+          ? env.ORIGIN_WEB
+          : env.ORIGIN_LANDING
+
+    const upstream = new URL(request.url)
+    upstream.host = origin
+    upstream.protocol = 'https:'
+
+    // Preserve method + body + most headers; forward the original Host
+    // so the Pages project can log accurately.
+    const fwd = new Request(upstream.toString(), request)
+    fwd.headers.set('X-Forwarded-Host', url.host)
+    fwd.headers.set('X-Forwarded-Proto', 'https')
+
+    const res = await fetch(fwd)
+    const out = new Response(res.body, res)
+    out.headers.set('x-spool-route', route)
+    return out
+  },
+}

--- a/workers/spool-pro-router/tsconfig.json
+++ b/workers/spool-pro-router/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/workers/spool-pro-router/wrangler.toml
+++ b/workers/spool-pro-router/wrangler.toml
@@ -1,0 +1,31 @@
+# spool-pro-router — the single Worker bound to spool.pro/* that
+# dispatches each path to the right *.pages.dev origin so users only
+# ever see one domain. Vendored from the launch runbook (2026-06-12) so
+# route changes ride code review; previously the source lived only in
+# the Cloudflare dashboard.
+#
+# Deploy: pnpm --filter spool-pro-router deploy            (production)
+#         pnpm --filter spool-pro-router deploy:staging    (staging)
+
+name = "spool-pro-router"
+main = "src/worker.ts"
+compatibility_date = "2026-05-01"
+
+routes = [
+  { pattern = "spool.pro/*", zone_name = "spool.pro" },
+]
+
+[vars]
+ORIGIN_BACKEND = "spool-share-backend.pages.dev"
+ORIGIN_WEB = "spool-share-web.pages.dev"
+ORIGIN_LANDING = "spool-landing.pages.dev"
+
+[env.staging]
+routes = [
+  { pattern = "staging.spool.pro/*", zone_name = "spool.pro" },
+]
+
+[env.staging.vars]
+ORIGIN_BACKEND = "spool-share-backend-staging.pages.dev"
+ORIGIN_WEB = "spool-share-web-staging.pages.dev"
+ORIGIN_LANDING = "spool-landing.pages.dev"


### PR DESCRIPTION
## What

- **`workers/spool-pro-router/`** — the Worker that owns `spool.pro/*` routing, vendored into the repo (new `workers/*` pnpm-workspace glob, typecheck wiring, `deploy` / `deploy:staging` scripts). `routeFor` includes the `/terms` and `/privacy` paths the legal pages (#389) need; without this routing update those URLs fall through to the landing project in production.
- **share-web** gains `deploy:staging` / `deploy:prod` scripts (it was the only deployable package without any) plus the `wrangler` devDependency they use.

## Why

The dispatcher source previously existed only in the Cloudflare dashboard, with the launch runbook as the de-facto source of truth — route changes couldn't ride code review, and the #389 legal pages would have silently 404'd at launch. Deploying from the repo (`pnpm --filter spool-pro-router deploy`) makes the routing table reviewable like everything else.

## Test plan

- `pnpm --filter spool-pro-router typecheck` clean; `wrangler deploy --dry-run` bundles successfully with the expected vars
- share-web suite re-run after the package.json change: 70 green
- Deploys themselves are exercised at launch per the runbook's §5 URL probes (`x-spool-route` assertions incl. the new legal paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)