### PR TITLE
Extend `spool projects <query>` resolution to match project display paths and session `cwd`

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,13 +30,14 @@ spool show <uuid> --json       # Output as JSON
 spool status                   # Show index stats (session count, DB size)
 
 spool projects                 # List projects, grouped across sources
-spool projects spool           # List sessions in a project (by name or identity)
+spool projects spool           # List sessions in a project (by name, identity, path, or cwd)
 spool projects spool -n 50     # Limit how many sessions are shown
 spool projects spool --json    # Output as JSON
 ```
 
-A project query matches its name or identity key — an exact name wins over
-partial matches, and ambiguous queries list the candidates so you can refine.
+A project query matches its name, identity key, project display path, or any
+session cwd — an exact name wins over partial matches, and ambiguous queries
+list the candidates so you can refine.
 
 ### Pin
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -63,7 +63,7 @@ function createSeededDir(): { dir: string; cleanup: () => void } {
   insertSession.run(1, src, SESSION_UUID_1, '/fake/session1.jsonl',
     'Debugging authentication flow', '2026-04-10T10:00:00Z', '2026-04-10T11:00:00Z', 3, '/Users/test/my-project', 'claude-4', '2026-04-10')
   insertSession.run(1, src, SESSION_UUID_2, '/fake/session2.jsonl',
-    'Refactoring database queries', '2026-04-12T14:00:00Z', '2026-04-12T15:00:00Z', 2, '/Users/test/my-project', 'claude-4', '2026-04-12')
+    'Refactoring database queries', '2026-04-12T14:00:00Z', '2026-04-12T15:00:00Z', 2, '/Users/test/my-project/packages/api', 'claude-4', '2026-04-12')
 
   const insertMsg = db.prepare(`
     INSERT INTO messages (session_id, source_id, msg_uuid, role, content_text, timestamp, tool_names, seq)
