### PR TITLE
fix(share): stop leaking content-derived turn ids in published snapshots

### DIFF
--- a/packages/app/src/renderer/components/share-editor/snapshot-adapter.test.ts
+++ b/packages/app/src/renderer/components/share-editor/snapshot-adapter.test.ts
@@ -65,10 +65,11 @@ describe('buildSnapshotFromEditor — hidden-turn body redaction', () => {
       conversation: conv,
       opts: opts({ redact: false, selected: [0] }),
     })
-    expect(snap.conversation.turn_order).toEqual(['t-0', 't-1'])
-    expect(snap.conversation.hidden_turns).toEqual(['t-1'])
-    const t0 = snap.conversation.turns.find((t) => t.id === 't-0')!
-    const t1 = snap.conversation.turns.find((t) => t.id === 't-1')!
+    // IDs are remapped to opaque positional tokens.
+    expect(snap.conversation.turn_order).toEqual(['t0', 't1'])
+    expect(snap.conversation.hidden_turns).toEqual(['t1'])
+    const t0 = snap.conversation.turns.find((t) => t.id === 't0')!
+    const t1 = snap.conversation.turns.find((t) => t.id === 't1')!
     expect(t0.content).toBe('hello')
     expect(t1.content).toBe('')
     // The R2 JSON must not retain the credential anywhere.
@@ -100,7 +101,7 @@ describe('buildSnapshotFromEditor — hidden-turn body redaction', () => {
       conversation: conv,
       opts: opts({ redact: false, selected: [] }),
     })
-    expect(snap.conversation.hidden_turns).toEqual(['t-0', 't-1'])
+    expect(snap.conversation.hidden_turns).toEqual(['t0', 't1'])
     expect(snap.conversation.turns.every((t) => t.content === '')).toBe(true)
   })
 
@@ -114,8 +115,48 @@ describe('buildSnapshotFromEditor — hidden-turn body redaction', () => {
       conversation: conv,
       opts: opts({ redact: false, selected: [1] }),
     })
-    expect(snap.conversation.turn_order).toEqual(['a', 'b', 'c'])
+    // Positional remap: a→t0, b→t1, c→t2; b is the only kept turn.
+    expect(snap.conversation.turn_order).toEqual(['t0', 't1', 't2'])
     expect(snap.conversation.turns).toHaveLength(3)
-    expect(snap.conversation.hidden_turns.sort()).toEqual(['a', 'c'])
+    expect(snap.conversation.hidden_turns.sort()).toEqual(['t0', 't2'])
+  })
+})
+
+describe('buildSnapshotFromEditor — opaque positional ids', () => {
+  // Regression for the content-derived-id leak: the original turn ids
+  // (from `ensureTurnIds`, an fnv1a32 hash of the turn content) must
+  // never appear anywhere in the emitted snapshot. This test FAILS on
+  // the pre-fix code, which passed the original ids straight through to
+  // turns[].id / turn_order[] / hidden_turns[].
+  it('emits no content-derived id in turns, turn_order, or hidden_turns', () => {
+    const originalIds = ['hash-9f3a', 'hash-2b71', 'hash-c40d']
+    const conv = convo([
+      { id: originalIds[0], role: 'user', body: 'public question' },
+      { id: originalIds[1], role: 'assistant', body: `secret=${API_KEY}` },
+      { id: originalIds[2], role: 'user', body: 'another public turn' },
+    ])
+    const snap = buildSnapshotFromEditor({
+      conversation: conv,
+      // Hide the credential-bearing middle turn.
+      opts: opts({ redact: false, selected: [0, 2] }),
+    })
+
+    const emittedIds = [
+      ...snap.conversation.turns.map((t) => t.id),
+      ...snap.conversation.turn_order,
+      ...snap.conversation.hidden_turns,
+    ]
+    for (const original of originalIds) {
+      expect(emittedIds).not.toContain(original)
+    }
+    // The serialized wire object must not carry any original id either.
+    const wire = JSON.stringify(snap)
+    for (const original of originalIds) {
+      expect(wire).not.toContain(original)
+    }
+    // Ids are opaque positional tokens, internally consistent.
+    expect(snap.conversation.turn_order).toEqual(['t0', 't1', 't2'])
+    expect(snap.conversation.hidden_turns).toEqual(['t1'])
+    expect(snap.conversation.turns.find((t) => t.id === 't1')!.content).toBe('')
   })
 })

