### PR TITLE
feat: support new Gemini CLI JSONL format and filter metadata

### DIFF
--- a/packages/core/src/db/queries.ts
+++ b/packages/core/src/db/queries.ts
@@ -290,21 +290,26 @@ export function insertMessages(
 export function getMessageSnapshot(
   db: Database.Database,
   sessionUuid: string,
-): { firstUuid: string | null; total: number } {
-  // Single window-function query: pulls total and leading uuid in one
-  // index scan over (session_id, msg_uuid). `LIMIT 1` returns the
-  // smallest-seq row; `COUNT(*) OVER ()` annotates it with the total
-  // across the windowed partition (no GROUP BY needed since the
-  // WHERE already scopes to one session).
+): { firstUuid: string | null; lastUuid: string | null; total: number } {
+  // Single window-function query: pulls total plus leading and trailing
+  // uuids in one index scan over (session_id, msg_uuid). `LIMIT 1`
+  // returns the smallest-seq row; `COUNT(*) OVER ()` / `LAST_VALUE`
+  // annotate it with the partition-wide total and tail (no GROUP BY
+  // needed since the WHERE already scopes to one session).
   const row = db.prepare(
-    `SELECT m.msg_uuid AS msg_uuid, COUNT(*) OVER () AS total
+    `SELECT m.msg_uuid AS msg_uuid,
+            COUNT(*) OVER () AS total,
+            LAST_VALUE(m.msg_uuid) OVER (
+              ORDER BY m.seq, m.id
+              ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+            ) AS last_uuid
        FROM messages m
        JOIN sessions s ON s.id = m.session_id
       WHERE s.session_uuid = ? AND m.msg_uuid IS NOT NULL
       ORDER BY m.seq, m.id LIMIT 1`,
-  ).get(sessionUuid) as { msg_uuid: string; total: number } | undefined
-  if (!row) return { firstUuid: null, total: 0 }
-  return { firstUuid: row.msg_uuid, total: row.total }
+  ).get(sessionUuid) as { msg_uuid: string; last_uuid: string; total: number } | undefined
+  if (!row) return { firstUuid: null, lastUuid: null, total: 0 }
+  return { firstUuid: row.msg_uuid, lastUuid: row.last_uuid, total: row.total }
 }
 
 /** Refresh `sessions.message_count` for a single session from the

--- a/packages/core/src/parsers/gemini.test.ts
+++ b/packages/core/src/parsers/gemini.test.ts
@@ -91,4 +91,55 @@ describe('parseGeminiSession', () => {
 
     expect(parseGeminiSession(filePath)).toBeNull()
   })
+
+  it('parses Gemini chat sessions in JSONL format', () => {
+    const geminiCliHome = makeGeminiHome()
+    const geminiHome = join(geminiCliHome, '.gemini')
+    const chatsDir = join(geminiHome, 'tmp', 'workspace', 'chats')
+    mkdirSync(chatsDir, { recursive: true })
+    vi.stubEnv('GEMINI_CLI_HOME', geminiCliHome)
+
+    const filePath = join(chatsDir, 'session-2026-04-08T00-00-jsonl.jsonl')
+    writeFileSync(filePath, [
+      JSON.stringify({ sessionId: 'jsonl-session', startTime: '2026-04-08T00:00:00Z', kind: 'main', summary: 'Test JSONL summary' }),
+      JSON.stringify({ $set: { messages: [{ id: 'm1', timestamp: '2026-04-08T00:00:00Z', type: 'user', content: [{ text: 'User prompt' }] }] } }),
+      JSON.stringify({ id: 'm2', timestamp: '2026-04-08T00:00:30Z', type: 'gemini', content: 'Gemini answer', model: 'gemini-2.5-flash' })
+    ].join('\n'))
+
+    const parsed = parseGeminiSession(filePath)
+    expect(parsed?.source).toBe('gemini')
+    expect(parsed?.title).toBe('Test JSONL summary')
+    expect(parsed?.messages).toHaveLength(2)
+    expect(parsed?.messages[0]?.role).toBe('user')
+    expect(parsed?.messages[0]?.contentText).toBe('User prompt')
+    expect(parsed?.messages[1]?.role).toBe('assistant')
+    expect(parsed?.messages[1]?.contentText).toBe('Gemini answer')
+    expect(parsed?.model).toBe('gemini-2.5-flash')
+  })
+
+  it('strips session_context tags and skips messages that contain nothing else', () => {
+    const geminiCliHome = makeGeminiHome()
+    const geminiHome = join(geminiCliHome, '.gemini')
+    const chatsDir = join(geminiHome, 'tmp', 'workspace', 'chats')
+    mkdirSync(chatsDir, { recursive: true })
+    vi.stubEnv('GEMINI_CLI_HOME', geminiCliHome)
+
+    const filePath = join(chatsDir, 'session-2026-04-08T00-00-context.jsonl')
+    writeFileSync(filePath, [
+      JSON.stringify({ sessionId: 'context-session', startTime: '2026-04-08T00:00:00Z', kind: 'main' }),
+      JSON.stringify({ $set: { messages: [
+        { id: 'm1', timestamp: '2026-04-08T00:00:00Z', type: 'user', content: [{ text: '<session_context>\nSystem info here...\n</session_context>' }] },
+        { id: 'm2', timestamp: '2026-04-08T00:00:10Z', type: 'user', content: [{ text: '<session_context>\nSystem info...\n</session_context>\nActual user prompt' }] }
+      ] } })
+    ].join('\n'))
+
+    const parsed = parseGeminiSession(filePath)
+    expect(parsed?.source).toBe('gemini')
+    expect(parsed?.messages).toHaveLength(1)
+    expect(parsed?.messages[0]?.role).toBe('user')
+    expect(parsed?.messages[0]?.contentText).toBe('Actual user prompt')
+    expect(parsed?.title).toBe('Actual user prompt')
+  })
+
+
 })

--- a/packages/core/src/parsers/gemini.test.ts
+++ b/packages/core/src/parsers/gemini.test.ts
@@ -141,5 +141,62 @@ describe('parseGeminiSession', () => {
     expect(parsed?.title).toBe('Actual user prompt')
   })
 
+  it('drops the rewound message and everything after it on $rewindTo', () => {
+    const geminiCliHome = makeGeminiHome()
+    const chatsDir = join(geminiCliHome, '.gemini', 'tmp', 'workspace', 'chats')
+    mkdirSync(chatsDir, { recursive: true })
+    vi.stubEnv('GEMINI_CLI_HOME', geminiCliHome)
 
+    const filePath = join(chatsDir, 'session-2026-04-08T00-00-rewind.jsonl')
+    writeFileSync(filePath, [
+      JSON.stringify({ sessionId: 'rewind-session', startTime: '2026-04-08T00:00:00Z', kind: 'main' }),
+      JSON.stringify({ id: 'm1', timestamp: '2026-04-08T00:00:00Z', type: 'user', content: [{ text: 'first prompt' }] }),
+      JSON.stringify({ id: 'm2', timestamp: '2026-04-08T00:00:10Z', type: 'user', content: [{ text: 'abandoned prompt' }] }),
+      JSON.stringify({ id: 'm3', timestamp: '2026-04-08T00:00:20Z', type: 'gemini', content: 'abandoned answer' }),
+      JSON.stringify({ $rewindTo: 'm2' }),
+      JSON.stringify({ id: 'm4', timestamp: '2026-04-08T00:00:30Z', type: 'user', content: [{ text: 'new prompt' }] }),
+    ].join('\n'))
+
+    const parsed = parseGeminiSession(filePath)
+    expect(parsed?.messages.map(m => m.uuid)).toEqual(['m1', 'm4'])
+  })
+
+  it('treats $set.messages as a checkpoint that replaces prior messages', () => {
+    const geminiCliHome = makeGeminiHome()
+    const chatsDir = join(geminiCliHome, '.gemini', 'tmp', 'workspace', 'chats')
+    mkdirSync(chatsDir, { recursive: true })
+    vi.stubEnv('GEMINI_CLI_HOME', geminiCliHome)
+
+    const filePath = join(chatsDir, 'session-2026-04-08T00-00-checkpoint.jsonl')
+    writeFileSync(filePath, [
+      JSON.stringify({ sessionId: 'checkpoint-session', startTime: '2026-04-08T00:00:00Z', kind: 'main' }),
+      JSON.stringify({ id: 'm1', timestamp: '2026-04-08T00:00:00Z', type: 'user', content: [{ text: 'kept' }] }),
+      JSON.stringify({ id: 'm2', timestamp: '2026-04-08T00:00:10Z', type: 'user', content: [{ text: 'dropped by checkpoint' }] }),
+      JSON.stringify({ $set: { messages: [{ id: 'm1', timestamp: '2026-04-08T00:00:00Z', type: 'user', content: [{ text: 'kept' }] }] } }),
+    ].join('\n'))
+
+    const parsed = parseGeminiSession(filePath)
+    expect(parsed?.messages.map(m => m.uuid)).toEqual(['m1'])
+  })
+
+  it('replaces a message when a later snapshot with the same id arrives', () => {
+    const geminiCliHome = makeGeminiHome()
+    const chatsDir = join(geminiCliHome, '.gemini', 'tmp', 'workspace', 'chats')
+    mkdirSync(chatsDir, { recursive: true })
+    vi.stubEnv('GEMINI_CLI_HOME', geminiCliHome)
+
+    const filePath = join(chatsDir, 'session-2026-04-08T00-00-update.jsonl')
+    writeFileSync(filePath, [
+      JSON.stringify({ sessionId: 'update-session', startTime: '2026-04-08T00:00:00Z', kind: 'main' }),
+      JSON.stringify({ id: 'm1', timestamp: '2026-04-08T00:00:00Z', type: 'gemini', content: 'thinking…', toolCalls: [{ name: 'read_file' }] }),
+      // The later snapshot legitimately omits toolCalls — a shallow merge
+      // would wrongly keep the stale ones; upstream semantics are replace.
+      JSON.stringify({ id: 'm1', timestamp: '2026-04-08T00:00:05Z', type: 'gemini', content: 'final answer' }),
+    ].join('\n'))
+
+    const parsed = parseGeminiSession(filePath)
+    expect(parsed?.messages).toHaveLength(1)
+    expect(parsed?.messages[0]?.contentText).toBe('final answer')
+    expect(parsed?.messages[0]?.toolNames).toEqual([])
+  })
 })

--- a/packages/core/src/parsers/gemini.ts
+++ b/packages/core/src/parsers/gemini.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { homedir } from 'node:os'
 import type { ParseSessionResult, ParsedMessage, ParsedSession } from '../types.js'
@@ -29,68 +29,88 @@ interface GeminiSessionRecord {
 
 const GEMINI_INDEXABLE_TYPES = new Set(['user', 'gemini', 'info', 'warning', 'error'])
 
-export function loadGeminiSession(filePath: string): ParseSessionResult {
-  const raw = readFileSync(filePath, 'utf8')
-  let record: GeminiSessionRecord
+/** Replays a Gemini CLI JSONL session log into a single session record.
+ *
+ *  Mirrors the upstream loader (gemini-cli chatRecordingService.ts
+ *  loadConversationRecord): a line is exactly one of — a `$rewindTo`
+ *  marker (drop that message and everything after it), a message
+ *  snapshot keyed by `id` (later snapshots replace earlier ones, e.g.
+ *  tool-call status updates), a `$set` metadata update whose
+ *  `messages` array is a checkpoint that REPLACES all prior messages,
+ *  or the initial metadata line. */
+function loadJsonlRecord(raw: string): GeminiSessionRecord {
+  const record: GeminiSessionRecord = {}
+  const messages = new Map<string, GeminiMessageRecord>()
 
-  if (filePath.endsWith('.jsonl')) {
-    record = { messages: [] }
-    const lines = raw.split('\n').filter(l => l.trim().length > 0)
-    for (const line of lines) {
-      let obj: any
-      try {
-        obj = JSON.parse(line)
-      } catch {
-        continue
+  const setMessage = (msg: unknown): void => {
+    if (!msg || typeof msg !== 'object') return
+    const message = msg as GeminiMessageRecord
+    if (typeof message.id !== 'string') return
+    messages.set(message.id, message)
+  }
+
+  const applyMetadata = (src: Record<string, unknown>): void => {
+    if (typeof src['sessionId'] === 'string') record.sessionId = src['sessionId']
+    if (typeof src['startTime'] === 'string') record.startTime = src['startTime']
+    if (typeof src['lastUpdated'] === 'string') record.lastUpdated = src['lastUpdated']
+    if (typeof src['kind'] === 'string') record.kind = src['kind']
+    if (typeof src['summary'] === 'string') record.summary = src['summary']
+  }
+
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(line)
+    } catch {
+      continue
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue
+    const obj = parsed as Record<string, unknown>
+
+    if (typeof obj['$rewindTo'] === 'string') {
+      let found = false
+      for (const id of messages.keys()) {
+        if (id === obj['$rewindTo']) found = true
+        if (found) messages.delete(id)
       }
+      if (!found) messages.clear()
+      continue
+    }
 
-      if (!obj || typeof obj !== 'object') continue
+    if (typeof obj['id'] === 'string') {
+      setMessage(obj)
+      continue
+    }
 
-      // Handle standard metadata
-      if ('sessionId' in obj) {
-        if (obj.sessionId) record.sessionId = obj.sessionId
-        if (obj.startTime) record.startTime = obj.startTime
-        if (obj.lastUpdated) record.lastUpdated = obj.lastUpdated
-        if (obj.kind) record.kind = obj.kind
-        if (obj.summary) record.summary = obj.summary
+    if (obj['$set'] && typeof obj['$set'] === 'object') {
+      const set = obj['$set'] as Record<string, unknown>
+      if (Array.isArray(set['messages'])) {
+        messages.clear()
+        for (const msg of set['messages']) setMessage(msg)
       }
+      applyMetadata(set)
+      continue
+    }
 
-      // Helper to merge messages array
-      const mergeMessages = (msgsList: any[]) => {
-        for (const msg of msgsList) {
-          if (!msg || typeof msg !== 'object' || !msg.id) continue
-          const existingIdx = record.messages!.findIndex(m => m.id === msg.id)
-          if (existingIdx >= 0) {
-            record.messages![existingIdx] = { ...record.messages![existingIdx], ...msg }
-          } else {
-            record.messages!.push(msg)
-          }
-        }
-      }
-
-      // Handle $set operator
-      if ('$set' in obj && obj.$set && typeof obj.$set === 'object') {
-        const set = obj.$set
-        if (set.lastUpdated) record.lastUpdated = set.lastUpdated
-        if (set.summary) record.summary = set.summary
-        if (Array.isArray(set.messages)) {
-          mergeMessages(set.messages)
-        }
-      }
-
-      // Handle direct message entry
-      if ('id' in obj && 'type' in obj && obj.id) {
-        const existingIdx = record.messages!.findIndex(m => m.id === obj.id)
-        if (existingIdx >= 0) {
-          record.messages![existingIdx] = { ...record.messages![existingIdx], ...obj }
-        } else {
-          record.messages!.push(obj)
-        }
+    if (typeof obj['sessionId'] === 'string') {
+      applyMetadata(obj)
+      // A legacy whole-file record can appear as a single JSONL line.
+      if (Array.isArray(obj['messages'])) {
+        for (const msg of obj['messages']) setMessage(msg)
       }
     }
-  } else {
-    record = JSON.parse(raw) as GeminiSessionRecord
   }
+
+  record.messages = Array.from(messages.values())
+  return record
+}
+
+export function loadGeminiSession(filePath: string): ParseSessionResult {
+  const raw = readFileSync(filePath, 'utf8')
+  const record = filePath.endsWith('.jsonl')
+    ? loadJsonlRecord(raw)
+    : JSON.parse(raw) as GeminiSessionRecord
 
   if (record.kind === 'subagent') return { kind: 'filtered' }
   if (!Array.isArray(record.messages) || record.messages.length === 0) return { kind: 'skipped' }
@@ -102,7 +122,10 @@ export function loadGeminiSession(filePath: string): ParseSessionResult {
     const type = message.type
     if (!type || !GEMINI_INDEXABLE_TYPES.has(type)) continue
 
-    const contentText = stripSessionContext(extractText(message.content))
+    // <session_context> is environment metadata gemini-cli injects into the
+    // first user turn — strip it so it never pollutes FTS or derived titles.
+    const rawText = extractText(message.content)
+    const contentText = type === 'user' ? stripSessionContext(rawText) : rawText
     const toolNames = extractToolNames(message.toolCalls)
     if (!contentText && toolNames.length === 0) continue
 
@@ -246,5 +269,3 @@ function expandHome(filePath: string): string {
   if (filePath.startsWith('~/')) return join(homedir(), filePath.slice(2))
   return filePath
 }
-
-

--- a/packages/core/src/parsers/gemini.ts
+++ b/packages/core/src/parsers/gemini.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, statSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { homedir } from 'node:os'
 import type { ParseSessionResult, ParsedMessage, ParsedSession } from '../types.js'
@@ -31,7 +31,66 @@ const GEMINI_INDEXABLE_TYPES = new Set(['user', 'gemini', 'info', 'warning', 'er
 
 export function loadGeminiSession(filePath: string): ParseSessionResult {
   const raw = readFileSync(filePath, 'utf8')
-  const record = JSON.parse(raw) as GeminiSessionRecord
+  let record: GeminiSessionRecord
+
+  if (filePath.endsWith('.jsonl')) {
+    record = { messages: [] }
+    const lines = raw.split('\n').filter(l => l.trim().length > 0)
+    for (const line of lines) {
+      let obj: any
+      try {
+        obj = JSON.parse(line)
+      } catch {
+        continue
+      }
+
+      if (!obj || typeof obj !== 'object') continue
+
+      // Handle standard metadata
+      if ('sessionId' in obj) {
+        if (obj.sessionId) record.sessionId = obj.sessionId
+        if (obj.startTime) record.startTime = obj.startTime
+        if (obj.lastUpdated) record.lastUpdated = obj.lastUpdated
+        if (obj.kind) record.kind = obj.kind
+        if (obj.summary) record.summary = obj.summary
+      }
+
+      // Helper to merge messages array
+      const mergeMessages = (msgsList: any[]) => {
+        for (const msg of msgsList) {
+          if (!msg || typeof msg !== 'object' || !msg.id) continue
+          const existingIdx = record.messages!.findIndex(m => m.id === msg.id)
+          if (existingIdx >= 0) {
+            record.messages![existingIdx] = { ...record.messages![existingIdx], ...msg }
+          } else {
+            record.messages!.push(msg)
+          }
+        }
+      }
+
+      // Handle $set operator
+      if ('$set' in obj && obj.$set && typeof obj.$set === 'object') {
+        const set = obj.$set
+        if (set.lastUpdated) record.lastUpdated = set.lastUpdated
+        if (set.summary) record.summary = set.summary
+        if (Array.isArray(set.messages)) {
+          mergeMessages(set.messages)
+        }
+      }
+
+      // Handle direct message entry
+      if ('id' in obj && 'type' in obj && obj.id) {
+        const existingIdx = record.messages!.findIndex(m => m.id === obj.id)
+        if (existingIdx >= 0) {
+          record.messages![existingIdx] = { ...record.messages![existingIdx], ...obj }
+        } else {
+          record.messages!.push(obj)
+        }
+      }
+    }
+  } else {
+    record = JSON.parse(raw) as GeminiSessionRecord
+  }
 
   if (record.kind === 'subagent') return { kind: 'filtered' }
   if (!Array.isArray(record.messages) || record.messages.length === 0) return { kind: 'skipped' }
@@ -43,7 +102,7 @@ export function loadGeminiSession(filePath: string): ParseSessionResult {
     const type = message.type
     if (!type || !GEMINI_INDEXABLE_TYPES.has(type)) continue
 
-    const contentText = extractText(message.content)
+    const contentText = stripSessionContext(extractText(message.content))
     const toolNames = extractToolNames(message.toolCalls)
     if (!contentText && toolNames.length === 0) continue
 
@@ -123,6 +182,18 @@ function extractText(content: unknown): string {
     .join('\n'))
 }
 
+function stripSessionContext(text: string): string {
+  let result = text
+  let open = result.indexOf('<session_context>')
+  while (open !== -1) {
+    const close = result.indexOf('</session_context>', open + '<session_context>'.length)
+    if (close === -1) break
+    result = result.slice(0, open) + result.slice(close + '</session_context>'.length)
+    open = result.indexOf('<session_context>')
+  }
+  return result.trim()
+}
+
 function extractToolNames(toolCalls: unknown): string[] {
   if (!Array.isArray(toolCalls)) return []
 
@@ -175,3 +246,5 @@ function expandHome(filePath: string): string {
   if (filePath.startsWith('~/')) return join(homedir(), filePath.slice(2))
   return filePath
 }
+
+

--- a/packages/core/src/sync/source-paths.test.ts
+++ b/packages/core/src/sync/source-paths.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { detectSessionSource, getSessionRoots } from './source-paths.js'
+import { detectSessionSource, getSessionRoots, getSessionWatchPatterns } from './source-paths.js'
 
 const tempDirs: string[] = []
 
@@ -52,6 +52,22 @@ describe('getSessionRoots', () => {
 
     mkdirSync(join(geminiHome, 'tmp', 'workspace', 'chats'), { recursive: true })
     vi.stubEnv('SPOOL_GEMINI_DIR', baseDir)
+
+    expect(getSessionRoots('gemini')).toEqual([
+      join(geminiHome, 'tmp'),
+    ])
+  })
+
+  test('does not re-nest the Gemini root when a workspace directory is named "tmp"', () => {
+    const baseDir = mkdtempSync(join(tmpdir(), 'spool-gemini-tmp-tmp-'))
+    const geminiHome = join(baseDir, '.gemini')
+    tempDirs.push(baseDir)
+
+    // Running gemini-cli inside a directory whose basename is "tmp" creates a
+    // workspace folder at <home>/.gemini/tmp/tmp — the root must stay at tmp/.
+    mkdirSync(join(geminiHome, 'tmp', 'tmp', 'chats'), { recursive: true })
+    mkdirSync(join(geminiHome, 'tmp', 'workspace', 'chats'), { recursive: true })
+    vi.stubEnv('GEMINI_CLI_HOME', baseDir)
 
     expect(getSessionRoots('gemini')).toEqual([
       join(geminiHome, 'tmp'),
@@ -176,5 +192,49 @@ describe('detectSessionSource', () => {
     expect(
       detectSessionSource(join(codexRoot, '2026', '05', '21', 'rollout-abc.jsonl'), sourceRoots),
     ).toBe('codex')
+  })
+
+  test('accepts Gemini JSONL sessions and skips a legacy .json with a migrated .jsonl sibling', () => {
+    const baseDir = mkdtempSync(join(tmpdir(), 'spool-gemini-jsonl-'))
+    tempDirs.push(baseDir)
+
+    const geminiRoot = join(baseDir, 'gemini', 'tmp')
+    const chatsDir = join(geminiRoot, 'workspace', 'chats')
+    mkdirSync(chatsDir, { recursive: true })
+
+    const sourceRoots = {
+      claude: [join(baseDir, 'claude-empty')],
+      codex: [join(baseDir, 'codex-empty')],
+      gemini: [geminiRoot],
+      opencode: [join(baseDir, 'opencode-empty')],
+    } as const
+
+    // New JSONL format is a gemini session.
+    const jsonlOnly = join(chatsDir, 'session-2026-04-08T00-00-aaaaaaaa.jsonl')
+    writeFileSync(jsonlOnly, '')
+    expect(detectSessionSource(jsonlOnly, sourceRoots)).toBe('gemini')
+
+    // A lone legacy .json is still indexed.
+    const jsonOnly = join(chatsDir, 'session-2026-04-08T00-00-bbbbbbbb.json')
+    writeFileSync(jsonOnly, '')
+    expect(detectSessionSource(jsonOnly, sourceRoots)).toBe('gemini')
+
+    // Resume-migration leaves the stale .json next to the live .jsonl with the
+    // same sessionId; only the .jsonl may be indexed or the two files clobber
+    // each other's session row on every scan.
+    writeFileSync(`${jsonOnly}l`, '')
+    expect(detectSessionSource(jsonOnly, sourceRoots)).toBeUndefined()
+    expect(detectSessionSource(`${jsonOnly}l`, sourceRoots)).toBe('gemini')
+  })
+})
+
+describe('getSessionWatchPatterns', () => {
+  test('watches both legacy .json and JSONL Gemini session files', () => {
+    const geminiRoot = join('/tmp', 'gemini', 'tmp')
+
+    expect(getSessionWatchPatterns('gemini', [geminiRoot])).toEqual([
+      join(geminiRoot, '**', 'session-*.json'),
+      join(geminiRoot, '**', 'session-*.jsonl'),
+    ])
   })
 })

--- a/packages/core/src/sync/source-paths.ts
+++ b/packages/core/src/sync/source-paths.ts
@@ -33,7 +33,9 @@ export function getSessionRoots(source: SessionSource): string[] {
   }
 
   if (source === 'gemini') {
-    return dedupePaths([normalizeSourceRoot('gemini', join(getGeminiBaseDir(), 'tmp'))])
+    return dedupePaths([
+      normalizeSourceRoot('gemini', join(getGeminiBaseDir(), 'tmp')),
+    ])
   }
 
   if (source === 'opencode') {
@@ -81,11 +83,15 @@ export function getSessionWatchPatterns(
   source: SessionSource,
   roots = getSessionRoots(source),
 ): string[] {
-  const pattern = source === 'gemini'
-    ? 'session-*.json'
-    : source === 'opencode'
-      ? OPENCODE_DB_NAME
-      : '*.jsonl'
+  if (source === 'gemini') {
+    return roots.flatMap(root => [
+      join(root, '**', 'session-*.json'),
+      join(root, '**', 'session-*.jsonl'),
+    ])
+  }
+  const pattern = source === 'opencode'
+    ? OPENCODE_DB_NAME
+    : '*.jsonl'
   return roots.map(root => join(root, '**', pattern))
 }
 
@@ -100,6 +106,9 @@ function splitConfiguredPaths(value: string): string[] {
 function normalizeSourceRoot(source: SessionSource, filePath: string): string {
   const resolvedPath = resolve(expandHome(filePath))
   if (source === 'gemini') {
+    if (basename(resolvedPath) === 'tmp') {
+      return resolvedPath
+    }
     if (basename(resolvedPath) === '.gemini' || existsSync(join(resolvedPath, 'tmp'))) {
       return join(resolvedPath, 'tmp')
     }
@@ -155,7 +164,7 @@ function getOpenCodeBaseDir(): string {
 export function isSessionFileForSource(source: SessionSource, filePath: string, root: string): boolean {
   if (!isWithinRoot(filePath, root)) return false
   if (source === 'gemini') {
-    return filePath.endsWith('.json')
+    return (filePath.endsWith('.json') || filePath.endsWith('.jsonl'))
       && basename(filePath).startsWith('session-')
       && /(?:^|\/)chats\//.test(filePath)
   }

--- a/packages/core/src/sync/source-paths.ts
+++ b/packages/core/src/sync/source-paths.ts
@@ -164,9 +164,15 @@ function getOpenCodeBaseDir(): string {
 export function isSessionFileForSource(source: SessionSource, filePath: string, root: string): boolean {
   if (!isWithinRoot(filePath, root)) return false
   if (source === 'gemini') {
-    return (filePath.endsWith('.json') || filePath.endsWith('.jsonl'))
-      && basename(filePath).startsWith('session-')
-      && /(?:^|\/)chats\//.test(filePath)
+    if (!filePath.endsWith('.json') && !filePath.endsWith('.jsonl')) return false
+    if (!basename(filePath).startsWith('session-')) return false
+    if (!/(?:^|\/)chats\//.test(filePath)) return false
+    // Resuming a legacy session in gemini-cli ≥0.39 migrates it to a sibling
+    // .jsonl with the same basename and sessionId, leaving the stale .json in
+    // place. Index only the live .jsonl — syncing both makes the two files
+    // clobber each other's session row via UNIQUE(session_uuid) on every scan.
+    if (filePath.endsWith('.json') && existsSync(`${filePath}l`)) return false
+    return true
   }
   if (source === 'opencode') {
     return isOpenCodeDatabaseFile(filePath)

--- a/packages/core/src/sync/syncer.test.ts
+++ b/packages/core/src/sync/syncer.test.ts
@@ -899,6 +899,100 @@ describe('Syncer', () => {
     ).all(sessionId) as Array<{ msg_uuid: string }>
     expect(after.map(r => r.msg_uuid)).toEqual(['m1'])
   })
+
+  it('rewrites a Gemini session when a rewind plus new turns keeps the count from shrinking', async () => {
+    // $rewindTo can drop mid-stream messages while enough new turns land in
+    // the same sync that parsed.length >= stored total and the first uuid
+    // still matches. Head+count classification alone would say append,
+    // stranding the rewound rows next to the new ones with colliding seq
+    // values — the tail-uuid check must force rewrite instead.
+    const baseDir = makeTempDir('spool-syncer-gemini-rewind-')
+    const geminiCliHome = join(baseDir, 'gemini-home')
+    const chatsDir = join(geminiCliHome, '.gemini', 'tmp', 'workspace', 'chats')
+    const spoolDataDir = join(baseDir, 'spool-data')
+    mkdirSync(chatsDir, { recursive: true })
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDataDir)
+    vi.stubEnv('GEMINI_CLI_HOME', geminiCliHome)
+
+    const filePath = join(chatsDir, 'session-2026-04-08T00-00-rewind.jsonl')
+    const meta = JSON.stringify({ sessionId: 'gemini-rewind-session', startTime: '2026-04-08T00:00:00Z', kind: 'main' })
+    const msg = (id: string, text: string) => JSON.stringify({
+      id,
+      timestamp: '2026-04-08T00:00:00Z',
+      type: 'user',
+      content: [{ text }],
+    })
+    writeFileSync(filePath, [meta, msg('m1', 'first'), msg('m2', 'second'), msg('m3', 'third')].join('\n'))
+
+    const { getDB, Syncer } = await loadCoreModules()
+    const db = getDB()
+    openDbs.push(db)
+    expect(new Syncer(db).syncFile(filePath, 'gemini')).toBe('added')
+
+    const sessionId = (db.prepare(
+      "SELECT id FROM sessions WHERE session_uuid = 'gemini-rewind-session'"
+    ).get() as { id: number }).id
+
+    // User rewinds to m2 and sends two new turns: replay is [m1, m4, m5] —
+    // same length as the stored rows, same head, different tail.
+    writeFileSync(filePath, [
+      meta,
+      msg('m1', 'first'), msg('m2', 'second'), msg('m3', 'third'),
+      JSON.stringify({ $rewindTo: 'm2' }),
+      msg('m4', 'new prompt'), msg('m5', 'newer prompt'),
+    ].join('\n'))
+    touchFile(filePath)
+    expect(new Syncer(db).syncFile(filePath, 'gemini')).toBe('updated')
+
+    const after = db.prepare(
+      'SELECT msg_uuid, seq FROM messages WHERE session_id = ? ORDER BY seq, id'
+    ).all(sessionId) as Array<{ msg_uuid: string; seq: number }>
+    expect(after.map(r => r.msg_uuid)).toEqual(['m1', 'm4', 'm5'])
+    expect(after.map(r => r.seq)).toEqual([0, 1, 2])
+  })
+
+  it('rewrites message rows when the stored index version differs from the current one', async () => {
+    // An index-version bump exists to re-derive contentText. The bump makes
+    // the stored mtime string mismatch so the file is re-visited, but the
+    // append path (INSERT … DO NOTHING) would touch nothing — a version
+    // change must force the rewrite path.
+    const baseDir = makeTempDir('spool-syncer-version-bump-')
+    const geminiCliHome = join(baseDir, 'gemini-home')
+    const chatsDir = join(geminiCliHome, '.gemini', 'tmp', 'workspace', 'chats')
+    const spoolDataDir = join(baseDir, 'spool-data')
+    mkdirSync(chatsDir, { recursive: true })
+    vi.stubEnv('SPOOL_DATA_DIR', spoolDataDir)
+    vi.stubEnv('GEMINI_CLI_HOME', geminiCliHome)
+
+    const filePath = join(chatsDir, 'session-2026-04-08T00-00-version.jsonl')
+    writeFileSync(filePath, [
+      JSON.stringify({ sessionId: 'gemini-version-session', startTime: '2026-04-08T00:00:00Z', kind: 'main' }),
+      JSON.stringify({ id: 'm1', timestamp: '2026-04-08T00:00:00Z', type: 'user', content: [{ text: 'derived from source' }] }),
+    ].join('\n'))
+
+    const { getDB, Syncer } = await loadCoreModules()
+    const db = getDB()
+    openDbs.push(db)
+    expect(new Syncer(db).syncFile(filePath, 'gemini')).toBe('added')
+
+    // Simulate rows indexed under a previous parser version: stale derived
+    // content plus the old version suffix in the stored mtime.
+    db.prepare(
+      "UPDATE messages SET content_text = 'stale v1 derivation' WHERE msg_uuid = 'm1'"
+    ).run()
+    db.prepare(
+      `UPDATE sessions
+          SET raw_file_mtime = replace(raw_file_mtime, '::', '::old-')
+        WHERE session_uuid = 'gemini-version-session'`,
+    ).run()
+
+    // File itself unchanged on disk — only the version suffix differs.
+    expect(new Syncer(db).syncFile(filePath, 'gemini')).toBe('updated')
+    const msg = db.prepare(
+      "SELECT content_text FROM messages WHERE msg_uuid = 'm1'"
+    ).get() as { content_text: string }
+    expect(msg.content_text).toBe('derived from source')
+  })
 })
 
 async function loadCoreModules() {

--- a/packages/core/src/sync/syncer.ts
+++ b/packages/core/src/sync/syncer.ts
@@ -205,6 +205,7 @@ export class Syncer {
   private classifySync(
     sessionUuid: string,
     parsed: ParsedMessage[],
+    source: SessionSource,
   ): UpsertSessionMode {
     // One join'd query — covers "session row missing", "session row
     // exists with no messages", and the leading-uuid / total-row
@@ -214,6 +215,16 @@ export class Syncer {
     if (parsed.length === 0) return 'rewrite'
     if (parsed.length < snapshot.total) return 'rewrite'
     if (parsed[0]!.uuid !== snapshot.firstUuid) return 'rewrite'
+    // Gemini's JSONL replay can drop mid-stream messages ($rewindTo) while
+    // new turns keep parsed.length >= total, so head+count alone misclassifies
+    // a rewound session as append and strands the dropped rows (with colliding
+    // seq values). Pure append requires the parsed message at the stored tail
+    // position to still be the stored tail. Gemini-only: claude parses emit
+    // duplicate uuids (tool-use shadow records) that the DB dedupes, so
+    // parsed[total-1] doesn't align with stored rows there.
+    if (source === 'gemini' && parsed[snapshot.total - 1]!.uuid !== snapshot.lastUuid) {
+      return 'rewrite'
+    }
     return 'append'
   }
 
@@ -268,6 +279,14 @@ export class Syncer {
       // the in-place updates some providers do without bumping
       // mtime on the spool side).
       if (!force && existingMtime === mtime) return 'skipped'
+
+      // An index-version bump (the `::<version>` suffix in the stored mtime)
+      // exists to re-derive content, but append-mode INSERT … DO NOTHING never
+      // updates uuid-matched rows — a version-only mismatch must rewrite, or
+      // the bump re-visits every file and changes nothing.
+      const versionChanged = existingMtime !== null
+        && existingMtime.includes('::')
+        && !existingMtime.endsWith(`::${getIndexVersion(source)}`)
 
       const parseResult = source === 'claude'
         ? loadClaudeSession(filePath)
@@ -328,7 +347,8 @@ export class Syncer {
       // Explicit force overrides classification — the user has
       // accepted that any per-message user-side state (Security Scan
       // purge, dismiss) on this session will be rebuilt from source.
-      const mode: UpsertSessionMode = force ?? this.classifySync(parsed.sessionUuid, parsed.messages)
+      const mode: UpsertSessionMode = force
+        ?? (versionChanged ? 'rewrite' : this.classifySync(parsed.sessionUuid, parsed.messages, source))
 
       let committedSessionId: number | null = null
       let insertedCount = 0
@@ -522,7 +542,9 @@ function getIndexedMtime(filePath: string, source: SessionSource): string {
 
 function getIndexVersion(source: SessionSource): string {
   if (source === 'codex') return CODEX_INDEX_VERSION
-  if (source === 'gemini') return 'gemini-v1-session-search-fts'
+  // v2: <session_context> stripping + JSONL support — force re-derivation of
+  // contentText/titles for sessions indexed before the format change.
+  if (source === 'gemini') return 'gemini-v2-session-search-fts'
   if (source === 'opencode') return OPENCODE_INDEX_VERSION
   return 'claude-v3-session-search-fts'
 }


### PR DESCRIPTION
This PR adds support for the new Gemini CLI JSONL session transcript format and filters metadata blocks to prevent FTS/title indexing pollution.

### Changes
1. **JSONL Format Parser**: Added a JSONL parser in `packages/core/src/parsers/gemini.ts` that handles streaming JSON lines (supporting direct message entries and the `$set` operator).
2. **Metadata Filtering**: Implemented XML-style tag filtering for `<session_context>` blocks in user inputs to prevent metadata pollution.
3. **Session Paths**: Updated `packages/core/src/sync/source-paths.ts` to include `.jsonl` patterns in watch lists and fix nested `tmp/tmp` workspace folder resolution.