### PR TITLE
feat(terminal): add Ghostty as a terminal choice for session resume

### DIFF
--- a/packages/app/src/main/terminal.test.ts
+++ b/packages/app/src/main/terminal.test.ts
@@ -1,0 +1,74 @@
+// Unit tests for terminal resume launching. We stub `electron` (only
+// `shell.openExternal` is used) and `node:child_process` so the runners
+// can be exercised without opening real terminal windows, then assert
+// on the exact command each runner emits.
+
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+
+const execSync = vi.fn()
+const spawn = vi.fn(() => ({ unref: () => {} }))
+
+vi.mock('node:child_process', () => ({
+  execSync: (...args: unknown[]) => execSync(...args),
+  spawn: (...args: unknown[]) => spawn(...args),
+}))
+
+const existsSync = vi.fn(() => true)
+
+vi.mock('node:fs', async (importActual) => {
+  const actual = await importActual<typeof import('node:fs')>()
+  return { ...actual, existsSync: (...args: unknown[]) => existsSync(...args) }
+})
+
+vi.mock('electron', () => ({
+  shell: { openExternal: vi.fn() },
+}))
+
+// The macOS terminal runners are what we're testing, but CI runs the unit
+// suite on ubuntu, where openTerminal takes the Linux `xdg-terminal-exec`
+// branch instead. Pin the platform to darwin before terminal.js captures
+// IS_LINUX at import time so the runners are exercised on any host.
+const realPlatform = process.platform
+Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+
+const { SUPPORTED_TERMINALS, openTerminal } = await import('./terminal.js')
+
+afterAll(() => {
+  Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true })
+})
+
+beforeEach(() => {
+  execSync.mockClear()
+  spawn.mockClear()
+  existsSync.mockReturnValue(true)
+})
+
+describe('SUPPORTED_TERMINALS', () => {
+  it('includes Ghostty', () => {
+    expect(SUPPORTED_TERMINALS).toContain('Ghostty')
+  })
+})
+
+describe('openTerminal — Ghostty', () => {
+  it('launches Ghostty via `open --args -e` and prepends cd for the cwd', () => {
+    openTerminal('spool-resume echo', 'Ghostty', '/tmp/proj')
+
+    expect(execSync).toHaveBeenCalledTimes(1)
+    expect(execSync.mock.calls[0][0]).toBe(
+      `open -a Ghostty --args -e sh -c 'cd '/tmp/proj' && spool-resume echo; exec $SHELL'`,
+    )
+  })
+
+  it('omits the cd prefix when no cwd is given', () => {
+    openTerminal('spool-resume echo', 'Ghostty')
+
+    expect(execSync.mock.calls[0][0]).toBe(
+      `open -a Ghostty --args -e sh -c 'spool-resume echo; exec $SHELL'`,
+    )
+  })
+
+  it('keeps the window alive with `exec $SHELL`', () => {
+    openTerminal('spool-resume echo', 'Ghostty')
+    expect(execSync.mock.calls[0][0]).toContain('exec $SHELL')
+  })
+})

--- a/packages/app/src/main/terminal.ts
+++ b/packages/app/src/main/terminal.ts
@@ -35,11 +35,13 @@ const IS_LINUX = process.platform === 'linux'
  * Terminal identifiers. These double as the display names shown in settings
  * and the keys used in the runners map.
  */
-export const SUPPORTED_TERMINALS = ['Terminal', 'iTerm2', 'Warp', 'kitty', 'Alacritty', 'WezTerm'] as const
+export const SUPPORTED_TERMINALS = ['Terminal', 'iTerm2', 'Warp', 'Ghostty', 'kitty', 'Alacritty', 'WezTerm'] as const
 export type SupportedTerminal = (typeof SUPPORTED_TERMINALS)[number]
 