--- a/packages/app/src/renderer/components/share-editor/snapshot-adapter.ts
+++ b/packages/app/src/renderer/components/share-editor/snapshot-adapter.ts
@@ -64,21 +64,36 @@ export function buildSnapshotFromEditor(args: {
   // published, full stop."
   const hiddenIdSet = new Set(hiddenTurnIds)
 
-  const snapshotTurns = redactedConv.turns.map((t) => {
-    const id = t.id!
+  // Turn ids coming off `ensureTurnIds` are an fnv1a32 hash of the turn
+  // content. Emitting them on the wire would leak content-derived
+  // fingerprints (reversible for known content classes) and, via
+  // `hidden_turns`, enumerate exactly which turns the author excluded —
+  // contradicting the blank-body guarantee above. Remap every id to an
+  // OPAQUE POSITIONAL token (`t0`, `t1`, … by array index) before
+  // emitting. The reader only uses ids for ordering and hidden lookup,
+  // never for content, so positional ids are fully compatible.
+  const opaqueIdFor = new Map(
+    redactedConv.turns.map((t, idx) => [t.id!, `t${idx}`]),
+  )
+
+  const snapshotTurns = redactedConv.turns.map((t, idx) => {
+    const originalId = t.id!
+    const id = `t${idx}`
     const role = (t.role === 'user' || t.role === 'assistant'
       ? t.role
       : 'assistant') as 'user' | 'assistant'
-    if (hiddenIdSet.has(id)) {
+    if (hiddenIdSet.has(originalId)) {
       return { id, role, content: '' }
     }
     return {
       id,
       role,
       content: t.body,
-      ...(perTurnRedacted.has(id) ? { redacted: true as const } : {}),
+      ...(perTurnRedacted.has(originalId) ? { redacted: true as const } : {}),
     }
   })
+
+  const hiddenOpaqueIds = hiddenTurnIds.map((id) => opaqueIdFor.get(id)!)
 
   return {
     schema_version: 1,
@@ -97,7 +112,7 @@ export function buildSnapshotFromEditor(args: {
       title: rawConv.title || 'Untitled',
       turns: snapshotTurns,
       turn_order: snapshotTurns.map((t) => t.id),
-      hidden_turns: hiddenTurnIds,
+      hidden_turns: hiddenOpaqueIds,
     },
     editor_opts: {
       template: opts.template,

--- a/packages/share-kit/src/reader/snapshot-to-conversation.test.ts
+++ b/packages/share-kit/src/reader/snapshot-to-conversation.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest'
+import { decodeSnapshot } from './snapshot-to-conversation'
+import type { Snapshot } from '../lib/types'
+
+function snapshot(over: Partial<Snapshot> = {}): Snapshot {
+  return {
+    schema_version: 1,
+    source: { kind: 'spool-session', captured_at: '2026-06-12T00:00:00.000Z' },
+    conversation: {
+      title: 'Hi',
+      turns: [
+        { id: 't0', role: 'user', content: 'hello' },
+        { id: 't1', role: 'assistant', content: 'world' },
+      ],
+      turn_order: ['t0', 't1'],
+      hidden_turns: [],
+    },
+    editor_opts: {
+      template: 'chat',
+      paper: 'snow',
+      typeface: 'inter',
+      colorway: 'amber',
+      density: 'compact',
+      masthead: true,
+      colophon: true,
+      avatars: true,
+      show_byline: false,
+    },
+    ...over,
+  }
+}
+
+describe('decodeSnapshot — schema_version guard', () => {
+  it('decodes a version-1 snapshot without warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { conversation } = decodeSnapshot(snapshot())
+    expect(conversation.turns.map((t) => t.body)).toEqual(['hello', 'world'])
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('best-effort decodes an unknown future version and warns once', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // Simulate a snapshot written by a newer client.
+    const future = snapshot({ schema_version: 2 as unknown as 1 })
+    const { conversation } = decodeSnapshot(future)
+    // Does not throw; still produces a usable conversation.
+    expect(conversation.turns.map((t) => t.body)).toEqual(['hello', 'world'])
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(String(warn.mock.calls[0]?.[0])).toContain('schema_version')
+    warn.mockRestore()
+  })
+})

--- a/packages/share-kit/src/reader/snapshot-to-conversation.ts
+++ b/packages/share-kit/src/reader/snapshot-to-conversation.ts
@@ -73,7 +73,23 @@ export interface DecodedSnapshot {
   opts: EditorOpts
 }
 
+const SUPPORTED_SCHEMA_VERSION = 1
+
 export function decodeSnapshot(snapshot: Snapshot): DecodedSnapshot {
+  // The wire object is server-validated at publish time, but a snapshot
+  // written by a newer client could carry a future schema_version. We
+  // best-effort decode (the field shapes the reader reads are stable)
+  // and log once rather than throwing — callers like `paperHexFor`
+  // invoke this outside the render error boundary, so a throw would
+  // blank the whole page instead of degrading visibly.
+  if (snapshot.schema_version !== SUPPORTED_SCHEMA_VERSION) {
+    console.warn(
+      `decodeSnapshot: unsupported schema_version ${String(
+        snapshot.schema_version,
+      )} (supported: ${SUPPORTED_SCHEMA_VERSION}); decoding best-effort.`,
+    )
+  }
+
   const hidden = new Set(snapshot.conversation.hidden_turns ?? [])
   const orderIdx = new Map(
     (snapshot.conversation.turn_order ?? []).map((id, idx) => [id, idx]),

--- a/packages/share-kit/src/templates/body.test.tsx
+++ b/packages/share-kit/src/templates/body.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Body } from './body'
+
+function renderBody(text: string): string {
+  return renderToStaticMarkup(
+    <Body text={text} accent="#C85A00" accentBg="rgba(200,90,0,0.1)" />,
+  )
+}
+
+describe('Body — link hardening', () => {
+  it('external links carry target=_blank and rel=noreferrer noopener', () => {
+    const html = renderBody('See [the docs](https://example.com/page).')
+    expect(html).toContain('href="https://example.com/page"')
+    expect(html).toContain('target="_blank"')
+    expect(html).toContain('rel="noreferrer noopener"')
+  })
+
+  it('in-page anchors stay same-frame (no target/rel)', () => {
+    const html = renderBody('Jump to [section](#section).')
+    expect(html).toContain('href="#section"')
+    expect(html).not.toContain('target="_blank"')
+    expect(html).not.toContain('rel="noreferrer noopener"')
+  })
+
+  it('react-markdown still neutralizes javascript: hrefs', () => {
+    // react-markdown v10's default urlTransform strips dangerous
+    // protocols, so the rendered href must not be the javascript: URL.
+    const html = renderBody('[click](javascript:alert(1))')
+    expect(html).not.toContain('javascript:alert')
+  })
+})

--- a/packages/share-kit/src/templates/body.tsx
+++ b/packages/share-kit/src/templates/body.tsx
@@ -271,11 +271,24 @@ export function Body({ text, redact, mono, sansFont, fontSize: sizeOverride, acc
         {...props}
       />
     ),
-    a: ({ href, children }: { href?: string | undefined; children?: React.ReactNode }) => (
-      <a href={href} style={{ color: accent, textDecoration: 'none', borderBottom: `1px solid ${accent}`, overflowWrap: 'anywhere' }}>
-        {children}
-      </a>
-    ),
+    a: ({ href, children }: { href?: string | undefined; children?: React.ReactNode }) => {
+      // In-page anchors stay same-frame; everything else opens in a new
+      // tab with `noreferrer noopener` so a reader click can't navigate
+      // the top frame and the destination can't reach back through
+      // `window.opener`. (react-markdown v10 already neutralizes
+      // `javascript:`/`data:` hrefs via its default urlTransform, so no
+      // extra sanitization is needed here.)
+      const inPage = !!href && href.startsWith('#')
+      return (
+        <a
+          href={href}
+          {...(inPage ? {} : { target: '_blank', rel: 'noreferrer noopener' })}
+          style={{ color: accent, textDecoration: 'none', borderBottom: `1px solid ${accent}`, overflowWrap: 'anywhere' }}
+        >
+          {children}
+        </a>
+      )
+    },
     img: ({ src, alt }: { src?: string | undefined; alt?: string | undefined }) => <MarkdownImage src={src} alt={alt} accent={accent} />,
   }), [accent, accentBg, blockStroke])
   /* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
## What
Remap every turn id to an opaque positional token (\`t0\`, \`t1\`, …) before a snapshot is uploaded, so neither \`turns[].id\`, \`turn_order\`, nor \`hidden_turns\` carry content-derived values. Also: external links in rendered markdown now open in a new tab with \`rel="noreferrer noopener"\`, and the reader's \`decodeSnapshot\` best-effort decodes (and warns) on an unknown \`schema_version\` instead of trusting it silently.

## Why
Turn ids came from \`ensureTurnIds\`, an fnv1a32 hash of the turn body. Emitting them on the public snapshot let any reader of \`/api/snapshots/<id>\` fingerprint content (reversible for known content classes) and enumerate exactly which/how many turns the author excluded — contradicting the blank-body guarantee for hidden turns. The markdown links lacked \`rel\`/\`target\`, allowing top-frame navigation and a window.opener handle.

## How it connects
The reader only uses ids for ordering and hidden-lookup, never for content, so opaque positional ids are fully compatible. Adds a regression test that fails on the pre-fix code (asserts no content-hash id appears in the emitted snapshot) plus link-hardening and unknown-version tests.