### PR TITLE
perf(share-editor): merge autosave and drift-check onto one debounce window

### DIFF
--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -28,6 +28,7 @@ import Menu from './Menu.js'
 import { buildPreviewDocument } from '@spool/share-kit'
 import { useUndoableState } from '../hooks/useUndoableState.js'
 import { useHotkeys } from '../hooks/useHotkeys.js'
+import { useSharedDebounce } from '../hooks/useSharedDebounce.js'
 import { sharePublicUrl } from '../lib/sharePublicUrl.js'
 import type { PublishedRow, PublishSuccess, Visibility } from '../../shared/share-publish.js'
 
@@ -307,6 +308,12 @@ export default function ShareEditorPage({
   // that never landed the column) get no badge: we have nothing to
   // compare against, so silently treating them as up-to-date is
   // better than crying wolf on every open.
+  // One shared 400ms window for the two heavy post-edit follow-ups
+  // (drift check + autosave): an edit wakes the main thread once and
+  // both builds run back-to-back, instead of two independent timers
+  // landing in the same breath.
+  const followUps = useSharedDebounce(400)
+
   const [hasUnpublishedEdits, setHasUnpublishedEdits] = useState(false)
   useEffect(() => {
     if (
@@ -320,11 +327,13 @@ export default function ShareEditorPage({
     let alive = true
     const rowVisibility = publishedRow.visibility as Visibility
     const rowHash = publishedRow.client_request_id
-    // Debounced (same window as autosave below): the hash runs the full
-    // snapshot build — redact pipeline included — which on large
-    // sessions is too heavy to fire on every keystroke / policy toggle.
-    // The badge appearing 400ms later is imperceptible.
-    const handle = window.setTimeout(() => {
+    // Debounced on the SAME window as the autosave below: the hash runs
+    // the full snapshot build — redact pipeline included — which on
+    // large sessions is too heavy to fire on every keystroke / policy
+    // toggle. Sharing one window means an edit wakes the main thread
+    // once for both follow-ups instead of two timers firing
+    // back-to-back. The badge appearing 400ms later is imperceptible.
+    followUps.schedule('drift', () => {
       void (async () => {
         try {
           const snapshot = buildSnapshotFromEditor({
@@ -344,12 +353,12 @@ export default function ShareEditorPage({
           setHasUnpublishedEdits(false)
         }
       })()
-    }, 400)
+    })
     return () => {
       alive = false
-      window.clearTimeout(handle)
+      followUps.cancel('drift')
     }
-  }, [publishedRow, liveConversation, opts])
+  }, [publishedRow, liveConversation, opts, followUps])
 
   // Autosave opts changes back into share_drafts. Debounced so a
   // rapid sequence of clicks (e.g. paging through colorways) collapses
@@ -402,14 +411,14 @@ export default function ShareEditorPage({
     pendingInputsRef.current = {
       draftId, sourceKind, sourceOrigin, effectiveTitle, liveConversation, opts,
     }
-    // The cleanup below clears any in-flight timer when a new edit
-    // arrives or the component unmounts, so only the latest stamped
-    // inputs ever feed flushPendingSave. If `handleDelete` has cleared
-    // pendingInputsRef in the meantime, flushPendingSave returns a
-    // no-op when it reads the ref.
-    const handle = window.setTimeout(flushPendingSave, 400)
-    return () => window.clearTimeout(handle)
-  }, [opts, liveConversation, draftId, sourceKind, sourceOrigin, effectiveTitle, flushPendingSave])
+    // Scheduled on the shared follow-up window (see `followUps` above).
+    // Re-scheduling on each edit replaces the pending callback, so only
+    // the latest stamped inputs ever feed flushPendingSave. If
+    // `handleDelete` has cleared pendingInputsRef in the meantime,
+    // flushPendingSave returns a no-op when it reads the ref. The
+    // unmount flush below is independent of this timer.
+    followUps.schedule('autosave', flushPendingSave)
+  }, [opts, liveConversation, draftId, sourceKind, sourceOrigin, effectiveTitle, flushPendingSave, followUps])
 
   // Flush the pending autosave on component unmount — user clicked
   // Back, navigated away, or the editor was replaced by another view.

--- a/packages/app/src/renderer/hooks/useSharedDebounce.test.ts
+++ b/packages/app/src/renderer/hooks/useSharedDebounce.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { createSharedDebounce } from './useSharedDebounce.js'
+
+/** Minimal manual timer host — fire() runs the pending callback. */
+function fakeTimers() {
+  let next = 1
+  const pending = new Map<number, () => void>()
+  return {
+    host: {
+      setTimeout: (fn: () => void, _ms: number) => {
+        const h = next++
+        pending.set(h, fn)
+        return h
+      },
+      clearTimeout: (h: number) => {
+        pending.delete(h)
+      },
+    },
+    fire: () => {
+      const fns = Array.from(pending.values())
+      pending.clear()
+      for (const fn of fns) fn()
+    },
+    pendingCount: () => pending.size,
+  }
+}
+
+describe('createSharedDebounce', () => {
+  it('runs every pending task once when the shared window fires', () => {
+    const t = fakeTimers()
+    const d = createSharedDebounce(400, t.host)
+    const ran: string[] = []
+    d.schedule('save', () => ran.push('save'))
+    d.schedule('drift', () => ran.push('drift'))
+    // One shared timer, not one per task.
+    expect(t.pendingCount()).toBe(1)
+    t.fire()
+    expect(ran).toEqual(['save', 'drift'])
+    // Tasks don't re-run on a later window.
+    d.schedule('save', () => ran.push('save2'))
+    t.fire()
+    expect(ran).toEqual(['save', 'drift', 'save2'])
+  })
+
+  it('re-scheduling a key replaces its pending callback (trailing debounce)', () => {
+    const t = fakeTimers()
+    const d = createSharedDebounce(400, t.host)
+    const ran: string[] = []
+    d.schedule('save', () => ran.push('stale'))
+    d.schedule('save', () => ran.push('latest'))
+    t.fire()
+    expect(ran).toEqual(['latest'])
+  })
+
+  it('re-arming for one key keeps the other key pending until the new window fires', () => {
+    const t = fakeTimers()
+    const d = createSharedDebounce(400, t.host)
+    const ran: string[] = []
+    d.schedule('save', () => ran.push('save'))
+    d.schedule('drift', () => ran.push('drift'))
+    // A new edit re-arms via 'save' — drift must survive into the new window.
+    d.schedule('save', () => ran.push('save'))
+    t.fire()
+    expect(ran.sort()).toEqual(['drift', 'save'])
+  })
+
+  it('cancel drops one task; dispose drops everything silently', () => {
+    const t = fakeTimers()
+    const d = createSharedDebounce(400, t.host)
+    const ran: string[] = []
+    d.schedule('save', () => ran.push('save'))
+    d.schedule('drift', () => ran.push('drift'))
+    d.cancel('drift')
+    t.fire()
+    expect(ran).toEqual(['save'])
+
+    d.schedule('save', () => ran.push('after-dispose'))
+    d.dispose()
+    t.fire()
+    expect(ran).toEqual(['save'])
+    expect(t.pendingCount()).toBe(0)
+  })
+})

--- a/packages/app/src/renderer/hooks/useSharedDebounce.ts
+++ b/packages/app/src/renderer/hooks/useSharedDebounce.ts
@@ -1,0 +1,78 @@
+// A single trailing-debounce window shared by several tasks.
+//
+// The share editor runs two heavy follow-ups after every edit — the
+// draft autosave and the publish drift check — each debounced at
+// 400ms. As two independent timers they fire back-to-back at t+400ms,
+// stacking two full document builds in the same breath on the main
+// thread, and tuning the window means keeping two constants in sync.
+// This gives them ONE window: scheduling any task (re)arms the shared
+// timer, and when it fires every pending task runs once.
+//
+// Semantics per task key match a plain trailing debounce: scheduling
+// the same key again replaces the pending callback, so only the latest
+// closure runs. Disposal cancels the window without running anything —
+// callers that must flush on unmount (autosave does) keep their own
+// unmount flush, which reads from refs and doesn't depend on this
+// timer.
+
+import { useEffect, useMemo } from 'react'
+
+export interface SharedDebounce {
+  /** Schedule `task` under `key`, (re)arming the shared window. A task
+   *  scheduled again before the window fires replaces the previous
+   *  callback for that key. */
+  schedule: (key: string, task: () => void) => void
+  /** Drop a pending task without running it (e.g. when the effect that
+   *  scheduled it re-runs and will schedule a replacement — or not). */
+  cancel: (key: string) => void
+  /** Cancel the window and every pending task. */
+  dispose: () => void
+}
+
+interface TimerHost {
+  setTimeout: (fn: () => void, ms: number) => number
+  clearTimeout: (handle: number) => void
+}
+
+/** Pure factory — timers injectable so the merge/replace/dispose
+ *  semantics are unit-testable without a DOM or fake global clock. */
+export function createSharedDebounce(delayMs: number, host: TimerHost): SharedDebounce {
+  let handle: number | null = null
+  const tasks = new Map<string, () => void>()
+
+  const schedule = (key: string, task: () => void) => {
+    tasks.set(key, task)
+    if (handle !== null) host.clearTimeout(handle)
+    handle = host.setTimeout(() => {
+      handle = null
+      const pending = Array.from(tasks.values())
+      tasks.clear()
+      for (const t of pending) t()
+    }, delayMs)
+  }
+
+  const cancel = (key: string) => {
+    tasks.delete(key)
+  }
+
+  const dispose = () => {
+    if (handle !== null) host.clearTimeout(handle)
+    handle = null
+    tasks.clear()
+  }
+
+  return { schedule, cancel, dispose }
+}
+
+export function useSharedDebounce(delayMs: number): SharedDebounce {
+  const debounce = useMemo(
+    () =>
+      createSharedDebounce(delayMs, {
+        setTimeout: (fn, ms) => window.setTimeout(fn, ms),
+        clearTimeout: (h) => window.clearTimeout(h),
+      }),
+    [delayMs],
+  )
+  useEffect(() => () => debounce.dispose(), [debounce])
+  return debounce
+}


### PR DESCRIPTION
## What
Replace the share editor's two independent 400ms timers (draft autosave + publish drift check) with a single shared trailing-debounce window. One edit now wakes the main thread once and runs both follow-up builds together.

## Why
The two timers listened to the same inputs and fired back-to-back at t+400ms, stacking two full document builds (snapshot build with the redact pipeline, plus the spool-document serialization) in the same breath — a doubled stall on large sessions, right when the user types the next character. Two separate constants also had to be kept in sync to tune the window.

## How it connects
`useSharedDebounce` is a pure factory (injected timers) with unit tests covering merge/replace/cancel/dispose semantics. Per-task behavior is unchanged: trailing-debounce replacement per key, the drift task's stale-async guard, and the autosave's unmount flush (which reads refs and never depended on the timer). Share e2e suites pass unchanged.