-/** Third-party terminals to probe, in order of popularity. */
-const THIRD_PARTY: SupportedTerminal[] = ['iTerm2', 'Warp', 'kitty', 'Alacritty', 'WezTerm']
+// Third-party terminals to probe, in order of popularity. New entries are
+// appended at the end so adding a terminal never changes which one an
+// existing user (with several running and no explicit preference) auto-detects.
+const THIRD_PARTY: SupportedTerminal[] = ['iTerm2', 'Warp', 'kitty', 'Alacritty', 'WezTerm', 'Ghostty']
 
 let autoDetectedTerminal: SupportedTerminal | undefined
 
@@ -125,6 +127,12 @@ windows:
     shell.openExternal(`warp://launch/${configName}`)
   },
 
+  // Ghostty — macOS has no direct CLI, so pass args through `open --args`.
+  // `-e` runs the command; `exec $SHELL` keeps the window alive afterwards.
+  'Ghostty': (cmd, cwd) => {
+    execSync(`open -a Ghostty --args -e sh -c '${withCwd(cmd, cwd)}; exec $SHELL'`)
+  },
+
   // Kitty — `open --args`; `exec $SHELL` keeps the window alive
   'kitty': (cmd, cwd) => {
     execSync(`open -a kitty --args sh -c '${withCwd(cmd, cwd)}; exec $SHELL'`)
@@ -146,6 +154,7 @@ const APP_PATHS: Record<SupportedTerminal, string> = {
   'Terminal': '/System/Applications/Utilities/Terminal.app',
   'iTerm2': '/Applications/iTerm.app',
   'Warp': '/Applications/Warp.app',
+  'Ghostty': '/Applications/Ghostty.app',
   'kitty': '/Applications/kitty.app',
   'Alacritty': '/Applications/Alacritty.app',
   'WezTerm': '/Applications/WezTerm.app',

--- a/packages/app/src/renderer/components/SettingsPanel.tsx
+++ b/packages/app/src/renderer/components/SettingsPanel.tsx
@@ -19,7 +19,7 @@ import Toggle from './Toggle.js'
 type SettingsTab = 'general' | 'appearance' | 'shortcuts' | 'sources' | 'agent' | 'account' | 'labs' | 'security'
 
 /** Must match SUPPORTED_TERMINALS in main/terminal.ts */
-const TERMINAL_VALUES = ['', 'Terminal', 'iTerm2', 'Warp', 'kitty', 'Alacritty', 'WezTerm'] as const
+const TERMINAL_VALUES = ['', 'Terminal', 'iTerm2', 'Warp', 'Ghostty', 'kitty', 'Alacritty', 'WezTerm'] as const
 
 interface Props {
   onClose: () => void


### PR DESCRIPTION
## What

Adds **Ghostty** to the terminals Spool can launch for "Resume in terminal", both as an explicit choice in Settings → Terminal and as an auto-detected running terminal.

## Why

Requested in #403. Ghostty is a popular terminal that Spool didn't support, so users running it had their resume fall back to Terminal.app.

## How it connects

- `main/terminal.ts` — Ghostty is added to `SUPPORTED_TERMINALS`, the installed-app check (`/Applications/Ghostty.app`), and a runner. macOS has no direct Ghostty CLI, so it launches via `open -a Ghostty --args -e sh -c '…; exec $SHELL'`, matching the existing kitty/Alacritty/WezTerm pattern where `exec $SHELL` keeps the window alive after the resume command exits.
- It is **appended** to the auto-detect probe list rather than inserted, so adding it never changes which terminal an existing user (running several, with no explicit preference) auto-detects.
- `renderer/SettingsPanel.tsx` — Ghostty added to the terminal picker.

## Test plan

- New vitest coverage in `terminal.test.ts`: Ghostty is in `SUPPORTED_TERMINALS`, the runner builds the expected `open --args -e` command with and without a cwd, and keeps the window alive. The suite pins `process.platform` to `darwin` before import so the macOS runners are exercised on the ubuntu-only CI unit job.
- Verified locally in `pnpm dev`: Settings → Terminal → Ghostty, then Resume in terminal opens a Ghostty window in the session directory.
- Full app vitest suite green.