### PR TITLE
fix(auth): make sign-in work across proxy configurations, desktop and local dev

### DIFF
--- a/packages/app/src/main/auth/oauth.test.ts
+++ b/packages/app/src/main/auth/oauth.test.ts
@@ -21,11 +21,18 @@ vi.mock('electron', () => ({
       void realFetch(cb.toString()).catch(() => undefined)
     }),
   },
-  // oauth.ts routes its outbound requests through net.fetch (system
-  // proxy support). Forward to globalThis.fetch so the per-test spies
-  // below keep intercepting the token exchange + backend sign-in.
+  // oauth.ts routes its outbound requests through robustFetch, whose
+  // first transport is net.fetch (system-proxy support). Forward to
+  // globalThis.fetch so the per-test spies below keep intercepting the
+  // token exchange + backend sign-in; the fallback transports (which
+  // would touch `session`) never engage because the first one works.
   net: {
     fetch: (url: string, init?: RequestInit) => globalThis.fetch(url, init),
+  },
+  session: {
+    fromPartition: () => {
+      throw new Error('fallback transport engaged unexpectedly in tests')
+    },
   },
 }))
 

--- a/packages/app/src/main/auth/oauth.test.ts
+++ b/packages/app/src/main/auth/oauth.test.ts
@@ -21,6 +21,12 @@ vi.mock('electron', () => ({
       void realFetch(cb.toString()).catch(() => undefined)
     }),
   },
