### PR TITLE
fix(terminal): quote the sh -c payload so resume survives spaces in paths

### DIFF
--- a/packages/app/src/main/terminal.test.ts
+++ b/packages/app/src/main/terminal.test.ts
@@ -4,14 +4,19 @@
 // on the exact command each runner emits.
 
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+import { execFileSync } from 'node:child_process'
 
 const execSync = vi.fn()
 const spawn = vi.fn(() => ({ unref: () => {} }))
 
-vi.mock('node:child_process', () => ({
-  execSync: (...args: unknown[]) => execSync(...args),
-  spawn: (...args: unknown[]) => spawn(...args),
-}))
+vi.mock('node:child_process', async (importActual) => {
+  const actual = await importActual<typeof import('node:child_process')>()
+  return {
+    ...actual,
+    execSync: (...args: unknown[]) => execSync(...args),
+    spawn: (...args: unknown[]) => spawn(...args),
+  }
+})
 
 const existsSync = vi.fn(() => true)
 
@@ -43,6 +48,17 @@ beforeEach(() => {
   existsSync.mockReturnValue(true)
 })
 
+/**
+ * Reproduce how the outer `/bin/sh -c` (what execSync runs) tokenizes the
+ * emitted command, and return the argument list that follows `sh -c`.
+ * The runners must hand the terminal a single argument; anything more means
+ * the outer shell split the payload and the resume command would break.
+ */
+function shArgsOf(emitted: string): string[] {
+  const dump = emitted.replace(/^open -a \S+ --args (?:-e |start -- )?sh -c /, `printf '%s\\n' `)
+  return execFileSync('/bin/sh', ['-c', dump]).toString().split('\n').slice(0, -1)
+}
+
 describe('SUPPORTED_TERMINALS', () => {
   it('includes Ghostty', () => {
     expect(SUPPORTED_TERMINALS).toContain('Ghostty')
@@ -55,7 +71,7 @@ describe('openTerminal — Ghostty', () => {
 
     expect(execSync).toHaveBeenCalledTimes(1)
     expect(execSync.mock.calls[0][0]).toBe(
-      `open -a Ghostty --args -e sh -c 'cd '/tmp/proj' && spool-resume echo; exec $SHELL'`,
+      `open -a Ghostty --args -e sh -c 'cd '\\''/tmp/proj'\\'' && spool-resume echo; exec $SHELL'`,
     )
   })
 
@@ -71,4 +87,35 @@ describe('openTerminal — Ghostty', () => {
     openTerminal('spool-resume echo', 'Ghostty')
     expect(execSync.mock.calls[0][0]).toContain('exec $SHELL')
   })
+})
+
+// Regression: the `sh -c` payload must survive the outer shell as ONE
+// argument even when the cwd or command contains a space or a single quote.
+// Before the fix, the runners wrapped the payload in raw single quotes, so a
+// path like "/tmp/My Proj" split into "cd /tmp/My" + "Proj && …" and the
+// resume command was dropped.
+describe('openTerminal — CLI runners keep the payload as one shell token', () => {
+  const cases: Array<[string, RegExp]> = [
+    ['Ghostty', /^open -a Ghostty --args -e sh -c /],
+    ['kitty', /^open -a kitty --args sh -c /],
+    ['Alacritty', /^open -a Alacritty --args -e sh -c /],
+    ['WezTerm', /^open -a WezTerm --args start -- sh -c /],
+  ]
+
+  for (const [terminal, prefix] of cases) {
+    it(`${terminal}: a cwd with a space stays intact`, () => {
+      openTerminal('spool-resume echo', terminal, '/tmp/My Proj')
+
+      const emitted = execSync.mock.calls[0][0] as string
+      expect(emitted).toMatch(prefix)
+      expect(shArgsOf(emitted)).toEqual([`cd '/tmp/My Proj' && spool-resume echo; exec $SHELL`])
+    })
+
+    it(`${terminal}: a command with a single quote stays intact`, () => {
+      openTerminal(`say 'hi there'`, terminal)
+
+      const emitted = execSync.mock.calls[0][0] as string
+      expect(shArgsOf(emitted)).toEqual([`say 'hi there'; exec $SHELL`])
+    })
+  }
 })

--- a/packages/app/src/main/terminal.ts
+++ b/packages/app/src/main/terminal.ts
@@ -75,6 +75,18 @@ function withCwd(cmd: string, cwd?: string): string {
   return cwd ? `cd ${shellQuote(cwd)} && ${cmd}` : cmd
 }
 
+/**
+ * Build the single `sh -c` argument for the `open --args` runners: run the
+ * command (in cwd) and keep the window alive with `exec $SHELL`. The whole
+ * payload is shell-quoted as one token so the outer shell (execSync) can't
+ * split it — otherwise a cwd or command containing a space (e.g. a project
+ * path like "/Users/x/My Project") or a single quote breaks apart the
+ * argument and the resume command is silently dropped.
+ */
+function keepAliveArg(cmd: string, cwd?: string): string {
+  return shellQuote(`${withCwd(cmd, cwd)}; exec $SHELL`)
+}
+
 import { shellQuote } from '../shared/resumeCommand.js'
 
 /**
@@ -130,22 +142,22 @@ windows:
   // Ghostty — macOS has no direct CLI, so pass args through `open --args`.
   // `-e` runs the command; `exec $SHELL` keeps the window alive afterwards.
   'Ghostty': (cmd, cwd) => {
-    execSync(`open -a Ghostty --args -e sh -c '${withCwd(cmd, cwd)}; exec $SHELL'`)
+    execSync(`open -a Ghostty --args -e sh -c ${keepAliveArg(cmd, cwd)}`)
   },
 
   // Kitty — `open --args`; `exec $SHELL` keeps the window alive
   'kitty': (cmd, cwd) => {
-    execSync(`open -a kitty --args sh -c '${withCwd(cmd, cwd)}; exec $SHELL'`)
+    execSync(`open -a kitty --args sh -c ${keepAliveArg(cmd, cwd)}`)
   },
 
   // Alacritty — uses `-e` flag for command execution
   'Alacritty': (cmd, cwd) => {
-    execSync(`open -a Alacritty --args -e sh -c '${withCwd(cmd, cwd)}; exec $SHELL'`)
+    execSync(`open -a Alacritty --args -e sh -c ${keepAliveArg(cmd, cwd)}`)
   },
 
   // WezTerm — `start --` separates wezterm args from the spawned command
   'WezTerm': (cmd, cwd) => {
-    execSync(`open -a WezTerm --args start -- sh -c '${withCwd(cmd, cwd)}; exec $SHELL'`)
+    execSync(`open -a WezTerm --args start -- sh -c ${keepAliveArg(cmd, cwd)}`)
   },
 }
 


### PR DESCRIPTION
## What

Fixes shell-quoting in the `open --args` terminal runners (Ghostty / kitty / Alacritty / WezTerm) so the resume command survives cwds and commands that contain spaces or single quotes.

Depends on #405 (stacked — this branch bases on `feat/terminal-ghostty`). Merge #405 first.

## Why

Each runner wrapped the `sh -c` payload in raw single quotes:

```
open -a kitty --args sh -c '<payload>'
```

But `withCwd` already single-quotes the cwd (`cd '<cwd>' && …`) and the resume command single-quotes the session id. The nested single quotes cancel out under the outer shell, so it only works when nothing contains a space. A common macOS project path like `/Users/x/My Project` tokenizes into:

```
sh -c argument = "cd /Users/x/My"    (+ stray args "Project", "&&", "claude"…)
```

so `sh -c cd` just cd's to `$HOME` and exits — the resume command is dropped and the window opens in the wrong directory (and never runs `exec $SHELL`).

## How it connects

- Extracts `keepAliveArg(cmd, cwd)`, which shell-quotes the entire `"<cmd>; exec $SHELL"` payload as one token, and routes all four `open --args` runners through it. This also removes the fourth byte-for-byte copy of the runner template.
- The AppleScript runners (Terminal.app / iTerm2) are untouched — they have a separate quoting model and are out of scope here.

## Test plan

- New regression tests tokenize each emitted command with a real `/bin/sh` and assert the payload survives as a **single** argument, for both a spaced cwd (`/tmp/My Proj`) and an embedded single quote. These fail on the pre-fix runners (the spaced path splits into two argv tokens) and pass after.
- Existing Ghostty string assertions updated to the correctly-escaped form.
- Full app vitest suite green (290 tests).