### PR TITLE
fix(share-backend): scope visibility writes, fix OG clamp and slug regex

### DIFF
--- a/packages/share-backend/functions/_scheduled/deletion-worker.ts
+++ b/packages/share-backend/functions/_scheduled/deletion-worker.ts
@@ -71,7 +71,6 @@ async function sweepDeletedUsers(env: DeletionEnv, now: number): Promise<void> {
             JSON.stringify({
               owner: row.user_id,
               revoked_at: now,
-              expires_at: null,
               visibility: 'unlisted',
               version: 0,
             }),

--- a/packages/share-backend/functions/api/me/shares/[id].ts
+++ b/packages/share-backend/functions/api/me/shares/[id].ts
@@ -91,9 +91,9 @@ export const onRequestPatch: PagesFunction<Env, 'id'> = async (ctx) => {
     // it, and rewriting a multi-MB object to flip one cosmetic field
     // isn't worth the partial-failure surface.
     await ctx.env.DB.prepare(
-      'UPDATE published_shares SET visibility=? WHERE id=?',
+      'UPDATE published_shares SET visibility=? WHERE id=? AND user_id=?',
     )
-      .bind(visibility, id)
+      .bind(visibility, id, user.id)
       .run()
 
     const metaRaw = await ctx.env.META.get(`meta/${id}`)

--- a/packages/share-backend/src/publish/og.ts
+++ b/packages/share-backend/src/publish/og.ts
@@ -23,7 +23,11 @@ export function escapeHtml(s: string): string {
 // the rendered title and the font-subset fetch — otherwise a long title
 // would load glyphs we never paint.
 export function clampTitle(raw: string): string {
-  return escapeHtml(raw).slice(0, 140)
+  // Slice the RAW string first, THEN escape: escaping before slicing can
+  // cut through the middle of an entity (e.g. `&amp;` → `&am`), emitting
+  // a broken token into the OG image. Slicing the raw input keeps the
+  // ≤140-visible-char intent while guaranteeing every entity stays whole.
+  return escapeHtml(raw.slice(0, 140))
 }
 
 export function buildOgHtml(snap: SnapshotForOg): string {

--- a/packages/share-backend/src/publish/slug.ts
+++ b/packages/share-backend/src/publish/slug.ts
@@ -13,5 +13,9 @@ export function nanoidSlug(): string {
 }
 
 export function isValidSlug(s: string): boolean {
-  return new RegExp(`^[\\w-]{${SLUG_LEN}}$`).test(s)
+  // Explicit ASCII alphabet rather than `\w`: under the `u` flag (or
+  // future engine changes) `\w` can match Unicode word chars, which would
+  // widen this public-facing gate. The generated alphabet is ASCII, so
+  // pinning it here only tightens the validator.
+  return new RegExp(`^[A-Za-z0-9_-]{${SLUG_LEN}}$`).test(s)
 }

--- a/packages/share-backend/src/publish/validators.ts
+++ b/packages/share-backend/src/publish/validators.ts
@@ -97,7 +97,7 @@ export const PublishRequest = z.object({
   // handler re-runs `isValidSlug()` after this, but enforcing at the
   // schema boundary lets us reject malformed slugs before any DB
   // round-trips fire (idempotency SELECT, ownership SELECT).
-  override_slug: z.string().regex(/^[\w-]{21}$/).optional(),
+  override_slug: z.string().regex(/^[A-Za-z0-9_-]{21}$/).optional(),
 })
 
 export type PublishRequestT = z.infer<typeof PublishRequest>

--- a/packages/share-backend/src/request.ts
+++ b/packages/share-backend/src/request.ts
@@ -1,3 +1,12 @@
+// Trust assumption: in production this Worker is reachable ONLY via the
+// Cloudflare edge, which strips any inbound `CF-Connecting-IP` and sets it
+// to the real client IP — so trusting the header is safe there. On a
+// direct-origin or `wrangler dev` path the header is client-controlled and
+// therefore spoofable, which would let an attacker rotate the value to
+// dodge the IP-keyed rate limits (oauth-callback / signin / profile). Keep
+// this path edge-only in prod. Not hardened via `request.cf` because its
+// presence isn't a reliable "came through the edge" signal in the Pages
+// runtime; gating on it could drop legitimate traffic.
 export function clientIp(req: Request): string {
   return req.headers.get('CF-Connecting-IP') ?? '0.0.0.0'
 }

--- a/packages/share-backend/tests/_helpers/fakes.ts
+++ b/packages/share-backend/tests/_helpers/fakes.ts
@@ -430,6 +430,12 @@ export function makeDb(state: FakeDbState = emptyState()): {
           if (s) s.revoked_at = revoked_at
           return { success: true, meta: { changes: 1 } }
         }
+        if (/^UPDATE published_shares SET visibility=\? WHERE id=\? AND user_id=\?/i.test(sql)) {
+          const [visibility, id, user_id] = params as [string, string, string]
+          const s = state.published_shares.find((x) => x.id === id && x.user_id === user_id)
+          if (s) s.visibility = visibility
+          return { success: true, meta: { changes: s ? 1 : 0 } }
+        }
         if (/^UPDATE published_shares SET visibility=\? WHERE id=\?/i.test(sql)) {
           const [visibility, id] = params as [string, string]
           const s = state.published_shares.find((x) => x.id === id)

--- a/packages/share-backend/tests/deletion-worker.test.ts
+++ b/packages/share-backend/tests/deletion-worker.test.ts
@@ -98,6 +98,9 @@ describe('runDeletionSweep', () => {
     const meta = JSON.parse(metaRaw!) as { revoked_at: number | null; version: number }
     expect(typeof meta.revoked_at).toBe('number')
     expect(meta.version).toBe(0)
+    // expires_at was removed with the expiry feature (#385/#386); the
+    // tombstone must not resurrect the dead field.
+    expect('expires_at' in meta).toBe(false)
     // D1 share marked revoked
     expect(env.state.published_shares.find((s) => s.id === slug)?.revoked_at).toBeTruthy()
     // handle released

--- a/packages/share-backend/tests/og.test.ts
+++ b/packages/share-backend/tests/og.test.ts
@@ -186,6 +186,23 @@ describe('renderOgPng', () => {
     expect(longest).toBeLessThanOrEqual(140)
   })
 
+  it('does not truncate inside an HTML entity when an & sits near the 140 boundary', async () => {
+    // Pre-fix `escapeHtml(raw).slice(0,140)` could cut `&amp;` mid-entity
+    // (e.g. into `&am`), emitting a garbled token. Slicing raw first then
+    // escaping keeps every entity whole. Place a literal `&` at raw index
+    // 139 so the escaped form `&amp;` would straddle the old 140 cutoff.
+    const { clampTitle } = await import('../src/publish/og')
+    const raw = 'a'.repeat(139) + '&' + 'b'.repeat(20)
+    const out = clampTitle(raw)
+    // The trailing `&` of the 140-char raw slice escapes to a full `&amp;`.
+    expect(out.endsWith('&amp;')).toBe(true)
+    // No dangling/partial entity anywhere: every `&` is the start of a
+    // complete known entity.
+    expect(out).not.toMatch(/&(?!amp;|lt;|gt;|quot;|#39;)/)
+    // Raw visible-char intent preserved: 140 source chars in, escaped out.
+    expect(out).toBe('a'.repeat(139) + '&amp;')
+  })
+
   it('emits zero whitespace between tags so Satori does not count them as child text nodes', async () => {
     // workers-og throws `Expected <div> to have explicit "display: flex"
     // or "display: none" if it has more than one child node` when a

--- a/packages/share-backend/tests/publish.test.ts
+++ b/packages/share-backend/tests/publish.test.ts
@@ -7,6 +7,7 @@ import { onRequestGet as metaGet } from '../functions/api/meta/[id]'
 import { onRequestGet as snapshotGet } from '../functions/api/snapshots/[id]'
 import type { SessionRecord } from '../src/auth/session'
 import { isValidSlug, nanoidSlug } from '../src/publish/slug'
+import { PublishRequest } from '../src/publish/validators'
 
 import { invoke } from './_helpers/ctx'
 import { emptyState, makeDb, makeKv, makeR2, type FakeDbState } from './_helpers/fakes'
@@ -167,6 +168,45 @@ describe('isValidSlug', () => {
   it('rejects bad characters', () => {
     expect(isValidSlug('!'.repeat(21))).toBe(false)
     expect(isValidSlug('a/'.repeat(10) + 'a')).toBe(false)
+  })
+  it('rejects a 21-char string with a non-ASCII word char (no Unicode \\w widening)', () => {
+    // `\w` under a Unicode-aware engine can match letters like fullwidth
+    // chars; the explicit [A-Za-z0-9_-] class must reject them. Both are
+    // exactly 21 chars so only the alphabet — not the length — gates them.
+    expect(isValidSlug('a'.repeat(20) + 'ａ')).toBe(false) // U+FF41 fullwidth a
+    expect(isValidSlug('a'.repeat(20) + '·')).toBe(false) // U+00B7 middle dot
+    expect(isValidSlug('a'.repeat(20) + 'é')).toBe(false) // U+00E9 accented
+  })
+})
+
+describe('PublishRequest.override_slug', () => {
+  function base(overrideSlug: string) {
+    return {
+      snapshot: {
+        schema_version: 1,
+        source: { kind: 'spool-session', captured_at: new Date().toISOString() },
+        conversation: {
+          title: 'hi',
+          turns: [{ id: 't1', role: 'user', content: 'x' }],
+          turn_order: ['t1'],
+          hidden_turns: [],
+        },
+        editor_opts: {
+          template: 'forum', paper: 'cream', typeface: 'geist', colorway: 'amber',
+          density: 'relaxed', masthead: true, colophon: true, avatars: true, show_byline: true,
+        },
+      },
+      visibility: 'unlisted',
+      draft_id: 'd1',
+      idempotency_key: 'k'.repeat(8),
+      override_slug: overrideSlug,
+    }
+  }
+  it('accepts an ASCII 21-char override_slug', () => {
+    expect(PublishRequest.safeParse(base(nanoidSlug())).success).toBe(true)
+  })
+  it('rejects a 21-char override_slug containing a non-ASCII word char', () => {
+    expect(PublishRequest.safeParse(base('a'.repeat(20) + 'ａ')).success).toBe(false)
   })
 })
 

--- a/packages/share-backend/tests/share-visibility.test.ts
+++ b/packages/share-backend/tests/share-visibility.test.ts
@@ -188,6 +188,43 @@ describe('PATCH /api/me/shares/:id (visibility)', () => {
     expect(share.visibility).toBe('profile-listed')
   })
 
+  it("UPDATE is scoped to user_id: a passing ownership SELECT still can't mutate another user's row", async () => {
+    // Defense-in-depth for the UPDATE itself. The ownership SELECT 404s a
+    // cross-user share today, so this forces the SELECT to pass (as a
+    // future refactor or a bug might) and asserts the WHERE id=? AND
+    // user_id=? clause keeps the victim's row untouched. On the pre-fix
+    // `WHERE id=?` UPDATE this mutates user-2's share and the test fails.
+    const state = emptyState()
+    seedUser(state, 'user-1')
+    seedUser(state, 'user-2')
+    state.handles.push({ handle: 'alice', user_id: 'user-1', claimed_at: Date.now(), released_at: null })
+    // Victim row belongs to user-2.
+    const victim = seedShare(state, { user_id: 'user-2', visibility: 'unlisted' })
+    const env = envFor(state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+
+    // Force the ownership SELECT to report success for the attacker
+    // (user-1) even though the row is user-2's. Every other prepared
+    // statement (the UPDATE included) runs against the real fake DB.
+    const realPrepare = env.DB.prepare.bind(env.DB)
+    const intercept = (sql: string) => {
+      if (/^SELECT visibility, revoked_at FROM published_shares WHERE id=\? AND user_id=\?/i.test(sql)) {
+        return {
+          bind: () => ({ first: async () => ({ visibility: 'unlisted', revoked_at: null }) }),
+        } as unknown as ReturnType<typeof realPrepare>
+      }
+      return realPrepare(sql)
+    }
+    ;(env.DB as unknown as { prepare: typeof realPrepare }).prepare =
+      intercept as unknown as typeof realPrepare
+
+    const res = await invoke(visibilityPatch, patchReq(victim.id, { visibility: 'profile-listed' }), env, { id: victim.id })
+    expect(res.status).toBe(200)
+    // The UPDATE's user_id=? clause matched no row for user-1, so the
+    // victim's visibility is unchanged.
+    expect(victim.visibility).toBe('unlisted')
+  })
+
   it('429s past the hourly per-user cap', async () => {
     const { env, share } = await setup()
     for (let i = 0; i < 60; i++) {

--- a/packages/share-backend/wrangler.toml
+++ b/packages/share-backend/wrangler.toml
@@ -68,7 +68,6 @@ crons = ["0 */6 * * *"]
 #   wrangler pages secret put GOOGLE_CLIENT_ID_DESKTOP --project-name spool-share-backend
 #   wrangler pages secret put GOOGLE_CLIENT_ID_WEB     --project-name spool-share-backend
 #   wrangler pages secret put GOOGLE_CLIENT_SECRET_WEB --project-name spool-share-backend
-#   wrangler pages secret put SESSION_SIGNING_KEY      --project-name spool-share-backend
 #   wrangler pages secret put ADMIN_USER_IDS           --project-name spool-share-backend
 #       (comma-separated user ids allowed to hit /api/admin/*)
 #


### PR DESCRIPTION
## What
- Scope the PATCH visibility \`UPDATE\` to \`WHERE id=? AND user_id=?\` (matching every other write in the codebase).
- \`clampTitle\` now slices the raw title before escaping, so a title with \`&\` near the 140-char boundary can't emit a truncated HTML entity into the OG image.
- Slug validation uses explicit \`[A-Za-z0-9_-]{21}\` instead of \`\w\` for the public-facing \`override_slug\` gate.
- Remove the stale \`expires_at\` field from the deletion-worker KV tombstone (left over from the expiry removal), drop the misleading \`SESSION_SIGNING_KEY\` line from the wrangler secrets comment, and document the \`CF-Connecting-IP\` trust assumption.

## Why
The visibility UPDATE relied solely on a prior ownership SELECT; binding \`user_id\` on the write is defense-in-depth against future refactors. The escape-then-slice order could ship garbled OG text. \`\w\` is ASCII-only without the \`/u\` flag today but tightening the regex removes any engine ambiguity on a public input. The remaining items are dead/misleading metadata cleanup.

## How it connects
Adds regression tests for the ownership-scoped write, the OG entity boundary, and non-ASCII slug rejection; updates the deletion-worker test for the tombstone shape. \`CF-Connecting-IP\` is comment-only — production is reachable only through the CF edge, and gating on \`request.cf\` risks dropping legitimate traffic.