### PR TITLE
fix(share-editor): drop uppercase on draft card relative time

### DIFF
--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -915,7 +915,7 @@ function DraftCard({
             className="block w-1.5 h-1.5 rounded-full flex-none"
             style={{ background: getSessionSourceColor(doc.conversation.source) }}
           />
-          <span className="font-mono uppercase tracking-[0.04em] flex-none">{formatRelative(draft.updated_at, t as unknown as RelativeT)}</span>
+          <span className="font-mono tracking-[0.04em] flex-none">{formatRelative(draft.updated_at, t as unknown as RelativeT)}</span>
         </span>
       </span>
     </button>


### PR DESCRIPTION
## What
Render the Shares draft-card relative timestamp as the formatter emits it ("just now", "2d ago") instead of forcing it to UPPERCASE.

## Why
The card applied an \`uppercase\` class, producing "JUST NOW" / "2D AGO" against the project's sentence-case label convention.

## How it connects
Single-class change; keeps the mono face per the DESIGN.md timestamp styling. No behavior change.