@@ -427,6 +427,18 @@ describe('projects', () => {
 
   it('lists the sessions in a project when given a query', () => {
     const out = run(['projects', 'my-project'], { SPOOL_DATA_DIR: seeded.dir })
+    expect(out).toContain('Debugging authentication flow')
+    expect(out).toContain('Refactoring database queries')
+  })
+
+  it('matches a project by display path', () => {
+    const out = run(['projects', '/Users/test/my-project'], { SPOOL_DATA_DIR: seeded.dir })
+    expect(out).toContain('Debugging authentication flow')
+    expect(out).toContain('Refactoring database queries')
+  })
+
+  it('matches a project by session cwd', () => {
+    const out = run(['projects', 'packages/api'], { SPOOL_DATA_DIR: seeded.dir })
     expect(out).toContain('Debugging authentication flow')
     expect(out).toContain('Refactoring database queries')
   })

--- a/packages/cli/src/commands/projects.test.ts
+++ b/packages/cli/src/commands/projects.test.ts
@@ -7,6 +7,8 @@ function group(displayName: string, identityKey: string): ProjectGroup {
     identityKind: 'path',
     identityKey,
     displayName,
+    displayPaths: [],
+    cwds: [],
     sources: ['claude'],
     sessionCount: 1,
     lastSessionAt: '2026-04-10T10:00:00Z',
@@ -41,6 +43,50 @@ describe('resolveProjectQuery', () => {
 
   it('matches against the identity key as well as the name', () => {
     expect(resolveProjectQuery(groups, 'graydawnc')).toEqual({ kind: 'match', group: groups[2] })
+  })
+
+  it('matches against project display paths', () => {
+    const local = {
+      ...group('inventory', '/Users/me/src/inventory'),
+      displayPaths: ['/Users/me/src/inventory'],
+    }
+    expect(resolveProjectQuery([local], 'src/inventory')).toEqual({ kind: 'match', group: local })
+  })
+
+  it('matches against session cwd paths', () => {
+    const monorepo = {
+      ...group('platform', 'github.com/acme/platform'),
+      displayPaths: ['/Users/me/src/platform'],
+      cwds: ['/Users/me/src/platform/packages/api'],
+    }
+    expect(resolveProjectQuery([monorepo], 'packages/api')).toEqual({ kind: 'match', group: monorepo })
+  })
+
+  it('uses cwd substring matches only when names and identity keys do not match', () => {
+    const service = group('data-service-main', 'git.example.com/acme/service-main')
+    const worker = group('data-service-worker', 'github.com/example/data-service-worker')
+    const scratch = {
+      ...group('scratch', '/Users/example/.git'),
+      cwds: ['/Users/example/work/data-service'],
+    }
+
+    const res = resolveProjectQuery([service, scratch, worker], 'data-service')
+
+    expect(res.kind).toBe('ambiguous')
+    if (res.kind === 'ambiguous') {
+      expect(res.groups).toEqual([service, worker])
+    }
+  })
+
+  it('prefers exact identity basename matches over display name substrings', () => {
+    const service = group('data-service-main', 'git.example.com/acme/data-service')
+    const worker = group('data-service-worker', 'github.com/example/data-service-worker')
+    const scratch = {
+      ...group('scratch', '/Users/example/.git'),
+      cwds: ['/Users/example/work/data-service'],
+    }
+
+    expect(resolveProjectQuery([service, scratch, worker], 'data-service')).toEqual({ kind: 'match', group: service })
   })
 
   it('reports ambiguity when several projects match a substring', () => {

--- a/packages/cli/src/commands/projects.test.ts
+++ b/packages/cli/src/commands/projects.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import type { ProjectGroup } from '@spool-lab/core'
+import type { ProjectGroupWithPaths } from '@spool-lab/core'
 import { resolveProjectQuery } from './projects.js'
 
-function group(displayName: string, identityKey: string): ProjectGroup {
+function group(displayName: string, identityKey: string): ProjectGroupWithPaths {
   return {
     identityKind: 'path',
     identityKey,
@@ -15,7 +15,7 @@ function group(displayName: string, identityKey: string): ProjectGroup {
   }
 }
 
-const groups: ProjectGroup[] = [
+const groups: ProjectGroupWithPaths[] = [
   group('spool', 'github.com/spool-lab/spool'),
   group('spool-daemon', 'github.com/spool-lab/spool-daemon'),
   group('quilt', 'github.com/graydawnc/quilt'),
@@ -76,6 +76,19 @@ describe('resolveProjectQuery', () => {
     if (res.kind === 'ambiguous') {
       expect(res.groups).toEqual([service, worker])
     }
+  })
+
+  it('an exact project-path basename preempts a previously-unique name substring match', () => {
+    // Before the basename tier existed, "api" resolved uniquely to
+    // gateway-api-service by name substring. A project whose directory is
+    // literally named "api" now wins — pin that flip so it stays deliberate.
+    const gateway = group('gateway-api-service', 'github.com/acme/gateway-api-service')
+    const apiDir = {
+      ...group('backend', 'github.com/acme/backend'),
+      displayPaths: ['/Users/me/api'],
+    }
+
+    expect(resolveProjectQuery([gateway, apiDir], 'api')).toEqual({ kind: 'match', group: apiDir })
   })
 
   it('prefers exact identity basename matches over display name substrings', () => {

--- a/packages/cli/src/commands/projects.ts
+++ b/packages/cli/src/commands/projects.ts
@@ -1,11 +1,11 @@
 import { Command } from 'commander'
 import { getDB, listProjectGroups, listSessionsByIdentity } from '@spool-lab/core'
-import type { ProjectGroup } from '@spool-lab/core'
+import type { ProjectGroup, ProjectGroupWithPaths } from '@spool-lab/core'
 import { formatDate, printSession } from '../format.js'
 
 export type ProjectResolution =
-  | { kind: 'match'; group: ProjectGroup }
-  | { kind: 'ambiguous'; groups: ProjectGroup[] }
+  | { kind: 'match'; group: ProjectGroupWithPaths }
+  | { kind: 'ambiguous'; groups: ProjectGroupWithPaths[] }
   | { kind: 'none' }
 
 /**
@@ -18,7 +18,7 @@ export type ProjectResolution =
  * Otherwise fall back to substring matching by field priority, reporting
  * ambiguity when more than one group matches at the winning priority.
  */
-export function resolveProjectQuery(groups: ProjectGroup[], query: string): ProjectResolution {
+export function resolveProjectQuery(groups: ProjectGroupWithPaths[], query: string): ProjectResolution {
   const q = query.toLowerCase()
 
   const exact = groups.filter(g => allSearchableProjectFields(g).some(v => v === q))
@@ -35,7 +35,7 @@ export function resolveProjectQuery(groups: ProjectGroup[], query: string): Proj
   return { kind: 'none' }
 }
 
-function allSearchableProjectFields(group: ProjectGroup): string[] {
+function allSearchableProjectFields(group: ProjectGroupWithPaths): string[] {
   return [
     group.displayName,
     group.identityKey,
@@ -44,7 +44,7 @@ function allSearchableProjectFields(group: ProjectGroup): string[] {
   ].map(v => v.toLowerCase())
 }
 
-function basenameSearchableProjectFields(group: ProjectGroup): string[] {
+function basenameSearchableProjectFields(group: ProjectGroupWithPaths): string[] {
   return [
     group.identityKey,
     ...group.displayPaths,
@@ -57,13 +57,13 @@ function basename(value: string): string {
   return idx >= 0 ? normalized.slice(idx + 1) : normalized
 }
 
-const partialSearchableProjectFieldTiers: Array<(group: ProjectGroup) => string[]> = [
+const partialSearchableProjectFieldTiers: Array<(group: ProjectGroupWithPaths) => string[]> = [
   group => [group.displayName, group.identityKey].map(v => v.toLowerCase()),
   group => group.displayPaths.map(v => v.toLowerCase()),
   group => group.cwds.map(v => v.toLowerCase()),
 ]
 
-function pick(matches: ProjectGroup[]): ProjectResolution {
+function pick(matches: ProjectGroupWithPaths[]): ProjectResolution {
   const [first, ...rest] = matches
   if (first && rest.length === 0) return { kind: 'match', group: first }
   return { kind: 'ambiguous', groups: matches }
@@ -76,14 +76,13 @@ export const projectsCommand = new Command('projects')
   .option('--json', 'Output as JSON')
   .action((query: string | undefined, opts: { limit: string; json?: boolean }) => {
     const db = getDB(true)
-    const groups = listProjectGroups(db)
 
     if (!query) {
-      listGroups(groups, opts.json === true)
+      listGroups(listProjectGroups(db), opts.json === true)
       return
     }
 
-    const resolved = resolveProjectQuery(groups, query)
+    const resolved = resolveProjectQuery(listProjectGroups(db, { withPaths: true }), query)
     if (resolved.kind === 'none') {
       console.error(`No project matching: ${query}`)
       process.exit(1)

--- a/packages/cli/src/commands/projects.ts
+++ b/packages/cli/src/commands/projects.ts
@@ -10,25 +10,58 @@ export type ProjectResolution =
 
 /**
  * Resolve a free-text query to a single project group. An exact (case-
- * insensitive) hit on the display name or identity key wins outright, so
- * `projects spool` picks "spool" over the "spool-daemon" substring and a
- * pasted identity key always lands uniquely. Otherwise fall back to
- * substring matching, reporting ambiguity when more than one group matches.
+ * insensitive) hit on the display name, identity key, project path, or any
+ * session cwd wins outright, so `projects spool` picks "spool" over the
+ * "spool-daemon" substring and a pasted identity key always lands uniquely.
+ * Exact basename hits on identity keys or project paths win over substring
+ * matches, so a repo slug can disambiguate similarly named projects.
+ * Otherwise fall back to substring matching by field priority, reporting
+ * ambiguity when more than one group matches at the winning priority.
  */
 export function resolveProjectQuery(groups: ProjectGroup[], query: string): ProjectResolution {
   const q = query.toLowerCase()
 
-  const exact = groups.filter(
-    g => g.displayName.toLowerCase() === q || g.identityKey.toLowerCase() === q,
-  )
+  const exact = groups.filter(g => allSearchableProjectFields(g).some(v => v === q))
   if (exact.length > 0) return pick(exact)
 
-  const partial = groups.filter(
-    g => g.displayName.toLowerCase().includes(q) || g.identityKey.toLowerCase().includes(q),
-  )
-  if (partial.length === 0) return { kind: 'none' }
-  return pick(partial)
+  const exactBasename = groups.filter(g => basenameSearchableProjectFields(g).some(v => v === q))
+  if (exactBasename.length > 0) return pick(exactBasename)
+
+  for (const tier of partialSearchableProjectFieldTiers) {
+    const matches = groups.filter(g => tier(g).some(v => v.includes(q)))
+    if (matches.length > 0) return pick(matches)
+  }
+
+  return { kind: 'none' }
 }
+
+function allSearchableProjectFields(group: ProjectGroup): string[] {
+  return [
+    group.displayName,
+    group.identityKey,
+    ...group.displayPaths,
+    ...group.cwds,
+  ].map(v => v.toLowerCase())
+}
+
+function basenameSearchableProjectFields(group: ProjectGroup): string[] {
+  return [
+    group.identityKey,
+    ...group.displayPaths,
+  ].map(v => basename(v).toLowerCase()).filter(Boolean)
+}
+
+function basename(value: string): string {
+  const normalized = value.replace(/\.git$/i, '').replace(/\/+$/g, '')
+  const idx = normalized.lastIndexOf('/')
+  return idx >= 0 ? normalized.slice(idx + 1) : normalized
+}
+
+const partialSearchableProjectFieldTiers: Array<(group: ProjectGroup) => string[]> = [
+  group => [group.displayName, group.identityKey].map(v => v.toLowerCase()),
+  group => group.displayPaths.map(v => v.toLowerCase()),
+  group => group.cwds.map(v => v.toLowerCase()),
+]
 
 function pick(matches: ProjectGroup[]): ProjectResolution {
   const [first, ...rest] = matches
@@ -38,7 +71,7 @@ function pick(matches: ProjectGroup[]): ProjectResolution {
 
 export const projectsCommand = new Command('projects')
   .description('List your projects, or the sessions in one')
-  .argument('[query]', 'Show sessions in the project matching this name or identity key')
+  .argument('[query]', 'Show sessions in the project matching this name, identity key, project path, or cwd')
   .option('-n, --limit <n>', 'Max sessions to show (with a query)', '20')
   .option('--json', 'Output as JSON')
   .action((query: string | undefined, opts: { limit: string; json?: boolean }) => {
@@ -60,7 +93,7 @@ export const projectsCommand = new Command('projects')
       for (const g of resolved.groups) {
         console.error(`  ${g.displayName}  (${g.identityKey})`)
       }
-      console.error('Refine the query, or pass a full identity key.')
+      console.error('Refine the query, or pass a full identity key, project path, or cwd.')
       process.exit(1)
     }
 

--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -729,6 +729,38 @@ export function runMigrations(db: Database.Database): void {
   rebuildFtsTableIfEmpty(db, 'messages', 'messages_fts_trigram')
   rebuildFtsTableIfEmpty(db, 'session_search', 'session_search_fts')
   rebuildFtsTableIfEmpty(db, 'session_search', 'session_search_fts_trigram')
+
+  recreateProjectGroupsView(db)
+}
+
+/**
+ * project_groups_v is the single definition of cross-source project grouping
+ * (consumed by projects/groups.ts). It holds no data, so instead of being
+ * frozen at its migration-time definition (v6) it is dropped and recreated on
+ * every launch — old and new installs always run the definition below.
+ *
+ * The path/cwd aggregates use JSON_GROUP_ARRAY rather than GROUP_CONCAT so
+ * paths containing commas survive round-tripping (e.g. "/Users/me/foo,bar").
+ */
+function recreateProjectGroupsView(db: Database.Database): void {
+  db.exec(`
+    DROP VIEW IF EXISTS project_groups_v;
+    CREATE VIEW project_groups_v AS
+    SELECT
+      p.identity_kind,
+      p.identity_key,
+      MIN(p.display_name)             AS display_name,
+      GROUP_CONCAT(DISTINCT src.name) AS sources_csv,
+      JSON_GROUP_ARRAY(DISTINCT p.display_path) FILTER (WHERE p.display_path IS NOT NULL AND p.display_path <> '') AS display_paths_json,
+      JSON_GROUP_ARRAY(DISTINCT s.cwd)          FILTER (WHERE s.cwd IS NOT NULL AND s.cwd <> '')                   AS cwds_json,
+      COUNT(s.id)                     AS session_count,
+      MAX(s.started_at)               AS last_session_at
+    FROM projects p
+    JOIN sources src ON src.id = p.source_id
+    LEFT JOIN sessions s ON s.project_id = p.id AND s.message_count > 0
+    WHERE p.identity_kind IS NOT NULL
+    GROUP BY p.identity_kind, p.identity_key;
+  `)
 }
 
 export function backfillProjectIdentities(db: Database.Database, fs: IdentityFs) {

--- a/packages/core/src/projects/groups.test.ts
+++ b/packages/core/src/projects/groups.test.ts
@@ -26,7 +26,7 @@ describe('listProjectGroups', () => {
         (1,1,'u1','/p1','t','2026-04-28T10:00:00Z','2026-04-28T10:30:00Z',5,0,'2026-04-28T10:30:00Z','/Users/chen/Code/spool/packages/app'),
         (2,2,'u2','/p2','t','2026-04-27T10:00:00Z','2026-04-27T10:30:00Z',3,0,'2026-04-27T10:30:00Z','/Users/chen/Code/spool');
     `)
-    const groups = listProjectGroups(db)
+    const groups = listProjectGroups(db, { withPaths: true })
     expect(groups).toHaveLength(1)
     expect(groups[0]).toMatchObject({
       identityKey: 'github.com/spool-lab/spool',
@@ -38,6 +38,19 @@ describe('listProjectGroups', () => {
       sources: expect.arrayContaining(['claude', 'codex']),
       sessionCount: 2,
     })
+  })
+
+  it('omits path fields unless withPaths is requested', () => {
+    db.exec(`
+      INSERT INTO projects (source_id, slug, display_path, display_name, identity_kind, identity_key)
+      VALUES (1,'spool-c','/Users/chen/Code/spool','spool','git_remote','github.com/spool-lab/spool');
+      INSERT INTO sessions (project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count, has_tool_use, raw_file_mtime, cwd)
+      VALUES (1,1,'u1','/p1','t','2026-04-28T10:00:00Z','2026-04-28T10:30:00Z',5,0,'2026-04-28T10:30:00Z','/Users/chen/Code/spool');
+    `)
+    const groups = listProjectGroups(db)
+    expect(groups).toHaveLength(1)
+    expect(groups[0]).not.toHaveProperty('displayPaths')
+    expect(groups[0]).not.toHaveProperty('cwds')
   })
 
   it('preserves commas in display paths and session cwds', () => {
@@ -52,7 +65,7 @@ describe('listProjectGroups', () => {
         (2,2,'comma-2','/pc2','t','2026-04-27T10:00:00Z','2026-04-27T10:30:00Z',3,0,'2026-04-27T10:30:00Z','/Users/me/foo,bar');
     `)
 
-    const groups = listProjectGroups(db)
+    const groups = listProjectGroups(db, { withPaths: true })
 
     expect(groups).toHaveLength(1)
     expect(groups[0]).toMatchObject({

--- a/packages/core/src/projects/groups.test.ts
+++ b/packages/core/src/projects/groups.test.ts
@@ -21,18 +21,50 @@ describe('listProjectGroups', () => {
       VALUES
         (1,'spool-c','/Users/chen/Code/spool','spool','git_remote','github.com/spool-lab/spool'),
         (2,'spool-x','/Users/chen/Code/spool','spool','git_remote','github.com/spool-lab/spool');
-      INSERT INTO sessions (project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count, has_tool_use, raw_file_mtime)
+      INSERT INTO sessions (project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count, has_tool_use, raw_file_mtime, cwd)
       VALUES
-        (1,1,'u1','/p1','t','2026-04-28T10:00:00Z','2026-04-28T10:30:00Z',5,0,'2026-04-28T10:30:00Z'),
-        (2,2,'u2','/p2','t','2026-04-27T10:00:00Z','2026-04-27T10:30:00Z',3,0,'2026-04-27T10:30:00Z');
+        (1,1,'u1','/p1','t','2026-04-28T10:00:00Z','2026-04-28T10:30:00Z',5,0,'2026-04-28T10:30:00Z','/Users/chen/Code/spool/packages/app'),
+        (2,2,'u2','/p2','t','2026-04-27T10:00:00Z','2026-04-27T10:30:00Z',3,0,'2026-04-27T10:30:00Z','/Users/chen/Code/spool');
     `)
     const groups = listProjectGroups(db)
     expect(groups).toHaveLength(1)
     expect(groups[0]).toMatchObject({
       identityKey: 'github.com/spool-lab/spool',
+      displayPaths: ['/Users/chen/Code/spool'],
+      cwds: expect.arrayContaining([
+        '/Users/chen/Code/spool',
+        '/Users/chen/Code/spool/packages/app',
+      ]),
       sources: expect.arrayContaining(['claude', 'codex']),
       sessionCount: 2,
     })
+  })
+
+  it('preserves commas in display paths and session cwds', () => {
+    db.exec(`
+      INSERT INTO projects (source_id, slug, display_path, display_name, identity_kind, identity_key)
+      VALUES
+        (1,'foo-bar','/Users/me/foo,bar','foo,bar','path','/Users/me/foo,bar'),
+        (2,'foo-bar-2','/Users/me/foo,bar','foo,bar','path','/Users/me/foo,bar');
+      INSERT INTO sessions (project_id, source_id, session_uuid, file_path, title, started_at, ended_at, message_count, has_tool_use, raw_file_mtime, cwd)
+      VALUES
+        (1,1,'comma-1','/pc1','t','2026-04-28T10:00:00Z','2026-04-28T10:30:00Z',5,0,'2026-04-28T10:30:00Z','/Users/me/foo,bar/packages/core'),
+        (2,2,'comma-2','/pc2','t','2026-04-27T10:00:00Z','2026-04-27T10:30:00Z',3,0,'2026-04-27T10:30:00Z','/Users/me/foo,bar');
+    `)
+
+    const groups = listProjectGroups(db)
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0]).toMatchObject({
+      identityKey: '/Users/me/foo,bar',
+      displayPaths: ['/Users/me/foo,bar'],
+      cwds: expect.arrayContaining([
+        '/Users/me/foo,bar',
+        '/Users/me/foo,bar/packages/core',
+      ]),
+    })
+    expect(groups[0].displayPaths).not.toContain('/Users/me/foo')
+    expect(groups[0].cwds).not.toContain('bar')
   })
 
   it('orders by lastSessionAt desc, loose last', () => {

--- a/packages/core/src/projects/groups.ts
+++ b/packages/core/src/projects/groups.ts
@@ -1,22 +1,18 @@
 import type Database from 'better-sqlite3'
-import type { ProjectGroup, ProjectIdentityKind, SessionSource } from '../types.js'
+import type { ProjectGroup, ProjectGroupWithPaths, ProjectIdentityKind, SessionSource } from '../types.js'
 
-export function listProjectGroups(db: Database.Database): ProjectGroup[] {
+export function listProjectGroups(db: Database.Database): ProjectGroup[]
+export function listProjectGroups(db: Database.Database, opts: { withPaths: true }): ProjectGroupWithPaths[]
+export function listProjectGroups(
+  db: Database.Database,
+  opts?: { withPaths?: boolean },
+): ProjectGroup[] {
+  const withPaths = opts?.withPaths === true
   const rows = db.prepare(`
-    SELECT
-      p.identity_kind,
-      p.identity_key,
-      MIN(p.display_name) AS display_name,
-      GROUP_CONCAT(DISTINCT src.name) AS sources_csv,
-      JSON_GROUP_ARRAY(DISTINCT p.display_path) FILTER (WHERE p.display_path IS NOT NULL AND p.display_path <> '') AS display_paths_json,
-      JSON_GROUP_ARRAY(DISTINCT s.cwd) FILTER (WHERE s.cwd IS NOT NULL AND s.cwd <> '') AS cwds_json,
-      COUNT(s.id) AS session_count,
-      MAX(s.started_at) AS last_session_at
-    FROM projects p
-    JOIN sources src ON src.id = p.source_id
-    LEFT JOIN sessions s ON s.project_id = p.id AND s.message_count > 0
-    WHERE p.identity_kind IS NOT NULL
-    GROUP BY p.identity_kind, p.identity_key
+    SELECT identity_kind, identity_key, display_name, sources_csv,
+           ${withPaths ? 'display_paths_json, cwds_json,' : ''}
+           session_count, last_session_at
+    FROM project_groups_v
     ORDER BY
       CASE identity_kind WHEN 'loose' THEN 1 ELSE 0 END,
       last_session_at IS NULL,
@@ -26,21 +22,27 @@ export function listProjectGroups(db: Database.Database): ProjectGroup[] {
     identity_key: string
     display_name: string
     sources_csv: string | null
-    display_paths_json: string | null
-    cwds_json: string | null
+    display_paths_json?: string | null
+    cwds_json?: string | null
     session_count: number
     last_session_at: string | null
   }>
-  return rows.map(r => ({
-    identityKind: r.identity_kind,
-    identityKey: r.identity_key,
-    displayName: r.display_name,
-    displayPaths: parseStringArray(r.display_paths_json),
-    cwds: parseStringArray(r.cwds_json),
-    sources: (r.sources_csv ?? '').split(',').filter(Boolean) as SessionSource[],
-    sessionCount: r.session_count,
-    lastSessionAt: r.last_session_at,
-  }))
+  return rows.map(r => {
+    const group: ProjectGroup = {
+      identityKind: r.identity_kind,
+      identityKey: r.identity_key,
+      displayName: r.display_name,
+      sources: (r.sources_csv ?? '').split(',').filter(Boolean) as SessionSource[],
+      sessionCount: r.session_count,
+      lastSessionAt: r.last_session_at,
+    }
+    if (!withPaths) return group
+    return {
+      ...group,
+      displayPaths: parseStringArray(r.display_paths_json ?? null),
+      cwds: parseStringArray(r.cwds_json ?? null),
+    } satisfies ProjectGroupWithPaths
+  })
 }
 
 function parseStringArray(value: string | null): string[] {

--- a/packages/core/src/projects/groups.ts
+++ b/packages/core/src/projects/groups.ts
@@ -3,9 +3,20 @@ import type { ProjectGroup, ProjectIdentityKind, SessionSource } from '../types.
 
 export function listProjectGroups(db: Database.Database): ProjectGroup[] {
   const rows = db.prepare(`
-    SELECT identity_kind, identity_key, display_name, sources_csv,
-           session_count, last_session_at
-    FROM project_groups_v
+    SELECT
+      p.identity_kind,
+      p.identity_key,
+      MIN(p.display_name) AS display_name,
+      GROUP_CONCAT(DISTINCT src.name) AS sources_csv,
+      JSON_GROUP_ARRAY(DISTINCT p.display_path) FILTER (WHERE p.display_path IS NOT NULL AND p.display_path <> '') AS display_paths_json,
+      JSON_GROUP_ARRAY(DISTINCT s.cwd) FILTER (WHERE s.cwd IS NOT NULL AND s.cwd <> '') AS cwds_json,
+      COUNT(s.id) AS session_count,
+      MAX(s.started_at) AS last_session_at
+    FROM projects p
+    JOIN sources src ON src.id = p.source_id
+    LEFT JOIN sessions s ON s.project_id = p.id AND s.message_count > 0
+    WHERE p.identity_kind IS NOT NULL
+    GROUP BY p.identity_kind, p.identity_key
     ORDER BY
       CASE identity_kind WHEN 'loose' THEN 1 ELSE 0 END,
       last_session_at IS NULL,
@@ -15,6 +26,8 @@ export function listProjectGroups(db: Database.Database): ProjectGroup[] {
     identity_key: string
     display_name: string
     sources_csv: string | null
+    display_paths_json: string | null
+    cwds_json: string | null
     session_count: number
     last_session_at: string | null
   }>
@@ -22,8 +35,16 @@ export function listProjectGroups(db: Database.Database): ProjectGroup[] {
     identityKind: r.identity_kind,
     identityKey: r.identity_key,
     displayName: r.display_name,
+    displayPaths: parseStringArray(r.display_paths_json),
+    cwds: parseStringArray(r.cwds_json),
     sources: (r.sources_csv ?? '').split(',').filter(Boolean) as SessionSource[],
     sessionCount: r.session_count,
     lastSessionAt: r.last_session_at,
   }))
+}
+
+function parseStringArray(value: string | null): string[] {
+  if (!value) return []
+  const parsed = JSON.parse(value) as unknown
+  return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string' && v.length > 0) : []
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -85,6 +85,8 @@ export interface ProjectGroup {
   identityKind: ProjectIdentityKind
   identityKey: string
   displayName: string
+  displayPaths: string[]
+  cwds: string[]
   sources: SessionSource[]          // unique sources contributing
   sessionCount: number
   lastSessionAt: string | null

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -85,11 +85,17 @@ export interface ProjectGroup {
   identityKind: ProjectIdentityKind
   identityKey: string
   displayName: string
-  displayPaths: string[]
-  cwds: string[]
   sources: SessionSource[]          // unique sources contributing
   sessionCount: number
   lastSessionAt: string | null
+}
+
+// Filesystem paths stay out of the base type so app IPC payloads don't carry
+// every distinct cwd on each sidebar refetch; only the CLI query resolver
+// needs them (listProjectGroups with { withPaths: true }).
+export interface ProjectGroupWithPaths extends ProjectGroup {
+  displayPaths: string[]            // distinct project display_path values
+  cwds: string[]                    // distinct session cwd values
 }
 
 export interface Message {


### PR DESCRIPTION
## Summary

- Extend `spool projects <query>` resolution to match project display paths and session `cwd` values in addition to display name and identity key.
- Preserve arbitrary filesystem paths containing commas by aggregating `display_path` and `cwd` as SQLite JSON arrays instead of comma-delimited `GROUP_CONCAT` strings.
- Add coverage for path/cwd query matching and comma-containing display paths/cwds.

## Notes

The `a,b` path was also valid because SQLite `GROUP_CONCAT` uses comma as its default delimiter, so a valid path like `/Users/me/foo,bar` would be split into `/Users/me/foo` and `bar`. The implementation now uses `JSON_GROUP_ARRAY(DISTINCT ...) FILTER (...)`, then parses the JSON array in TypeScript, so commas and other normal path characters stay intact.

`JSON.parse` should not fail for values produced by SQLite `JSON_GROUP_ARRAY`; it would only fail if the SQL expression stopped returning JSON or the DB engine lacked JSON aggregate support. The current migration/test path already exercises the function through `better-sqlite3`.

## Verification

- `pnpm --filter @spool-lab/core exec vitest run src/projects/groups.test.ts`
- `pnpm --filter @spool-lab/core run build`
- `pnpm --filter @spool-lab/core test`
- `pnpm --filter @spool-lab/cli test`
