### PR TITLE
fix(share-web): correct /me failure states and legal-page header auth

### DIFF
--- a/packages/share-web/functions/s/id.test.ts
+++ b/packages/share-web/functions/s/id.test.ts
@@ -1,0 +1,107 @@
+// Cross-package OG contract test for the /s/<id> Pages Function.
+//
+// The contract: the function injects Open Graph tags only when
+// /api/meta/<id> returns 200. share-backend returns 410 for a revoked
+// share, and the function MUST treat that as a tombstone — no OG
+// injection — so social crawlers don't cache live-looking metadata
+// (og:title / og:url / og:image) for a dead URL. This pins that contract
+// on the web side; the backend behavior is mocked, not changed.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { onRequest } from './[id]'
+
+const VALID_ID = 'abcdefghijklmnopqrstu' // 21 chars, matches SLUG_RE
+const ORIGIN = 'https://spool.pro'
+
+const SHELL_HTML = [
+  '<!doctype html>',
+  '<html lang="en">',
+  '  <head>',
+  '    <meta charset="UTF-8" />',
+  '    <meta name="robots" content="noindex" />',
+  '    <title>spool.pro</title>',
+  '  </head>',
+  '  <body><div id="root"></div></body>',
+  '</html>',
+].join('\n')
+
+function makeEnv() {
+  return {
+    ASSETS: {
+      fetch: vi.fn(async () =>
+        new Response(SHELL_HTML, {
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        }),
+      ),
+    },
+  }
+}
+
+function makeCtx(id: string, env: ReturnType<typeof makeEnv>) {
+  return {
+    request: new Request(`${ORIGIN}/s/${id}`),
+    env,
+    params: { id },
+  }
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('/s/[id] OG injection contract', () => {
+  it('a 410 from /api/meta produces a tombstone shell with NO OG injection', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('gone', { status: 410 }),
+    )
+    const res = await onRequest(makeCtx(VALID_ID, makeEnv()))
+    const body = await res.text()
+
+    expect(res.status).toBe(410)
+    // No live-looking metadata for a dead share.
+    expect(body).not.toContain('og:title')
+    expect(body).not.toContain('og:url')
+    expect(body).not.toContain('og:image')
+    expect(body).not.toContain(`/s/${VALID_ID}`)
+    // The passthrough shell keeps its noindex (so a 410 page can't be
+    // crawled as if it were a live share) and never caches.
+    expect(body).toMatch(/name=["']robots["']/i)
+    expect(res.headers.get('cache-control')).toBe('no-store')
+  })
+
+  it('a 200 from /api/meta injects the normal OG tags', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ title: 'My great chat' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    const res = await onRequest(makeCtx(VALID_ID, makeEnv()))
+    const body = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(body).toContain('<meta property="og:title" content="My great chat">')
+    expect(body).toContain(`<meta property="og:url" content="${ORIGIN}/s/${VALID_ID}">`)
+    expect(body).toContain(
+      `<meta property="og:image" content="${ORIGIN}/api/og/${VALID_ID}.png">`,
+    )
+    // A served-with-200 share IS indexable — the noindex is stripped.
+    expect(body).not.toMatch(/name=["']robots["']/i)
+    expect(res.headers.get('cache-control')).toContain('max-age=30')
+  })
+
+  it('skips the API round-trip and tombstones on an invalid slug', async () => {
+    const res = await onRequest(makeCtx('too-short', makeEnv()))
+    expect(res.status).toBe(404)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/share-web/src/App.tsx
+++ b/packages/share-web/src/App.tsx
@@ -10,6 +10,14 @@ import { Terms } from './pages/Terms'
 import { Tombstone } from './pages/Tombstone'
 
 export function App() {
+  // Route is computed once at mount. This is intentional: every
+  // in-app navigation uses full-page window.location.assign/replace
+  // (see Me.tsx, SignIn, the sign-out flow), and there is no
+  // history.pushState anywhere in the SPA. So the document fully
+  // reloads on each navigation and on browser back/forward — there is
+  // no client-side history for a popstate listener to react to. If a
+  // pushState-based navigation is ever introduced, add a popstate
+  // listener here to recompute the route.
   const route = useMemo(
     () => routeFor(window.location.pathname, window.location.search),
     [],

--- a/packages/share-web/src/lib/page-title.test.ts
+++ b/packages/share-web/src/lib/page-title.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeTabTitle } from './page-title'
+
+describe('normalizeTabTitle', () => {
+  it('passes a normal title through unchanged', () => {
+    expect(normalizeTabTitle('My great chat')).toBe('My great chat')
+  })
+
+  it('strips control characters and collapses whitespace', () => {
+    expect(normalizeTabTitle('a\n\tb   cd')).toBe('a b cd')
+  })
+
+  it('trims leading and trailing whitespace', () => {
+    expect(normalizeTabTitle('  spaced  ')).toBe('spaced')
+  })
+
+  it('bounds the length of a pathological title', () => {
+    const out = normalizeTabTitle('x'.repeat(500))
+    expect(out.length).toBeLessThanOrEqual(120)
+    expect(out.endsWith('…')).toBe(true)
+  })
+})

--- a/packages/share-web/src/lib/page-title.ts
+++ b/packages/share-web/src/lib/page-title.ts
@@ -1,0 +1,24 @@
+// Normalise a server-supplied title before it goes into document.title.
+//
+// document.title doesn't execute markup, so this is not an XSS vector —
+// but a raw title containing newlines, control characters, or a stray
+// `</title>` shows garbage in the browser tab, and it's inconsistent
+// with the SSR OG path (og-meta.ts) which escapes + length-caps. We
+// drop control characters, collapse whitespace, and bound the length so
+// the tab stays sane.
+
+const MAX_TAB_TITLE_LEN = 120
+
+// C0 + C1 control characters (incl. newline / tab). Stripped, not
+// space-replaced, before whitespace collapse handles the rest.
+const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g
+
+export function normalizeTabTitle(raw: string): string {
+  // Collapse whitespace (incl. newlines / tabs) to single spaces first,
+  // THEN strip any remaining non-whitespace control characters — so a
+  // newline becomes a space rather than vanishing.
+  const cleaned = raw.replace(/\s+/g, ' ').replace(CONTROL_CHARS, '').trim()
+  return cleaned.length > MAX_TAB_TITLE_LEN
+    ? `${cleaned.slice(0, MAX_TAB_TITLE_LEN - 1)}…`
+    : cleaned
+}

--- a/packages/share-web/src/pages/Me.load.test.ts
+++ b/packages/share-web/src/pages/Me.load.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  MeFetchResult,
+  MeResponse,
+  MySharesFetchResult,
+} from '../lib/api'
+import { resolveLoadOutcome } from './Me'
+
+const ME: MeResponse = {
+  email: 'a@b.com',
+  name: 'Alice',
+  display_name: 'Alice',
+  avatar_url: null,
+  handle: null,
+  deletion_pending_until: null,
+} as MeResponse
+
+const meOk: MeFetchResult = { kind: 'ok', me: ME }
+
+describe('resolveLoadOutcome', () => {
+  it('redirects when /api/me is unauthenticated', () => {
+    expect(
+      resolveLoadOutcome({ kind: 'unauthenticated' }, { kind: 'ok', shares: [] }),
+    ).toEqual({ kind: 'redirect' })
+  })
+
+  it('surfaces an error when /api/me fails', () => {
+    expect(resolveLoadOutcome({ kind: 'error' }, { kind: 'ok', shares: [] })).toEqual({
+      kind: 'error',
+    })
+  })
+
+  // Regression for the bug: a 5xx / network failure on /api/me/shares was
+  // swallowed into an empty list, so the page rendered "nothing
+  // published" — a lie. It must surface the error/retry card instead.
+  it('surfaces an error (NOT an empty list) when /api/me/shares fails', () => {
+    const out = resolveLoadOutcome(meOk, { kind: 'error' })
+    expect(out.kind).toBe('error')
+  })
+
+  it('surfaces an error when /api/me/shares races to unauthenticated after /api/me succeeded', () => {
+    const out = resolveLoadOutcome(meOk, { kind: 'unauthenticated' })
+    expect(out.kind).toBe('error')
+  })
+
+  it('renders ok with the real rows when both succeed', () => {
+    const shares: MySharesFetchResult = {
+      kind: 'ok',
+      shares: [{ id: 'x' } as never],
+    }
+    const out = resolveLoadOutcome(meOk, shares)
+    expect(out).toEqual({ kind: 'ok', me: ME, shares: [{ id: 'x' }] })
+  })
+
+  it('renders the genuine empty case (200 with zero rows) as ok+empty, not error', () => {
+    const out = resolveLoadOutcome(meOk, { kind: 'ok', shares: [] })
+    expect(out).toEqual({ kind: 'ok', me: ME, shares: [] })
+  })
+
+  // Deletion-pending: /api/me carries deletion_pending_until and the UI
+  // hides the shares section, so a 403 on /api/me/shares is expected and
+  // must NOT trip the error card.
+  it('treats a shares 403 (deletion-pending) as ok with an empty list', () => {
+    const out = resolveLoadOutcome(meOk, { kind: 'forbidden' })
+    expect(out).toEqual({ kind: 'ok', me: ME, shares: [] })
+  })
+})

--- a/packages/share-web/src/pages/Me.tsx
+++ b/packages/share-web/src/pages/Me.tsx
@@ -17,8 +17,10 @@ import {
   setShareVisibility,
   scheduleAccountDeletion,
   signOut,
+  type MeFetchResult,
   type MeResponse,
   type MeShareRow,
+  type MySharesFetchResult,
 } from '../lib/api'
 import { humanDate, humanDateTime } from '../lib/dates'
 import { ProfileEditor } from '../components/ProfileEditor'
@@ -43,6 +45,44 @@ type LoadState =
       unpublishErr?: string | null
     }
   | { kind: 'error' }
+
+// Pure mapping from the two parallel fetch results to a load outcome.
+// Kept side-effect-free (no setState, no navigation) so the
+// /api/me-vs-/api/me/shares failure matrix can be unit-tested without a
+// DOM. The caller turns 'redirect' into a navigation and the rest into
+// a LoadState.
+//
+// The asymmetry that motivates this: a 5xx/network failure on
+// /api/me/shares must NOT collapse into the empty-state ("nothing
+// published") — that's a lie. Only a genuine 200-with-zero-rows is
+// empty. We reuse the same 'error' card the /api/me failure already
+// uses so the two are consistent. A shares-side 'unauthenticated' after
+// /api/me succeeded is a cookie race; treat it as an error+retry rather
+// than silently empty. 'forbidden' (deletion-pending) is NOT a failure
+// here — /api/me carries deletion_pending_until and the shares section
+// is hidden in that state, so we render with an empty list.
+export type LoadOutcome =
+  | { kind: 'redirect' }
+  | { kind: 'error' }
+  | { kind: 'ok'; me: MeResponse; shares: MeShareRow[] }
+
+export function resolveLoadOutcome(
+  meResult: MeFetchResult,
+  sharesResult: MySharesFetchResult,
+): LoadOutcome {
+  if (meResult.kind === 'unauthenticated') return { kind: 'redirect' }
+  if (meResult.kind !== 'ok') return { kind: 'error' }
+  if (sharesResult.kind === 'ok') {
+    return { kind: 'ok', me: meResult.me, shares: sharesResult.shares }
+  }
+  // deletion-pending: shares are hidden anyway, render with an empty list.
+  if (sharesResult.kind === 'forbidden') {
+    return { kind: 'ok', me: meResult.me, shares: [] }
+  }
+  // 'error' or a racing 'unauthenticated' — surface the retry card
+  // instead of a false empty-state.
+  return { kind: 'error' }
+}
 
 function shareUrl(id: string): string {
   return `${window.location.origin}/s/${encodeURIComponent(id)}`
@@ -594,19 +634,25 @@ export function Me() {
   // commits the `unpublishBusy: true` write. The ref blocks the second
   // call synchronously, before any async work.
   const unpublishingRef = useRef(false)
+  // confirmUnpublish closes over `state`, which can be stale if a
+  // background refreshMe() re-rendered between modal-open and the confirm
+  // click. Mirror the current target into a ref so the action always
+  // operates on what the modal is actually showing.
+  const unpublishTargetRef = useRef<MeShareRow | null>(null)
 
   const load = useCallback(async () => {
+    setState({ kind: 'loading' })
     const [meResult, sharesResult] = await Promise.all([fetchMe(), fetchMyShares()])
-    if (meResult.kind === 'unauthenticated') {
+    const outcome = resolveLoadOutcome(meResult, sharesResult)
+    if (outcome.kind === 'redirect') {
       window.location.replace('/sign-in?next=/me')
       return
     }
-    if (meResult.kind !== 'ok') {
+    if (outcome.kind === 'error') {
       setState({ kind: 'error' })
       return
     }
-    const shares = sharesResult.kind === 'ok' ? sharesResult.shares : []
-    setState({ kind: 'ok', me: meResult.me, shares })
+    setState({ kind: 'ok', me: outcome.me, shares: outcome.shares })
   }, [])
 
   // Re-fetch only /api/me (not /me/shares) after a profile edit so the
@@ -623,6 +669,13 @@ export function Me() {
     document.title = 'Your account · spool.pro'
     load()
   }, [load])
+
+  // Keep the unpublish-target ref in lockstep with the rendered target so
+  // confirmUnpublish never reads a stale closed-over value.
+  const currentTarget = state.kind === 'ok' ? state.unpublishTarget ?? null : null
+  useEffect(() => {
+    unpublishTargetRef.current = currentTarget
+  }, [currentTarget])
 
   async function onToggleVisibility(row: MeShareRow): Promise<{ ok: boolean; reason?: string }> {
     const next = row.visibility === 'profile-listed' ? 'unlisted' as const : 'profile-listed' as const
@@ -733,9 +786,9 @@ export function Me() {
               type="button"
               className="sw-btn sw-btn-ghost"
               style={{ marginTop: 20 }}
-              onClick={() => window.location.reload()}
+              onClick={() => void load()}
             >
-              Refresh
+              Try again
             </button>
           </div>
         </main>
@@ -774,10 +827,13 @@ export function Me() {
     )
   }
   async function confirmUnpublish() {
-    if (state.kind !== 'ok' || !state.unpublishTarget) return
+    // Read the target from the ref, not the closed-over `state`: a
+    // background refreshMe() between modal-open and click can leave this
+    // closure pointing at a stale snapshot.
+    const target = unpublishTargetRef.current
+    if (!target) return
     if (unpublishingRef.current) return
     unpublishingRef.current = true
-    const target = state.unpublishTarget
     setState((s) => (s.kind === 'ok' ? { ...s, unpublishBusy: true, unpublishErr: null } : s))
     try {
       const r = await onUnpublish(target.id)
@@ -885,23 +941,29 @@ export function Me() {
             </p>
           ) : (
             <>
-              {liveShares.length === 0 && revokedShares.length === 0 ? (
-                <p className="sw-empty">You haven’t published anything yet.</p>
-              ) : (
-                liveShares.length > 0 && (
-                  <ul className="sw-list">
-                    {liveShares.map((row) => (
-                      <ShareRow
-                        key={row.id}
-                        row={row}
-                        disabled={pending}
-                        hasHandle={me.handle !== null}
-                        onUnpublishRequest={requestUnpublish}
-                        onToggleVisibility={onToggleVisibility}
-                      />
-                    ))}
-                  </ul>
+              {liveShares.length === 0 ? (
+                // No live shares. With zero revoked history this is the
+                // genuine first-run empty-state (full CTA). With revoked
+                // history below, a short line is enough — the collapsed
+                // Unpublished section carries the rest of the story.
+                revokedShares.length === 0 ? (
+                  <p className="sw-empty">You haven’t published anything yet.</p>
+                ) : (
+                  <p className="sw-empty">No live shares.</p>
                 )
+              ) : (
+                <ul className="sw-list">
+                  {liveShares.map((row) => (
+                    <ShareRow
+                      key={row.id}
+                      row={row}
+                      disabled={pending}
+                      hasHandle={me.handle !== null}
+                      onUnpublishRequest={requestUnpublish}
+                      onToggleVisibility={onToggleVisibility}
+                    />
+                  ))}
+                </ul>
               )}
               {/* Revoked shares are history records: collapsed by default
                *  (they accumulate forever — only account deletion purges

--- a/packages/share-web/src/pages/Privacy.tsx
+++ b/packages/share-web/src/pages/Privacy.tsx
@@ -17,7 +17,7 @@ export function Privacy() {
 
   return (
     <Page>
-      <Header auth="out" />
+      <Header />
       <main className="sw-main">
         <article className="sw-card w-600 sw-legal">
           <p className="sw-eyebrow">spool.pro</p>

--- a/packages/share-web/src/pages/Profile.tsx
+++ b/packages/share-web/src/pages/Profile.tsx
@@ -8,6 +8,7 @@ import {
 } from '../components/Chrome'
 import { fetchProfile, type ProfileFetchResult, type ProfileResponse } from '../lib/api'
 import { humanDate } from '../lib/dates'
+import { normalizeTabTitle } from '../lib/page-title'
 
 type State =
   | { kind: 'loading' }
@@ -31,7 +32,7 @@ export function Profile({ handle }: { handle: string }) {
       setState(next)
       if (next.kind === 'ok') {
         const display = next.profile.name ?? `@${next.profile.handle}`
-        document.title = `${display} · spool.pro`
+        document.title = `${normalizeTabTitle(display)} · spool.pro`
       } else {
         document.title = 'Profile not found · spool.pro'
       }

--- a/packages/share-web/src/pages/Reader.tsx
+++ b/packages/share-web/src/pages/Reader.tsx
@@ -10,6 +10,7 @@ import type { Snapshot } from '@spool/share-kit'
 import { Footer, Header, Page } from '../components/Chrome'
 import { fetchSnapshot, type SnapshotFetchResult } from '../lib/api'
 import { reportMailto } from '../lib/mailto'
+import { normalizeTabTitle } from '../lib/page-title'
 import { Tombstone } from './Tombstone'
 
 const DEFAULT_PAPER_HEX = '#FAF7F0'
@@ -80,7 +81,7 @@ export function Reader({ id }: { id: string }) {
       const next = fromFetch(result)
       setState(next)
       if (next.kind === 'ok') {
-        document.title = `${next.snapshot.conversation.title} · spool.pro`
+        document.title = `${normalizeTabTitle(next.snapshot.conversation.title)} · spool.pro`
       } else if (next.kind === 'gone' || next.kind === 'not-found') {
         document.title = 'Unavailable · spool.pro'
       }

--- a/packages/share-web/src/pages/Terms.tsx
+++ b/packages/share-web/src/pages/Terms.tsx
@@ -18,7 +18,7 @@ export function Terms() {
 
   return (
     <Page>
-      <Header auth="out" />
+      <Header />
       <main className="sw-main">
         <article className="sw-card w-600 sw-legal">
           <p className="sw-eyebrow">spool.pro</p>

--- a/packages/share-web/vitest.config.ts
+++ b/packages/share-web/vitest.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/**/*.test.{ts,tsx}', 'tests/**/*.test.{ts,tsx}'],
+    include: [
+      'src/**/*.test.{ts,tsx}',
+      'tests/**/*.test.{ts,tsx}',
+      'functions/**/*.test.{ts,tsx}',
+    ],
   },
 })


### PR DESCRIPTION
## What
- A failed \`/api/me/shares\` fetch now surfaces an error/retry card instead of silently rendering the "nothing published" empty state.
- \`confirmUnpublish\` reads its target from a ref so a background \`refreshMe()\` can't make it act on a stale closure.
- The /me live-shares area shows a short "no live shares" line when only revoked history exists, instead of a blank gap.
- Terms and Privacy pages use the default \`auth="auto"\` header so a signed-in visitor isn't shown a "Sign in" link.
- Tab titles are normalized (control chars stripped, length-bounded).

## Why
The shares-fetch failure was indistinguishable from a genuinely empty account — user-visible misinformation. The unpublish handler's stale closure and the blank revoked-only state were latent correctness/UX gaps. The legal pages hard-pinned the signed-out header.

## How it connects
Adds a regression test for the shares-fetch-error → error-state mapping and a Pages-function test pinning the revoked-share OG 410 contract (no \`og:title\`/\`og:url\` for a dead share). No backend changes; reader behavior stays compatible with the existing share-kit API.