### PR TITLE
fix(share): pre-launch hardening — PDF sandbox, publish size gate, reader performance

### DIFF
--- a/packages/app/e2e/share-export-pdf.spec.ts
+++ b/packages/app/e2e/share-export-pdf.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, waitForSync, type AppContext } from './helpers/launch'
+import {
+  installSaveFilePickerMock,
+  openShareEditorFromSessionDetail,
+  waitForSavedFile,
+} from './helpers/share'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+// End-to-end regression for the PDF export pipeline: the renderer
+// serializes the preview DOM, main renders it in a hidden SANDBOXED
+// BrowserWindow (spool:print-to-pdf) and returns printToPDF bytes,
+// the renderer shows the preview modal, and "Save PDF" writes the
+// bytes through the save picker. Asserting on the saved bytes proves
+// the sandboxed print window actually produced a valid PDF — guarding
+// the sandbox:false → sandbox:true hardening against silent breakage.
+
+let ctx: AppContext
+
+const SESSION_UUID = 'test-session-uuid-001'
+const ARTIFACT_PATH = join(__dirname, '..', 'e2e-output', 'share-export-pdf.png')
+
+test.beforeAll(async () => {
+  ctx = await launchApp()
+})
+
+test.afterAll(async () => {
+  await ctx?.cleanup()
+})
+
+test('PDF export produces a valid PDF through the sandboxed print window', async () => {
+  test.setTimeout(120_000)
+  const { window } = ctx
+  await waitForSync(window)
+  await openShareEditorFromSessionDetail(window, SESSION_UUID)
+  await installSaveFilePickerMock(window)
+
+  await window.locator('[data-testid="share-menu-trigger"]').click()
+  await window.locator('[data-testid="share-menu-popover"]').waitFor({ state: 'visible' })
+  const exportTab = window.locator('[data-testid="share-menu-tab-export"]')
+  if (await exportTab.count()) await exportTab.click()
+  await window.locator('[data-testid="share-menu-export-pdf"]').click()
+  await window.locator('[data-testid="share-menu-download"]').click()
+
+  // The preview modal only appears after main's print window has
+  // loaded the renderer URL, executed the injected artifact swap, and
+  // returned printToPDF bytes — so its visibility already proves the
+  // sandboxed pipeline completed.
+  const saveButton = window.locator('[data-testid="pdf-preview-save"]')
+  await expect(saveButton).toBeVisible({ timeout: 60_000 })
+
+  mkdirSync(dirname(ARTIFACT_PATH), { recursive: true })
+  await window.screenshot({ path: ARTIFACT_PATH })
+
+  await saveButton.click()
+  const saved = await waitForSavedFile(window, '.pdf')
+
+  expect(saved.filename).toMatch(/\.pdf$/)
+  assertValidPdf(saved.bytes)
+  writeFileSync(join(dirname(ARTIFACT_PATH), 'share-export-pdf.pdf'), saved.bytes)
+
+  // Second export in the same session: the print window is created and
+  // destroyed per export, so a repeat run guards the teardown path
+  // (a leaked/broken hidden window would hang or corrupt this pass).
+  await window.locator('[data-testid="share-menu-trigger"]').click()
+  await window.locator('[data-testid="share-menu-popover"]').waitFor({ state: 'visible' })
+  if (await exportTab.count()) await exportTab.click()
+  await window.locator('[data-testid="share-menu-export-pdf"]').click()
+  await window.locator('[data-testid="share-menu-download"]').click()
+  await expect(saveButton).toBeVisible({ timeout: 60_000 })
+  await saveButton.click()
+  const savedAgain = await waitForSavedFile(window, '.pdf')
+  assertValidPdf(savedAgain.bytes)
+})
+
+function assertValidPdf(bytes: Uint8Array): void {
+  // %PDF-x.y header — the definitive "these bytes are a PDF" check.
+  const head = new TextDecoder().decode(bytes.slice(0, 8))
+  expect(head).toMatch(/^%PDF-\d\.\d/)
+  // EOF marker near the tail, and a size that implies real page content.
+  const tail = new TextDecoder().decode(bytes.slice(-32))
+  expect(tail).toContain('%%EOF')
+  expect(bytes.byteLength).toBeGreaterThan(1000)
+}

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -1131,7 +1131,18 @@ ipcMain.handle(
       width: A4_PAGE_WIDTH_PX,
       height: 1123,
       useContentSize: true,
-      webPreferences: { sandbox: false, offscreen: true },
+      // Keep the OS sandbox on: the injected artifact HTML is
+      // renderer-supplied and can carry hostile inline handlers /
+      // embeds. printToPDF, executeJavaScript and document.fonts all
+      // work sandboxed, and this window needs no Node/preload.
+      webPreferences: { sandbox: true, offscreen: true },
+    })
+    // The window only ever renders the caller's artifact for one
+    // printToPDF pass — deny any popup or navigation so a malicious
+    // href/embed in that HTML can't drive it off the loaded page.
+    printWin.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
+    printWin.webContents.on('will-navigate', (event, url) => {
+      if (url !== callerUrl) event.preventDefault()
     })
     try {
       await printWin.loadURL(callerUrl)

--- a/packages/app/src/main/ipc/share-publish.test.ts
+++ b/packages/app/src/main/ipc/share-publish.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  MAX_PUBLISH_BODY_BYTES,
+  type PublishRequestBody,
+} from '../../shared/share-publish.js'
+
+type Handler = (e: unknown, ...args: unknown[]) => unknown
+
+const { handlers, authedFetch } = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  authedFetch: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (ch: string, fn: Handler) => handlers.set(ch, fn) },
+}))
+vi.mock('../share/api-client.js', () => ({ authedFetch }))
+vi.mock('../auth/session-store.js', () => ({ clearToken: vi.fn() }))
+vi.mock('@spool-lab/core', () => ({
+  getDB: () => ({}),
+  getByDraftId: vi.fn(),
+  listAll: vi.fn(() => []),
+  markRevoked: vi.fn(),
+  replaceAll: vi.fn(),
+  upsertMany: vi.fn(),
+}))
+
+import { registerSharePublishIpc } from './share-publish.js'
+
+function makeBody(content: string): PublishRequestBody {
+  return {
+    snapshot: {
+      schema_version: 1,
+      source: { kind: 'spool-session', captured_at: '2026-07-01T00:00:00.000Z' },
+      conversation: {
+        title: 'T',
+        turns: [{ id: 't0', role: 'assistant', content }],
+        turn_order: ['t0'],
+        hidden_turns: [],
+      },
+      editor_opts: {
+        template: 'chat',
+        paper: 'ivory',
+        typeface: 'sans',
+        colorway: 'amber',
+        density: 'compact',
+        masthead: false,
+        colophon: false,
+        avatars: true,
+        show_byline: false,
+      },
+    },
+    visibility: 'unlisted',
+    draft_id: 'd1',
+    idempotency_key: 'k1',
+  }
+}
+
+function publish(body: PublishRequestBody) {
+  const handler = handlers.get('share-publish:publish')
+  if (!handler) throw new Error('publish handler not registered')
+  return handler(null, body)
+}
+
+describe('share-publish:publish size gate', () => {
+  beforeEach(() => {
+    handlers.clear()
+    authedFetch.mockReset()
+    registerSharePublishIpc()
+  })
+
+  it('rejects an oversized payload with 413 and never hits the network', async () => {
+    const body = makeBody('x'.repeat(MAX_PUBLISH_BODY_BYTES))
+    // Sanity: the serialized body must actually exceed the cap.
+    expect(JSON.stringify(body).length).toBeGreaterThan(MAX_PUBLISH_BODY_BYTES)
+
+    const res = await publish(body)
+
+    expect(res).toEqual({
+      ok: false,
+      status: 413,
+      error: { error: 'PAYLOAD_TOO_LARGE' },
+    })
+    expect(authedFetch).not.toHaveBeenCalled()
+  })
+
+  it('measures UTF-8 bytes, not string length — CJK payloads are capped by wire size', async () => {
+    // 800k CJK chars ≈ 800k UTF-16 code units but ~2.4MB of UTF-8 —
+    // under the cap by string length, over it by actual bytes.
+    const body = makeBody('汉'.repeat(800_000))
+    const payload = JSON.stringify(body)
+    expect(payload.length).toBeLessThan(MAX_PUBLISH_BODY_BYTES)
+    expect(Buffer.byteLength(payload, 'utf8')).toBeGreaterThan(MAX_PUBLISH_BODY_BYTES)
+
+    const res = await publish(body)
+
+    expect(res).toMatchObject({ ok: false, status: 413 })
+    expect(authedFetch).not.toHaveBeenCalled()
+  })
+
+  it('mirrors the backend cap exactly (guards against silent drift)', () => {
+    // The backend constant is not importable from here (Cloudflare
+    // function module), so read its source — if the server cap moves,
+    // this fails and forces the shared constant to move with it.
+    const src = readFileSync(
+      join(__dirname, '../../../../share-backend/functions/api/publish.ts'),
+      'utf8',
+    )
+    const m = src.match(/MAX_SNAPSHOT_BYTES\s*=\s*([0-9*\s]+)/)
+    expect(m).not.toBeNull()
+    const backendCap = m![1]
+      .split('*')
+      .map((n) => Number(n.trim()))
+      .reduce((a, b) => a * b, 1)
+    expect(MAX_PUBLISH_BODY_BYTES).toBe(backendCap)
+  })
+
+  it('uploads a normally-sized payload with the serialized body', async () => {
+    const body = makeBody('hello world')
+    authedFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 's1', url: 'https://spool.pro/s/s1', version: 1 }),
+    })
+
+    const res = (await publish(body)) as { ok: boolean }
+
+    expect(authedFetch).toHaveBeenCalledWith('/api/publish', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+    expect(res.ok).toBe(true)
+  })
+})

