### PR TITLE
perf(share-editor): keep the preview responsive on multi-thousand-turn sessions

### DIFF
--- a/packages/app/e2e/share-turn-selector.spec.ts
+++ b/packages/app/e2e/share-turn-selector.spec.ts
@@ -20,13 +20,20 @@ test('switch to Messages view, exclude turns, see preview reflect change', async
   await waitForSync(window)
   await openShareEditorFromSessionDetail(window, SESSION_UUID)
 
+  // The large fixture exceeds the preview's first progressive chunk, so
+  // wait for the full document to commit before taking DOM baselines —
+  // counting anchors mid-fill would race the chunked mount.
+  await expect(
+    window.locator('[data-testid="share-preview-render"][data-render-complete]'),
+  ).toBeVisible({ timeout: 15_000 })
+
   // Switch to Messages view on the right ControlPanel.
   await window.locator('[data-testid="share-editor-view-messages"]').click()
   const firstRow = window.locator('[data-testid="share-editor-turn-row"]').first()
   await expect(firstRow).toBeVisible({ timeout: 5000 })
 
-  // The preview renders the full conversation at first. We count its
-  // turn anchors as a baseline.
+  // With the fill complete, the preview holds the whole conversation.
+  // We count its turn anchors as a baseline.
   const previewTurns = window.locator('[data-share-preview-scroll] [data-turn-index]')
   const startCount = await previewTurns.count()
   expect(startCount).toBeGreaterThan(0)

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -196,27 +196,28 @@ export default function App() {
     if (isNewDraft) {
       // Persist the freshly composed draft AFTER the view switch so a
       // large session doesn't stall the click on two megabyte-scale
-      // JSON.stringify calls plus an IPC round-trip. Deferred a tick to
-      // let the editor's first frame paint. Failure is non-fatal: the
-      // editor already holds the conversation, and the first edit's
-      // autosave (ShareEditorPage) writes the same payload.
-      const composed = conversation
-      const composedOpts = opts
-      window.setTimeout(() => {
+      // JSON.stringify calls plus an IPC round-trip. Double-rAF, not
+      // setTimeout(0): a zero timer fires before the compositor
+      // produces the first frame, which would block the very paint
+      // this defers past. Failure is non-fatal: the editor already
+      // holds the conversation, and the first edit's autosave
+      // (ShareEditorPage) writes the same payload.
+      const persistDraft = () => {
         try {
-          const doc = buildSpoolDocument(composed, composedOpts)
+          const doc = buildSpoolDocument(conversation, opts)
           void window.spool?.shareDraft?.upsert({
             draft_id: draftId,
             source_kind: 'spool-session',
             source_origin: session.sessionUuid,
-            title: composed.title,
+            title: conversation.title,
             snapshot_json: JSON.stringify(doc),
             preview_json: JSON.stringify(buildPreviewDocument(doc)),
           }).catch((err) => console.error('Persist new share draft failed:', err))
         } catch (err) {
           console.error('Persist new share draft failed:', err)
         }
-      }, 0)
+      }
+      requestAnimationFrame(() => requestAnimationFrame(persistDraft))
     }
   }, [openShareEditor])
 