+  // oauth.ts routes its outbound requests through net.fetch (system
+  // proxy support). Forward to globalThis.fetch so the per-test spies
+  // below keep intercepting the token exchange + backend sign-in.
+  net: {
+    fetch: (url: string, init?: RequestInit) => globalThis.fetch(url, init),
+  },
 }))
 
 describe('signInWith (loopback OAuth orchestrator)', () => {

--- a/packages/app/src/main/auth/oauth.test.ts
+++ b/packages/app/src/main/auth/oauth.test.ts
@@ -80,6 +80,12 @@ describe('signInWith (loopback OAuth orchestrator)', () => {
         // Loopback: delegate to the real fetch (mock should be transparent here).
         return realFetch(input as Parameters<typeof realFetch>[0], init)
       }
+      // fetchOnce probes each target's origin with a GET before the
+      // real request; any HTTP response (status irrelevant) selects
+      // the transport.
+      if (url === 'https://oauth2.googleapis.com/' || url === 'https://example.test/') {
+        return new Response('probe', { status: 404 })
+      }
       if (url.startsWith('https://oauth2.googleapis.com/token')) {
         const body = init?.body as URLSearchParams
         capturedVerifier = body.get('code_verifier')

--- a/packages/app/src/main/auth/oauth.ts
+++ b/packages/app/src/main/auth/oauth.ts
@@ -12,7 +12,7 @@
 import { shell } from 'electron'
 import crypto from 'node:crypto'
 
-import { robustFetch } from '../net/robust-fetch.js'
+import { fetchOnce } from '../net/robust-fetch.js'
 import { backendUrl } from '../share/backend-url.js'
 
 import { startLoopback } from './loopback-server.js'
@@ -125,11 +125,13 @@ export async function signInWith(providerId: ProviderId = 'google'): Promise<Sig
   })
   if (csecret) tokenBody.set('client_secret', csecret)
   // Sign-in must work regardless of how (or whether) the user's
-  // traffic is proxied — robustFetch falls back across system-proxy /
-  // env-proxy / direct transports on connect-level failures. The body
-  // is a URLSearchParams (replayable), and HTTP errors never retry, so
-  // the single-use code can't double-spend.
-  const tokenRes = await robustFetch(config.tokenUrl, {
+  // traffic is proxied. Both requests below carry one-shot values (the
+  // auth code here, the nonce'd id_token next), so they go through
+  // fetchOnce: a side-effect-free probe picks the working transport
+  // (system proxy / env proxy / direct), then the real POST is sent
+  // exactly once — a blind cross-transport retry double-spends the
+  // code/nonce when a transport delivers but loses the response.
+  const tokenRes = await fetchOnce(config.tokenUrl, {
     method: 'POST',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
     body: tokenBody,
@@ -139,7 +141,7 @@ export async function signInWith(providerId: ProviderId = 'google'): Promise<Sig
   }
   const tokens = (await tokenRes.json()) as { id_token: string }
 
-  const backendRes = await robustFetch(`${backendUrl()}/api/auth/sign-in-with-id-token`, {
+  const backendRes = await fetchOnce(`${backendUrl()}/api/auth/sign-in-with-id-token`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ provider: providerId, id_token: tokens.id_token, nonce }),

--- a/packages/app/src/main/auth/oauth.ts
+++ b/packages/app/src/main/auth/oauth.ts
@@ -9,12 +9,19 @@
 // runs the matching verifier. The session token comes back the same
 // way regardless of which provider issued the id_token.
 
-import { shell } from 'electron'
+import { net, shell } from 'electron'
 import crypto from 'node:crypto'
 
 import { backendUrl } from '../share/backend-url.js'
 
 import { startLoopback } from './loopback-server.js'
+
+// Electron's `net.fetch` honours the OS proxy and trust store; the
+// global `fetch` (undici in main) bypasses both, so behind a system
+// proxy the Google token exchange times out on a direct connection
+// (bug_electron_proxy — same fix as authedFetch in share/api-client.ts).
+const netFetch: typeof globalThis.fetch = (url, init) =>
+  net.fetch(url as string, init as RequestInit)
 
 export type ProviderId = 'google'
 
@@ -123,7 +130,7 @@ export async function signInWith(providerId: ProviderId = 'google'): Promise<Sig
     code_verifier: verifier,
   })
   if (csecret) tokenBody.set('client_secret', csecret)
-  const tokenRes = await fetch(config.tokenUrl, {
+  const tokenRes = await netFetch(config.tokenUrl, {
     method: 'POST',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
     body: tokenBody,
@@ -133,7 +140,7 @@ export async function signInWith(providerId: ProviderId = 'google'): Promise<Sig
   }
   const tokens = (await tokenRes.json()) as { id_token: string }
 
-  const backendRes = await fetch(`${backendUrl()}/api/auth/sign-in-with-id-token`, {
+  const backendRes = await netFetch(`${backendUrl()}/api/auth/sign-in-with-id-token`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ provider: providerId, id_token: tokens.id_token, nonce }),

--- a/packages/app/src/main/auth/oauth.ts
+++ b/packages/app/src/main/auth/oauth.ts
@@ -9,19 +9,13 @@
 // runs the matching verifier. The session token comes back the same
 // way regardless of which provider issued the id_token.
 
-import { net, shell } from 'electron'
+import { shell } from 'electron'
 import crypto from 'node:crypto'
 
+import { robustFetch } from '../net/robust-fetch.js'
 import { backendUrl } from '../share/backend-url.js'
 
 import { startLoopback } from './loopback-server.js'
-
-// Electron's `net.fetch` honours the OS proxy and trust store; the
-// global `fetch` (undici in main) bypasses both, so behind a system
-// proxy the Google token exchange times out on a direct connection
-// (bug_electron_proxy — same fix as authedFetch in share/api-client.ts).
-const netFetch: typeof globalThis.fetch = (url, init) =>
-  net.fetch(url as string, init as RequestInit)
 
 export type ProviderId = 'google'
 
@@ -130,7 +124,12 @@ export async function signInWith(providerId: ProviderId = 'google'): Promise<Sig
     code_verifier: verifier,
   })
   if (csecret) tokenBody.set('client_secret', csecret)
-  const tokenRes = await netFetch(config.tokenUrl, {
+  // Sign-in must work regardless of how (or whether) the user's
+  // traffic is proxied — robustFetch falls back across system-proxy /
+  // env-proxy / direct transports on connect-level failures. The body
+  // is a URLSearchParams (replayable), and HTTP errors never retry, so
+  // the single-use code can't double-spend.
+  const tokenRes = await robustFetch(config.tokenUrl, {
     method: 'POST',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
     body: tokenBody,
@@ -140,7 +139,7 @@ export async function signInWith(providerId: ProviderId = 'google'): Promise<Sig
   }
   const tokens = (await tokenRes.json()) as { id_token: string }
 
-  const backendRes = await netFetch(`${backendUrl()}/api/auth/sign-in-with-id-token`, {
+  const backendRes = await robustFetch(`${backendUrl()}/api/auth/sign-in-with-id-token`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ provider: providerId, id_token: tokens.id_token, nonce }),

--- a/packages/app/src/main/net/robust-fetch.test.ts
+++ b/packages/app/src/main/net/robust-fetch.test.ts
@@ -1,11 +1,26 @@
 import { describe, expect, it, vi } from 'vitest'
 
+const directSessionFetch = vi.fn()
+
 vi.mock('electron', () => ({
   net: { fetch: vi.fn() },
-  session: { fromPartition: vi.fn() },
+  session: {
+    fromPartition: vi.fn(() => ({
+      setProxy: vi.fn(async () => undefined),
+      fetch: (...args: unknown[]) => directSessionFetch(...args),
+    })),
+  },
 }))
 
-import { isNetworkError, proxyRulesFromEnv, robustFetch, type Transport } from './robust-fetch.js'
+import {
+  fetchOnce,
+  isLoopbackUrl,
+  isNetworkError,
+  probeTransport,
+  proxyRulesFromEnv,
+  robustFetch,
+  type Transport,
+} from './robust-fetch.js'
 
 function transport(label: string, impl: () => Promise<Response>): Transport {
   return { label, fetch: vi.fn(impl) as unknown as Transport['fetch'] }
@@ -59,6 +74,78 @@ describe('robustFetch', () => {
     const second = transport('b', async () => { throw last })
     await expect(robustFetch('https://x.test/', {}, [first, second]))
       .rejects.toBe(last)
+  })
+})
+
+describe('fetchOnce', () => {
+  it('probes with a GET, then sends the real request exactly once on the winner', async () => {
+    const calls: { url: string; method?: string }[] = []
+    const dead = transport('dead', async () => { throw netErr() })
+    const alive: Transport = {
+      label: 'alive',
+      fetch: vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({ url: String(url), ...(init?.method !== undefined && { method: init.method }) })
+        return new Response('ok', { status: init?.method === 'POST' ? 200 : 404 })
+      }) as unknown as Transport['fetch'],
+    }
+    const res = await fetchOnce(
+      'https://api.test/token',
+      { method: 'POST', body: 'code=once' },
+      [dead, alive],
+    )
+    expect(res.status).toBe(200)
+    // dead transport saw only the probe; the POST went out once, on alive.
+    expect(dead.fetch).toHaveBeenCalledTimes(1)
+    expect(calls).toEqual([
+      { url: 'https://api.test/', method: 'GET' },
+      { url: 'https://api.test/token', method: 'POST' },
+    ])
+  })
+
+  it('a probe 4xx still selects the transport — status is irrelevant to reachability', async () => {
+    const t = transport('a', async () => new Response('nope', { status: 403 }))
+    const picked = await probeTransport('https://api.test/token', [t])
+    expect(picked).toBe(t)
+  })
+
+  it('does NOT retry the real request on another transport after the probe commits', async () => {
+    let probed = false
+    const flaky: Transport = {
+      label: 'flaky',
+      fetch: vi.fn(async () => {
+        if (!probed) { probed = true; return new Response('probe ok') }
+        throw netErr() // the committed POST dies mid-flight
+      }) as unknown as Transport['fetch'],
+    }
+    const second = transport('never', async () => new Response('never'))
+    await expect(fetchOnce('https://api.test/token', { method: 'POST' }, [flaky, second]))
+      .rejects.toThrow('fetch failed')
+    expect(second.fetch).not.toHaveBeenCalled()
+  })
+
+  it('throws when every probe fails', async () => {
+    const a = transport('a', async () => { throw netErr() })
+    const b = transport('b', async () => { throw netErr() })
+    await expect(fetchOnce('https://api.test/x', {}, [a, b])).rejects.toThrow('fetch failed')
+  })
+})
+
+describe('loopback handling', () => {
+  it.each(['http://localhost:8788/api', 'http://127.0.0.1:3002/', 'http://[::1]:8080/x'])(
+    '%s is loopback',
+    (url) => expect(isLoopbackUrl(url)).toBe(true),
+  )
+
+  it('public hosts are not loopback', () => {
+    expect(isLoopbackUrl('https://spool.pro/api')).toBe(false)
+  })
+
+  it('loopback targets skip the provided chain and go direct', async () => {
+    directSessionFetch.mockResolvedValue(new Response('local ok'))
+    const proxyish = transport('system', async () => new Response('via proxy'))
+    const res = await robustFetch('http://localhost:8788/api/health', {}, [proxyish])
+    expect(await res.text()).toBe('local ok')
+    expect(proxyish.fetch).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/app/src/main/net/robust-fetch.test.ts
+++ b/packages/app/src/main/net/robust-fetch.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  net: { fetch: vi.fn() },
+  session: { fromPartition: vi.fn() },
+}))
+
+import { isNetworkError, proxyRulesFromEnv, robustFetch, type Transport } from './robust-fetch.js'
+
+function transport(label: string, impl: () => Promise<Response>): Transport {
+  return { label, fetch: vi.fn(impl) as unknown as Transport['fetch'] }
+}
+
+const netErr = () => Object.assign(new Error('fetch failed'), {
+  cause: new Error('connect ETIMEDOUT 142.250.0.1:443'),
+})
+
+describe('robustFetch', () => {
+  it('returns the first transport result without touching the rest', async () => {
+    const ok = new Response('hi', { status: 200 })
+    const first = transport('a', async () => ok)
+    const second = transport('b', async () => new Response('no'))
+    const res = await robustFetch('https://x.test/', {}, [first, second])
+    expect(res).toBe(ok)
+    expect(second.fetch).not.toHaveBeenCalled()
+  })
+
+  it('falls through to the next transport on a network-level failure', async () => {
+    const ok = new Response('hi', { status: 200 })
+    const first = transport('a', async () => { throw netErr() })
+    const second = transport('b', async () => ok)
+    const res = await robustFetch('https://x.test/', {}, [first, second])
+    expect(res).toBe(ok)
+  })
+
+  it('does NOT fall through on an HTTP error response — 4xx resolves normally', async () => {
+    // fetch resolves (not rejects) on HTTP errors; a 400 from the OAuth
+    // endpoint must reach the caller, not trigger a code-double-spend
+    // retry on another transport.
+    const bad = new Response('invalid_grant', { status: 400 })
+    const first = transport('a', async () => bad)
+    const second = transport('b', async () => new Response('never'))
+    const res = await robustFetch('https://x.test/', {}, [first, second])
+    expect(res.status).toBe(400)
+    expect(second.fetch).not.toHaveBeenCalled()
+  })
+
+  it('rethrows non-network errors immediately', async () => {
+    const first = transport('a', async () => { throw new TypeError('body used already') })
+    const second = transport('b', async () => new Response('never'))
+    await expect(robustFetch('https://x.test/', {}, [first, second]))
+      .rejects.toThrow('body used already')
+    expect(second.fetch).not.toHaveBeenCalled()
+  })
+
+  it('throws the last network error when every transport fails', async () => {
+    const first = transport('a', async () => { throw netErr() })
+    const last = Object.assign(new Error('fetch failed'), { cause: new Error('net::ERR_CONNECTION_REFUSED') })
+    const second = transport('b', async () => { throw last })
+    await expect(robustFetch('https://x.test/', {}, [first, second]))
+      .rejects.toBe(last)
+  })
+})
+
+describe('proxyRulesFromEnv', () => {
+  it('maps an http proxy URL to host:port rules', () => {
+    expect(proxyRulesFromEnv({ https_proxy: 'http://127.0.0.1:7897' })).toBe('127.0.0.1:7897')
+  })
+
+  it('maps a socks proxy to socks5 rules', () => {
+    expect(proxyRulesFromEnv({ all_proxy: 'socks5://127.0.0.1:7897' })).toBe('socks5://127.0.0.1:7897')
+  })
+
+  it('prefers https_proxy over all_proxy and uppercase variants', () => {
+    expect(proxyRulesFromEnv({
+      ALL_PROXY: 'socks5://1.1.1.1:1080',
+      https_proxy: 'http://2.2.2.2:8080',
+    })).toBe('2.2.2.2:8080')
+  })
+
+  it('returns null when unset or unparseable', () => {
+    expect(proxyRulesFromEnv({})).toBeNull()
+    expect(proxyRulesFromEnv({ https_proxy: 'not a url' })).toBeNull()
+    expect(proxyRulesFromEnv({ https_proxy: 'http://127.0.0.1' })).toBeNull()
+  })
+})
+
+describe('isNetworkError', () => {
+  it.each([
+    ['undici fetch failed with cause', netErr()],
+    ['chromium net error', new Error('net::ERR_PROXY_CONNECTION_FAILED')],
+    ['timeout abort', Object.assign(new Error('The operation was aborted due to timeout'), { name: 'TimeoutError' })],
+  ])('%s → true', (_name, err) => {
+    expect(isNetworkError(err)).toBe(true)
+  })
+
+  it('programming errors → false', () => {
+    expect(isNetworkError(new TypeError('x is not a function'))).toBe(false)
+    expect(isNetworkError('string')).toBe(false)
+  })
+})

--- a/packages/app/src/main/net/robust-fetch.ts
+++ b/packages/app/src/main/net/robust-fetch.ts
@@ -1,0 +1,130 @@
+// Proxy-resilient fetch for main-process calls that must reach the
+// outside internet (OAuth token exchange, prod backend). One transport
+// is never right for every user (bug_electron_proxy):
+//
+//   - undici (globalThis.fetch) ignores proxies entirely
+//   - net.fetch follows the OS proxy, but a stale/broken system-proxy
+//     config takes working direct connectivity down with it, and one
+//     observed loopback-proxy setup (mihomo on 127.0.0.1 as macOS
+//     system proxy) fails through net.fetch while the proxy itself is
+//     healthy
+//   - dev shells often carry https_proxy env vars that neither of the
+//     above consult
+//
+// So: try transports in order, falling through ONLY on network-level
+// failures (connect timeout / refused / net::ERR_*). HTTP responses —
+// including 4xx/5xx — resolve normally and never trigger a retry, so a
+// single-use OAuth code can't be double-spent across transports.
+//
+//   1. net.fetch          — OS proxy when configured, direct otherwise
+//   2. env-proxy session  — https_proxy/all_proxy env, when present
+//   3. direct session     — forced direct, rescues a broken proxy config
+//
+// Every transport goes through Chromium's network stack (net.fetch /
+// ses.fetch), so the OS trust store applies uniformly and no proxy
+// dependency is bundled.
+
+import { net, session } from 'electron'
+
+const ATTEMPT_TIMEOUT_MS = 8_000
+
+/** Map the conventional proxy env vars to Chromium proxyRules syntax.
+ *  Returns null when no usable proxy env is set. Exported for tests. */
+export function proxyRulesFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  const raw =
+    env['https_proxy'] ??
+    env['HTTPS_PROXY'] ??
+    env['http_proxy'] ??
+    env['HTTP_PROXY'] ??
+    env['all_proxy'] ??
+    env['ALL_PROXY']
+  if (!raw) return null
+  try {
+    const u = new URL(raw)
+    if (!u.hostname || !u.port) return null
+    return u.protocol.startsWith('socks')
+      ? `socks5://${u.hostname}:${u.port}`
+      : `${u.hostname}:${u.port}`
+  } catch {
+    return null
+  }
+}
+
+/** Network-level failure (request never completed) vs everything else.
+ *  Only the former is safe grounds to retry on another transport.
+ *  Exported for tests. */
+export function isNetworkError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false
+  if (e.name === 'AbortError' || e.name === 'TimeoutError') return true
+  const text = e.message + (e.cause instanceof Error ? ` ${e.cause.message}` : '')
+  return /fetch failed|net::ERR_|ECONNREFUSED|ECONNRESET|ETIMEDOUT|UND_ERR_/i.test(text)
+}
+
+export interface Transport {
+  label: string
+  fetch: typeof globalThis.fetch
+}
+
+function sessionTransport(partition: string, config: Electron.ProxyConfig): Transport['fetch'] {
+  return async (url, init) => {
+    const ses = session.fromPartition(partition)
+    await ses.setProxy(config)
+    return ses.fetch(url as string, init as RequestInit)
+  }
+}
+
+export function defaultTransports(): Transport[] {
+  const transports: Transport[] = [
+    {
+      label: 'system',
+      fetch: (url, init) => net.fetch(url as string, init as RequestInit),
+    },
+  ]
+  const envRules = proxyRulesFromEnv()
+  if (envRules) {
+    transports.push({
+      label: `env-proxy ${envRules}`,
+      // <local> keeps loopback targets (dev backend) off the proxy.
+      fetch: sessionTransport('spool-net-env-proxy', {
+        proxyRules: envRules,
+        proxyBypassRules: '<local>',
+      }),
+    })
+  }
+  transports.push({
+    label: 'direct',
+    fetch: sessionTransport('spool-net-direct', { mode: 'direct' }),
+  })
+  return transports
+}
+
+/**
+ * Fetch through the transport chain. `init.body` must be replayable
+ * (string / URLSearchParams / FormData — not a stream), since a later
+ * transport re-sends it.
+ */
+export async function robustFetch(
+  url: string,
+  init: RequestInit = {},
+  transports: Transport[] = defaultTransports(),
+): Promise<Response> {
+  let lastError: unknown
+  for (const transport of transports) {
+    try {
+      return await transport.fetch(url, {
+        ...init,
+        signal: init.signal ?? AbortSignal.timeout(ATTEMPT_TIMEOUT_MS),
+      })
+    } catch (e) {
+      if (!isNetworkError(e)) throw e
+      lastError = e
+      console.warn(
+        `[robust-fetch] ${transport.label} transport failed for ${new URL(url).host}:`,
+        e instanceof Error ? e.message : e,
+      )
+    }
+  }
+  throw lastError
+}

--- a/packages/app/src/main/net/robust-fetch.ts
+++ b/packages/app/src/main/net/robust-fetch.ts
@@ -13,8 +13,7 @@
 //
 // So: try transports in order, falling through ONLY on network-level
 // failures (connect timeout / refused / net::ERR_*). HTTP responses —
-// including 4xx/5xx — resolve normally and never trigger a retry, so a
-// single-use OAuth code can't be double-spent across transports.
+// including 4xx/5xx — resolve normally and never trigger a retry.
 //
 //   1. net.fetch          — OS proxy when configured, direct otherwise
 //   2. env-proxy session  — https_proxy/all_proxy env, when present
@@ -23,10 +22,36 @@
 // Every transport goes through Chromium's network stack (net.fetch /
 // ses.fetch), so the OS trust store applies uniformly and no proxy
 // dependency is bundled.
+//
+// Two hard-won rules on top of the chain:
+//
+// - Loopback targets NEVER go through a proxy transport. A local
+//   proxy will happily accept a CONNECT to localhost and then sit on
+//   it — observed live: the dev backend received the sign-in POST
+//   through the system proxy, but the response never came back.
+//
+// - A request whose effect can't be replayed (one-shot OAuth code,
+//   anti-replay nonce) must NOT be blindly re-sent on the next
+//   transport: "delivered but response lost" is indistinguishable
+//   from "never delivered" at the connect level, and the retry burned
+//   a nonce that the server had already consumed (403 nonce replay).
+//   Use fetchOnce() for those: it picks a working transport with a
+//   side-effect-free GET probe first, then sends the real request
+//   exactly once.
 
 import { net, session } from 'electron'
 
-const ATTEMPT_TIMEOUT_MS = 8_000
+const PROBE_TIMEOUT_MS = 6_000
+// The committed request gets a generous window — a slow-but-alive
+// response must not be misread as a dead transport once side effects
+// may already exist on the server.
+const REQUEST_TIMEOUT_MS = 30_000
+
+/** Loopback targets must never touch a proxy — see the header note. */
+export function isLoopbackUrl(url: string): boolean {
+  const host = new URL(url).hostname
+  return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1'
+}
 
 /** Map the conventional proxy env vars to Chromium proxyRules syntax.
  *  Returns null when no usable proxy env is set. Exported for tests. */
@@ -75,6 +100,11 @@ function sessionTransport(partition: string, config: Electron.ProxyConfig): Tran
   }
 }
 
+const directTransport: Transport = {
+  label: 'direct',
+  fetch: sessionTransport('spool-net-direct', { mode: 'direct' }),
+}
+
 export function defaultTransports(): Transport[] {
   const transports: Transport[] = [
     {
@@ -86,24 +116,26 @@ export function defaultTransports(): Transport[] {
   if (envRules) {
     transports.push({
       label: `env-proxy ${envRules}`,
-      // <local> keeps loopback targets (dev backend) off the proxy.
+      // <local> keeps loopback targets off the proxy even here.
       fetch: sessionTransport('spool-net-env-proxy', {
         proxyRules: envRules,
         proxyBypassRules: '<local>',
       }),
     })
   }
-  transports.push({
-    label: 'direct',
-    fetch: sessionTransport('spool-net-direct', { mode: 'direct' }),
-  })
+  transports.push(directTransport)
   return transports
 }
 
+function transportsFor(url: string, transports: Transport[]): Transport[] {
+  return isLoopbackUrl(url) ? [directTransport] : transports
+}
+
 /**
- * Fetch through the transport chain. `init.body` must be replayable
- * (string / URLSearchParams / FormData — not a stream), since a later
- * transport re-sends it.
+ * Fetch through the transport chain, falling through on network-level
+ * failures. ONLY for requests that are safe to replay (idempotent GETs,
+ * retriable POSTs): a transport that delivered the request but lost
+ * the response still falls through, re-sending the body.
  */
 export async function robustFetch(
   url: string,
@@ -111,11 +143,11 @@ export async function robustFetch(
   transports: Transport[] = defaultTransports(),
 ): Promise<Response> {
   let lastError: unknown
-  for (const transport of transports) {
+  for (const transport of transportsFor(url, transports)) {
     try {
       return await transport.fetch(url, {
         ...init,
-        signal: init.signal ?? AbortSignal.timeout(ATTEMPT_TIMEOUT_MS),
+        signal: init.signal ?? AbortSignal.timeout(PROBE_TIMEOUT_MS),
       })
     } catch (e) {
       if (!isNetworkError(e)) throw e
@@ -127,4 +159,55 @@ export async function robustFetch(
     }
   }
   throw lastError
+}
+
+/**
+ * Transport selection for non-replayable requests: GET the target's
+ * origin through the chain and return the first transport that yields
+ * ANY HTTP response (status is irrelevant — a 404 proves the path
+ * works). The probe carries no side effects, so falling through here
+ * is always safe.
+ */
+export async function probeTransport(
+  targetUrl: string,
+  transports: Transport[] = defaultTransports(),
+): Promise<Transport> {
+  const probeUrl = new URL('/', targetUrl).toString()
+  let lastError: unknown
+  for (const transport of transportsFor(targetUrl, transports)) {
+    try {
+      await transport.fetch(probeUrl, {
+        method: 'GET',
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      })
+      return transport
+    } catch (e) {
+      if (!isNetworkError(e)) throw e
+      lastError = e
+      console.warn(
+        `[robust-fetch] probe via ${transport.label} failed for ${new URL(probeUrl).host}:`,
+        e instanceof Error ? e.message : e,
+      )
+    }
+  }
+  throw lastError
+}
+
+/**
+ * Send a request whose effect must not be duplicated (one-shot OAuth
+ * code, anti-replay nonce): pick a transport with a side-effect-free
+ * probe, then send the real request EXACTLY ONCE on it. A failure
+ * after that propagates — never retried, because the server may
+ * already have consumed the side effect.
+ */
+export async function fetchOnce(
+  url: string,
+  init: RequestInit = {},
+  transports: Transport[] = defaultTransports(),
+): Promise<Response> {
+  const transport = await probeTransport(url, transports)
+  return transport.fetch(url, {
+    ...init,
+    signal: init.signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  })
 }

--- a/packages/share-backend/functions/api/auth/sign-in-with-id-token.ts
+++ b/packages/share-backend/functions/api/auth/sign-in-with-id-token.ts
@@ -10,6 +10,7 @@
 
 import type { D1Database, KVNamespace, PagesFunction } from '@cloudflare/workers-types'
 
+import { setDevJwks } from '../../../src/auth/jwks'
 import { createSession } from '../../../src/auth/session'
 import { getProvider } from '../../../src/auth/providers/registry'
 import { audit } from '../../../src/audit'
@@ -24,6 +25,9 @@ type Env = {
   RATE: KVNamespace
   NONCE: KVNamespace
   GOOGLE_CLIENT_ID_DESKTOP: string
+  /** Local dev only — host-prefetched Google JWKS injected by
+   *  share-dev.sh (see setDevJwks). Never set in production. */
+  DEV_JWKS?: string
 }
 
 type Body = { provider: string; id_token: string; nonce: string }
@@ -40,6 +44,7 @@ const NONCE_TTL_SEC = 10 * 60
 
 export const onRequestPost: PagesFunction<Env> = async (ctx) => {
   try {
+    if (ctx.env.DEV_JWKS) setDevJwks(ctx.env.DEV_JWKS)
     const rate = await checkRate(ctx.env.RATE, {
       bucket: 'signin',
       key: clientIp(ctx.request),

--- a/packages/share-backend/src/auth/jwks.ts
+++ b/packages/share-backend/src/auth/jwks.ts
@@ -36,6 +36,19 @@ export function setJwksFetcherForTests(fn: ((force?: boolean) => Promise<Jwk[]>)
   jwksFetcher = fn ?? defaultFetchJwks
 }
 
+// Local-dev escape hatch: workerd's outbound fetch consults no proxy,
+// so on proxy-only dev networks (no TUN) the JWKS fetch above hangs
+// and every sign-in times out. share-dev.sh pre-fetches the certs on
+// the host (curl follows the shell proxy) and injects them via the
+// DEV_JWKS binding; when set, verification never leaves the machine.
+// Prod deployments don't define the binding, so this path is inert
+// there. Keys rotate on Google's schedule — a dev session running past
+// a rotation gets a clean 401, and restarting share-dev.sh refreshes.
+export function setDevJwks(json: string): void {
+  const { keys } = JSON.parse(json) as { keys: Jwk[] }
+  jwksFetcher = async () => keys
+}
+
 export async function fetchJwks(force = false): Promise<Jwk[]> {
   return jwksFetcher(force)
 }

--- a/packages/share-backend/src/auth/providers/google.ts
+++ b/packages/share-backend/src/auth/providers/google.ts
@@ -1,5 +1,5 @@
 import { ApiError } from '../../errors'
-import { verifyIdToken } from '../jwks'
+import { setDevJwks, verifyIdToken } from '../jwks'
 import type {
   BuildAuthRequestParams,
   ExchangeCodeParams,
@@ -49,7 +49,9 @@ export const googleProvider: OAuthProvider = {
   },
 
   async exchangeCode(params: ExchangeCodeParams, env: ProviderEnv): Promise<IdentityClaim> {
-    const tokenRes = await fetch(TOKEN_URL, {
+    // Local-dev reroutes — see ProviderEnv. No-ops in prod.
+    if (env.DEV_JWKS) setDevJwks(env.DEV_JWKS)
+    const tokenRes = await fetch(env.DEV_GOOGLE_TOKEN_URL ?? TOKEN_URL, {
       method: 'POST',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({

--- a/packages/share-backend/src/auth/providers/types.ts
+++ b/packages/share-backend/src/auth/providers/types.ts
@@ -43,6 +43,13 @@ export interface ProviderEnv {
   GOOGLE_CLIENT_SECRET_WEB?: string
   // Native / desktop (Electron loopback) audience
   GOOGLE_CLIENT_ID_DESKTOP?: string
+  // Local-dev bindings injected by share-dev.sh; never set in prod.
+  // workerd's outbound fetch consults no proxy (workers-sdk#4515), so
+  // on proxy-only dev networks the JWKS fetch and the token exchange
+  // are rerouted: keys are host-prefetched, the exchange goes through
+  // the share-web vite dev middleware (/__dev/google-token).
+  DEV_JWKS?: string
+  DEV_GOOGLE_TOKEN_URL?: string
 }
 
 export interface OAuthProvider {

--- a/packages/share-backend/tests/auth.test.ts
+++ b/packages/share-backend/tests/auth.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, it } from 'vitest'
 import {
   type Jwk,
   _resetJwksCacheForTests,
+  setDevJwks,
   setJwksFetcherForTests,
   verifyIdToken,
   verifyIdTokenWithKeys,
@@ -187,6 +188,43 @@ describe('PKCE helpers', () => {
     const a = randomUrlSafe(16)
     const b = randomUrlSafe(16)
     expect(a).not.toBe(b)
+  })
+})
+
+describe('setDevJwks — host-injected keys for local dev', () => {
+  it('verifies with the injected keys and never invokes a network fetcher', async () => {
+    const devKp = await generateKeypair('kid-dev')
+    let networkCalls = 0
+    setJwksFetcherForTests(async () => {
+      networkCalls++
+      return []
+    })
+    // setDevJwks replaces the fetcher wholesale — same slot share-dev.sh
+    // reaches through the DEV_JWKS binding.
+    setDevJwks(JSON.stringify({ keys: [devKp.publicJwk] }))
+    _resetJwksCacheForTests()
+
+    const tok = await mintTestJwt(devKp, {
+      iss: ISS,
+      aud: AUD,
+      sub: 'g-dev',
+      email: 'd@example.com',
+      email_verified: true,
+      name: 'D',
+      exp: future(600),
+      iat: past(0),
+    })
+    const claims = await verifyIdToken(tok, { audience: AUD })
+    expect(claims.sub).toBe('g-dev')
+    expect(networkCalls).toBe(0)
+
+    setJwksFetcherForTests(null)
+    _resetJwksCacheForTests()
+  })
+
+  it('throws on malformed injected JSON instead of silently falling back', () => {
+    expect(() => setDevJwks('not json')).toThrow()
+    setJwksFetcherForTests(null)
   })
 })
 

--- a/packages/share-web/package.json
+++ b/packages/share-web/package.json
@@ -18,11 +18,11 @@
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource/geist-mono": "^5.2.7",
     "@spool/share-kit": "workspace:*",
+    "lucide-react": "^0.460.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1",
-    "lucide-react": "^0.460.0"
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.19.17",
@@ -30,6 +30,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.7.0",
     "typescript": "^5.7.3",
+    "undici": "^6.25.0",
     "vite": "^6.3.3",
     "vitest": "^3.2.4",
     "wrangler": "^4.0.0"

--- a/packages/share-web/vite.config.ts
+++ b/packages/share-web/vite.config.ts
@@ -1,5 +1,54 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
+
+// Dev-only relay for the backend's Google token exchange. workerd
+// (wrangler pages dev) makes its outbound fetches with no proxy
+// support (cloudflare/workers-sdk#4515), so on proxy-only dev networks
+// the web sign-in callback hangs on the POST to oauth2.googleapis.com.
+// share-dev.sh points the backend at this middleware via the
+// DEV_GOOGLE_TOKEN_URL binding; Node's undici honours the proxy env
+// (EnvHttpProxyAgent), so the exchange rides the same proxy the rest
+// of the shell uses. Never part of the production build — vite dev
+// middleware only exists under `vite serve`.
+function devGoogleTokenRelay(): Plugin {
+  return {
+    name: 'dev-google-token-relay',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use('/__dev/google-token', (req, res) => {
+        if (req.method !== 'POST') {
+          res.statusCode = 405
+          res.end()
+          return
+        }
+        const chunks: Buffer[] = []
+        req.on('data', (c: Buffer) => chunks.push(c))
+        req.on('end', () => {
+          void (async () => {
+            try {
+              const { EnvHttpProxyAgent } = await import('undici')
+              const upstream = await fetch('https://oauth2.googleapis.com/token', {
+                method: 'POST',
+                headers: {
+                  'content-type': req.headers['content-type'] ?? 'application/x-www-form-urlencoded',
+                },
+                body: Buffer.concat(chunks),
+                // Non-standard undici option: route via http(s)_proxy env.
+                dispatcher: new EnvHttpProxyAgent(),
+              } as RequestInit)
+              res.statusCode = upstream.status
+              res.setHeader('content-type', upstream.headers.get('content-type') ?? 'application/json')
+              res.end(Buffer.from(await upstream.arrayBuffer()))
+            } catch (e) {
+              res.statusCode = 502
+              res.end(JSON.stringify({ error: 'dev token relay failed', detail: String(e) }))
+            }
+          })()
+        })
+      })
+    },
+  }
+}
 
 // SPA build for spool.pro's reader / tombstone pages.
 // All API calls go to /api/* on the same origin (Cloudflare Pages
@@ -11,7 +60,7 @@ import react from '@vitejs/plugin-react'
 // Worker dispatcher routes both surfaces under the same origin, so the
 // relative `/api/...` fetches just work.
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), devGoogleTokenRelay()],
   build: {
     outDir: 'dist',
     target: 'es2022',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,13 +136,6 @@ importers:
       zustand:
         specifier: ^5.0.3
         version: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
-    optionalDependencies:
-      acp-extension-codex-darwin-arm64:
-        specifier: ^0.10.0
-        version: 0.10.0
-      acp-extension-codex-linux-x64:
-        specifier: ^0.10.0
-        version: 0.10.0
     devDependencies:
       '@electron/rebuild':
         specifier: ^3.7.1
@@ -176,7 +169,7 @@ importers:
         version: 34.5.8
       electron-builder:
         specifier: ^26.0.12
-        version: 26.8.1(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1))
+        version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
       electron-vite:
         specifier: ^3.1.0
         version: 3.1.0(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
@@ -189,6 +182,13 @@ importers:
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+    optionalDependencies:
+      acp-extension-codex-darwin-arm64:
+        specifier: ^0.10.0
+        version: 0.10.0
+      acp-extension-codex-linux-x64:
+        specifier: ^0.10.0
+        version: 0.10.0
 
   packages/cli:
     dependencies:
@@ -284,7 +284,7 @@ importers:
         version: 0.7.2(@types/markdown-it@14.1.2)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))(markdown-it@14.1.1)(void@0.7.2)
       '@void/react':
         specifier: ^0.7.2
-        version: 0.7.2(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(void@0.7.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@void/md@0.7.2)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))(arktype@2.2.0)(kysely@0.28.17)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(valibot@1.4.0(typescript@5.9.3))(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)))(workerd@1.20260507.1)(zod@4.3.6))
+        version: 0.7.2(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(void@0.7.2)
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -420,6 +420,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      undici:
+        specifier: ^6.25.0
+        version: 6.25.0
       vite:
         specifier: ^6.3.3
         version: 6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
@@ -1371,89 +1374,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1585,30 +1604,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-arm64-musl@1.3.0':
     resolution: {integrity: sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
     resolution: {integrity: sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-x64-gnu@1.3.0':
     resolution: {integrity: sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-x64-musl@1.3.0':
     resolution: {integrity: sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
     resolution: {integrity: sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==}
@@ -1771,48 +1795,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.46.0':
     resolution: {integrity: sha512-aAUPBWJ1lGwwnxZUEDLJ94+Iy6MuwJwPxUgO4sCA5mEEyDk7b+cDQ+JpX1VR150Zoyd+D49gsrUzpUK5h587Eg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.46.0':
     resolution: {integrity: sha512-ufBCJukyFX/UDrokP/r6BGDoTInnsDs7bxyzKAgMiZlt2Qu8GPJSJ6Zm6whIiJzKk0naxA8ilwmbO1LMw6Htxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.46.0':
     resolution: {integrity: sha512-eqtlC2YmPqjun76R1gVfGLuKWx7NuEnLEAudZ7n6ipSKbCZTqIKSs1b5Y8K/JHZsRpLkeSmAAjig5HOIg8fQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.46.0':
     resolution: {integrity: sha512-yccVOO2nMXkQLGgy0He3EQEwKD7NF0zEk+/OWmroznkqXyJdN6bfK0LtNnr6/14Bh3FjpYq7bP33l/VloCnxpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.46.0':
     resolution: {integrity: sha512-aAf7fG23OQCey6VRPj9IeCraoYtpgtx0ZyJ1CXkPyT1wjzBE7c3xtuxHe/AdHaJfVVb/SXpSk8Gl1LzyQupSqw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.46.0':
     resolution: {integrity: sha512-q0JPsTMyJNjYrBvYFDz4WbVsafNZaPCZv4RnFypRotLqpKROtBZcEaXQW4eb9YmvLU3NckVemLJnzkSZSdmOxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.46.0':
     resolution: {integrity: sha512-7LsLY9Cw57GPkhSR+duI3mt9baRczK/DtHYSldQ4BEU92da9igBQNl4z7Vq5U9NNPsh1FmpKvv1q9WDtiUQR1A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.46.0':
     resolution: {integrity: sha512-lHiBOz8Duaku7JtRNLlps3j++eOaICPZSd8FCVmTDM4DFOPT71Bjn7g6iar1z7StXlKRweUKxWUs4sA+zWGDXg==}
@@ -1915,48 +1947,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.61.0':
     resolution: {integrity: sha512-bl1dQh8LnVqsj6oOQAcxwbuOmNJkwc4p6o//HTBZhNTzJy21TLDwAviMqUFNUxDHkPGpmdKTSN4tWTjLryP8xg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.61.0':
     resolution: {integrity: sha512-QoOX6KB2IiEpyOj/HKqaxi+NQHPnOgNgnr22n9N4ANJCzXkUlj1UmeAbFb4PpqdlHIzvGDM5xZ0OKtcLq9RhiQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.61.0':
     resolution: {integrity: sha512-1TGcTerjY6p152wCof3oKElccq3xHljS/Mucp04gV/4ATpP6nO7YNnp7opEg6SHkv2a57/b4b8Ndm9znJ1/qAw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.61.0':
     resolution: {integrity: sha512-65wXEmZIrX2ADwC8i/qFL4EWLSbeuBpAm3suuX1vu4IQkKd+wLT/HU/BOl84kp91u2SxPkPDyQgu4yrqp8vwVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.61.0':
     resolution: {integrity: sha512-TVvhgMvor7Qa6COeXxCJ7ENOM+lcAOGsQ0iUdPSCv2hxb9qSHLQ4XF1h50S6RE1gBOJ0WV3rNukg4JJJP1LWRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.61.0':
     resolution: {integrity: sha512-SjpS5uYuFoDnDdZPwZE59ndF95AsY47R5MliuneTWR1pDm2CxGJaYXbKULI71t5TVfLQUWmrHEGRL9xvuq6dnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.61.0':
     resolution: {integrity: sha512-gGfAeGD4sNJGILZbc/yKcIimO9wQnPMoYp9swAaKeEtwsSQAbU+rsdQze5SBtIP6j0QDzeYd4XSSUCRCF+LIeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.61.0':
     resolution: {integrity: sha512-OlVT0LrG/ct33EVtWRyR+B/othwmDWeRxfi13wUdPeb3lAT5TgTcFDcfLfarZtzB4W1nWF/zICMgYdkggX2WmQ==}
@@ -2086,66 +2126,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -2321,24 +2374,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -2728,24 +2785,28 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.20':
     resolution: {integrity: sha512-Oh/pxMdTLR/wsDl/OONjItjLOeTewFBLuKkH5RQmcI9g3AVqKzLj1/uawujgysBI5E25tonRRK7I2q/zu8Uqvg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.20':
     resolution: {integrity: sha512-msO1ZoUX5aSK8L6kN1C3XQO4CcH9aFsNPRSNcO1cjk1kTnaLyVYzkVxgvbh3vk7nzZAAMkmyZ4SlMpqJrdahrg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.20':
     resolution: {integrity: sha512-U93urREvg23ZFDkxKkkfWWIOI4GI9erhbWAZpXG+GeYqygWKrVC6PUTXiuexVg3/CFg2sSMTdm1W6V7TFG5hYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@voidzero-dev/vite-plus-test@0.1.20':
     resolution: {integrity: sha512-vy2dJYw1bhgQ/+BrQrfwPlSKzQ2mm3YLJ9kGF7Yo0UJ2P3XKpshtgFIWLjSg/IASnC93OAx0c/7j3NM0I1RMuA==}
@@ -4340,24 +4401,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -7927,7 +7992,7 @@ snapshots:
       - '@types/markdown-it'
       - markdown-it
 
-  '@void/react@0.7.2(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(void@0.7.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@void/md@0.7.2)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))(arktype@2.2.0)(kysely@0.28.17)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(valibot@1.4.0(typescript@5.9.3))(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)))(workerd@1.20260507.1)(zod@4.3.6))':
+  '@void/react@0.7.2(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(void@0.7.2)':
     dependencies:
       '@vitejs/plugin-react': 6.0.1(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3))
       react: 19.2.5
@@ -8168,7 +8233,7 @@ snapshots:
 
   app-builder-bin@5.0.0-alpha.12: {}
 
-  app-builder-lib@26.8.1(dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1))(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1)):
+  app-builder-lib@26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/asar': 3.4.1
@@ -8657,7 +8722,7 @@ snapshots:
 
   dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1):
     dependencies:
-      app-builder-lib: 26.8.1(dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1))(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1))
+      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
       builder-util: 26.8.1
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
@@ -8740,16 +8805,16 @@ snapshots:
 
   electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1):
     dependencies:
-      app-builder-lib: 26.8.1(dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1))(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1))
+      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
       builder-util: 26.8.1
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
       - dmg-builder
       - supports-color
 
-  electron-builder@26.8.1(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1)):
+  electron-builder@26.8.1(electron-builder-squirrel-windows@26.8.1):
     dependencies:
-      app-builder-lib: 26.8.1(dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1))(electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1))
+      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
       builder-util: 26.8.1
       builder-util-runtime: 9.5.1
       chalk: 4.1.2

--- a/scripts/share-dev.sh
+++ b/scripts/share-dev.sh
@@ -63,8 +63,34 @@ done
 
 trap 'echo; echo "shutting down share-dev"; kill 0' INT TERM EXIT
 
+# Sign-in verifies the Google id_token server-side, which needs the
+# JWKS from www.googleapis.com — but workerd's outbound fetch consults
+# no proxy (cloudflare/workers-sdk#4515, backlog), so on proxy-only
+# networks (no TUN) that fetch hangs and every sign-in times out.
+# Standard emulator move: fetch the (public) signing keys on the host —
+# curl follows the shell's proxy env — and inject them via a binding so
+# the worker never has to leave the machine to verify. Best-effort: if
+# the fetch fails (fully offline), the worker falls back to fetching
+# JWKS itself, which works wherever workerd has direct connectivity.
+DEV_JWKS_ARGS=()
+if jwks_json=$(curl -sf --max-time 10 https://www.googleapis.com/oauth2/v3/certs) && [[ -n "$jwks_json" ]]; then
+  DEV_JWKS_ARGS=(--binding "DEV_JWKS=$jwks_json")
+  echo "→ JWKS           pre-fetched on host ($(printf '%s' "$jwks_json" | wc -c | tr -d ' ') bytes)"
+else
+  echo "→ JWKS           host pre-fetch failed; worker will fetch directly" >&2
+fi
+# Web sign-in's code→token exchange also runs inside workerd. When the
+# shell carries a proxy env, reroute it through the share-web vite dev
+# middleware (Node side, proxy-aware) — see devGoogleTokenRelay in
+# packages/share-web/vite.config.ts. Without a proxy env, workerd's
+# direct connection is assumed to work and the binding stays unset.
+if [[ -n "${https_proxy:-}${HTTPS_PROXY:-}${all_proxy:-}${ALL_PROXY:-}" ]]; then
+  DEV_JWKS_ARGS+=(--binding "DEV_GOOGLE_TOKEN_URL=http://localhost:3002/__dev/google-token")
+  echo "→ token relay    workerd → vite /__dev/google-token (proxy env detected)"
+fi
+
 echo "→ share-backend  http://localhost:8788"
-(cd packages/share-backend && corepack pnpm dev) &
+(cd packages/share-backend && corepack pnpm dev ${DEV_JWKS_ARGS[@]+"${DEV_JWKS_ARGS[@]}"}) &
 
 echo "→ share-web      http://localhost:3002"
 (cd packages/share-web && corepack pnpm dev) &


### PR DESCRIPTION
## What

Sign-in failed for users behind a proxy — `share-auth:signin: TypeError: fetch failed`, later plain 30s timeouts. Field-testing on a proxy-only network (no TUN) peeled three distinct layers, each real:

1. **Desktop transport** — `signInWith()` used undici, which consults no proxy; the direct connection to `oauth2.googleapis.com` times out.
2. **Blind transport retry double-spent one-shot values** — the sign-in POST reached the backend through the system proxy (consuming the anti-replay nonce), the proxy swallowed the response, and the fallback transport re-sent the same id_token → `403 nonce replay`. Bonus finding from the same incident: a local proxy accepts CONNECTs to localhost and hangs them.
3. **The local backend itself must reach Google** — JWKS for id_token verification (both flows) and the code→token exchange (web flow) run inside workerd, whose outbound fetch consults no proxy ([workers-sdk#4515](https://github.com/cloudflare/workers-sdk/issues/4515), backlog). Production is unaffected — the deployed backend runs on Cloudflare's network.

## How

**`main/net/robust-fetch.ts`** — transport chain through Chromium's stack (no new dependency): `net.fetch` (OS proxy) → env-proxy session → forced-direct session. Loopback targets always bypass proxies. Replayable requests (`robustFetch`) fall through on connect-level failures only; one-shot requests (`fetchOnce`) pick a transport with a side-effect-free GET probe, then send the real request **exactly once** — never retried across transports. Both OAuth calls use `fetchOnce`.

**Local-dev backend reroutes** (standard emulator move — inject what the sandbox can't reach; active only via share-dev.sh bindings, prod never sets them):
- `DEV_JWKS` — share-dev.sh pre-fetches the public signing keys on the host (curl follows the shell proxy); `setDevJwks()` verifies with zero worker egress
- `DEV_GOOGLE_TOKEN_URL` — the web flow's token exchange relays through a dev-only vite middleware on share-web (`/__dev/google-token`, Node undici `EnvHttpProxyAgent`), added only when a proxy env is present

## Coverage matrix (validated live)

| Scenario | Desktop | Web (local dev) |
|---|---|---|
| Direct connectivity, no proxy | net.fetch direct | unchanged (no bindings) |
| System/env proxy, no TUN | probe picks proxy transport; backend calls stay direct-loopback | JWKS injected + token relay |
| TUN mode | any transport | any path |

## Test plan

- `robust-fetch.test.ts` (17): transport fall-through, 4xx no-retry, probe-then-commit single-send, commit failure not retried, loopback forced direct, env parsing, error classification
- `oauth.test.ts` 4/4 (electron mock provides `net.fetch`; `session.fromPartition` stub throws if a fallback engages unexpectedly)
- share-backend 247/247 incl. new `setDevJwks` cases (verifies with injected keys + zero network fetcher calls; malformed JSON throws)
- Full suites green in final state: app 476, share-web 84, `share-publish.spec.ts` e2e 15/15
- Live validation on a proxy-only network (TUN off): desktop sign-in ✅, web sign-in ✅; fake-code probes returned Google 400 / backend 403 in <1s at every layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)