--- a/packages/app/src/main/ipc/share-publish.ts
+++ b/packages/app/src/main/ipc/share-publish.ts
@@ -10,16 +10,17 @@ import {
 } from '@spool-lab/core'
 import { authedFetch } from '../share/api-client.js'
 import { clearToken } from '../auth/session-store.js'
-import type {
-  PublishRequestBody,
-  PublishResult,
-  PublishErrorBody,
-  MySharesResponse,
-  HandleCheckResponse,
-  HandleClaimResponse,
-  ScheduleDeleteResponse,
-  SetVisibilityResult,
-  Visibility,
+import {
+  MAX_PUBLISH_BODY_BYTES,
+  type PublishRequestBody,
+  type PublishResult,
+  type PublishErrorBody,
+  type MySharesResponse,
+  type HandleCheckResponse,
+  type HandleClaimResponse,
+  type ScheduleDeleteResponse,
+  type SetVisibilityResult,
+  type Visibility,
 } from '../../shared/share-publish.js'
 
 async function readBody(res: Response): Promise<Record<string, unknown>> {
@@ -32,9 +33,18 @@ async function readBody(res: Response): Promise<Record<string, unknown>> {
 
 export function registerSharePublishIpc(): void {
   ipcMain.handle('share-publish:publish', async (_e, body: PublishRequestBody): Promise<PublishResult> => {
+    const payload = JSON.stringify(body)
+    // Fail fast on oversized payloads rather than buffering the whole
+    // body up to the server just to get a 422 back. The renderer maps
+    // this 413 to a localized "too large" message. Measured in UTF-8
+    // bytes (what actually transits and what the server caps), not
+    // string length — those differ by up to 3x for CJK content.
+    if (Buffer.byteLength(payload, 'utf8') > MAX_PUBLISH_BODY_BYTES) {
+      return { ok: false, status: 413, error: { error: 'PAYLOAD_TOO_LARGE' } }
+    }
     const r = await authedFetch('/api/publish', {
       method: 'POST',
-      body: JSON.stringify(body),
+      body: payload,
     })
     const json = await readBody(r)
     if (!r.ok) {

--- a/packages/app/src/renderer/components/ShareEditorPage.tsx
+++ b/packages/app/src/renderer/components/ShareEditorPage.tsx
@@ -772,6 +772,7 @@ export default function ShareEditorPage({
                 </button>
                 <button
                   type="button"
+                  data-testid="pdf-preview-save"
                   onClick={() => { void savePdfFromPreview() }}
                   className="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md text-[12px] font-medium text-white bg-accent dark:bg-accent-dark hover:opacity-90 transition-opacity"
                 >

--- a/packages/app/src/renderer/components/share-editor/preview-progressive.ts
+++ b/packages/app/src/renderer/components/share-editor/preview-progressive.ts
@@ -1,9 +1,13 @@
-// Progressive-mount chunking for the share-editor preview. Pure logic
-// + a small stateful hook, split out of PreviewPane so the math is
-// unit-testable without dragging the template/markdown render chain
-// (which needs a DOM) into the node test environment.
+// Progressive-mount chunking for the share-editor preview. The fill
+// state machine itself lives in @spool/share-kit (useProgressiveTurns)
+// and is shared with the public reader — one implementation, so fixes
+// to the scheduling/clamp semantics can't drift between surfaces. This
+// module only pins the editor-tuned constants.
 
-import { useEffect, useState } from 'react'
+import {
+  useProgressiveTurns,
+  nextReaderCount,
+} from '@spool/share-kit/progressive'
 
 /** First progressive chunk. Must stay comfortably above the e2e
  *  fixtures' turn counts so small documents render whole on the first
@@ -20,7 +24,7 @@ export function nextProgressiveCount(
   total: number,
   step: number = PREVIEW_TURNS_PER_FRAME,
 ): number {
-  return Math.min(current + step, total)
+  return nextReaderCount(current, total, step)
 }
 
 /**
@@ -36,19 +40,5 @@ export function useProgressiveCount(
   initial: number = PREVIEW_INITIAL_TURNS,
   step: number = PREVIEW_TURNS_PER_FRAME,
 ): number {
-  const [count, setCount] = useState(() => Math.min(initial, total))
-  useEffect(() => {
-    // Clamp when the document shrinks (e.g. fewer turns after a draft
-    // reload); never reset an already-filled view back to the first
-    // chunk on unrelated conversation identity churn.
-    setCount((c) => Math.min(c, total))
-  }, [total])
-  useEffect(() => {
-    if (count >= total) return
-    const raf = requestAnimationFrame(() => {
-      setCount((c) => nextProgressiveCount(c, total, step))
-    })
-    return () => cancelAnimationFrame(raf)
-  }, [count, total, step])
-  return Math.min(count, total)
+  return useProgressiveTurns(total, initial, step)
 }

--- a/packages/app/src/renderer/components/share-editor/publish-logic.test.ts
+++ b/packages/app/src/renderer/components/share-editor/publish-logic.test.ts
@@ -4,8 +4,10 @@ import type { Conversation, EditorOpts } from '@spool/share-kit'
 
 import {
   computeUnredactedMatches,
+  publishErrorKey,
   truncatePreview,
 } from './publish-logic.js'
+import enLocale from '../../i18n/locales/en.json'
 
 const API_KEY = 'sk_live_abcdef1234567890ABCDEF'
 
@@ -172,5 +174,28 @@ describe('computeUnredactedMatches — hidden turns', () => {
     )
     expect(r.high).toEqual([])
     expect(r.medium).toEqual([])
+  })
+})
+
+describe('publishErrorKey', () => {
+  it('maps the statuses with dedicated copy to i18n keys that exist', () => {
+    const en = enLocale as Record<string, unknown>
+    const resolve = (key: string): unknown =>
+      key.split('.').reduce<unknown>((node, part) => {
+        return node && typeof node === 'object' ? (node as Record<string, unknown>)[part] : undefined
+      }, en)
+    for (const status of [401, 413, 429]) {
+      const key = publishErrorKey(status)
+      expect(key, `status ${status}`).toBeTruthy()
+      // Guard against typo'd keys rendering raw like
+      // "shareEditor.publishTab.error_tooLarge" in the error banner.
+      expect(typeof resolve(key!), `key ${key} missing from en.json`).toBe('string')
+    }
+  })
+
+  it('returns null for statuses without dedicated copy (backend detail surfaces)', () => {
+    expect(publishErrorKey(422)).toBeNull()
+    expect(publishErrorKey(500)).toBeNull()
+    expect(publishErrorKey(0)).toBeNull()
   })
 })

--- a/packages/app/src/renderer/components/share-editor/publish-logic.ts
+++ b/packages/app/src/renderer/components/share-editor/publish-logic.ts
@@ -119,3 +119,20 @@ export function computeUnredactedMatches(
   })
   return { high, medium }
 }
+
+/** Map a failed publish IPC result to the i18n key of the message the
+ *  error banner shows. Returns null when the backend's own detail
+ *  string should surface instead (generic server-side failures, where
+ *  the detail is more specific than any canned copy we have). */
+export function publishErrorKey(status: number): string | null {
+  switch (status) {
+    case 401:
+      return 'shareEditor.publishTab.error_sessionExpired'
+    case 413:
+      return 'shareEditor.publishTab.error_tooLarge'
+    case 429:
+      return 'shareEditor.publishTab.error_rateLimited'
+    default:
+      return null
+  }
+}

--- a/packages/app/src/renderer/components/share-editor/share-tabs/PublishTab.tsx
+++ b/packages/app/src/renderer/components/share-editor/share-tabs/PublishTab.tsx
@@ -15,7 +15,7 @@ import {
   Send,
 } from 'lucide-react'
 import type { Conversation, EditorOpts } from '@spool/share-kit'
-import { computeUnredactedMatches } from '../publish-logic.js'
+import { computeUnredactedMatches, publishErrorKey } from '../publish-logic.js'
 import { buildSnapshotFromEditor } from '../snapshot-adapter.js'
 import { ConnectCard } from '../ConnectCard.js'
 import { useShareAuth } from '../../../hooks/useShareAuth.js'
@@ -148,10 +148,9 @@ export function PublishTab({
         ...(published?.id !== undefined && { override_slug: published.id }),
       })
       if (!res.ok) {
-        if (res.status === 401) {
-          setError(t('shareEditor.publishTab.error_sessionExpired'))
-        } else if (res.status === 429) {
-          setError(t('shareEditor.publishTab.error_rateLimited'))
+        const key = publishErrorKey(res.status)
+        if (key) {
+          setError(t(key))
         } else {
           setError(res.error.detail ?? res.error.error ?? t('shareEditor.publishTab.error_generic'))
         }

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -623,6 +623,7 @@
       "error_sessionExpired": "Ihre Sitzung ist abgelaufen — bitte erneut anmelden, um zu veröffentlichen.",
       "error_rateLimited": "Zu viele Veröffentlichungen. Bitte in wenigen Minuten erneut versuchen.",
       "error_generic": "Veröffentlichen fehlgeschlagen. Prüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+      "error_tooLarge": "Diese Freigabe ist zu groß zum Veröffentlichen. Wählen Sie einige Turns ab und versuchen Sie es erneut.",
       "pii_high_warning_one": "{{count}} anmeldedatenartiger Wert würde unmaskiert veröffentlicht",
       "pii_high_warning_other": "{{count}} anmeldedatenartige Werte würden unmaskiert veröffentlicht",
       "pii_more_one": "+{{count}} weitere",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -623,6 +623,7 @@
       "error_sessionExpired": "Your session expired — sign in again to publish.",
       "error_rateLimited": "Too many publishes. Try again in a few minutes.",
       "error_generic": "Publish failed. Check your connection and try again.",
+      "error_tooLarge": "This share is too large to publish. Deselect some turns and try again.",
       "pii_high_warning_one": "{{count}} credential-like value would publish unredacted",
       "pii_high_warning_other": "{{count}} credential-like values would publish unredacted",
       "pii_more_one": "+{{count}} more",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -623,6 +623,7 @@
       "error_sessionExpired": "Votre session a expiré — reconnectez-vous pour publier.",
       "error_rateLimited": "Trop de publications. Réessayez dans quelques minutes.",
       "error_generic": "Échec de la publication. Vérifiez votre connexion et réessayez.",
+      "error_tooLarge": "Ce partage est trop volumineux pour être publié. Désélectionnez quelques tours et réessayez.",
       "pii_high_warning_one": "{{count}} valeur de type identifiant serait publiée sans masque",
       "pii_high_warning_other": "{{count}} valeurs de type identifiant seraient publiées sans masque",
       "pii_more_one": "+{{count}} de plus",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -593,6 +593,7 @@
       "error_sessionExpired": "セッションの有効期限が切れました — 公開するには再度サインインしてください。",
       "error_rateLimited": "公開回数が多すぎます。数分後に再試行してください。",
       "error_generic": "公開に失敗しました。接続を確認して再試行してください。",
+      "error_tooLarge": "この共有は大きすぎて公開できません。一部のターンの選択を解除して、もう一度お試しください。",
       "pii_high_warning_other": "{{count}} 件の認証情報のような値がマスクされずに公開されます",
       "pii_more_other": "+{{count}} 件",
       "pii_redactAll": "すべてマスク",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -593,6 +593,7 @@
       "error_sessionExpired": "세션이 만료되었습니다 — 게시하려면 다시 로그인하세요.",
       "error_rateLimited": "게시 횟수가 너무 많습니다. 몇 분 후 다시 시도하세요.",
       "error_generic": "게시에 실패했습니다. 연결을 확인하고 다시 시도하세요.",
+      "error_tooLarge": "이 공유는 너무 커서 게시할 수 없습니다. 일부 턴 선택을 해제하고 다시 시도하세요.",
       "pii_high_warning_other": "{{count}}개의 자격 증명 형식 값이 가리지 않고 게시됩니다",
       "pii_more_other": "+{{count}}개 더",
       "pii_redactAll": "모두 가리기",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -593,6 +593,7 @@
       "error_sessionExpired": "登录已过期——请重新登录后再发布。",
       "error_rateLimited": "发布次数过多，请几分钟后重试。",
       "error_generic": "发布失败，请检查网络后重试。",
+      "error_tooLarge": "此分享内容过大，无法发布。请取消选择部分对话后重试。",
       "pii_high_warning_other": "{{count}} 个疑似凭证的值将以未脱敏方式发布",
       "pii_more_other": "另有 {{count}} 个",
       "pii_redactAll": "全部脱敏",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -593,6 +593,7 @@
       "error_sessionExpired": "登入已過期——請重新登入後再發布。",
       "error_rateLimited": "發布次數過多，請幾分鐘後重試。",
       "error_generic": "發布失敗，請檢查網路後重試。",
+      "error_tooLarge": "此分享內容過大，無法發布。請取消選取部分對話後再試一次。",
       "pii_high_warning_other": "{{count}} 個疑似憑證的值將以未脫敏方式發布",
       "pii_more_other": "另有 {{count}} 個",
       "pii_redactAll": "全部脫敏",

--- a/packages/app/src/shared/share-publish.ts
+++ b/packages/app/src/shared/share-publish.ts
@@ -70,6 +70,17 @@ export interface PublishRequestBody {
   override_slug?: string
 }
 
+/** Hard cap on the serialized publish request body, in UTF-8 bytes.
+ *  Mirrors the backend's `MAX_SNAPSHOT_BYTES`
+ *  (packages/share-backend/functions/api/publish.ts) — a test in
+ *  share-publish.test.ts asserts the two stay equal. The main-process
+ *  IPC handler measures the payload against this before uploading, so an
+ *  oversized session fails fast with a friendly message instead of
+ *  buffering the whole body up to the server only to get a 422. Both
+ *  sides measure the encoded bytes of the same JSON body, so the client
+ *  gate and the server cap reject exactly the same payloads. */
+export const MAX_PUBLISH_BODY_BYTES = 2 * 1024 * 1024
+
 export interface PublishSuccess {
   id: string
   url: string

--- a/packages/share-backend/functions/api/publish.ts
+++ b/packages/share-backend/functions/api/publish.ts
@@ -56,13 +56,17 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
     })
     if (!daily.ok) throw new ApiError('TOO_MANY_REQUESTS')
 
-    const raw = await ctx.request.text()
-    if (raw.length > MAX_SNAPSHOT_BYTES) {
+    // Measure the actual request bytes, not string length — .text()
+    // decodes to UTF-16 code units, which undercounts multi-byte
+    // (CJK) content by up to 3x and would let a nominal "2MB" cap
+    // admit ~6MB of R2 storage per share.
+    const rawBytes = await ctx.request.arrayBuffer()
+    if (rawBytes.byteLength > MAX_SNAPSHOT_BYTES) {
       throw new ApiError('UNPROCESSABLE', 'payload too large')
     }
     let json: unknown
     try {
-      json = JSON.parse(raw)
+      json = JSON.parse(new TextDecoder().decode(rawBytes))
     } catch {
       throw new ApiError('UNPROCESSABLE', 'invalid json')
     }

--- a/packages/share-kit/package.json
+++ b/packages/share-kit/package.json
@@ -10,6 +10,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./progressive": {
+      "types": "./dist/progressive.d.ts",
+      "import": "./dist/progressive.js"
+    },
     "./styles.css": "./src/styles/global.css",
     "./styles/tokens.css": "./src/styles/tokens.css",
     "./styles/fonts.css": "./src/styles/fonts.css"

--- a/packages/share-kit/src/index.ts
+++ b/packages/share-kit/src/index.ts
@@ -55,6 +55,12 @@ export { SnapshotReader } from './reader/SnapshotReader'
 export type { SnapshotReaderProps } from './reader/SnapshotReader'
 export { decodeSnapshot } from './reader/snapshot-to-conversation'
 export type { DecodedSnapshot } from './reader/snapshot-to-conversation'
+export {
+  useProgressiveTurns,
+  nextReaderCount,
+  READER_INITIAL_TURNS,
+  READER_TURNS_PER_FRAME,
+} from './reader/use-progressive-turns'
 
 // ─── Template primitives (for hosts assembling custom layouts) ──
 export { Body } from './templates/body'

--- a/packages/share-kit/src/progressive.ts
+++ b/packages/share-kit/src/progressive.ts
@@ -1,0 +1,12 @@
+// Lean subpath entry (`@spool/share-kit/progressive`) exposing only the
+// progressive-mount hook. The main barrel drags in the full template /
+// markdown render chain, which requires a DOM at import time — hosts
+// that only need the fill state machine (the editor preview, node-env
+// unit tests) import this entry instead.
+
+export {
+  useProgressiveTurns,
+  nextReaderCount,
+  READER_INITIAL_TURNS,
+  READER_TURNS_PER_FRAME,
+} from './reader/use-progressive-turns'

--- a/packages/share-kit/src/reader/SnapshotReader.test.tsx
+++ b/packages/share-kit/src/reader/SnapshotReader.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { SnapshotReader } from './SnapshotReader'
+import { READER_INITIAL_TURNS } from './use-progressive-turns'
+import type { Snapshot } from '../lib/types'
+
+// Each turn body carries a unique marker so we can assert exactly which
+// turns made it into the first paint.
+function marker(i: number): string {
+  return `TURNMARKER_${i}_END`
+}
+
+function makeSnapshot(turnCount: number): Snapshot {
+  const turns = Array.from({ length: turnCount }, (_, i) => ({
+    id: `t${i}`,
+    role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+    content: `Message ${marker(i)}`,
+  }))
+  return {
+    schema_version: 1,
+    source: { kind: 'spool-session', captured_at: '2026-07-01T00:00:00.000Z' },
+    conversation: {
+      title: 'Big conversation',
+      turns,
+      turn_order: turns.map((t) => t.id),
+      hidden_turns: [],
+    },
+    editor_opts: {
+      template: 'chat',
+      paper: 'ivory',
+      typeface: 'sans',
+      colorway: 'amber',
+      density: 'compact',
+      masthead: false,
+      colophon: false,
+      avatars: true,
+      show_byline: false,
+    },
+  }
+}
+
+// The initial-slice branch only engages when requestAnimationFrame
+// exists (a browser). This vitest env is node, so simulate the browser
+// by installing a no-op rAF around the client-behavior tests; without
+// it the hook initializes to the COMPLETE document (the SSR guarantee).
+function withFakeRaf<T>(fn: () => T): T {
+  const g = globalThis as { requestAnimationFrame?: unknown; cancelAnimationFrame?: unknown }
+  g.requestAnimationFrame = () => 0
+  g.cancelAnimationFrame = () => {}
+  try {
+    return fn()
+  } finally {
+    delete g.requestAnimationFrame
+    delete g.cancelAnimationFrame
+  }
+}
+
+describe('SnapshotReader progressive mount', () => {
+  it('renders every turn for a small snapshot on first paint', () => {
+    const html = withFakeRaf(() =>
+      renderToStaticMarkup(<SnapshotReader snapshot={makeSnapshot(5)} />),
+    )
+    for (let i = 0; i < 5; i++) {
+      expect(html).toContain(marker(i))
+    }
+  })
+
+  it('renders only the initial slice for a large snapshot in a browser, deferring the tail', () => {
+    const total = READER_INITIAL_TURNS + 50
+    const html = withFakeRaf(() =>
+      renderToStaticMarkup(<SnapshotReader snapshot={makeSnapshot(total)} />),
+    )
+    // First slice is present…
+    expect(html).toContain(marker(0))
+    expect(html).toContain(marker(READER_INITIAL_TURNS - 1))
+    // …the tail is deferred to later animation frames, so it is NOT in
+    // the first commit that gates first paint.
+    expect(html).not.toContain(marker(READER_INITIAL_TURNS))
+    expect(html).not.toContain(marker(total - 1))
+  })
+
+  it('renders the COMPLETE document under SSR (no requestAnimationFrame)', () => {
+    // Effects never run during server/static rendering, so completeness
+    // must come from state initialization — a prerender or static export
+    // of a large share must never ship a silently truncated conversation.
+    const total = READER_INITIAL_TURNS + 50
+    const html = renderToStaticMarkup(<SnapshotReader snapshot={makeSnapshot(total)} />)
+    expect(html).toContain(marker(0))
+    expect(html).toContain(marker(READER_INITIAL_TURNS))
+    expect(html).toContain(marker(total - 1))
+  })
+})

--- a/packages/share-kit/src/reader/SnapshotReader.tsx
+++ b/packages/share-kit/src/reader/SnapshotReader.tsx
@@ -8,15 +8,35 @@
 // guard test in `packages/share-web/tests/safety.test.ts` enforces this
 // across both share-web and the reader path.
 
+import { useMemo } from 'react'
 import { TemplateRender } from '../templates'
 import type { Snapshot } from '../lib/types'
 import { decodeSnapshot } from './snapshot-to-conversation'
+import { useProgressiveTurns } from './use-progressive-turns'
 
 export interface SnapshotReaderProps {
   snapshot: Snapshot
 }
 
 export function SnapshotReader({ snapshot }: SnapshotReaderProps) {
-  const { conversation, opts } = decodeSnapshot(snapshot)
-  return <TemplateRender template={opts.template} convo={conversation} opts={opts} />
+  // Decode once per snapshot — the sort + map over every turn must not
+  // re-run on each progressive-fill frame.
+  const { conversation, opts } = useMemo(() => decodeSnapshot(snapshot), [snapshot])
+
+  // Mount the document progressively so a large snapshot doesn't block
+  // first paint. The decoded snapshot renders with `redact: false`, so
+  // the sliced re-renders don't retrigger detection (see
+  // `useResolvedRedactList`) and a full-conversation redact list is not
+  // needed for stability.
+  const total = conversation.turns.length
+  const mounted = useProgressiveTurns(total)
+  const convo = useMemo(
+    () =>
+      mounted >= total
+        ? conversation
+        : { ...conversation, turns: conversation.turns.slice(0, mounted) },
+    [conversation, mounted, total],
+  )
+
+  return <TemplateRender template={opts.template} convo={convo} opts={opts} />
 }

--- a/packages/share-kit/src/reader/use-progressive-turns.test.ts
+++ b/packages/share-kit/src/reader/use-progressive-turns.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import {
+  READER_INITIAL_TURNS,
+  READER_TURNS_PER_FRAME,
+  nextReaderCount,
+} from './use-progressive-turns'
+
+describe('nextReaderCount', () => {
+  it('grows by one frame step', () => {
+    expect(nextReaderCount(READER_INITIAL_TURNS, 10_000)).toBe(
+      READER_INITIAL_TURNS + READER_TURNS_PER_FRAME,
+    )
+  })
+
+  it('never overshoots the total', () => {
+    for (const total of [0, 1, READER_INITIAL_TURNS, 517, 10_000]) {
+      let c = Math.min(READER_INITIAL_TURNS, total)
+      // Drive the fill loop to completion and assert it lands exactly on
+      // total and never exceeds it.
+      for (let i = 0; i < 1000 && c < total; i++) {
+        const next = nextReaderCount(c, total)
+        expect(next).toBeGreaterThan(c)
+        expect(next).toBeLessThanOrEqual(total)
+        c = next
+      }
+      expect(c).toBe(total)
+    }
+  })
+
+  it('respects a custom step', () => {
+    expect(nextReaderCount(0, 100, 25)).toBe(25)
+    expect(nextReaderCount(90, 100, 25)).toBe(100)
+  })
+})

--- a/packages/share-kit/src/reader/use-progressive-turns.ts
+++ b/packages/share-kit/src/reader/use-progressive-turns.ts
@@ -1,0 +1,76 @@
+// Progressive-mount chunking for large conversation documents. A
+// published snapshot can carry up to the backend's 2MB cap — a few
+// thousand turns — and rendering them all in one synchronous commit
+// blocks the main thread for seconds, freezing first paint (especially
+// on mobile). Mount a small initial slice cheaply, then grow one chunk
+// per animation frame until the whole document is in.
+//
+// This is the single implementation shared by the public reader and
+// the editor preview (packages/app/.../preview-progressive.ts wraps it
+// with editor-tuned constants) — the fill semantics are load-bearing
+// on both surfaces and must not drift.
+
+import { useEffect, useState } from 'react'
+
+/** First slice rendered on mount — kept small so first paint is cheap. */
+export const READER_INITIAL_TURNS = 80
+
+/** Turns appended per animation frame while filling the document. */
+export const READER_TURNS_PER_FRAME = 400
+
+/** Backstop cadence for filling while the tab is hidden — rAF is
+ *  paused in background tabs, and browsers throttle hidden-tab timers
+ *  to ~1/sec, so this fills a few hundred turns per second until the
+ *  tab is shown (when rAF takes over at full rate). */
+const HIDDEN_TAB_FILL_MS = 200
+
+/** One growth step: pure so the chunking math is unit-testable. */
+export function nextReaderCount(
+  current: number,
+  total: number,
+  step: number = READER_TURNS_PER_FRAME,
+): number {
+  return Math.min(current + step, total)
+}
+
+/**
+ * Progressive mount counter: start at `initial` turns, then grow one
+ * chunk per animation frame until every turn is mounted.
+ *
+ * Completeness guarantees:
+ * - No `requestAnimationFrame` (SSR / static prerender, where effects
+ *   never run): the counter INITIALIZES to `total`, so the first —
+ *   and only — render is the complete document.
+ * - Hidden/background tab (rAF paused): a throttled timeout backstop
+ *   keeps the fill progressing, so the document reaches completion
+ *   even if the tab is printed or read without ever being focused.
+ */
+export function useProgressiveTurns(
+  total: number,
+  initial: number = READER_INITIAL_TURNS,
+  step: number = READER_TURNS_PER_FRAME,
+): number {
+  const [count, setCount] = useState(() =>
+    typeof requestAnimationFrame === 'function' ? Math.min(initial, total) : total,
+  )
+  useEffect(() => {
+    // Clamp when the document shrinks (e.g. fewer turns after a draft
+    // reload); never reset an already-filled view back to the first
+    // chunk on unrelated conversation identity churn.
+    setCount((c) => Math.min(c, total))
+  }, [total])
+  useEffect(() => {
+    if (count >= total) return
+    const advance = () => setCount((c) => nextReaderCount(c, total, step))
+    const raf = requestAnimationFrame(advance)
+    // Both schedulers race; the state change re-runs this effect and
+    // the cleanup cancels the loser. If both fire before a re-render,
+    // advance is monotonic-safe — the fill just moves two steps.
+    const timer = setTimeout(advance, HIDDEN_TAB_FILL_MS)
+    return () => {
+      cancelAnimationFrame(raf)
+      clearTimeout(timer)
+    }
+  }, [count, total, step])
+  return Math.min(count, total)
+}

--- a/packages/share-kit/src/templates/chat.tsx
+++ b/packages/share-kit/src/templates/chat.tsx
@@ -4,11 +4,10 @@
 // evoke the native chat UI of ChatGPT/Claude/Gemini while still
 // reading as a considered artifact.
 
-import { useMemo } from 'react'
 import type { Conversation, EditorOpts } from '@/lib/types'
 import { typefaceFamily } from '@/lib/types'
 import { accentBgFor, templateTokens, bodyStyleVars, BODY_VAR_PROPS, BODY_VAR_BLOCK_BORDER } from './tokens'
-import { collectRedactList, type RedactReplacement } from './redact'
+import { useResolvedRedactList, type RedactReplacement } from './redact'
 import { selectSegments } from './selection'
 import { GapMarker } from './gap-marker'
 import { Body } from './body'
@@ -25,14 +24,7 @@ export function Chat({ convo, opts, redactList: injectedRedactList }: Props) {
   const accent = opts.accentHex
   const accentBg = accentBgFor(accent)
   const tf = typefaceFamily(opts.typeface)
-  // Memo so style-only opts changes (paper / typeface / colorway /
-  // density / selection) don't re-trigger the 22-regex detection
-  // pass. Re-runs only when source turns or redact policy moves.
-  const computedRedactList = useMemo(
-    () => collectRedactList(convo.turns, opts),
-    [convo.turns, opts.redactExclude],
-  )
-  const redactList = injectedRedactList ?? computedRedactList
+  const redactList = useResolvedRedactList(convo.turns, opts, injectedRedactList)
   const segments = selectSegments(convo, opts)
   const turnGap = opts.density === 'compact' ? 20 : 30
 

--- a/packages/share-kit/src/templates/forum.tsx
+++ b/packages/share-kit/src/templates/forum.tsx
@@ -5,11 +5,10 @@
 // post numbers on the right margin. Reads like a forum thread or a
 // session-detail panel rather than chat bubbles or editorial prose.
 
-import { useMemo } from 'react'
 import type { Conversation, EditorOpts } from '@/lib/types'
 import { typefaceFamily } from '@/lib/types'
 import { accentBgFor, templateTokens, bodyStyleVars, BODY_VAR_PROPS, BODY_VAR_BLOCK_BORDER } from './tokens'
-import { collectRedactList, type RedactReplacement } from './redact'
+import { useResolvedRedactList, type RedactReplacement } from './redact'
 import { selectSegments } from './selection'
 import { GapMarker } from './gap-marker'
 import { Body } from './body'
@@ -26,11 +25,7 @@ export function Forum({ convo, opts, redactList: injectedRedactList }: Props) {
   const accent = opts.accentHex
   const accentBg = accentBgFor(accent)
   const tf = typefaceFamily(opts.typeface)
-  const computedRedactList = useMemo(
-    () => collectRedactList(convo.turns, opts),
-    [convo.turns, opts.redactExclude],
-  )
-  const redactList = injectedRedactList ?? computedRedactList
+  const redactList = useResolvedRedactList(convo.turns, opts, injectedRedactList)
   const segments = selectSegments(convo, opts)
   const postGap = opts.density === 'compact' ? 18 : 26
   const innerPad = opts.density === 'compact' ? 12 : 16

--- a/packages/share-kit/src/templates/letter.tsx
+++ b/packages/share-kit/src/templates/letter.tsx
@@ -11,11 +11,10 @@
 // underscore and each user's byline — the colorway picker is visible
 // at a glance.
 
-import { useMemo } from 'react'
 import type { Conversation, EditorOpts } from '@/lib/types'
 import { typefaceFamily } from '@/lib/types'
 import { accentBgFor, templateTokens, bodyStyleVars, BODY_VAR_PROPS } from './tokens'
-import { collectRedactList, type RedactReplacement } from './redact'
+import { useResolvedRedactList, type RedactReplacement } from './redact'
 import { selectSegments } from './selection'
 import { GapMarker } from './gap-marker'
 import { Body } from './body'
@@ -32,11 +31,7 @@ export function Letter({ convo, opts, redactList: injectedRedactList }: Props) {
   const accent = opts.accentHex
   const accentBg = accentBgFor(accent)
   const tf = typefaceFamily(opts.typeface)
-  const computedRedactList = useMemo(
-    () => collectRedactList(convo.turns, opts),
-    [convo.turns, opts.redactExclude],
-  )
-  const redactList = injectedRedactList ?? computedRedactList
+  const redactList = useResolvedRedactList(convo.turns, opts, injectedRedactList)
   const turnGap = opts.density === 'compact' ? 20 : 32
   const segments = selectSegments(convo, opts)
 

--- a/packages/share-kit/src/templates/redact-hook.test.tsx
+++ b/packages/share-kit/src/templates/redact-hook.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { useResolvedRedactList, type RedactReplacement } from './redact'
+import type { EditorOpts, Turn } from '@/lib/types'
+
+// Built at runtime so the source literal doesn't trip secret scanners.
+const STRIPE_FIXTURE = 'sk_' + 'live_' + 'aH1xK9pQrSt7VwYzA3bC5dF8gJ'
+
+const turns: Turn[] = [
+  { role: 'assistant', body: `here is a key: ${STRIPE_FIXTURE}` } as Turn,
+]
+
+// Render a probe component so the hook runs inside a real React render
+// (useMemo executes during server render; effects don't, which is fine
+// here — the hook's value is memo-derived, not effect-derived).
+function resolve(
+  opts: Pick<EditorOpts, 'redact' | 'redactExclude'>,
+  injected: RedactReplacement[] | undefined,
+): RedactReplacement[] {
+  let captured: RedactReplacement[] = []
+  function Probe(): null {
+    captured = useResolvedRedactList(turns, opts, injected)
+    return null
+  }
+  renderToStaticMarkup(<Probe />)
+  return captured
+}
+
+describe('useResolvedRedactList', () => {
+  it('skips detection and returns empty when redaction is off', () => {
+    const result = resolve({ redact: false, redactExclude: undefined }, undefined)
+    expect(result).toEqual([])
+  })
+
+  it('runs detection when redaction is on and no list is injected', () => {
+    const result = resolve({ redact: true, redactExclude: undefined }, undefined)
+    expect(result.map((r) => r.value)).toContain(STRIPE_FIXTURE)
+  })
+
+  it('returns the injected list verbatim, bypassing detection', () => {
+    const injected: RedactReplacement[] = [{ value: 'x', replacement: '[redacted]' }]
+    // Even with redaction on, an injected list wins (and its identity is
+    // preserved so downstream memoized Body components stay stable).
+    expect(resolve({ redact: true, redactExclude: undefined }, injected)).toBe(injected)
+    expect(resolve({ redact: false, redactExclude: undefined }, injected)).toBe(injected)
+  })
+})

--- a/packages/share-kit/src/templates/redact.tsx
+++ b/packages/share-kit/src/templates/redact.tsx
@@ -16,6 +16,7 @@
 // and the per-kind mask to substitute. The body renderer and the
 // markdown / .spool exporters consume the same shape.
 
+import { useMemo } from 'react'
 import type { EditorOpts, RedactExclude, Turn } from '@/lib/types'
 import {
   detectSensitiveSpansCached,
@@ -139,4 +140,36 @@ export function collectRedactList(
   opts?: Pick<EditorOpts, 'redactExclude'>,
 ): RedactReplacement[] {
   return applyRedactPolicy(detectPII(turns), opts?.redactExclude)
+}
+
+// Stable identity for the empty case so a template's memoized Body
+// components bail out instead of reconciling on a fresh `[]` each frame.
+const EMPTY_REDACT_LIST: RedactReplacement[] = []
+
+/**
+ * Resolve the redact list a template should render with, computing the
+ * detection pass only when it will actually be used.
+ *
+ * - An injected list (from a host that mounts the document
+ *   progressively) always wins and short-circuits detection, keeping
+ *   the list identity stable across the host's per-frame re-renders.
+ * - Otherwise the pass runs ONLY when redaction is on. The public
+ *   reader decodes snapshots with `redact: false` (bodies are already
+ *   masked at publish time), so without this guard every page load
+ *   would run the full detection suite over the whole conversation and
+ *   then discard the result at the `opts.redact ? … : undefined` gate.
+ */
+export function useResolvedRedactList(
+  turns: Turn[],
+  opts: Pick<EditorOpts, 'redact' | 'redactExclude'>,
+  injected: RedactReplacement[] | undefined,
+): RedactReplacement[] {
+  const computed = useMemo(
+    () =>
+      injected || !opts.redact
+        ? EMPTY_REDACT_LIST
+        : collectRedactList(turns, opts),
+    [turns, opts.redact, opts.redactExclude, injected],
+  )
+  return injected ?? computed
 }

--- a/packages/share-kit/src/templates/timeline.tsx
+++ b/packages/share-kit/src/templates/timeline.tsx
@@ -11,11 +11,10 @@
 // Legacy drafts saved before `Turn.timestamp` existed gracefully
 // degrade: the gutter shows a dash and no gaps are drawn.
 
-import { useMemo } from 'react'
 import type { Conversation, EditorOpts } from '@/lib/types'
 import { typefaceFamily } from '@/lib/types'
 import { accentBgFor, templateTokens, bodyStyleVars, BODY_VAR_PROPS } from './tokens'
-import { collectRedactList, type RedactReplacement } from './redact'
+import { useResolvedRedactList, type RedactReplacement } from './redact'
 import { selectSegments } from './selection'
 import { Body } from './body'
 
@@ -31,11 +30,7 @@ export function Timeline({ convo, opts, redactList: injectedRedactList }: Props)
   const accent = opts.accentHex
   const accentBg = accentBgFor(accent)
   const tf = typefaceFamily(opts.typeface)
-  const computedRedactList = useMemo(
-    () => collectRedactList(convo.turns, opts),
-    [convo.turns, opts.redactExclude],
-  )
-  const redactList = injectedRedactList ?? computedRedactList
+  const redactList = useResolvedRedactList(convo.turns, opts, injectedRedactList)
   const segments = selectSegments(convo, opts)
   const turnGap = opts.density === 'compact' ? 18 : 28
 

--- a/packages/share-kit/vite.config.ts
+++ b/packages/share-kit/vite.config.ts
@@ -20,9 +20,12 @@ export default defineConfig({
   },
   build: {
     lib: {
-      entry: fileURLToPath(new URL('./src/index.ts', import.meta.url)),
+      entry: {
+        index: fileURLToPath(new URL('./src/index.ts', import.meta.url)),
+        // Lean DOM-free entry — see src/progressive.ts.
+        progressive: fileURLToPath(new URL('./src/progressive.ts', import.meta.url)),
+      },
       formats: ['es'],
-      fileName: 'index',
     },
     rollupOptions: {
       external: ['react', 'react-dom', 'react/jsx-runtime'],


### PR DESCRIPTION
## What

Three hardening/perf fixes for the share feature ahead of the GA flip, from a full pre-launch audit (security, performance, completeness, tests) plus a high-effort adversarial review of the diff itself:

1. **PDF export print window is now sandboxed.** The hidden window that renders the artifact for `printToPDF` ran with `sandbox: false` while executing renderer-supplied HTML via `innerHTML` — inline event handlers or embeds in that markup would run in an unsandboxed process. `printToPDF`, `executeJavaScript`, and `document.fonts` all work sandboxed and the window needs no Node access, so the flag flips to `true`, with `setWindowOpenHandler` deny + `will-navigate` guard for the one-shot print pass.
2. **Oversized publish payloads fail fast with a localized error.** Publishing a >2MB session previously uploaded the whole payload just to receive a 422 whose raw English `detail` leaked into the error banner. The main process now measures the serialized body before the network call and returns 413; the renderer maps it to a new `error_tooLarge` message in all 7 locales. Both sides now measure real UTF-8 bytes — the backend cap counted UTF-16 code units of the decoded text, so CJK-heavy payloads could ship ~3x the nominal limit into R2. A drift-guard test pins the client constant to the backend's.
3. **Public reader stops wasting a full PII scan per page load and mounts progressively.** Every share page ran the complete redact detection suite over the whole conversation, then discarded the result (the reader decodes with `redact: false` — bodies are masked at publish time). Templates now share one `useResolvedRedactList` hook that skips detection when redaction is off. The reader also rendered all turns in one synchronous commit — multi-second main-thread freeze on large shares, especially mobile; it now mounts 80 turns for first paint and fills per animation frame, with a timeout backstop for hidden/background tabs and init-to-complete under SSR so a prerender can never ship a truncated conversation.

## Why

These were the "fix before GA" items from the launch review: the sandbox flag was the only sandbox-off surface in the app; the size-gate gap meant the worst-case user (huge session) got the worst experience (full upload, then an unlocalized error); the reader issues degrade exactly the readers the share links are for.

## How it connects

- The fill state machine now lives once in `@spool/share-kit` behind a lean DOM-free subpath entry (`@spool/share-kit/progressive`); the editor preview's `preview-progressive.ts` delegates to it with its own constants instead of maintaining a diverging copy — the editor e2e now exercises the same hook the public reader uses.
- The status→i18n-key mapping is extracted pure (`publishErrorKey`) and tested against `en.json`, so a typo'd key can't render raw in the banner.
- Backend size check moved from `text().length` to `arrayBuffer().byteLength` — same 2MB constant, now true bytes on both ends.

## Test plan

- New: PDF export e2e driving editor → sandboxed print window → preview modal → saved bytes, asserting `%PDF` header/`%%EOF`/content, twice in one session to cover window teardown (fills a coverage gap — PDF export previously had zero e2e).
- New: IPC size-gate tests (ASCII cap, CJK byte-vs-length boundary, no network call), cap drift guard, `publishErrorKey` tests, reader SSR-complete + browser-slice tests, redact-gate hook tests.
- Suites: share-kit 68 ✓ (+tsc), share-web 84 ✓ (+tsc), share-backend 247 ✓ (+tsc), app vitest 482 ✓, share e2e specs (`share-exports`, `share-publish`, `share-turn-selector`, `share-privacy`, new `share-export-pdf`) 30 ✓.
- Manual: PDF export verified end-to-end in `pnpm dev` (preview renders, saved file opens, content intact).
- Known gap, documented rather than papered over: the progressive-fill effect loop has no DOM-level unit test (no jsdom in the workspace); it is covered by the editor e2e through the now-shared hook, plus pure-math and first-commit render tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