--- a/packages/app/src/renderer/App.tsx
+++ b/packages/app/src/renderer/App.tsx
@@ -165,6 +165,7 @@ export default function App() {
     // one with DEFAULT_OPTS and persist it.
     let conversation: Conversation
     let opts: EditorOpts
+    let isNewDraft = false
     try {
       const existing = await window.spool?.shareDraft?.get(draftId)
       if (existing) {
@@ -178,15 +179,7 @@ export default function App() {
       } else {
         conversation = composeFromSession(session, messages)
         opts = DEFAULT_OPTS
-        const doc = buildSpoolDocument(conversation, opts)
-        await window.spool?.shareDraft?.upsert({
-          draft_id: draftId,
-          source_kind: 'spool-session',
-          source_origin: session.sessionUuid,
-          title: conversation.title,
-          snapshot_json: JSON.stringify(doc),
-          preview_json: JSON.stringify(buildPreviewDocument(doc)),
-        })
+        isNewDraft = true
       }
     } catch (err) {
       console.error('Failed to load or persist share draft, falling back to a fresh compose:', err)
@@ -200,6 +193,31 @@ export default function App() {
       conversation,
       opts,
     }, returnView)
+    if (isNewDraft) {
+      // Persist the freshly composed draft AFTER the view switch so a
+      // large session doesn't stall the click on two megabyte-scale
+      // JSON.stringify calls plus an IPC round-trip. Deferred a tick to
+      // let the editor's first frame paint. Failure is non-fatal: the
+      // editor already holds the conversation, and the first edit's
+      // autosave (ShareEditorPage) writes the same payload.
+      const composed = conversation
+      const composedOpts = opts
+      window.setTimeout(() => {
+        try {
+          const doc = buildSpoolDocument(composed, composedOpts)
+          void window.spool?.shareDraft?.upsert({
+            draft_id: draftId,
+            source_kind: 'spool-session',
+            source_origin: session.sessionUuid,
+            title: composed.title,
+            snapshot_json: JSON.stringify(doc),
+            preview_json: JSON.stringify(buildPreviewDocument(doc)),
+          }).catch((err) => console.error('Persist new share draft failed:', err))
+        } catch (err) {
+          console.error('Persist new share draft failed:', err)
+        }
+      }, 0)
+    }
   }, [openShareEditor])
 
   const handleStartShareFromUuid = useCallback(async (sessionUuid: string) => {

--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -320,27 +320,34 @@ export default function ShareEditorPage({
     let alive = true
     const rowVisibility = publishedRow.visibility as Visibility
     const rowHash = publishedRow.client_request_id
-    void (async () => {
-      try {
-        const snapshot = buildSnapshotFromEditor({
-          conversation: liveConversation,
-          opts,
-        })
-        const key = await computePublishIdempotencyKey({
-          snapshot,
-          visibility: rowVisibility,
-        })
-        if (!alive) return
-        setHasUnpublishedEdits(key !== rowHash)
-      } catch (err) {
-        if (!alive) return
-        // Hash compute failures shouldn't lie — default to no badge.
-        console.warn('Compute live draft hash for drift check failed:', err)
-        setHasUnpublishedEdits(false)
-      }
-    })()
+    // Debounced (same window as autosave below): the hash runs the full
+    // snapshot build — redact pipeline included — which on large
+    // sessions is too heavy to fire on every keystroke / policy toggle.
+    // The badge appearing 400ms later is imperceptible.
+    const handle = window.setTimeout(() => {
+      void (async () => {
+        try {
+          const snapshot = buildSnapshotFromEditor({
+            conversation: liveConversation,
+            opts,
+          })
+          const key = await computePublishIdempotencyKey({
+            snapshot,
+            visibility: rowVisibility,
+          })
+          if (!alive) return
+          setHasUnpublishedEdits(key !== rowHash)
+        } catch (err) {
+          if (!alive) return
+          // Hash compute failures shouldn't lie — default to no badge.
+          console.warn('Compute live draft hash for drift check failed:', err)
+          setHasUnpublishedEdits(false)
+        }
+      })()
+    }, 400)
     return () => {
       alive = false
+      window.clearTimeout(handle)
     }
   }, [publishedRow, liveConversation, opts])
 
@@ -436,6 +443,25 @@ export default function ShareEditorPage({
     )
   }, [])
 
+  // PNG / PDF capture the LIVE preview DOM. The preview mounts large
+  // documents progressively and re-renders through a deferred value, so
+  // an export fired mid-fill (or right after an opts toggle) would
+  // capture a partial / stale frame. Gate every DOM capture on the
+  // pane's render-state callback; the timeout is a safety valve so a
+  // wedged render can't brick the export button (the capture then
+  // proceeds with whatever is committed, matching pre-progressive
+  // behavior).
+  const previewCompleteRef = useRef(true)
+  const handlePreviewRenderState = useCallback((s: { complete: boolean }) => {
+    previewCompleteRef.current = s.complete
+  }, [])
+  const waitForPreviewComplete = useCallback(async () => {
+    const deadline = Date.now() + 10_000
+    while (!previewCompleteRef.current && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 100))
+    }
+  }, [])
+
   const exportPng = useCallback(async () => {
     const node = previewRef.current
     if (!node) return
@@ -467,7 +493,15 @@ export default function ShareEditorPage({
 
     await beginSaving()
     try {
-      const blob = await rasterizeToPngBlob(node, { width, height })
+      // The slot is picked (gesture satisfied) — now wait for the
+      // preview to finish mounting/refreshing before measuring and
+      // capturing, then re-measure: the pre-picker height may have been
+      // taken mid-fill. rasterizeToPngBlob re-throws PngTooTallError if
+      // the full height busts the canvas cap; the catch below cleans up
+      // the picked slot.
+      await waitForPreviewComplete()
+      const fullHeight = node.scrollHeight
+      const blob = await rasterizeToPngBlob(node, { width, height: fullHeight })
       await writeToSlot(slot, blob, filename)
       setSaveState('idle')
       toast.success(t('shareEditor.savedFile', { filename }))
@@ -490,12 +524,15 @@ export default function ShareEditorPage({
         toast.error(t('shareEditor.couldntExportPng'), { description: t('shareEditor.seeConsole') })
       }
     }
-  }, [beginSaving, liveConversation, opts.template])
+  }, [beginSaving, waitForPreviewComplete, liveConversation, opts.template])
 
   const exportPdf = useCallback(async () => {
     const node = previewRef.current
     if (!node) return
     await beginSaving()
+    // Same progressive-mount gate as PNG: serialize the DOM only once
+    // the full, up-to-date document is committed.
+    await waitForPreviewComplete()
     const width = TEMPLATE_RATIO[opts.template].w
     const height = node.scrollHeight
     const filename = filenameForExport(liveConversation, opts.template, 'pdf')
@@ -511,7 +548,7 @@ export default function ShareEditorPage({
       setSaveState('error')
       toast.error(t('shareEditor.couldntExportPdf'), { description: t('shareEditor.seeConsole') })
     }
-  }, [beginSaving, liveConversation, opts.template])
+  }, [beginSaving, waitForPreviewComplete, liveConversation, opts.template])
 
   const savePdfFromPreview = useCallback(async () => {
     if (!pdfPreview) return
@@ -749,6 +786,7 @@ export default function ShareEditorPage({
             opts={opts}
             zoom={zoom}
             setZoom={setZoom}
+            onRenderState={handlePreviewRenderState}
           />
         </div>
       </div>

--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -460,6 +460,12 @@ export default function ShareEditorPage({
     while (!previewCompleteRef.current && Date.now() < deadline) {
       await new Promise((r) => setTimeout(r, 100))
     }
+    if (!previewCompleteRef.current) {
+      // Timed out — the capture proceeds with whatever is committed.
+      // Loud breadcrumb so a truncated export is diagnosable instead of
+      // silently indistinguishable from success.
+      console.warn('Preview did not reach render-complete within 10s; exporting the committed state.')
+    }
   }, [])
 
   const exportPng = useCallback(async () => {

--- a/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
+++ b/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   COLORWAYS,
@@ -19,6 +19,7 @@ import {
 } from '@spool/share-kit'
 import { TemplateThumb } from './TemplateThumb.js'
 import { TurnSelector } from './TurnSelector.js'
+import { useProgressiveCount } from './preview-progressive.js'
 
 /** Tiny helper that updates the persisted opt-out lists. Both fields
  *  are kept sorted+deduped to keep diffs/autosave snapshots stable. */
@@ -77,8 +78,29 @@ export function ControlPanel({ convo, opts, setOpts }: Props) {
   // Detection runs over every turn (not the selection) so the user
   // can spot leaks in turns they're about to include. The Body
   // renderer applies the final list per-turn at render time.
-  const pii = useMemo(() => detectPII(convo.turns), [convo.turns])
-  const totalRedactions = pii.groups.reduce((n, g) => n + g.count, 0) + pii.names.length
+  //
+  // Async (post-paint) rather than a render-time useMemo: the first
+  // scan over a multi-thousand-turn session costs hundreds of ms, and
+  // running it inside the editor's first commit stalled the open.
+  // `null` = scan in flight; the Privacy tab shows a scanning hint and
+  // the redact-off warning simply appears once the count is known.
+  // Subsequent runs are near-free (share-kit caches detection per
+  // Turn), so re-scans on conversation change don't flash the hint.
+  const [pii, setPii] = useState<ReturnType<typeof detectPII> | null>(null)
+  useEffect(() => {
+    let alive = true
+    const handle = window.setTimeout(() => {
+      const result = detectPII(convo.turns)
+      if (alive) setPii(result)
+    }, 0)
+    return () => {
+      alive = false
+      window.clearTimeout(handle)
+    }
+  }, [convo.turns])
+  const totalRedactions = pii
+    ? pii.groups.reduce((n, g) => n + g.count, 0) + pii.names.length
+    : 0
 
   return (
     <div className="w-full h-full p-2 pt-0">
@@ -390,6 +412,11 @@ function RedactRow({
   onToggleValue: (value: string) => void
 }) {
   const [open, setOpen] = useState(false)
+  // Expanded value rows mount progressively: a category like
+  // absolute-path can carry thousands of distinct values, and mounting
+  // them in one commit froze the panel on expand. Rows stream in over
+  // a few frames; closing resets to zero via the total clamp.
+  const shownValues = useProgressiveCount(open ? values.length : 0, 0, 400)
   // Header `×N` sums occurrences across duplicates so the user sees
   // how many times sensitive data appears in the source. The
   // expanded list still shows one row per distinct value.
@@ -447,7 +474,7 @@ function RedactRow({
       {open && (
         <div className="px-2.5 pb-2 pt-1 flex flex-col gap-0.5 border-t border-warm-border/40 dark:border-dark-border/40">
           {note && <div className="text-[10.5px] text-warm-faint dark:text-dark-muted py-1">{note}</div>}
-          {values.map((v, i) => {
+          {values.slice(0, shownValues).map((v, i) => {
             const excluded = isValueExcluded(v.value) || kindExcluded
             const interactive = !kindExcluded
             return (
@@ -696,10 +723,23 @@ function PrivacyView({
 }: {
   opts: EditorOpts
   setOpts: (next: EditorOpts) => void
-  pii: ReturnType<typeof detectPII>
+  /** `null` while the initial detection scan is still running. */
+  pii: ReturnType<typeof detectPII> | null
   totalRedactions: number
 }) {
   const { t } = useTranslation()
+  if (!pii) {
+    return (
+      <div
+        data-testid="share-editor-privacy-panel"
+        className="flex-1 min-h-0 flex items-center justify-center"
+      >
+        <span className="text-[11px] text-warm-faint dark:text-dark-muted">
+          {t('shareEditorPanel.privacy_scanning')}
+        </span>
+      </div>
+    )
+  }
   // How many sensitive occurrences would be VISIBLE in the shared
   // / exported artifact under the current policy. Drives both the
   // header count line and decides whether to show the Reset button.

--- a/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
+++ b/packages/app/src/renderer/components/share-editor/ControlPanel.tsx
@@ -88,15 +88,10 @@ export function ControlPanel({ convo, opts, setOpts }: Props) {
   // Turn), so re-scans on conversation change don't flash the hint.
   const [pii, setPii] = useState<ReturnType<typeof detectPII> | null>(null)
   useEffect(() => {
-    let alive = true
-    const handle = window.setTimeout(() => {
-      const result = detectPII(convo.turns)
-      if (alive) setPii(result)
-    }, 0)
-    return () => {
-      alive = false
-      window.clearTimeout(handle)
-    }
+    // The callback is fully synchronous, so clearTimeout alone is a
+    // complete stale-set guard — no alive flag needed.
+    const handle = window.setTimeout(() => setPii(detectPII(convo.turns)), 0)
+    return () => window.clearTimeout(handle)
   }, [convo.turns])
   const totalRedactions = pii
     ? pii.groups.reduce((n, g) => n + g.count, 0) + pii.names.length
@@ -728,27 +723,19 @@ function PrivacyView({
   totalRedactions: number
 }) {
   const { t } = useTranslation()
-  if (!pii) {
-    return (
-      <div
-        data-testid="share-editor-privacy-panel"
-        className="flex-1 min-h-0 flex items-center justify-center"
-      >
-        <span className="text-[11px] text-warm-faint dark:text-dark-muted">
-          {t('shareEditorPanel.privacy_scanning')}
-        </span>
-      </div>
-    )
-  }
   // How many sensitive occurrences would be VISIBLE in the shared
   // / exported artifact under the current policy. Drives both the
   // header count line and decides whether to show the Reset button.
+  // While the initial scan is in flight (`pii === null`) the header —
+  // including the master redact toggle, a safety control that must
+  // never disappear — still renders; only the counts and the category
+  // list wait for the scan.
   const excludedKinds = new Set(opts.redactExclude?.kinds ?? [])
   const excludedHashes = new Set(opts.redactExclude?.valueHashes ?? [])
   const isValueAllowed = (v: string) =>
     excludedHashes.size > 0 && excludedHashes.has(hashValueForRedactExclude(v))
   let visibleOccurrences = 0
-  if (opts.redact) {
+  if (opts.redact && pii) {
     for (const g of pii.groups) {
       const kindIsAllowed = excludedKinds.has(g.kind)
       for (const v of g.values) {
@@ -775,7 +762,8 @@ function PrivacyView({
   // user really wants to know "what will leak?" — so only the
   // visible count carries the warning weight.
   let countLabel: string
-  if (totalRedactions === 0) countLabel = t('shareEditorPanel.redact_noneDetected')
+  if (!pii) countLabel = t('shareEditorPanel.privacy_scanning')
+  else if (totalRedactions === 0) countLabel = t('shareEditorPanel.redact_noneDetected')
   else if (!opts.redact) countLabel = t('shareEditorPanel.redact_willBeVisible', { count: totalRedactions })
   else if (visibleOccurrences === 0) countLabel = t('shareEditorPanel.redact_items_other', { count: totalRedactions })
   else countLabel = t('shareEditorPanel.redact_visible', { count: visibleOccurrences })
@@ -849,13 +837,19 @@ function PrivacyView({
        *  stay pinned above. */}
       {opts.redact && (
         <div className="flex-1 min-h-0 overflow-y-auto scrollbar-none px-4 pb-4">
-          <RedactSummary
-            groups={pii.groups}
-            authorNames={pii.names}
-            manualValues={pii.manual}
-            opts={opts}
-            setOpts={setOpts}
-          />
+          {pii ? (
+            <RedactSummary
+              groups={pii.groups}
+              authorNames={pii.names}
+              manualValues={pii.manual}
+              opts={opts}
+              setOpts={setOpts}
+            />
+          ) : (
+            <div className="py-6 text-center text-[11px] text-warm-faint dark:text-dark-muted">
+              {t('shareEditorPanel.privacy_scanning')}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/packages/app/src/renderer/components/share-editor/PreviewPane.test.ts
+++ b/packages/app/src/renderer/components/share-editor/PreviewPane.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  nextProgressiveCount,
+  PREVIEW_INITIAL_TURNS,
+  PREVIEW_TURNS_PER_FRAME,
+} from './preview-progressive.js'
+
+describe('nextProgressiveCount', () => {
+  it('advances by one chunk per step and clamps at total', () => {
+    expect(nextProgressiveCount(PREVIEW_INITIAL_TURNS, 10_000)).toBe(
+      PREVIEW_INITIAL_TURNS + PREVIEW_TURNS_PER_FRAME,
+    )
+    expect(nextProgressiveCount(9_900, 10_000)).toBe(10_000)
+    expect(nextProgressiveCount(10_000, 10_000)).toBe(10_000)
+  })
+
+  it('reaches every total in finitely many steps', () => {
+    for (const total of [0, 1, PREVIEW_INITIAL_TURNS, 7126, 20_000]) {
+      let c = Math.min(PREVIEW_INITIAL_TURNS, total)
+      let steps = 0
+      while (c < total) {
+        c = nextProgressiveCount(c, total)
+        steps++
+        expect(steps).toBeLessThan(1_000)
+      }
+      expect(c).toBe(total)
+    }
+  })
+})
+
+describe('PREVIEW_INITIAL_TURNS covers every e2e fixture', () => {
+  // The whole regression story for the share e2e suites rests on small
+  // documents rendering WHOLE on the first commit — progressive
+  // mounting must be invisible to them. JSONL line counts upper-bound
+  // the turn count (meta/sidechain lines get filtered out), so this
+  // guard trips before a grown fixture can silently put the e2e suite
+  // into mid-fill territory.
+  // Fixtures that intentionally exceed the first chunk AND are never
+  // opened in the share editor by any spec. If a share spec starts
+  // using one of these, remove it from the list and either shrink the
+  // fixture or make the spec await the progressive fill.
+  const EXEMPT = new Set([
+    'test-session-large.jsonl', // session-detail.spec.ts virtuoso coverage only
+  ])
+
+  it('every claude-projects fixture fits in the first chunk', () => {
+    const root = join(__dirname, '..', '..', '..', '..', 'e2e', 'fixtures', 'claude-projects')
+    const jsonls: string[] = []
+    const walk = (dir: string) => {
+      for (const name of readdirSync(dir)) {
+        const p = join(dir, name)
+        if (statSync(p).isDirectory()) walk(p)
+        else if (name.endsWith('.jsonl') && !EXEMPT.has(name)) jsonls.push(p)
+      }
+    }
+    walk(root)
+    expect(jsonls.length).toBeGreaterThan(0)
+    for (const p of jsonls) {
+      const lines = readFileSync(p, 'utf8').split('\n').filter(Boolean).length
+      expect(lines, p).toBeLessThanOrEqual(PREVIEW_INITIAL_TURNS)
+    }
+  })
+})

--- a/packages/app/src/renderer/components/share-editor/PreviewPane.test.ts
+++ b/packages/app/src/renderer/components/share-editor/PreviewPane.test.ts
@@ -37,12 +37,15 @@ describe('PREVIEW_INITIAL_TURNS covers every e2e fixture', () => {
   // the turn count (meta/sidechain lines get filtered out), so this
   // guard trips before a grown fixture can silently put the e2e suite
   // into mid-fill territory.
-  // Fixtures that intentionally exceed the first chunk AND are never
-  // opened in the share editor by any spec. If a share spec starts
-  // using one of these, remove it from the list and either shrink the
-  // fixture or make the spec await the progressive fill.
+  // Fixtures that intentionally exceed the first chunk. Specs that
+  // open one of these in the share editor MUST wait for the
+  // `[data-render-complete]` marker on share-preview-render before
+  // asserting on preview DOM (see share-turn-selector.spec.ts) — the
+  // document mounts progressively and mid-fill counts race.
   const EXEMPT = new Set([
-    'test-session-large.jsonl', // session-detail.spec.ts virtuoso coverage only
+    // session-detail.spec.ts (virtuoso) + share-turn-selector.spec.ts
+    // (fill-aware via data-render-complete).
+    'test-session-large.jsonl',
   ])
 
   it('every claude-projects fixture fits in the first chunk', () => {

--- a/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
+++ b/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useCallback, useDeferredValue, useEffect, useLayoutEffect, 
 import { useTranslation } from 'react-i18next'
 import { MoreHorizontal } from 'lucide-react'
 import {
+  collectRedactList,
   TemplateRender,
   TEMPLATE_RATIO,
   TEMPLATES,
@@ -64,7 +65,6 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
   ref,
 ) {
   const { t } = useTranslation()
-  const ratio = TEMPLATE_RATIO[opts.template]
 
   // Progressive mount + deferred render. `slicedConvo` grows by chunks
   // until the full document is in; `useDeferredValue` keeps the canvas
@@ -78,12 +78,34 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
     () => (filled ? convo : { ...convo, turns: convo.turns.slice(0, turnCount) }),
     [convo, filled, turnCount],
   )
+  // The redact list is computed from the FULL turn list so its identity
+  // is stable across chunk frames. Left to the templates, the list
+  // would recompute per chunk (the sliced turns array is new each
+  // frame), changing every mounted Body's `redact` prop identity and
+  // re-parsing the whole document once per chunk — O(n²) during fill.
+  const fullRedactList = useMemo(
+    () => collectRedactList(convo.turns, opts),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [convo.turns, opts.redactExclude],
+  )
   const renderConvo = useDeferredValue(slicedConvo)
   const renderOpts = useDeferredValue(opts)
-  const renderComplete = filled && renderConvo === slicedConvo && renderOpts === opts
+  const renderRedactList = useDeferredValue(fullRedactList)
+  const renderComplete =
+    filled &&
+    renderConvo === slicedConvo &&
+    renderOpts === opts &&
+    renderRedactList === fullRedactList
   useEffect(() => {
     onRenderState?.({ complete: renderComplete })
   }, [renderComplete, onRenderState])
+
+  // Canvas geometry follows the DEFERRED opts, not the urgent ones:
+  // on a template switch the content takes a moment to catch up, and
+  // resizing the box to the new template's ratio while the old
+  // template's DOM is still committed shows the document mangled into
+  // the wrong aspect for the whole catch-up window.
+  const ratio = TEMPLATE_RATIO[renderOpts.template]
 
   const innerRef = useRef<HTMLDivElement>(null)
   const [naturalH, setNaturalH] = useState(ratio.h)
@@ -91,6 +113,20 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
     if (!innerRef.current) return
     setNaturalH(Math.max(ratio.h, innerRef.current.scrollHeight))
   }, [renderConvo, renderOpts, ratio.h])
+
+  // Size transitions are enabled one frame AFTER the document is fully
+  // committed: gating on the fill counter alone re-armed them on the
+  // same render the counter finished, so the LAST (largest) naturalH
+  // jump still animated — the exact "pumping" the gate exists to avoid.
+  const [sizeTransitions, setSizeTransitions] = useState(false)
+  useEffect(() => {
+    if (!renderComplete) {
+      setSizeTransitions(false)
+      return
+    }
+    const raf = requestAnimationFrame(() => setSizeTransitions(true))
+    return () => cancelAnimationFrame(raf)
+  }, [renderComplete])
 
   // Pan: drag-to-scroll on the empty backdrop / padding around the
   // canvas. Holding Space extends pan over the canvas too — that's
@@ -249,7 +285,7 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
           {/* Header chrome above the canvas — template name + dims. */}
           <div className="flex items-center gap-2.5 text-[10px] uppercase tracking-[0.08em] font-mono text-warm-muted dark:text-dark-muted">
             <span className="w-4 h-px bg-warm-border dark:bg-dark-border" />
-            {TEMPLATES.find((x) => x.id === opts.template)?.name} · {ratio.w}×{Math.round(naturalH)}
+            {TEMPLATES.find((x) => x.id === renderOpts.template)?.name} · {ratio.w}×{Math.round(naturalH)}
             <span className="w-4 h-px bg-warm-border dark:bg-dark-border" />
           </div>
           {/* Scaled canvas — width/height transition for smooth zoom.
@@ -273,8 +309,9 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
               borderRadius: 2,
               // No size transition while the document is still filling
               // in — the canvas grows once per chunk and animating every
-              // step reads as the page "pumping".
-              transition: filled
+              // step reads as the page "pumping". Re-armed one frame
+              // after the final commit (see sizeTransitions above).
+              transition: sizeTransitions
                 ? 'width 220ms cubic-bezier(.2,.8,.2,1), height 220ms cubic-bezier(.2,.8,.2,1)'
                 : 'none',
               cursor: spaceHeld || isPanning ? 'inherit' : 'default',
@@ -289,17 +326,28 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
                 willChange: 'transform',
               }}
             >
+              {/* data-* attrs mirror the DEFERRED opts so they always
+                  describe the DOM actually committed below — e2e and
+                  styling hooks read them next to the content. The
+                  data-render-complete marker is the e2e wait handle for
+                  "the full, caught-up document is committed". */}
               <div
                 ref={setRefs}
                 data-testid="share-preview-render"
-                data-template={opts.template}
-                data-paper={opts.paper}
-                data-typeface={opts.typeface}
-                data-colorway={opts.colorway}
-                data-density={opts.density}
+                data-template={renderOpts.template}
+                data-paper={renderOpts.paper}
+                data-typeface={renderOpts.typeface}
+                data-colorway={renderOpts.colorway}
+                data-density={renderOpts.density}
+                data-render-complete={renderComplete ? '' : undefined}
                 style={{ width: ratio.w, userSelect: 'text' }}
               >
-                <TemplateRender template={renderOpts.template} convo={renderConvo} opts={renderOpts} />
+                <TemplateRender
+                  template={renderOpts.template}
+                  convo={renderConvo}
+                  opts={renderOpts}
+                  redactList={renderRedactList}
+                />
               </div>
             </div>
           </div>

--- a/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
+++ b/packages/app/src/renderer/components/share-editor/PreviewPane.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
+import { forwardRef, useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { MoreHorizontal } from 'lucide-react'
 import {
@@ -9,6 +9,7 @@ import {
   type EditorOpts,
 } from '@spool/share-kit'
 import { useHotkeys } from '../../hooks/useHotkeys.js'
+import { useProgressiveCount } from './preview-progressive.js'
 
 export type Zoom = number | 'fit'
 
@@ -43,6 +44,12 @@ type Props = {
   opts: EditorOpts
   zoom: Zoom
   setZoom: (z: Zoom) => void
+  /** Reports whether the canvas currently shows the COMPLETE, up-to-
+   *  date document — all turns mounted AND the deferred render has
+   *  caught up with the latest convo/opts. DOM-capturing consumers
+   *  (PNG / PDF export) must wait for `complete` before reading the
+   *  preview node, or they capture a partially-filled / stale frame. */
+  onRenderState?: ((state: { complete: boolean }) => void) | undefined
 }
 
 /**
@@ -53,18 +60,37 @@ type Props = {
  * scroll.
  */
 export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPane(
-  { convo, opts, zoom, setZoom },
+  { convo, opts, zoom, setZoom, onRenderState },
   ref,
 ) {
   const { t } = useTranslation()
   const ratio = TEMPLATE_RATIO[opts.template]
+
+  // Progressive mount + deferred render. `slicedConvo` grows by chunks
+  // until the full document is in; `useDeferredValue` keeps the canvas
+  // re-render interruptible so a redact/opts toggle updates the control
+  // panel immediately while the document refreshes in the background
+  // (the previous frame stays visible — no blank flash).
+  const totalTurns = convo.turns.length
+  const turnCount = useProgressiveCount(totalTurns)
+  const filled = turnCount >= totalTurns
+  const slicedConvo = useMemo(
+    () => (filled ? convo : { ...convo, turns: convo.turns.slice(0, turnCount) }),
+    [convo, filled, turnCount],
+  )
+  const renderConvo = useDeferredValue(slicedConvo)
+  const renderOpts = useDeferredValue(opts)
+  const renderComplete = filled && renderConvo === slicedConvo && renderOpts === opts
+  useEffect(() => {
+    onRenderState?.({ complete: renderComplete })
+  }, [renderComplete, onRenderState])
 
   const innerRef = useRef<HTMLDivElement>(null)
   const [naturalH, setNaturalH] = useState(ratio.h)
   useLayoutEffect(() => {
     if (!innerRef.current) return
     setNaturalH(Math.max(ratio.h, innerRef.current.scrollHeight))
-  }, [convo, opts, ratio.h])
+  }, [renderConvo, renderOpts, ratio.h])
 
   // Pan: drag-to-scroll on the empty backdrop / padding around the
   // canvas. Holding Space extends pan over the canvas too — that's
@@ -245,7 +271,12 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
               height: naturalH * scale,
               boxShadow: '0 2px 6px rgba(0,0,0,.1), 0 20px 50px rgba(0,0,0,.08)',
               borderRadius: 2,
-              transition: 'width 220ms cubic-bezier(.2,.8,.2,1), height 220ms cubic-bezier(.2,.8,.2,1)',
+              // No size transition while the document is still filling
+              // in — the canvas grows once per chunk and animating every
+              // step reads as the page "pumping".
+              transition: filled
+                ? 'width 220ms cubic-bezier(.2,.8,.2,1), height 220ms cubic-bezier(.2,.8,.2,1)'
+                : 'none',
               cursor: spaceHeld || isPanning ? 'inherit' : 'default',
             }}
           >
@@ -268,13 +299,15 @@ export const PreviewPane = forwardRef<HTMLDivElement, Props>(function PreviewPan
                 data-density={opts.density}
                 style={{ width: ratio.w, userSelect: 'text' }}
               >
-                <TemplateRender template={opts.template} convo={convo} opts={opts} />
+                <TemplateRender template={renderOpts.template} convo={renderConvo} opts={renderOpts} />
               </div>
             </div>
           </div>
           {/* Footer chrome below. */}
           <div className="text-[10px] font-mono tracking-[0.04em] text-warm-faint dark:text-dark-muted">
-            1 / 1 · {t('shareEditorPanel.preview_wordCount_other', { count: convo.wordCount })}
+            {filled
+              ? <>1 / 1 · {t('shareEditorPanel.preview_wordCount_other', { count: convo.wordCount })}</>
+              : t('shareEditorPanel.preview_rendering')}
           </div>
         </div>
       </div>

--- a/packages/app/src/renderer/components/share-editor/TurnSelector.tsx
+++ b/packages/app/src/renderer/components/share-editor/TurnSelector.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Virtuoso } from 'react-virtuoso'
 import { Check, CheckCheck, Eraser } from 'lucide-react'
 import type { Conversation, EditorOpts } from '@spool/share-kit'
 
@@ -80,29 +81,39 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
   }, [opts, setOpts])
 
   const jumpToTurn = useCallback((index: number) => {
-    const el = document.querySelector<HTMLElement>(`[data-turn-index="${index}"]`)
-    if (!el) return
-    // Compute scrollTop manually instead of `scrollIntoView` so we
-    // only touch the vertical axis. scrollIntoView walks up the DOM
-    // and (under zoom transform) ends up shifting the artifact card
-    // horizontally off-center too.
-    const sc = el.closest<HTMLElement>('[data-share-preview-scroll]')
-    if (sc) {
-      const turnRect = el.getBoundingClientRect()
-      const scRect = sc.getBoundingClientRect()
-      const offsetFromContainerTop = (turnRect.top - scRect.top) + sc.scrollTop
-      const centered = offsetFromContainerTop - (scRect.height - turnRect.height) / 2
-      sc.scrollTop = Math.max(0, centered)
-    } else {
-      // Fallback for anything not inside our preview pane.
-      el.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'nearest' })
+    // The preview mounts large documents progressively, so a turn deep
+    // in the conversation may not be in the DOM yet right after the
+    // editor opens. Retry across frames (bounded) until the fill
+    // reaches it instead of silently doing nothing.
+    const tryJump = (attempt: number) => {
+      const el = document.querySelector<HTMLElement>(`[data-turn-index="${index}"]`)
+      if (!el) {
+        if (attempt < 120) requestAnimationFrame(() => tryJump(attempt + 1))
+        return
+      }
+      // Compute scrollTop manually instead of `scrollIntoView` so we
+      // only touch the vertical axis. scrollIntoView walks up the DOM
+      // and (under zoom transform) ends up shifting the artifact card
+      // horizontally off-center too.
+      const sc = el.closest<HTMLElement>('[data-share-preview-scroll]')
+      if (sc) {
+        const turnRect = el.getBoundingClientRect()
+        const scRect = sc.getBoundingClientRect()
+        const offsetFromContainerTop = (turnRect.top - scRect.top) + sc.scrollTop
+        const centered = offsetFromContainerTop - (scRect.height - turnRect.height) / 2
+        sc.scrollTop = Math.max(0, centered)
+      } else {
+        // Fallback for anything not inside our preview pane.
+        el.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'nearest' })
+      }
+      // Brief flash so the user sees where they landed. Remove + force
+      // reflow + re-add so the animation restarts on repeated clicks.
+      el.removeAttribute('data-spool-share-flash')
+      void el.offsetWidth
+      el.setAttribute('data-spool-share-flash', '')
+      window.setTimeout(() => el.removeAttribute('data-spool-share-flash'), 1700)
     }
-    // Brief flash so the user sees where they landed. Remove + force
-    // reflow + re-add so the animation restarts on repeated clicks.
-    el.removeAttribute('data-spool-share-flash')
-    void el.offsetWidth
-    el.setAttribute('data-spool-share-flash', '')
-    window.setTimeout(() => el.removeAttribute('data-spool-share-flash'), 1700)
+    tryJump(0)
   }, [])
 
   if (total === 0) {
@@ -142,13 +153,21 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
           </button>
         </span>
       </div>
-      <ul className="flex-1 min-h-0 overflow-y-auto scrollbar-none py-1">
-        {visibleTurns.map(({ turn, originalIndex: i }) => {
+      {/* Virtualised: a session can carry thousands of turns and the
+          panel used to mount one row per turn in a single synchronous
+          commit — switching to this tab froze the editor for seconds.
+          Same react-virtuoso setup as SessionDetail's MessageList. */}
+      <Virtuoso
+        data={visibleTurns}
+        computeItemKey={(_idx, row) => row.originalIndex}
+        defaultItemHeight={26}
+        increaseViewportBy={200}
+        className="flex-1 min-h-0 scrollbar-none"
+        itemContent={(_idx, { turn, originalIndex: i }) => {
           const included = selectedSet === null ? true : selectedSet.has(i)
           const preview = firstLinePreview(turn.body)
           return (
-            <li
-              key={i}
+            <div
               data-testid="share-editor-turn-row"
               data-row-turn-index={i}
               data-included={included ? '' : undefined}
@@ -195,10 +214,10 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
                   {preview || <span className="text-warm-faint dark:text-dark-faint italic">{t('shareEditorPanel.turnSelector_empty_body')}</span>}
                 </span>
               </button>
-            </li>
+            </div>
           )
-        })}
-      </ul>
+        }}
+      />
     </div>
   )
 }

--- a/packages/app/src/renderer/components/share-editor/TurnSelector.tsx
+++ b/packages/app/src/renderer/components/share-editor/TurnSelector.tsx
@@ -1,8 +1,20 @@
-import { useCallback, useMemo } from 'react'
+import { forwardRef, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Virtuoso } from 'react-virtuoso'
+import { Virtuoso, type Components } from 'react-virtuoso'
 import { Check, CheckCheck, Eraser } from 'lucide-react'
 import type { Conversation, EditorOpts } from '@spool/share-kit'
+
+// Restore the list semantics + breathing room the old <ul>/<li> markup
+// carried: Virtuoso renders bare divs by default, which drops the
+// screen-reader list context and the py-1 inset around the rows.
+const virtuosoComponents: Components<{ turn: { body: string }; originalIndex: number }> = {
+  List: forwardRef(function TurnList(props, ref) {
+    return <div role="list" {...props} ref={ref} className="py-1" />
+  }),
+  Item: function TurnItem(props) {
+    return <div role="listitem" {...props} />
+  },
+}
 
 type Props = {
   convo: Conversation
@@ -162,6 +174,7 @@ export function TurnSelector({ convo, opts, setOpts }: Props) {
         computeItemKey={(_idx, row) => row.originalIndex}
         defaultItemHeight={26}
         increaseViewportBy={200}
+        components={virtuosoComponents}
         className="flex-1 min-h-0 scrollbar-none"
         itemContent={(_idx, { turn, originalIndex: i }) => {
           const included = selectedSet === null ? true : selectedSet.has(i)

--- a/packages/app/src/renderer/components/share-editor/preview-progressive.ts
+++ b/packages/app/src/renderer/components/share-editor/preview-progressive.ts
@@ -1,0 +1,54 @@
+// Progressive-mount chunking for the share-editor preview. Pure logic
+// + a small stateful hook, split out of PreviewPane so the math is
+// unit-testable without dragging the template/markdown render chain
+// (which needs a DOM) into the node test environment.
+
+import { useEffect, useState } from 'react'
+
+/** First progressive chunk. Must stay comfortably above the e2e
+ *  fixtures' turn counts so small documents render whole on the first
+ *  commit — progressive mounting only kicks in for genuinely large
+ *  sessions. Guarded by PreviewPane.test.ts against fixture growth. */
+export const PREVIEW_INITIAL_TURNS = 150
+
+/** Turns appended per animation frame while filling the document. */
+export const PREVIEW_TURNS_PER_FRAME = 600
+
+/** One growth step: pure so the chunking math is unit-testable. */
+export function nextProgressiveCount(
+  current: number,
+  total: number,
+  step: number = PREVIEW_TURNS_PER_FRAME,
+): number {
+  return Math.min(current + step, total)
+}
+
+/**
+ * Progressive mount counter: start at `initial` turns so the first
+ * commit (and the fit-scale measurement behind it) is cheap, then
+ * grow one chunk per animation frame until the whole document is in.
+ * Rendering all turns synchronously blocks the main thread for
+ * seconds on multi-thousand-turn sessions — the editor froze on open
+ * and painted at fallback scale until the giant commit finished.
+ */
+export function useProgressiveCount(
+  total: number,
+  initial: number = PREVIEW_INITIAL_TURNS,
+  step: number = PREVIEW_TURNS_PER_FRAME,
+): number {
+  const [count, setCount] = useState(() => Math.min(initial, total))
+  useEffect(() => {
+    // Clamp when the document shrinks (e.g. fewer turns after a draft
+    // reload); never reset an already-filled view back to the first
+    // chunk on unrelated conversation identity churn.
+    setCount((c) => Math.min(c, total))
+  }, [total])
+  useEffect(() => {
+    if (count >= total) return
+    const raf = requestAnimationFrame(() => {
+      setCount((c) => nextProgressiveCount(c, total, step))
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [count, total, step])
+  return Math.min(count, total)
+}

--- a/packages/app/src/renderer/components/share-editor/publish-logic.ts
+++ b/packages/app/src/renderer/components/share-editor/publish-logic.ts
@@ -2,8 +2,11 @@
 // exercise the PII gate without standing up React. The modal is the
 // only consumer.
 
+// Cached per-Turn detection (same cache the templates / ControlPanel /
+// snapshot build warm) — a raw detectSensitiveSpans loop here re-ran
+// the full regex suite over every body on each publish-gate compute.
 import {
-  detectSensitiveSpans,
+  detectSensitiveSpansCached,
   hashValueForRedactExclude,
   SENSITIVE_KIND_LABEL,
   type SensitiveKind,
@@ -98,7 +101,7 @@ export function computeUnredactedMatches(
   const medium: UnredactedMatch[] = []
   conversation.turns.forEach((turn, idx) => {
     if (isHidden(idx)) return
-    const matches = detectSensitiveSpans(turn.body)
+    const matches = detectSensitiveSpansCached(turn)
     if (matches.length === 0) return
     for (const m of matches) {
       if (policyCovers(m)) continue

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -792,6 +792,7 @@
     "tab_style": "Stil",
     "tab_messages": "Nachrichten",
     "tab_privacy": "Datenschutz",
+    "privacy_scanning": "Suche nach sensiblen Daten…",
     "panel_view": "Panelansicht",
     "section_template": "Vorlage",
     "section_template_count": "{{count}} Looks",

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -843,6 +843,7 @@
     "preview_pageOf_short": "{{current}} / {{total}}",
     "preview_wordCount_one": "{{count}} Wort",
     "preview_wordCount_other": "{{count}} Wörter",
+    "preview_rendering": "Wird gerendert…",
     "preview_prevPage": "Vorherige Seite",
     "preview_nextPage": "Nächste Seite",
     "turnSelector_selectAll": "Alle Nachrichten einbeziehen",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -792,6 +792,7 @@
     "tab_style": "Style",
     "tab_messages": "Messages",
     "tab_privacy": "Privacy",
+    "privacy_scanning": "Scanning for sensitive data…",
     "panel_view": "Panel view",
     "section_template": "Template",
     "section_template_count": "{{count}} looks",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -843,6 +843,7 @@
     "preview_pageOf_short": "{{current}} / {{total}}",
     "preview_wordCount_one": "{{count}} word",
     "preview_wordCount_other": "{{count}} words",
+    "preview_rendering": "Rendering…",
     "preview_prevPage": "Previous page",
     "preview_nextPage": "Next page",
     "turnSelector_selectAll": "Include all messages",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -792,6 +792,7 @@
     "tab_style": "Style",
     "tab_messages": "Messages",
     "tab_privacy": "Confidentialité",
+    "privacy_scanning": "Recherche de données sensibles…",
     "panel_view": "Vue du panneau",
     "section_template": "Modèle",
     "section_template_count": "{{count}} styles",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -843,6 +843,7 @@
     "preview_pageOf_short": "{{current}} / {{total}}",
     "preview_wordCount_one": "{{count}} mot",
     "preview_wordCount_other": "{{count}} mots",
+    "preview_rendering": "Rendu en cours…",
     "preview_prevPage": "Page précédente",
     "preview_nextPage": "Page suivante",
     "turnSelector_selectAll": "Inclure tous les messages",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -755,6 +755,7 @@
     "tab_style": "スタイル",
     "tab_messages": "メッセージ",
     "tab_privacy": "プライバシー",
+    "privacy_scanning": "機密データをスキャン中…",
     "panel_view": "パネルビュー",
     "section_template": "テンプレート",
     "section_template_count": "{{count}} 種類",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -804,6 +804,7 @@
     "preview_pageOf": "{{current}} / {{total}} ページ",
     "preview_pageOf_short": "{{current}} / {{total}}",
     "preview_wordCount_other": "{{count}} 語",
+    "preview_rendering": "レンダリング中…",
     "preview_prevPage": "前のページ",
     "preview_nextPage": "次のページ",
     "turnSelector_selectAll": "すべてのメッセージを含める",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -804,6 +804,7 @@
     "preview_pageOf": "{{current}} / {{total}} 페이지",
     "preview_pageOf_short": "{{current}} / {{total}}",
     "preview_wordCount_other": "{{count}}단어",
+    "preview_rendering": "렌더링 중…",
     "preview_prevPage": "이전 페이지",
     "preview_nextPage": "다음 페이지",
     "turnSelector_selectAll": "모든 메시지 포함",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -755,6 +755,7 @@
     "tab_style": "스타일",
     "tab_messages": "메시지",
     "tab_privacy": "개인정보",
+    "privacy_scanning": "민감한 데이터 스캔 중…",
     "panel_view": "패널 보기",
     "section_template": "템플릿",
     "section_template_count": "{{count}}종",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -755,6 +755,7 @@
     "tab_style": "样式",
     "tab_messages": "消息",
     "tab_privacy": "隐私",
+    "privacy_scanning": "正在扫描敏感数据…",
     "panel_view": "面板视图",
     "section_template": "模板",
     "section_template_count": "{{count}} 种",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -804,6 +804,7 @@
     "preview_pageOf": "第 {{current}} / {{total}} 页",
     "preview_pageOf_short": "{{current}} / {{total}}",
     "preview_wordCount_other": "{{count}} 字",
+    "preview_rendering": "渲染中…",
     "preview_prevPage": "上一页",
     "preview_nextPage": "下一页",
     "turnSelector_selectAll": "包含全部消息",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -755,6 +755,7 @@
     "tab_style": "樣式",
     "tab_messages": "訊息",
     "tab_privacy": "隱私",
+    "privacy_scanning": "正在掃描敏感資料…",
     "panel_view": "面板檢視",
     "section_template": "模板",
     "section_template_count": "{{count}} 種",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -804,6 +804,7 @@
     "preview_pageOf": "第 {{current}} / {{total}} 頁",
     "preview_pageOf_short": "{{current}} / {{total}}",
     "preview_wordCount_other": "{{count}} 字",
+    "preview_rendering": "渲染中…",
     "preview_prevPage": "上一頁",
     "preview_nextPage": "下一頁",
     "turnSelector_selectAll": "包含全部訊息",

--- a/packages/redact/src/index.ts
+++ b/packages/redact/src/index.ts
@@ -49,6 +49,27 @@ export function detectSensitiveSpans(text: string): SensitiveMatch[] {
   return detectWithRegex(text)
 }
 
+// Detection is a pure function of the text, but the regex suite is a
+// full multi-pattern scan — expensive when a caller re-scans thousands
+// of bodies per policy change. Holders (share-kit turns, app publish
+// gates) keep the SAME body-carrying objects across a session, so a
+// WeakMap keyed on the holder gives cross-surface hits with zero
+// invalidation hazard: the entry stores the body it was computed from
+// and is ignored when the body has since changed, and dropping the
+// holder drops the entry.
+const spanCache = new WeakMap<object, { body: string; matches: SensitiveMatch[] }>()
+
+/** Cached `detectSensitiveSpans`, keyed on a stable body-carrying
+ *  object (e.g. a share-kit Turn). Semantically identical to scanning
+ *  `holder.body` fresh. */
+export function detectSensitiveSpansCached(holder: { body: string }): SensitiveMatch[] {
+  const hit = spanCache.get(holder)
+  if (hit && hit.body === holder.body) return hit.matches
+  const matches = detectWithRegex(holder.body)
+  spanCache.set(holder, { body: holder.body, matches })
+  return matches
+}
+
 /** Group matches by kind, deduplicating identical literals so the
  *  editor's expanded list shows one row per decision (not one row
  *  per occurrence). `group.count` keeps the total occurrence sum so

--- a/packages/share-kit/src/index.ts
+++ b/packages/share-kit/src/index.ts
@@ -132,6 +132,7 @@ export type {
 } from './lib/redaction-detect'
 export {
   detectPII,
+  detectSensitiveSpansCached,
   collectRedactList,
   applyRedactPolicy,
   SYNTHETIC_KIND_AUTHOR,

--- a/packages/share-kit/src/lib/storage/spool-file.ts
+++ b/packages/share-kit/src/lib/storage/spool-file.ts
@@ -123,11 +123,24 @@ function fnv1a32(s: string): number {
 
 /** Backfill stable ids on any turns that lack one. Idempotent: turns
  *  with an existing `id` pass through untouched, so it's safe to call
- *  on every load path (`readSpoolFile`, draft open, session import). */
+ *  on every load path (`readSpoolFile`, draft open, session import).
+ *
+ *  Identity-preserving and memoized per input array: callers like the
+ *  publish drift check run this on every debounce tick, and id-less
+ *  conversations (session-composed drafts) used to get a FRESH clone
+ *  of every turn per call — which defeated the per-Turn detection
+ *  cache downstream and re-ran the full regex scan each tick. */
+const turnIdsCache = new WeakMap<Turn[], Turn[]>()
+
 export function ensureTurnIds(turns: Turn[]): Turn[] {
-  return turns.map((t, idx) =>
+  if (turns.every((t) => t.id)) return turns
+  const hit = turnIdsCache.get(turns)
+  if (hit) return hit
+  const withIds = turns.map((t, idx) =>
     t.id ? t : { ...t, id: `legacy-${idx}-${fnv1a32(t.body).toString(16)}` },
   )
+  turnIdsCache.set(turns, withIds)
+  return withIds
 }
 
 export async function downloadSpoolFile(

--- a/packages/share-kit/src/templates/body.test.tsx
+++ b/packages/share-kit/src/templates/body.test.tsx
@@ -30,3 +30,41 @@ describe('Body — link hardening', () => {
     expect(html).not.toContain('javascript:alert')
   })
 })
+
+describe('Body — shared compiled redact matcher', () => {
+  const redact = [
+    { value: 'sk_live_aaaabbbbccccdddd1111', replacement: '[redacted: Stripe key]' },
+    { value: '/Users/chen/secret.txt', replacement: '[redacted path]' },
+  ]
+
+  function renderWith(text: string): string {
+    return renderToStaticMarkup(
+      <Body text={text} redact={redact} accent="#C85A00" accentBg="rgba(200,90,0,0.1)" />,
+    )
+  }
+
+  it('masks every entry, and a second render off the cached matcher is byte-identical', () => {
+    const text = 'key sk_live_aaaabbbbccccdddd1111 at /Users/chen/secret.txt and again sk_live_aaaabbbbccccdddd1111'
+    const first = renderWith(text)
+    expect(first).toContain('[redacted: Stripe key]')
+    expect(first).toContain('[redacted path]')
+    expect(first).not.toContain('sk_live_aaaabbbbccccdddd1111')
+    // Same redact array identity -> compiled matcher is reused across
+    // renders (and across turns). The output must not depend on that.
+    const second = renderWith(text)
+    expect(second).toBe(first)
+  })
+
+  it('a different redact list compiles its own matcher', () => {
+    const html = renderToStaticMarkup(
+      <Body
+        text="other-secret here"
+        redact={[{ value: 'other-secret', replacement: '[redacted]' }]}
+        accent="#C85A00"
+        accentBg="rgba(200,90,0,0.1)"
+      />,
+    )
+    expect(html).toContain('[redacted]')
+    expect(html).not.toContain('other-secret')
+  })
+})

--- a/packages/share-kit/src/templates/body.tsx
+++ b/packages/share-kit/src/templates/body.tsx
@@ -14,7 +14,7 @@
 // invisible in the rendered output and survives the markdown export
 // round-trip cleanly.
 
-import { useMemo, useState } from 'react'
+import { memo, useMemo, useState } from 'react'
 import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import type { RedactReplacement } from './redact'
@@ -110,17 +110,39 @@ function escapeRx(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
-function preprocess(text: string, redact?: RedactReplacement[]): string {
-  if (!redact || redact.length === 0) return text
+// One compiled matcher per redact list, shared across every Body in
+// the document. The list can carry thousands of entries (e.g. one per
+// absolute path in a large session); compiling the alternation inside
+// each Body made a single policy toggle recompile it once per turn.
+// Keyed on the array identity — templates memoize the list per policy
+// change and never mutate it. Sharing one `/g` RegExp across
+// `String.replace` calls is safe: replace resets lastIndex itself.
+const compiledRedact = new WeakMap<RedactReplacement[], { rx: RegExp; map: Map<string, string> }>()
+
+function compileRedact(redact: RedactReplacement[]): { rx: RegExp; map: Map<string, string> } {
+  const hit = compiledRedact.get(redact)
+  if (hit) return hit
   const map = new Map(redact.map((r) => [r.value, r.replacement]))
   const rx = new RegExp(Array.from(map.keys()).map(escapeRx).join('|'), 'g')
+  const compiled = { rx, map }
+  compiledRedact.set(redact, compiled)
+  return compiled
+}
+
+function preprocess(text: string, redact?: RedactReplacement[]): string {
+  if (!redact || redact.length === 0) return text
+  const { rx, map } = compileRedact(redact)
   return text.replace(rx, (match) => {
     const mask = map.get(match) ?? '[redacted]'
     return '`' + REDACT_CHIP_MARKER + mask + '`'
   })
 }
 
-export function Body({ text, redact, mono, sansFont, fontSize: sizeOverride, accent, accentBg, blockBorder }: BodyProps) {
+// memo: a turn's rendered markdown only depends on these scalar/stable
+// props. On large documents the markdown parse dominates render cost,
+// so bailing out here is what keeps unrelated state changes (zoom,
+// pan, progressive-mount growth) from re-parsing thousands of turns.
+export const Body = memo(function Body({ text, redact, mono, sansFont, fontSize: sizeOverride, accent, accentBg, blockBorder }: BodyProps) {
   const processed = useMemo(() => preprocess(text, redact), [text, redact])
   const blockStroke = blockBorder ?? accent
 
@@ -303,7 +325,7 @@ export function Body({ text, redact, mono, sansFont, fontSize: sizeOverride, acc
       </ReactMarkdown>
     </div>
   )
-}
+})
 
 function headStyle(size: number): React.CSSProperties {
   return {

--- a/packages/share-kit/src/templates/body.tsx
+++ b/packages/share-kit/src/templates/body.tsx
@@ -79,7 +79,10 @@ function MarkdownImage({ src, alt, accent }: { src?: string | undefined; alt?: s
       )}
       {state !== 'ok' && (
         <span style={{ display: 'inline-flex', alignItems: 'center', gap: 10, textAlign: 'left' }}>
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke={accent} strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+          {/* stroke via style, not the SVG attribute — the accent may be
+              a `var(--sk-accent)` reference, which only resolves in CSS
+              contexts (presentation attributes don't evaluate var()). */}
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, stroke: accent }}>
             <rect x="2.5" y="2.5" width="13" height="13" rx="1.5" />
             <circle cx="6.5" cy="6.5" r="1.2" />
             <path d="M15 11l-3.5-3.5L4 14" />

--- a/packages/share-kit/src/templates/chat.tsx
+++ b/packages/share-kit/src/templates/chat.tsx
@@ -8,7 +8,7 @@ import { useMemo } from 'react'
 import type { Conversation, EditorOpts } from '@/lib/types'
 import { typefaceFamily } from '@/lib/types'
 import { accentBgFor, templateTokens, bodyStyleVars, BODY_VAR_PROPS, BODY_VAR_BLOCK_BORDER } from './tokens'
-import { collectRedactList } from './redact'
+import { collectRedactList, type RedactReplacement } from './redact'
 import { selectSegments } from './selection'
 import { GapMarker } from './gap-marker'
 import { Body } from './body'
@@ -16,9 +16,11 @@ import { Body } from './body'
 interface Props {
   convo: Conversation
   opts: EditorOpts
+  /** Host-provided stable redact list — see TemplateRender's prop doc. */
+  redactList?: RedactReplacement[] | undefined
 }
 
-export function Chat({ convo, opts }: Props) {
+export function Chat({ convo, opts, redactList: injectedRedactList }: Props) {
   const t = templateTokens(opts.paper)
   const accent = opts.accentHex
   const accentBg = accentBgFor(accent)
@@ -26,10 +28,11 @@ export function Chat({ convo, opts }: Props) {
   // Memo so style-only opts changes (paper / typeface / colorway /
   // density / selection) don't re-trigger the 22-regex detection
   // pass. Re-runs only when source turns or redact policy moves.
-  const redactList = useMemo(
+  const computedRedactList = useMemo(
     () => collectRedactList(convo.turns, opts),
     [convo.turns, opts.redactExclude],
   )
+  const redactList = injectedRedactList ?? computedRedactList
   const segments = selectSegments(convo, opts)
   const turnGap = opts.density === 'compact' ? 20 : 30
 

--- a/packages/share-kit/src/templates/chat.tsx
+++ b/packages/share-kit/src/templates/chat.tsx
@@ -7,7 +7,7 @@
 import { useMemo } from 'react'
 import type { Conversation, EditorOpts } from '@/lib/types'
 import { typefaceFamily } from '@/lib/types'
-import { accentBgFor, templateTokens } from './tokens'
+import { accentBgFor, templateTokens, bodyStyleVars, BODY_VAR_PROPS, BODY_VAR_BLOCK_BORDER } from './tokens'
 import { collectRedactList } from './redact'
 import { selectSegments } from './selection'
 import { GapMarker } from './gap-marker'
@@ -36,6 +36,7 @@ export function Chat({ convo, opts }: Props) {
   return (
     <div
       style={{
+        ...bodyStyleVars({ accent, accentBg, bodyFont: tf, blockBorder: t.border }),
         fontFamily: tf,
         background: t.paper,
         color: t.text,
@@ -119,11 +120,9 @@ export function Chat({ convo, opts }: Props) {
                     <Body
                       text={turn.body}
                       redact={opts.redact ? redactList : undefined}
-                      sansFont={tf}
                       fontSize={13.5}
-                      accent={accent}
-                      accentBg={accentBg}
-                      blockBorder={t.border}
+                      {...BODY_VAR_PROPS}
+                      blockBorder={BODY_VAR_BLOCK_BORDER}
                     />
                   </div>
                 </div>
@@ -170,10 +169,8 @@ export function Chat({ convo, opts }: Props) {
                     <Body
                       text={turn.body}
                       redact={opts.redact ? redactList : undefined}
-                      sansFont={tf}
                       fontSize={13.5}
-                      accent={accent}
-                      accentBg={accentBg}
+                      {...BODY_VAR_PROPS}
                     />
                   </div>
                 </div>

--- a/packages/share-kit/src/templates/forum.tsx
+++ b/packages/share-kit/src/templates/forum.tsx
@@ -9,7 +9,7 @@ import { useMemo } from 'react'
 import type { Conversation, EditorOpts } from '@/lib/types'
 import { typefaceFamily } from '@/lib/types'
 import { accentBgFor, templateTokens, bodyStyleVars, BODY_VAR_PROPS, BODY_VAR_BLOCK_BORDER } from './tokens'
-import { collectRedactList } from './redact'
+import { collectRedactList, type RedactReplacement } from './redact'
 import { selectSegments } from './selection'
 import { GapMarker } from './gap-marker'
 import { Body } from './body'
@@ -17,17 +17,20 @@ import { Body } from './body'
 interface Props {
   convo: Conversation
   opts: EditorOpts
+  /** Host-provided stable redact list — see TemplateRender's prop doc. */
+  redactList?: RedactReplacement[] | undefined
 }
 
-export function Forum({ convo, opts }: Props) {
+export function Forum({ convo, opts, redactList: injectedRedactList }: Props) {
   const t = templateTokens(opts.paper)
   const accent = opts.accentHex
   const accentBg = accentBgFor(accent)
   const tf = typefaceFamily(opts.typeface)
-  const redactList = useMemo(
+  const computedRedactList = useMemo(
     () => collectRedactList(convo.turns, opts),
     [convo.turns, opts.redactExclude],
   )
+  const redactList = injectedRedactList ?? computedRedactList
   const segments = selectSegments(convo, opts)
   const postGap = opts.density === 'compact' ? 18 : 26
   const innerPad = opts.density === 'compact' ? 12 : 16

--- a/packages/share-kit/src/templates/forum.tsx
+++ b/packages/share-kit/src/templates/forum.tsx
@@ -8,7 +8,7 @@
 import { useMemo } from 'react'
 import type { Conversation, EditorOpts } from '@/lib/types'
 import { typefaceFamily } from '@/lib/types'
-import { accentBgFor, templateTokens } from './tokens'
+import { accentBgFor, templateTokens, bodyStyleVars, BODY_VAR_PROPS, BODY_VAR_BLOCK_BORDER } from './tokens'
 import { collectRedactList } from './redact'
 import { selectSegments } from './selection'
 import { GapMarker } from './gap-marker'
@@ -35,6 +35,7 @@ export function Forum({ convo, opts }: Props) {
   return (
     <div
       style={{
+        ...bodyStyleVars({ accent, accentBg, bodyFont: tf, blockBorder: t.border }),
         fontFamily: tf,
         background: t.paper,
         color: t.text,
@@ -206,11 +207,9 @@ export function Forum({ convo, opts }: Props) {
                     <Body
                       text={turn.body}
                       redact={opts.redact ? redactList : undefined}
-                      sansFont={tf}
                       fontSize={13.5}
-                      accent={accent}
-                      accentBg={accentBg}
-                      blockBorder={t.border}
+                      {...BODY_VAR_PROPS}
+                      blockBorder={BODY_VAR_BLOCK_BORDER}
                     />
                   </div>
                 </div>

--- a/packages/share-kit/src/templates/index.tsx
+++ b/packages/share-kit/src/templates/index.tsx
@@ -5,7 +5,7 @@
 // the editor stays interactive and the user can switch template / opts
 // to recover.
 
-import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { Component, memo, type ErrorInfo, type ReactNode } from 'react'
 import type { Conversation, EditorOpts, Template } from '@/lib/types'
 import { paperTokens } from '@/lib/types'
 import { Forum } from './forum'
@@ -19,7 +19,11 @@ interface Props {
   opts: EditorOpts
 }
 
-export function TemplateRender(props: Props) {
+// memo: hosts (PreviewPane, thumbnails) re-render on local state the
+// document doesn't depend on — zoom, pan, hover. Without the bailout
+// every such tick reconciles the full turn tree, which on multi-
+// thousand-turn documents is visible jank.
+export const TemplateRender = memo(function TemplateRender(props: Props) {
   // Keying the boundary on `template` means switching templates
   // remounts a fresh boundary — a crash on one template doesn't leave
   // the user stuck looking at a fallback after they've already switched
@@ -29,7 +33,7 @@ export function TemplateRender(props: Props) {
       <TemplateDispatch {...props} />
     </TemplateBoundary>
   )
-}
+})
 
 function TemplateDispatch({ template, convo, opts }: Props) {
   // Defensive guard for cases where the conversation got into a shape

--- a/packages/share-kit/src/templates/index.tsx
+++ b/packages/share-kit/src/templates/index.tsx
@@ -8,6 +8,7 @@
 import { Component, memo, type ErrorInfo, type ReactNode } from 'react'
 import type { Conversation, EditorOpts, Template } from '@/lib/types'
 import { paperTokens } from '@/lib/types'
+import type { RedactReplacement } from './redact'
 import { Forum } from './forum'
 import { Letter } from './letter'
 import { Timeline } from './timeline'
@@ -17,6 +18,14 @@ interface Props {
   template: Template
   convo: Conversation
   opts: EditorOpts
+  /** Optional pre-computed redact list. Hosts that re-render the
+   *  template with changing turn-array identities (the app preview
+   *  mounts large documents progressively, growing a sliced copy each
+   *  frame) MUST pass a list computed from the FULL conversation so
+   *  its identity — and therefore every memoized Body — stays stable
+   *  across those re-renders. When omitted, templates compute their
+   *  own (reader / thumbnails, where the convo identity is stable). */
+  redactList?: RedactReplacement[] | undefined
 }
 
 // memo: hosts (PreviewPane, thumbnails) re-render on local state the
@@ -35,7 +44,7 @@ export const TemplateRender = memo(function TemplateRender(props: Props) {
   )
 })
 
-function TemplateDispatch({ template, convo, opts }: Props) {
+function TemplateDispatch({ template, convo, opts, redactList }: Props) {
   // Defensive guard for cases where the conversation got into a shape
   // the templates can't handle (no turns array, etc). Without this, the
   // first `.map()` inside the template would throw to the boundary —
@@ -46,19 +55,19 @@ function TemplateDispatch({ template, convo, opts }: Props) {
   }
   switch (template) {
     case 'forum':
-      return <Forum convo={convo} opts={opts} />
+      return <Forum convo={convo} opts={opts} redactList={redactList} />
     case 'letter':
-      return <Letter convo={convo} opts={opts} />
+      return <Letter convo={convo} opts={opts} redactList={redactList} />
     case 'timeline':
-      return <Timeline convo={convo} opts={opts} />
+      return <Timeline convo={convo} opts={opts} redactList={redactList} />
     case 'chat':
-      return <Chat convo={convo} opts={opts} />
+      return <Chat convo={convo} opts={opts} redactList={redactList} />
     default:
       // Belt-and-suspenders for snapshots saved with a since-retired
       // template id (e.g. 'interview' from pre-v0.5.0 drafts that
       // somehow slipped past normalizeOpts). Fall back to Chat rather
       // than rendering nothing.
-      return <Chat convo={convo} opts={opts} />
+      return <Chat convo={convo} opts={opts} redactList={redactList} />
   }
 }
 

--- a/packages/share-kit/src/templates/letter.tsx
+++ b/packages/share-kit/src/templates/letter.tsx
@@ -14,7 +14,7 @@
 import { useMemo } from 'react'
 import type { Conversation, EditorOpts } from '@/lib/types'
 import { typefaceFamily } from '@/lib/types'
-import { accentBgFor, templateTokens } from './tokens'
+import { accentBgFor, templateTokens, bodyStyleVars, BODY_VAR_PROPS } from './tokens'
 import { collectRedactList } from './redact'
 import { selectSegments } from './selection'
 import { GapMarker } from './gap-marker'
@@ -40,6 +40,7 @@ export function Letter({ convo, opts }: Props) {
   return (
     <div
       style={{
+        ...bodyStyleVars({ accent, accentBg, bodyFont: tf, blockBorder: t.border }),
         fontFamily: tf,
         background: t.paper,
         color: t.text,
@@ -158,9 +159,7 @@ export function Letter({ convo, opts }: Props) {
               <Body
                 text={turn.body}
                 redact={opts.redact ? redactList : undefined}
-                sansFont={tf}
-                accent={accent}
-                accentBg={accentBg}
+                {...BODY_VAR_PROPS}
               />
             </div>
           </div>

--- a/packages/share-kit/src/templates/letter.tsx
+++ b/packages/share-kit/src/templates/letter.tsx
@@ -15,7 +15,7 @@ import { useMemo } from 'react'
 import type { Conversation, EditorOpts } from '@/lib/types'
 import { typefaceFamily } from '@/lib/types'
 import { accentBgFor, templateTokens, bodyStyleVars, BODY_VAR_PROPS } from './tokens'
-import { collectRedactList } from './redact'
+import { collectRedactList, type RedactReplacement } from './redact'
 import { selectSegments } from './selection'
 import { GapMarker } from './gap-marker'
 import { Body } from './body'
@@ -23,17 +23,20 @@ import { Body } from './body'
 interface Props {
   convo: Conversation
   opts: EditorOpts
+  /** Host-provided stable redact list — see TemplateRender's prop doc. */
+  redactList?: RedactReplacement[] | undefined
 }
 
-export function Letter({ convo, opts }: Props) {
+export function Letter({ convo, opts, redactList: injectedRedactList }: Props) {
   const t = templateTokens(opts.paper)
   const accent = opts.accentHex
   const accentBg = accentBgFor(accent)
   const tf = typefaceFamily(opts.typeface)
-  const redactList = useMemo(
+  const computedRedactList = useMemo(
     () => collectRedactList(convo.turns, opts),
     [convo.turns, opts.redactExclude],
   )
+  const redactList = injectedRedactList ?? computedRedactList
   const turnGap = opts.density === 'compact' ? 20 : 32
   const segments = selectSegments(convo, opts)
 

--- a/packages/share-kit/src/templates/redact.test.ts
+++ b/packages/share-kit/src/templates/redact.test.ts
@@ -130,3 +130,52 @@ describe('collectRedactList wires policy through', () => {
       .not.toContain('Maya')
   })
 })
+
+describe('detection cache', () => {
+  it('repeated detectPII over the same Turn objects returns identical results', () => {
+    const ts: Turn[] = [
+      turn('user', `key ${STRIPE_FIXTURE} and mail ${EMAIL_FIXTURE}`),
+      turn('assistant', 'nothing sensitive here'),
+    ]
+    const first = detectPII(ts)
+    const second = detectPII(ts)
+    // Same match content (cache hit must be semantically identical to a
+    // fresh scan)…
+    expect(second.matches.map((m) => [m.kind, m.value])).toEqual(
+      first.matches.map((m) => [m.kind, m.value]),
+    )
+    // …and actually served from cache: the per-turn match objects are
+    // the same instances on the second pass.
+    expect(second.matches[0]).toBe(first.matches[0])
+  })
+
+  it('invalidates when a turn body changes in place', () => {
+    const t = turn('user', `mail ${EMAIL_FIXTURE}`)
+    const before = detectPII([t])
+    expect(values(applyRedactPolicy(before, undefined))).toContain(EMAIL_FIXTURE)
+
+    // Mutate the SAME object — the cache must notice the body moved
+    // and rescan rather than serving the stale email match.
+    t.body = `key ${STRIPE_FIXTURE}`
+    const after = detectPII([t])
+    const list = applyRedactPolicy(after, undefined)
+    expect(values(list)).toContain(STRIPE_FIXTURE)
+    expect(values(list)).not.toContain(EMAIL_FIXTURE)
+  })
+
+  it('publish-path equivalence: collectRedactList is stable across repeated policy toggles', () => {
+    const ts: Turn[] = [
+      turn('user', `reply to ${EMAIL_FIXTURE}`),
+      turn('assistant', `creds ${STRIPE_FIXTURE} at /Users/chen/.aws/credentials`),
+    ]
+    const baseline = collectRedactList(ts, { redactExclude: undefined })
+    // Toggle a kind off and back on a few times (cache-hit path), then
+    // assert the final list is byte-identical to the first computation.
+    for (let i = 0; i < 3; i++) {
+      collectRedactList(ts, { redactExclude: { kinds: ['email'] } })
+      collectRedactList(ts, { redactExclude: undefined })
+    }
+    const final = collectRedactList(ts, { redactExclude: undefined })
+    expect(final).toEqual(baseline)
+  })
+})

--- a/packages/share-kit/src/templates/redact.tsx
+++ b/packages/share-kit/src/templates/redact.tsx
@@ -18,13 +18,18 @@
 
 import type { EditorOpts, RedactExclude, Turn } from '@/lib/types'
 import {
-  detectSensitiveSpans,
+  detectSensitiveSpansCached,
   groupBySensitiveKind,
   hashValueForRedactExclude,
   maskValueByKind,
   type SensitiveGroup,
   type SensitiveMatch,
 } from '@spool-lab/redact'
+
+// Re-export so existing share-kit consumers keep their import path;
+// the cache itself lives in @spool-lab/redact so non-React surfaces
+// (publish gate, future CLI/scan callers) share the same hits.
+export { detectSensitiveSpansCached }
 
 /** Synthetic "kind" tags for non-regex sources that the Privacy
  *  panel still wants to surface as filterable rows. Keep these
@@ -57,28 +62,15 @@ export interface PIIDetection {
   all: string[]
 }
 
-// Per-turn detection cache. `detectSensitiveSpans` is a pure function
-// of the body text but costs a full regex-suite scan; on a 7k-turn
-// conversation every redact-policy toggle used to re-scan all bodies.
-// Editor surfaces (templates, ControlPanel, autosave, snapshot build)
-// all hold the SAME Turn objects across a session, so a WeakMap keyed
-// on the Turn gives cross-surface hits with zero invalidation hazard:
-// the entry stores the body it was computed from and is ignored when
-// the body has since changed, and dropping the Turn drops the entry.
-const detectCache = new WeakMap<Turn, { body: string; matches: SensitiveMatch[] }>()
-
-function detectSpansCached(turn: Turn): SensitiveMatch[] {
-  const hit = detectCache.get(turn)
-  if (hit && hit.body === turn.body) return hit.matches
-  const matches = detectSensitiveSpans(turn.body)
-  detectCache.set(turn, { body: turn.body, matches })
-  return matches
-}
-
+// Detection goes through @spool-lab/redact's per-Turn cache: editor
+// surfaces (templates, ControlPanel, autosave, snapshot build, publish
+// gate) all hold the same Turn objects across a session, so a policy
+// toggle re-aggregates cached matches instead of re-scanning every
+// body with the full regex suite.
 export function detectPII(turns: Turn[]): PIIDetection {
   const matches: SensitiveMatch[] = []
   for (const t of turns) {
-    matches.push(...detectSpansCached(t))
+    matches.push(...detectSensitiveSpansCached(t))
   }
   const names = Array.from(
     new Set(

--- a/packages/share-kit/src/templates/redact.tsx
+++ b/packages/share-kit/src/templates/redact.tsx
@@ -57,10 +57,28 @@ export interface PIIDetection {
   all: string[]
 }
 
+// Per-turn detection cache. `detectSensitiveSpans` is a pure function
+// of the body text but costs a full regex-suite scan; on a 7k-turn
+// conversation every redact-policy toggle used to re-scan all bodies.
+// Editor surfaces (templates, ControlPanel, autosave, snapshot build)
+// all hold the SAME Turn objects across a session, so a WeakMap keyed
+// on the Turn gives cross-surface hits with zero invalidation hazard:
+// the entry stores the body it was computed from and is ignored when
+// the body has since changed, and dropping the Turn drops the entry.
+const detectCache = new WeakMap<Turn, { body: string; matches: SensitiveMatch[] }>()
+
+function detectSpansCached(turn: Turn): SensitiveMatch[] {
+  const hit = detectCache.get(turn)
+  if (hit && hit.body === turn.body) return hit.matches
+  const matches = detectSensitiveSpans(turn.body)
+  detectCache.set(turn, { body: turn.body, matches })
+  return matches
+}
+
 export function detectPII(turns: Turn[]): PIIDetection {
   const matches: SensitiveMatch[] = []
   for (const t of turns) {
-    matches.push(...detectSensitiveSpans(t.body))
+    matches.push(...detectSpansCached(t))
   }
   const names = Array.from(
     new Set(

--- a/packages/share-kit/src/templates/timeline.tsx
+++ b/packages/share-kit/src/templates/timeline.tsx
@@ -15,24 +15,27 @@ import { useMemo } from 'react'
 import type { Conversation, EditorOpts } from '@/lib/types'
 import { typefaceFamily } from '@/lib/types'
 import { accentBgFor, templateTokens, bodyStyleVars, BODY_VAR_PROPS } from './tokens'
-import { collectRedactList } from './redact'
+import { collectRedactList, type RedactReplacement } from './redact'
 import { selectSegments } from './selection'
 import { Body } from './body'
 
 interface Props {
   convo: Conversation
   opts: EditorOpts
+  /** Host-provided stable redact list — see TemplateRender's prop doc. */
+  redactList?: RedactReplacement[] | undefined
 }
 
-export function Timeline({ convo, opts }: Props) {
+export function Timeline({ convo, opts, redactList: injectedRedactList }: Props) {
   const t = templateTokens(opts.paper)
   const accent = opts.accentHex
   const accentBg = accentBgFor(accent)
   const tf = typefaceFamily(opts.typeface)
-  const redactList = useMemo(
+  const computedRedactList = useMemo(
     () => collectRedactList(convo.turns, opts),
     [convo.turns, opts.redactExclude],
   )
+  const redactList = injectedRedactList ?? computedRedactList
   const segments = selectSegments(convo, opts)
   const turnGap = opts.density === 'compact' ? 18 : 28
 

--- a/packages/share-kit/src/templates/timeline.tsx
+++ b/packages/share-kit/src/templates/timeline.tsx
@@ -14,7 +14,7 @@
 import { useMemo } from 'react'
 import type { Conversation, EditorOpts } from '@/lib/types'
 import { typefaceFamily } from '@/lib/types'
-import { accentBgFor, templateTokens } from './tokens'
+import { accentBgFor, templateTokens, bodyStyleVars, BODY_VAR_PROPS } from './tokens'
 import { collectRedactList } from './redact'
 import { selectSegments } from './selection'
 import { Body } from './body'
@@ -39,6 +39,7 @@ export function Timeline({ convo, opts }: Props) {
   return (
     <div
       style={{
+        ...bodyStyleVars({ accent, accentBg, bodyFont: tf, blockBorder: t.border }),
         fontFamily: tf,
         background: t.paper,
         color: t.text,
@@ -244,9 +245,7 @@ export function Timeline({ convo, opts }: Props) {
                     <Body
                       text={turn.body}
                       redact={opts.redact ? redactList : undefined}
-                      sansFont={tf}
-                      accent={accent}
-                      accentBg={accentBg}
+                      {...BODY_VAR_PROPS}
                     />
                   </div>
                 </div>

--- a/packages/share-kit/src/templates/tokens.ts
+++ b/packages/share-kit/src/templates/tokens.ts
@@ -28,3 +28,34 @@ export function accentBgFor(accentHex: string, alphaHex = '26'): string {
   }
   return `#${hex}${alphaHex}`
 }
+
+/** CSS custom properties that carry the style-only Body inputs.
+ *
+ *  Templates set these on their ROOT element and hand `Body` literal
+ *  `var(--sk-*)` references (see BODY_VAR_PROPS). Because the prop
+ *  strings never change, a colorway / paper / typeface switch leaves
+ *  every memoized Body untouched — the restyle happens entirely in
+ *  CSS, instead of re-parsing the markdown of every turn. */
+export function bodyStyleVars(args: {
+  accent: string
+  accentBg: string
+  bodyFont: string
+  blockBorder: string
+}): Record<string, string> {
+  return {
+    '--sk-accent': args.accent,
+    '--sk-accent-bg': args.accentBg,
+    '--sk-body-font': args.bodyFont,
+    '--sk-block-border': args.blockBorder,
+  }
+}
+
+/** The literal var() references templates pass to `Body` so its props
+ *  stay referentially stable across style-only opts changes. */
+export const BODY_VAR_PROPS = {
+  accent: 'var(--sk-accent)',
+  accentBg: 'var(--sk-accent-bg)',
+  sansFont: 'var(--sk-body-font)',
+} as const
+
+export const BODY_VAR_BLOCK_BORDER = 'var(--sk-block-border)'


### PR DESCRIPTION
## What
Opening a 7k-turn session froze the editor for seconds and painted at fallback scale until the single giant commit finished; toggling a redact category, switching to the Messages tab, or changing colorway/paper/typeface each stalled for seconds more. This PR makes all of those interactions immediate:

- **share-kit**: per-Turn detection cache (lives in `@spool-lab/redact`, shared by templates / ControlPanel / snapshot build / publish gate), one compiled redact matcher per list instead of per Body, `React.memo` on `Body`/`TemplateRender`, and templates accept a host-injected `redactList` whose identity survives re-renders. Templates publish style inputs as `--sk-*` CSS variables and hand `Body` literal `var()` references, so colorway/paper/typeface switches restyle via CSS with zero markdown re-parsing.
- **app**: the preview mounts large documents progressively (150 turns first commit, one chunk per frame) and renders through `useDeferredValue`, with canvas geometry following the deferred opts so template switches stay atomic; PNG/PDF export waits for the complete, caught-up document before capturing the DOM; the Messages tab is virtualized with `react-virtuoso`; the first PII scan runs post-paint (Privacy tab keeps its master toggle visible while scanning); the publish drift check debounces like autosave; `ensureTurnIds` preserves identity so the drift tick hits the detection cache.

## Why
Measured on a real 7,126-turn session (~820 KB text): the full render is ~2 s of pure CPU producing an 11.7 MB DOM, every redact toggle recompiled a several-thousand-branch RegExp once per turn, and the Messages tab mounted ~70 k nodes in one commit. Each fix targets one of those whole-document synchronous costs; a self-review pass also caught that naive slicing made the fill itself O(n²) (per-chunk redact-list identity churn defeating the Body memo), which the injected stable list resolves.

## How it connects
Published snapshots, markdown/.spool exports, and the publish PII gate are data-path and byte-identical — covered by cache-equivalence unit tests and the full share e2e matrix (12 suites, 68 tests, all green). DOM-capturing exports gate on a `data-render-complete` marker that the turn-selector spec (which runs on the 1500-turn fixture) also waits on. A fixture-size guard in unit tests keeps future e2e fixtures within the first progressive chunk or forces them to be fill-aware.