### PR TITLE
chore(share): gate the public-profile surface off for launch

### DIFF
--- a/packages/app/e2e/share-publish.spec.ts
+++ b/packages/app/e2e/share-publish.spec.ts
@@ -137,6 +137,41 @@ test('Sign-in transitions the popover to the publish form', async () => {
   ).toBeEnabled()
 })
 
+test('Settings → Account offers no handle claim while profiles are cut', async () => {
+  const { window } = ctx
+  await signInAndOpenPublishForm(window)
+  await window.keyboard.press('Escape')
+  await window.locator('[data-testid="share-editor-back"]').click()
+
+  await window.locator('[data-testid="settings-button"]').click()
+  await expect(window.locator('[data-testid="settings-panel"]')).toBeVisible()
+  // The Account tab label is the hardcoded fallbackLabel (no i18n key
+  // authored yet), so the text match is stable — see SettingsPanel
+  // TAB_DEFS.
+  await window.getByRole('button', { name: 'Account', exact: true }).click()
+
+  // Signed in without a handle — the pre-cut UI showed the claim
+  // input here. Sign-out row proves the pane rendered (absence of the
+  // input isn't a pass if the whole pane failed to mount).
+  await expect(
+    window.locator('[data-testid="settings-account-signout"]'),
+  ).toBeVisible()
+  await expect(
+    window.locator('[data-testid="settings-account-handle-input"]'),
+  ).toHaveCount(0)
+
+  // The delete-account confirm must not mention a handle either: it
+  // renders exactly the two bullets that survive the profile cut.
+  await window.locator('[data-testid="settings-account-delete"]').click()
+  const modal = window.locator('[data-testid="delete-account-confirm"]')
+  await expect(modal).toBeVisible()
+  await expect(modal.locator('ul > li')).toHaveCount(2)
+  await expect(modal.locator('ul')).not.toContainText(
+    en.settings.account.deleteConfirm_item_handle,
+  )
+  await window.locator('[data-testid="delete-account-confirm-cancel"]').click()
+})
+
 test('Publish lands in the manage view with slug + copy-link + unpublish', async () => {
   const { window } = ctx
   await signInAndOpenPublishForm(window)

--- a/packages/app/e2e/share-publish.spec.ts
+++ b/packages/app/e2e/share-publish.spec.ts
@@ -11,8 +11,10 @@
 //     e2e-mode entry is dead-code-eliminated from production bundles
 //     and an invariant test (e2e-mode/e2e-mode-clean.test.ts) keeps
 //     it that way.
-//   - The signed-in publish form: visibility radios,
-//     Publish button, the spinner during in-flight publish
+//   - The signed-in publish form: Publish button, the spinner during
+//     in-flight publish (the visibility picker is gated off at launch
+//     — SHOW_VISIBILITY_PICKER in PublishTab.tsx — so the form must
+//     NOT render it)
 //   - The post-publish manage view: URL string with copy-link, the
 //     Unpublish action + the dedicated confirm modal (regression for
 //     the destructive-action discipline added in PR #371)
@@ -124,9 +126,12 @@ test('Sign-in transitions the popover to the publish form', async () => {
   await expect(
     window.locator('[data-testid="share-menu-form"]'),
   ).toBeVisible({ timeout: 5_000 })
+  // Profiles are cut from launch: the visibility picker must stay
+  // hidden and every publish goes out link-only (asserted on the mock
+  // backend in the publish test below).
   await expect(
     window.locator('[data-testid="share-menu-visibility-link-only"]'),
-  ).toBeVisible()
+  ).toHaveCount(0)
   await expect(
     window.locator('[data-testid="share-menu-submit"]'),
   ).toBeEnabled()
@@ -400,7 +405,10 @@ test('Published tab lists a live share with open/copy/unpublish affordances', as
 test('Row menu lists a share on the profile and back', async () => {
   const { window } = ctx
   // Handle must exist before sign-in so /api/me carries it — listing
-  // is gated on it at both the menu and the backend.
+  // is gated on it at both the menu and the backend. At launch no
+  // user can hold a handle (profiles are cut; claim is gated off
+  // server-side), so this covers the kept-but-dark code path that
+  // comes back with the PROFILES_ENABLED flip.
   mock.state.user.handle = 'e2e-user'
   await signInAndPublish(window)
 

--- a/packages/app/e2e/share-publish.spec.ts
+++ b/packages/app/e2e/share-publish.spec.ts
@@ -128,10 +128,14 @@ test('Sign-in transitions the popover to the publish form', async () => {
   ).toBeVisible({ timeout: 5_000 })
   // Profiles are cut from launch: the visibility picker must stay
   // hidden and every publish goes out link-only (asserted on the mock
-  // backend in the publish test below).
+  // backend in the publish test below). The snapshot summary card
+  // replaces the picker as the form's body.
   await expect(
     window.locator('[data-testid="share-menu-visibility-link-only"]'),
   ).toHaveCount(0)
+  await expect(
+    window.locator('[data-testid="share-menu-snapshot-card"]'),
+  ).toBeVisible()
   await expect(
     window.locator('[data-testid="share-menu-submit"]'),
   ).toBeEnabled()

--- a/packages/app/src/renderer/components/DeleteAccountConfirmModal.tsx
+++ b/packages/app/src/renderer/components/DeleteAccountConfirmModal.tsx
@@ -83,9 +83,12 @@ export function DeleteAccountConfirmModal({
           <p className="mt-3 text-[12.5px] leading-relaxed text-warm-text dark:text-dark-text">
             {t('settings.account.deleteConfirm_lead')} <strong>{t('settings.account.deleteConfirm_leadEmphasis')}</strong>{t('settings.account.deleteConfirm_leadSuffix')}
           </p>
+          {/* No handle bullet: public profiles are cut from the launch
+           *  scope (see PROFILES_ENABLED in SettingsAccount), so the
+           *  copy must not surface a handle concept — restore the
+           *  deleteConfirm_item_handle line with the profiles flip. */}
           <ul className="mt-2 ml-4 list-disc text-[12.5px] leading-relaxed text-warm-muted dark:text-dark-muted space-y-0.5">
             <li>{t('settings.account.deleteConfirm_item_shares_prefix')} <strong>{t('settings.account.deleteConfirm_item_shares_emphasis')}</strong></li>
-            <li>{t('settings.account.deleteConfirm_item_handle')}</li>
             <li>{t('settings.account.deleteConfirm_item_record')}</li>
           </ul>
           <p className="mt-3 text-[12px] leading-relaxed text-warm-muted dark:text-dark-muted">

--- a/packages/app/src/renderer/components/SettingsAccount.tsx
+++ b/packages/app/src/renderer/components/SettingsAccount.tsx
@@ -7,6 +7,13 @@ import { DeleteAccountConfirmModal } from './DeleteAccountConfirmModal.js'
 import ProfileEditor from './ProfileEditor.js'
 import { useShareAuth } from '../hooks/useShareAuth.js'
 
+// Public profiles (/@handle pages) are cut from the launch scope —
+// this hides the claim section below, the backend 404s the claim/check
+// endpoints (share-backend PROFILES_ENABLED env var), and PublishTab
+// hides its visibility picker (SHOW_VISIBILITY_PICKER). Flip all of
+// them together if user feedback brings profiles back.
+const PROFILES_ENABLED = false
+
 // 320ms matches the web /me HandleClaim debounce — see share-web/Me.tsx.
 // Without it, every keystroke fires a backend IPC + network call, and
 // out-of-order responses can stamp a stale 'available' over a fresh
@@ -146,7 +153,7 @@ export default function SettingsAccount() {
       <ProfileEditor />
 
       {/* Handle claim */}
-      {!user.handle && (
+      {PROFILES_ENABLED && !user.handle && (
         <div>
           <h4 className="text-[12px] font-medium text-warm-text dark:text-dark-text mb-2">
             {t('settings.account.handle_title')}

--- a/packages/app/src/renderer/components/share-editor/ShareMenu.tsx
+++ b/packages/app/src/renderer/components/share-editor/ShareMenu.tsx
@@ -5,7 +5,7 @@ import type { Conversation, EditorOpts } from '@spool/share-kit'
 import { useHotkeys } from '../../hooks/useHotkeys.js'
 import { useSharePublish } from '../../featureFlags.js'
 import type { PublishedRow, PublishSuccess } from '../../../shared/share-publish.js'
-import { PublishTab } from './share-tabs/PublishTab.js'
+import { PublishTab, PublishTabSkeleton } from './share-tabs/PublishTab.js'
 import { ExportTab, type ExportFormat } from './share-tabs/ExportTab.js'
 import { UnpublishConfirmModal } from './UnpublishConfirmModal.js'
 
@@ -257,9 +257,7 @@ export function ShareMenu({
               against any future bug that flips `tab` from elsewhere. */}
           {publishEnabled && tab === 'publish' ? (
             lookupLoading ? (
-              <div className="px-4 pb-4">
-                <div className="h-32 rounded-md bg-warm-surface dark:bg-dark-surface animate-pulse" />
-              </div>
+              <PublishTabSkeleton />
             ) : (
               <PublishTab
                 draftId={draftId}

--- a/packages/app/src/renderer/components/share-editor/share-tabs/PublishTab.tsx
+++ b/packages/app/src/renderer/components/share-editor/share-tabs/PublishTab.tsx
@@ -168,11 +168,7 @@ export function PublishTab({
 
   // ── State 1: auth loading ─────────────────────────────────────────
   if (authLoading) {
-    return (
-      <div className="px-4 pb-4">
-        <div className="h-32 rounded-md bg-warm-surface dark:bg-dark-surface animate-pulse" />
-      </div>
-    )
+    return <PublishTabSkeleton />
   }
 
   // ── State 2: signed out — embed the ConnectCard ──────────────────
@@ -229,6 +225,12 @@ export function PublishTab({
   }
 
   // ── State 4: signed in + draft — publish form ────────────────────
+  // How many turns actually publish: an active TurnSelector selection
+  // wins over the raw conversation length.
+  const publishTurnCount = pending
+    ? pending.opts.selected?.length ?? pending.conversation.turns.length
+    : null
+
   return (
     <div className="flex flex-col" data-testid="share-menu-form">
       {high.length > 0 && (
@@ -252,6 +254,39 @@ export function PublishTab({
           onToggle={() => setMediumOpen((v) => !v)}
         />
       )}
+
+      {/* Snapshot summary — with the visibility picker cut, this card
+       *  is what tells the user what's about to go out and who can see
+       *  it: title + published-turn count, then the link-only note
+       *  (reusing the retired picker's copy, so no new translations). */}
+      <div className="px-4 pb-3">
+        <div
+          data-testid="share-menu-snapshot-card"
+          className="flex items-center gap-2 rounded-md border border-warm-border dark:border-dark-border bg-warm-surface dark:bg-dark-surface px-3 py-2"
+        >
+          <span className="inline-flex w-7 h-7 flex-none items-center justify-center rounded-md bg-warm-bg dark:bg-dark-bg text-warm-muted dark:text-dark-muted">
+            <FileText size={15} strokeWidth={1.75} aria-hidden />
+          </span>
+          <div className="min-w-0">
+            <div className="text-[12px] font-medium text-warm-text dark:text-dark-text truncate">
+              {pending ? pending.conversation.title || t('common.untitled') : '—'}
+            </div>
+            <div className="text-[11px] font-mono text-warm-muted dark:text-dark-muted">
+              {publishTurnCount !== null
+                ? t('shareEditor.publishTab.snapshot_turns', { count: publishTurnCount })
+                : '—'}
+            </div>
+          </div>
+        </div>
+        <p className="mt-2 flex items-start gap-1.5 text-[11px] leading-snug text-warm-muted dark:text-dark-muted">
+          <LinkIcon size={12} strokeWidth={1.75} className="mt-0.5 flex-none" aria-hidden />
+          <span>
+            <span className="font-medium">{t('shareEditor.publishTab.visibility_link_title')}</span>
+            {' — '}
+            {t('shareEditor.publishTab.visibility_link_description')}
+          </span>
+        </p>
+      </div>
 
       {SHOW_VISIBILITY_PICKER && <fieldset disabled={publishing} className="px-4 pb-3">
         <legend className="text-[11.5px] font-medium text-warm-muted dark:text-dark-muted">
@@ -339,6 +374,29 @@ export function PublishTab({
 }
 
 // ── Subcomponents ─────────────────────────────────────────────────
+
+/**
+ * Loading placeholder mirroring the signed-in publish form's layout
+ * (snapshot card + note line + footer), so neither the cache-lookup
+ * skeleton (ShareMenu) nor the auth skeleton (state 1 above) causes a
+ * height jump when the real form swaps in. The previous flat h-32
+ * block was ~2× the post-picker-cut form height and made the popover
+ * visibly shrink on open.
+ */
+export function PublishTabSkeleton() {
+  return (
+    <div className="flex flex-col" aria-hidden>
+      <div className="px-4 pb-3">
+        <div className="h-[46px] rounded-md bg-warm-surface dark:bg-dark-surface animate-pulse" />
+        <div className="mt-2 h-4 w-2/3 rounded bg-warm-surface dark:bg-dark-surface animate-pulse" />
+      </div>
+      <div className="flex items-center justify-between gap-3 px-4 py-3 border-t border-warm-border/60 dark:border-dark-border/60 bg-warm-surface/40 dark:bg-dark-surface/40">
+        <div className="h-4 w-1/2 rounded bg-warm-surface dark:bg-dark-surface animate-pulse" />
+        <div className="h-8 w-24 rounded-md bg-warm-surface dark:bg-dark-surface animate-pulse" />
+      </div>
+    </div>
+  )
+}
 
 function VisibilityCard({
   icon,

--- a/packages/app/src/renderer/components/share-editor/share-tabs/PublishTab.tsx
+++ b/packages/app/src/renderer/components/share-editor/share-tabs/PublishTab.tsx
@@ -52,6 +52,15 @@ type Props = {
 
 const HIGH_ROW_LIMIT = 6
 
+// Public profiles (/@handle pages) are cut from the launch scope, and
+// the backend gates handle claiming off (share-backend
+// PROFILES_ENABLED env var). Without a claimable handle the
+// "On profile" card could never be enabled, so offering the picker
+// would only show a permanently-disabled option — every publish is
+// link-only instead. Flip together with the backend flag (and
+// PROFILES_ENABLED in share-web) if user feedback brings profiles back.
+const SHOW_VISIBILITY_PICKER = false
+
 /**
  * The Publish tab of the Share popover. State machine:
  *
@@ -244,7 +253,7 @@ export function PublishTab({
         />
       )}
 
-      <fieldset disabled={publishing} className="px-4 pb-3">
+      {SHOW_VISIBILITY_PICKER && <fieldset disabled={publishing} className="px-4 pb-3">
         <legend className="text-[11.5px] font-medium text-warm-muted dark:text-dark-muted">
           {t('shareEditor.publishTab.visibility_legend')}
         </legend>
@@ -269,7 +278,7 @@ export function PublishTab({
             onSelect={() => setVisibility('profile-listed')}
           />
         </div>
-      </fieldset>
+      </fieldset>}
 
       {error && (
         <p

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -608,6 +608,8 @@
       "visibility_legend": "Sichtbarkeit",
       "visibility_link_title": "Nur Link",
       "visibility_link_description": "Jeder mit dem Link kann es lesen.",
+      "snapshot_turns_one": "{{count}} Turn",
+      "snapshot_turns_other": "{{count}} Turns",
       "visibility_profile_title": "Auf Profil",
       "visibility_profile_description_listed": "Auf Ihrem @handle aufgeführt.",
       "visibility_profile_description_needsHandle": "Handle erforderlich.",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -608,6 +608,8 @@
       "visibility_legend": "Visibility",
       "visibility_link_title": "Link only",
       "visibility_link_description": "Anyone with the link can read it.",
+      "snapshot_turns_one": "{{count}} turn",
+      "snapshot_turns_other": "{{count}} turns",
       "visibility_profile_title": "On profile",
       "visibility_profile_description_listed": "Listed on your @handle.",
       "visibility_profile_description_needsHandle": "Needs a handle.",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -608,6 +608,8 @@
       "visibility_legend": "Visibilité",
       "visibility_link_title": "Lien uniquement",
       "visibility_link_description": "Lisible par quiconque a le lien.",
+      "snapshot_turns_one": "{{count}} tour",
+      "snapshot_turns_other": "{{count}} tours",
       "visibility_profile_title": "Sur le profil",
       "visibility_profile_description_listed": "Listé sur votre @handle.",
       "visibility_profile_description_needsHandle": "Nécessite un handle.",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -579,6 +579,7 @@
       "visibility_legend": "公開範囲",
       "visibility_link_title": "リンクのみ",
       "visibility_link_description": "リンクを知る人は誰でも閲覧できます。",
+      "snapshot_turns_other": "{{count}} 件",
       "visibility_profile_title": "プロフィールに掲載",
       "visibility_profile_description_listed": "@ハンドルに掲載されます。",
       "visibility_profile_description_needsHandle": "ハンドルが必要です。",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -579,6 +579,7 @@
       "visibility_legend": "공개 범위",
       "visibility_link_title": "링크만",
       "visibility_link_description": "링크가 있으면 누구나 볼 수 있습니다.",
+      "snapshot_turns_other": "{{count}}개",
       "visibility_profile_title": "프로필에 게시",
       "visibility_profile_description_listed": "@핸들에 게시됩니다.",
       "visibility_profile_description_needsHandle": "핸들이 필요합니다.",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -579,6 +579,7 @@
       "visibility_legend": "可见性",
       "visibility_link_title": "仅链接",
       "visibility_link_description": "持有链接的任何人都能阅读。",
+      "snapshot_turns_other": "{{count}} 段",
       "visibility_profile_title": "在个人主页",
       "visibility_profile_description_listed": "在你的 @handle 主页上展示。",
       "visibility_profile_description_needsHandle": "需要先设置 handle。",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -579,6 +579,7 @@
       "visibility_legend": "可見性",
       "visibility_link_title": "僅連結",
       "visibility_link_description": "持有連結的任何人都能閱讀。",
+      "snapshot_turns_other": "{{count}} 段",
       "visibility_profile_title": "在個人主頁",
       "visibility_profile_description_listed": "在你的 @handle 主頁上展示。",
       "visibility_profile_description_needsHandle": "需要先設定 handle。",

--- a/packages/share-backend/functions/api/handles/check.ts
+++ b/packages/share-backend/functions/api/handles/check.ts
@@ -1,13 +1,15 @@
 import type { D1Database, PagesFunction } from '@cloudflare/workers-types'
 
-import { jsonError, jsonOk } from '../../../src/errors'
-import { validateHandle } from '../../../src/handles'
+import { ApiError, jsonError, jsonOk } from '../../../src/errors'
+import { profilesEnabled, validateHandle } from '../../../src/handles'
 import { ccPublicRevalidate } from '../../../src/security/cache-control'
 
-type Env = { DB: D1Database }
+type Env = { DB: D1Database; PROFILES_ENABLED?: string }
 
 export const onRequestGet: PagesFunction<Env> = async (ctx) => {
   try {
+    // Profiles are gated off at launch — see profilesEnabled().
+    if (!profilesEnabled(ctx.env)) throw new ApiError('NOT_FOUND')
     const handle = new URL(ctx.request.url).searchParams.get('h') ?? ''
     const v = validateHandle(handle)
     const headers = { 'cache-control': ccPublicRevalidate(10) }

--- a/packages/share-backend/functions/api/handles/claim.ts
+++ b/packages/share-backend/functions/api/handles/claim.ts
@@ -3,10 +3,10 @@ import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers
 import { audit } from '../../../src/audit'
 import { requireUser } from '../../../src/auth/require'
 import { ApiError, jsonError, jsonOk } from '../../../src/errors'
-import { validateHandle } from '../../../src/handles'
+import { profilesEnabled, validateHandle } from '../../../src/handles'
 import { checkRate } from '../../../src/rate-limit'
 
-type Env = { DB: D1Database; SESSIONS: KVNamespace; RATE: KVNamespace }
+type Env = { DB: D1Database; SESSIONS: KVNamespace; RATE: KVNamespace; PROFILES_ENABLED?: string }
 
 // 5 attempts per user per day is enough for a real human exploring
 // available names, far short of bulk squatting.
@@ -21,6 +21,8 @@ function isUniqueViolation(e: unknown): boolean {
 
 export const onRequestPost: PagesFunction<Env> = async (ctx) => {
   try {
+    // Profiles are gated off at launch — see profilesEnabled().
+    if (!profilesEnabled(ctx.env)) throw new ApiError('NOT_FOUND')
     const user = await requireUser(ctx.request, ctx.env)
     const rate = await checkRate(ctx.env.RATE, {
       bucket: 'claim',

--- a/packages/share-backend/src/handles.ts
+++ b/packages/share-backend/src/handles.ts
@@ -1,3 +1,22 @@
+// Public profiles (/@handle pages) are cut from the launch scope: no
+// client offers handle claiming, and the claim/check endpoints behind
+// this gate return 404. Handles are the root of the whole profile
+// surface — publish and visibility-PATCH already reject profile-listed
+// without one, /@handle pages 404 without a row — so gating the claim
+// path keeps everything downstream unreachable without touching it.
+// That holds only while the handles table is empty: an existing row
+// would keep its /@handle page, /api/me handle, and List-on-profile
+// menu fully live. The production D1 launches with zero handle rows;
+// if any get seeded before this gate is deployed, release them.
+// If user feedback asks for public profiles, set PROFILES_ENABLED=1 on
+// the Pages project and restore the client entry points — grep for
+// PROFILES_ENABLED in share-web and SHOW_VISIBILITY_PICKER in the app,
+// and restore the handle-release wording cut from share-web's
+// DeleteAccountModal and the profile sections of /privacy and /terms.
+export function profilesEnabled(env: { PROFILES_ENABLED?: string }): boolean {
+  return env.PROFILES_ENABLED === '1'
+}
+
 // Two flavours of reserved name, merged into one set:
 //   1) URL-routing words that already mean something on spool.pro
 //      (collide with /api/*, /me, /settings, etc.)

--- a/packages/share-backend/tests/me.test.ts
+++ b/packages/share-backend/tests/me.test.ts
@@ -65,6 +65,10 @@ function envFor(state?: FakeDbState) {
     DB: db,
     SESSIONS: makeKv(),
     RATE: makeKv(),
+    // Handle claim/check are gated off at launch (profiles cut from
+    // scope). Behavior tests run with the gate open; the gated-off
+    // 404s have their own cases below.
+    PROFILES_ENABLED: '1',
     state: s,
   }
 }
@@ -138,6 +142,13 @@ describe('requireUser', () => {
 })
 
 describe('GET /api/handles/check', () => {
+  it('404 when PROFILES_ENABLED is not set (launch default)', async () => {
+    const env = { ...envFor(), PROFILES_ENABLED: '' }
+    const req = new Request('https://x/api/handles/check?h=alice')
+    const res = await invoke(checkHandleGet, req, env)
+    expect(res.status).toBe(404)
+  })
+
   it('returns available=true for an unclaimed valid handle', async () => {
     const env = envFor()
     const req = new Request('https://x/api/handles/check?h=alice')
@@ -178,6 +189,20 @@ describe('GET /api/handles/check', () => {
 })
 
 describe('POST /api/handles/claim', () => {
+  it('404 when PROFILES_ENABLED is not set (launch default), even signed in', async () => {
+    const env = { ...envFor(), PROFILES_ENABLED: '' }
+    seedUser(env.state)
+    await seedSession(env.SESSIONS, TOKEN, 'user-1')
+    const req = authedReq('https://x/api/handles/claim', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ handle: 'alice' }),
+    })
+    const res = await invoke(claimHandlePost, req, env)
+    expect(res.status).toBe(404)
+    expect(env.state.handles).toHaveLength(0)
+  })
+
   it('claims an available handle and writes audit', async () => {
     const env = envFor()
     seedUser(env.state)

--- a/packages/share-web/src/pages/Me.tsx
+++ b/packages/share-web/src/pages/Me.tsx
@@ -25,6 +25,14 @@ import {
 import { humanDate, humanDateTime } from '../lib/dates'
 import { ProfileEditor } from '../components/ProfileEditor'
 
+// Public profiles (/@handle pages) are cut from the launch scope. This
+// gates the handle-claim entry point; the backend gates the API side
+// (share-backend PROFILES_ENABLED env var — flip both together if user
+// feedback brings profiles back). Everything downstream — the profile
+// page, the per-share "List on profile" action — already keys off the
+// user having a handle, so it stays dark on its own.
+const PROFILES_ENABLED = false
+
 // Match the server-side handle regex (share-backend/src/handles.ts).
 // We pre-filter input so check requests + the submit button respond
 // to obvious mismatches without a round-trip.
@@ -527,11 +535,11 @@ function DeleteAccountModal({
       {pending && pendingUntil ? (
         <p className="sw-modal-body">
           Scheduled for <span className="sw-mono">{humanDateTime(pendingUntil)}</span>. Cancelling
-          keeps your shares, handle, and account intact.
+          keeps your shares and account intact.
         </p>
       ) : (
         <p className="sw-modal-body">
-          Unpublishes every share, releases your handle, and removes your account record after 24
+          Unpublishes every share and removes your account record after 24
           hours. You can undo this from the same place within that window.
         </p>
       )}
@@ -886,12 +894,10 @@ export function Me() {
               <Avatar src={me.avatar_url} name={me.display_name} size={54} />
               <div className="body">
                 <h1 className="name">{me.display_name}</h1>
-                {me.handle ? (
+                {me.handle && (
                   <p className="handle accent">
                     <a href={`/@${me.handle}`}>@{me.handle}</a>
                   </p>
-                ) : (
-                  <p className="handle">No public handle yet</p>
                 )}
               </div>
               <button
@@ -917,7 +923,7 @@ export function Me() {
             </div>
           )}
 
-          {!me.handle && !pending && (
+          {PROFILES_ENABLED && !me.handle && !pending && (
             <>
               <div className="sw-divider" style={{ margin: '24px 0 20px' }} />
               <HandleClaim

--- a/packages/share-web/src/pages/Privacy.tsx
+++ b/packages/share-web/src/pages/Privacy.tsx
@@ -8,7 +8,7 @@ import { useEffect } from 'react'
 
 import { Footer, Header, Page } from '../components/Chrome'
 
-const LAST_UPDATED = 'June 12, 2026'
+const LAST_UPDATED = 'July 7, 2026'
 
 export function Privacy() {
   useEffect(() => {
@@ -63,9 +63,10 @@ export function Privacy() {
             password and we request no access to any other Google data.
           </p>
           <p>
-            <strong>Profile, if you set one up.</strong> A handle, an
-            optional display name, and an optional uploaded avatar.
-            These are public on your profile page.
+            <strong>Account customization, if you use it.</strong> An
+            optional display name and an optional uploaded avatar,
+            which replace the Google-provided name and picture wherever
+            the service shows your account.
           </p>
           <p>
             <strong>Content you publish.</strong> When you click Publish
@@ -91,8 +92,8 @@ export function Privacy() {
 
           <h2>How we use it</h2>
           <p>
-            To operate the service you asked for (signing you in, hosting
-            your shares, showing your profile — in GDPR terms, performance
+            To operate the service you asked for (signing you in and
+            hosting your shares — in GDPR terms, performance
             of a contract) and to keep the service safe (rate limiting and
             audit logging — our legitimate interest in preventing abuse).
             That's the whole list.
@@ -111,9 +112,8 @@ export function Privacy() {
 
           <h2>Published content is public</h2>
           <p>
-            That's the point of publishing. A link-only share is visible
-            to anyone who has the URL; a share listed on your profile is
-            visible to anyone who visits it. Third parties — search
+            That's the point of publishing. A share is visible to
+            anyone who has its URL. Third parties — search
             engines, social-media link previews — may make their own
             copies, and those copies can outlive an unpublish. Treat
             publishing as you would posting publicly anywhere.
@@ -128,8 +128,8 @@ export function Privacy() {
           <p>
             <strong>Deleting your account</strong> starts a 24-hour grace
             window (so a mistaken click can be undone), after which every
-            share is unpublished and its content deleted, your handle is
-            released, and your account record is stripped of personal
+            share is unpublished and its content deleted, and your
+            account record is stripped of personal
             information. Residual copies in our infrastructure provider's
             automatic backups expire within 30 days.
           </p>

--- a/packages/share-web/src/pages/Terms.tsx
+++ b/packages/share-web/src/pages/Terms.tsx
@@ -9,7 +9,7 @@ import { useEffect } from 'react'
 
 import { Footer, Header, Page } from '../components/Chrome'
 
-const LAST_UPDATED = 'June 12, 2026'
+const LAST_UPDATED = 'July 7, 2026'
 
 export function Terms() {
   useEffect(() => {
@@ -36,8 +36,8 @@ export function Terms() {
           <h2>The service</h2>
           <p>
             spool.pro hosts conversation snapshots you explicitly publish
-            from the Spool app and serves them at public links, optionally
-            listed on a public profile page. The service is currently
+            from the Spool app and serves them at public links.
+            The service is currently
             free. We work hard to keep it fast and available, but it is
             provided <strong>as is</strong>, without warranties of any
             kind, and we may change or discontinue features — if we ever
@@ -57,8 +57,8 @@ export function Terms() {
           <p>
             What you publish stays yours. You grant us the non-exclusive
             license needed to operate the service — to store, copy,
-            display, and distribute your published shares at their links,
-            on your profile if listed, and in previews such as
+            display, and distribute your published shares at their links
+            and in previews such as
             social-media cards. This license ends for a share when you
             unpublish it, except where the privacy policy describes
             residual copies.


### PR DESCRIPTION
## What

Cuts public profiles (`/@handle` pages and everything that hangs off them) from the share-publish launch scope. Nothing is deleted — the surface is gated so it can come back cheaply if user feedback asks for it.

## Why

Profiles add ongoing moderation/impersonation surface and legal-copy obligations that aren't justified before there's real usage. The launch ships link-only sharing; a share is visible to whoever has its URL, nothing is listed anywhere.

## How it connects

Handles are the single root of the profile surface: publish and the visibility PATCH already reject `profile-listed` without a live handle, `/@handle` 404s without a row, and both clients key their profile affordances off `user.handle`. With the claim path gated and the production D1 launching with zero handle rows, every downstream path stays dark without being touched:

- **share-backend** — `POST /api/handles/claim` and `GET /api/handles/check` return 404 unless `PROFILES_ENABLED=1` is set on the Pages project. The revival checklist lives in a comment on `profilesEnabled()` in `src/handles.ts`.
- **share-web `/me`** — the Claim-a-handle card and the "No public handle yet" placeholder are gone; the delete-account modal no longer mentions releasing a handle.
- **desktop PublishTab** — the visibility picker is hidden (its "On profile" option could never be enabled without a claimable handle); every publish goes out `unlisted`.
- **desktop Settings → Account** — the handle-claim form (input + availability check + Claim button) is gated off, and the delete-account confirm no longer lists "your handle is released" as a consequence. The claim/check IPC plumbing stays, dark — its only consumer is the gated form.
- **`/privacy` + `/terms`** — profile-setup and profile-listed copy rewritten to describe the service as it actually launches.

Kept dark on purpose: `Profile.tsx` + the `/@` route, `handles.ts` validation, the `handles` table, the deletion worker's handle release, and the desktop/web List-on-profile row actions (all unreachable while no user holds a handle).

Known pre-existing quirk, unreachable while profiles are off: republishing from the share popover always submits `visibility: 'unlisted'`, so a listed share would be silently delisted on republish. Worth fixing before any future `PROFILES_ENABLED` flip.

## Test plan

- share-backend: two new tests — claim and check 404 with the flag unset (claim asserted to write no row, even signed in); suite 245/245 green, typecheck clean
- share-web: 84/84 green, typecheck clean
- app: unit 454/454 green; `share-publish.spec.ts` e2e 15/15 green — a new spec drives Settings → Account signed-in and asserts the claim input is absent and the delete confirm carries exactly the two surviving bullets; the publish-form spec asserts the visibility picker is absent and the publish lands `unlisted` on the mock backend; the row-menu listing spec stays as coverage for the dark path
- Visual check of the publish popover: sign-in → form shows PII gate + Publish only, no dead "needs a handle" option
