### PR TITLE
Stacked features 6: package size

### DIFF
--- a/docs/engineering-optimization-roadmap.md
+++ b/docs/engineering-optimization-roadmap.md
@@ -475,6 +475,52 @@ Acceptance criteria:
 Goal: remove demonstrably unused runtime payload without weakening Privacy
 Filter, ACP, or native database behavior.
 
+Implementation status: complete on `feat/package-size`; signed/notarized
+release artifacts remain CI-only verification.
+
+Implementation notes:
+
+1. Add `report:package-size`, which reports logical app, Frameworks, Resources,
+   asar, asar-unpacked, and the largest packaged modules without extracting the
+   archive. Hard-linked framework files are counted once.
+2. Prove that the inference renderer dynamically imports
+   `@huggingface/transformers` and explicitly selects WebGPU/WASM, while the
+   main-process model protocol resolves only `onnxruntime-web`. Exclude the
+   unreachable `onnxruntime-node` package from electron-builder files.
+3. Add a reproducible clean-profile packaged smoke. It launches the actual
+   `.app`, indexes fixtures through packaged `better-sqlite3`, searches, runs
+   mocked Claude and Codex ACP protocol turns while checking both packaged
+   extension assets, scans and purges a secret, and verifies the local ORT
+   resource protocol.
+4. Add `--full-pf` to the packaged smoke. It downloads and verifies the pinned
+   945 MB model, initializes the hidden inference renderer, waits for a
+   PF-enabled scan profile to drain, and removes the temporary profile.
+5. Fix two privacy defects exposed by that smoke: give the inference document
+   a dedicated CSP that permits only local `pf-model:`/blob resources, and make
+   purge rebuild message FTS, session FTS, session title, and the main-process
+   search cache atomically enough that a purged value cannot remain searchable.
+6. Include renderer feature flags in the app Turbo build cache key so a release
+   cannot reuse a bundle built without Security. Keep `onnxruntime-web` intact:
+   the package currently serves multiple WASM/WebGPU runtime variants from its
+   dist directory. Curating those files is a separate runtime-matrix change,
+   not required to remove the proven Node-only payload.
+
+Verification on 2026-07-12:
+
+- Before: 689.1 MB logical app, 210.1 MB asar, 246.9 MB unpacked;
+  `onnxruntime-node` contributed 87.5 MB of packaged files, including Linux and
+  Windows binaries.
+- After: 601.7 MB app, 210.1 MB asar, 159.5 MB unpacked. Net reduction is
+  87.4 MB, and the report contains no `onnxruntime-node` entry.
+- The clean-profile packaged smoke passed indexing/search, Claude/Codex ACP,
+  ORT resource loading, Security scan/purge, and post-purge FTS checks.
+- The full Privacy Filter smoke installed the pinned model, initialized WebGPU
+  in 12.1 seconds, completed a PF-profile scan, and exited with runtime
+  `ready` and model state `installed`.
+- App passed 488 tests; core passed 410 with one skipped. Nine-package
+  typecheck and type-aware lint passed. Ad-hoc packaging restored Node ABI and
+  the globally linked `sp status` remained healthy.
+
 Changes:
 
 1. Add a package-size report that records asar, unpacked resources, frameworks,
@@ -490,11 +536,11 @@ Changes:
 
 Acceptance criteria:
 
-- [ ] Packaged app starts on a clean macOS user profile.
-- [ ] Search and indexing work with the packaged native SQLite module.
-- [ ] Codex and Claude ACP launch paths work.
-- [ ] Privacy Filter downloads, initializes, scans, and purges locally.
-- [ ] The app bundle shrinks by at least the proven unused payload; expected
+- [x] Packaged app starts on a clean macOS user profile.
+- [x] Search and indexing work with the packaged native SQLite module.
+- [x] Codex and Claude ACP launch paths work.
+- [x] Privacy Filter downloads, initializes, scans, and purges locally.
+- [x] The app bundle shrinks by at least the proven unused payload; expected
       first target is approximately 80 MB from `onnxruntime-node`.
 
 ### PR 7: Dependency and Module Maintenance

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,6 +20,8 @@
     "package:mac": "node ../../scripts/with-electron-native.mjs pnpm exec electron-builder --mac --arm64 --publish never",
     "package:linux": "node ../../scripts/with-electron-native.mjs pnpm exec electron-builder --linux --publish never",
     "smoke:native:electron": "node ../../scripts/with-electron-native.mjs pnpm exec electron ../../scripts/check-electron-native.cjs",
+    "report:package-size": "node scripts/package-size-report.mjs",
+    "smoke:packaged": "node scripts/smoke-packaged.mjs",
     "preview": "electron-vite preview",
     "clean": "rm -rf out dist-electron",
     "typecheck": "tsc --noEmit",
@@ -82,7 +84,9 @@
       "!e2e/**/*",
       "!artifacts/**/*",
       "!src/**/*",
-      "!**/*.map"
+      "!**/*.map",
+      "!node_modules/onnxruntime-node",
+      "!node_modules/onnxruntime-node/**"
     ],
     "asarUnpack": [
       "node_modules/better-sqlite3/**",
@@ -153,6 +157,7 @@
     "acp-extension-codex-linux-x64": "^0.10.0"
   },
   "devDependencies": {
+    "@electron/asar": "^3.4.1",
     "@electron/rebuild": "^3.7.1",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.1.4",

--- a/packages/app/scripts/package-size-report.mjs
+++ b/packages/app/scripts/package-size-report.mjs
@@ -1,0 +1,99 @@
+import { lstat, readdir } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { getRawHeader } from '@electron/asar'
+
+const appPath = resolve(process.argv.slice(2).find(arg => !arg.startsWith('-')) ?? 'dist/mac-arm64/Spool.app')
+const json = process.argv.includes('--json')
+const contents = join(appPath, 'Contents')
+const resources = join(contents, 'Resources')
+const frameworks = join(contents, 'Frameworks')
+const asarPath = join(resources, 'app.asar')
+const unpackedPath = `${asarPath}.unpacked`
+
+const moduleBytes = new Map()
+const { header } = getRawHeader(asarPath)
+collectAsarFiles(header.files, '', moduleBytes)
+
+const report = {
+  app: appPath,
+  totals: {
+    app: await sizeOf(appPath),
+    frameworks: await sizeOf(frameworks),
+    resources: await sizeOf(resources),
+    asar: await sizeOf(asarPath),
+    asarUnpacked: await sizeOf(unpackedPath),
+  },
+  largestFrameworks: await largestChildren(frameworks, 10),
+  largestResources: await largestChildren(resources, 10),
+  largestModules: [...moduleBytes]
+    .map(([name, bytes]) => ({ name, bytes }))
+    .sort((a, b) => b.bytes - a.bytes)
+    .slice(0, 20),
+}
+
+if (json) {
+  console.log(JSON.stringify(report, null, 2))
+} else {
+  console.log(`Package size report: ${appPath}`)
+  printEntries('Totals', Object.entries(report.totals).map(([name, bytes]) => ({ name, bytes })))
+  printEntries('Largest frameworks', report.largestFrameworks)
+  printEntries('Largest resources', report.largestResources)
+  printEntries('Largest packaged modules', report.largestModules)
+}
+
+function collectAsarFiles(entries, parent, totals) {
+  for (const [name, entry] of Object.entries(entries)) {
+    const path = parent ? `${parent}/${name}` : name
+    if ('files' in entry) {
+      collectAsarFiles(entry.files, path, totals)
+      continue
+    }
+    if (!('size' in entry)) continue
+    const moduleName = packageName(path)
+    if (moduleName) totals.set(moduleName, (totals.get(moduleName) ?? 0) + entry.size)
+  }
+}
+
+function packageName(path) {
+  const parts = path.split('/')
+  const index = parts.indexOf('node_modules')
+  if (index < 0 || !parts[index + 1]) return null
+  const first = parts[index + 1]
+  return first.startsWith('@') && parts[index + 2] ? `${first}/${parts[index + 2]}` : first
+}
+
+async function largestChildren(path, limit) {
+  const entries = await readdir(path, { withFileTypes: true })
+  const sizes = await Promise.all(entries.map(async entry => ({
+    name: entry.name,
+    bytes: await sizeOf(join(path, entry.name)),
+  })))
+  return sizes.sort((a, b) => b.bytes - a.bytes).slice(0, limit)
+}
+
+async function sizeOf(path, seen = new Set()) {
+  const info = await lstat(path)
+  if (info.isSymbolicLink()) return 0
+  const identity = `${info.dev}:${info.ino}`
+  if (seen.has(identity)) return 0
+  seen.add(identity)
+  if (!info.isDirectory()) return info.size
+  const entries = await readdir(path, { withFileTypes: true })
+  return (await Promise.all(entries.map(entry => sizeOf(join(path, entry.name), seen)))).reduce((sum, size) => sum + size, 0)
+}
+
+function printEntries(title, entries) {
+  console.log(`\n${title}`)
+  for (const entry of entries) console.log(`${formatBytes(entry.bytes).padStart(10)}  ${entry.name}`)
+}
+
+function formatBytes(bytes) {
+  const units = ['B', 'KB', 'MB', 'GB']
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`
+}

--- a/packages/app/scripts/smoke-packaged.mjs
+++ b/packages/app/scripts/smoke-packaged.mjs
@@ -1,0 +1,192 @@
+import { _electron as electron } from '@playwright/test'
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const appDir = resolve(process.argv.slice(2).find(arg => !arg.startsWith('-')) ?? 'dist/mac-arm64/Spool.app')
+const fullPrivacyFilter = process.argv.includes('--full-pf')
+const keepProfile = process.argv.includes('--keep-profile')
+const executablePath = join(appDir, 'Contents', 'MacOS', 'Spool')
+if (!existsSync(executablePath)) throw new Error(`Packaged executable not found: ${executablePath}`)
+const unpackedModules = join(appDir, 'Contents', 'Resources', 'app.asar.unpacked', 'node_modules')
+assert(existsSync(join(unpackedModules, 'acp-extension-claude', 'dist', 'index.js')), 'packaged Claude ACP extension is missing')
+assert(existsSync(join(unpackedModules, 'acp-extension-codex-darwin-arm64', 'bin', 'acp-extension-codex')), 'packaged Codex ACP extension is missing')
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const fixturesDir = join(packageDir, 'e2e', 'fixtures')
+const mocksDir = join(packageDir, 'e2e', 'mocks')
+const tempDir = mkdtempSync(join(tmpdir(), 'spool-packaged-smoke-'))
+const claudeDir = join(tempDir, 'claude', 'projects')
+const codexDir = join(tempDir, 'codex', 'sessions')
+const geminiDir = join(tempDir, 'gemini')
+const opencodeDir = join(tempDir, 'opencode')
+const spoolHome = join(tempDir, 'spool-home')
+const mockBinDir = join(tempDir, 'bin')
+const secret = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+const sensitiveFixture = join(claudeDir, 'package-smoke', 'sensitive.jsonl')
+
+mkdirSync(join(claudeDir, 'test-project'), { recursive: true })
+cpSync(
+  join(fixturesDir, 'claude-projects', 'test-project', 'test-session-001.jsonl'),
+  join(claudeDir, 'test-project', 'test-session-001.jsonl'),
+)
+mkdirSync(codexDir, { recursive: true })
+mkdirSync(geminiDir, { recursive: true })
+mkdirSync(join(claudeDir, 'package-smoke'), { recursive: true })
+mkdirSync(opencodeDir, { recursive: true })
+mkdirSync(spoolHome, { recursive: true })
+mkdirSync(mockBinDir, { recursive: true })
+writeFileSync(sensitiveFixture, JSON.stringify({
+  type: 'user',
+  uuid: 'packaged-sensitive-message',
+  timestamp: '2026-07-12T00:00:00.000Z',
+  message: { role: 'user', content: `PACKAGED_SMOKE_SECRET ${secret}. My name is Harry Potter and my email is harry.potter@hogwarts.edu.` },
+  sessionId: 'packaged-sensitive-session',
+  cwd: '/tmp/package-smoke',
+}) + '\n')
+writeFileSync(join(spoolHome, 'agents.json'), JSON.stringify({ securityEnabled: true, defaultAgent: 'claude' }))
+for (const name of ['claude', 'codex']) {
+  const path = join(mockBinDir, name)
+  writeFileSync(path, '#!/bin/sh\nexit 0\n')
+  chmodSync(path, 0o755)
+}
+
+const env = {
+  ...process.env,
+  SPOOL_DATA_DIR: join(tempDir, 'data'),
+  SPOOL_ELECTRON_USER_DATA_DIR: join(tempDir, 'electron-user-data'),
+  SPOOL_HOME: spoolHome,
+  SPOOL_CLAUDE_DIR: claudeDir,
+  SPOOL_CODEX_DIR: codexDir,
+  SPOOL_GEMINI_DIR: geminiDir,
+  GEMINI_CLI_HOME: geminiDir,
+  SPOOL_OPENCODE_DIR: opencodeDir,
+  SPOOL_ACP_AGENT_BIN: join(mocksDir, 'acp-mock-agent.mjs'),
+  PATH: `${mockBinDir}:${process.env.PATH ?? ''}`,
+  ELECTRON_DISABLE_GPU: '1',
+}
+
+let app
+try {
+  app = await electron.launch({
+    executablePath,
+    args: ['--force-prefers-reduced-motion'],
+    cwd: packageDir,
+    env,
+    timeout: 30_000,
+  })
+  if (fullPrivacyFilter) {
+    app.process().stdout?.on('data', chunk => process.stdout.write(`[packaged-main] ${chunk}`))
+    app.process().stderr?.on('data', chunk => process.stderr.write(`[packaged-main] ${chunk}`))
+  }
+  const window = await app.firstWindow()
+
+  const searchResults = await poll(async () => {
+    const results = await window.evaluate(async () => globalThis.spool?.search('XYLOPHONE_CANARY_42', 5) ?? [])
+    return results.length > 0 ? results : null
+  }, 'fixture indexing')
+  assert(searchResults.length > 0, 'packaged SQLite search returned no fixture result')
+
+  const agents = await window.evaluate(async () => globalThis.spool.getAiAgents())
+  for (const agentId of ['claude', 'codex']) {
+    assert(agents.some(agent => agent.id === agentId && agent.status === 'ready'), `${agentId} was not detected`)
+    const response = await window.evaluate(async (id) => globalThis.spool.aiSearch('packaged ACP smoke', id, []), agentId)
+    assert(response.ok && response.fullText?.includes('MOCK_ACP_RESPONSE_42'), `${agentId} ACP launch failed: ${response.error ?? 'empty response'}`)
+  }
+
+  await poll(async () => window.evaluate(async () => {
+    const security = globalThis.spool?.security
+    if (!security) return false
+    try {
+      await security.getScanStatus()
+      return true
+    } catch {
+      return false
+    }
+  }), 'Security IPC')
+
+  const ortResource = await app.evaluate(async ({ net }) => {
+    const response = await net.fetch('pf-model:///ort/ort-wasm-simd-threaded.mjs')
+    return { ok: response.ok, bytes: (await response.arrayBuffer()).byteLength }
+  })
+  assert(ortResource.ok && ortResource.bytes > 1000, 'packaged ORT Web runtime is unavailable')
+
+  await window.evaluate(async () => globalThis.spool.security.rescanAll())
+  await poll(async () => window.evaluate(async () => {
+    const status = await globalThis.spool.security.getScanStatus()
+    return status.queued === 0 && status.scanning === null && status.backfillRemaining === 0
+  }), 'Security scan completion')
+  const sensitiveResults = await window.evaluate(async () => globalThis.spool.search('PACKAGED_SMOKE_SECRET', 5))
+  assert(sensitiveResults.length > 0, 'sensitive package-smoke session was not indexed')
+  const sensitiveSessionId = sensitiveResults[0].sessionId
+  const findings = await window.evaluate(
+    async (sessionId) => globalThis.spool.security.listFindings({ sessionId, state: 'active' }),
+    sensitiveSessionId,
+  )
+  const apiKey = findings.find(finding => finding.kind === 'api-key')
+  assert(apiKey, 'packaged Security scanner did not detect the fixture API key')
+  await window.evaluate(async (findingId) => globalThis.spool.security.purgeFinding(findingId), apiKey.id)
+  const purgedSession = await window.evaluate(async () => globalThis.spool.getSession('packaged-sensitive-session'))
+  const purgedText = purgedSession?.messages.map(message => message.contentText).join('\n') ?? ''
+  assert(!purgedText.includes(secret) && purgedText.includes('[redacted:'), 'packaged purge did not mask the indexed message')
+  const postPurgeSearch = await window.evaluate(async (query) => globalThis.spool.search(query, 5), secret)
+  assert(postPurgeSearch.length === 0, 'purged secret remains searchable in packaged FTS')
+
+  let pfState = await window.evaluate(async () => globalThis.spool.security.pfGetState())
+  let pfRuntime = null
+  if (fullPrivacyFilter) {
+    if (pfState.phase !== 'installed') {
+      const download = await window.evaluate(async () => globalThis.spool.security.pfDownloadStart())
+      assert(download.ok, `Privacy Filter download failed: ${download.reason ?? 'unknown error'}`)
+      pfState = await window.evaluate(async () => globalThis.spool.security.pfGetState())
+    }
+    assert(pfState.phase === 'installed', `Privacy Filter was not installed: ${pfState.phase}`)
+    await window.evaluate(async () => globalThis.spool.security.setPrefs({ pfEnabled: true }))
+    pfRuntime = await poll(
+      async () => window.evaluate(async () => globalThis.spool.security.pfGetRuntimeInfo()),
+      'Privacy Filter runtime',
+      180_000,
+    )
+    await window.evaluate(async () => globalThis.spool.security.rescanAll())
+    const pfScanStatus = await poll(async () => window.evaluate(async () => {
+      const status = await globalThis.spool.security.getScanStatus()
+      return status.currentProfile.includes('pf@')
+        && status.queued === 0
+        && status.scanning === null
+        && status.backfillRemaining === 0
+        ? status
+        : null
+    }), 'Privacy Filter scan completion', 180_000)
+    assert(pfScanStatus.currentProfile.includes('pf@'), `scan profile did not enable Privacy Filter: ${pfScanStatus.currentProfile}`)
+  }
+  assert(['not-installed', 'installed'].includes(pfState.phase), `unexpected Privacy Filter state: ${pfState.phase}`)
+  console.log(JSON.stringify({
+    app: appDir,
+    sessionsIndexed: true,
+    search: true,
+    acp: ['claude', 'codex'],
+    privacyFilterRuntimeBytes: ortResource.bytes,
+    privacyFilterRuntime: pfRuntime,
+    securityScanAndPurge: true,
+    privacyFilterState: pfState.phase,
+  }, null, 2))
+} finally {
+  await app?.close().catch(() => {})
+  if (keepProfile) console.log(`Kept packaged smoke profile: ${tempDir}`)
+  else rmSync(tempDir, { recursive: true, force: true })
+}
+
+function assert(value, message) {
+  if (!value) throw new Error(message)
+}
+
+async function poll(check, label, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const value = await check()
+    if (value) return value
+    await new Promise(resolve => setTimeout(resolve, 200))
+  }
+  throw new Error(`Timed out waiting for ${label}`)
+}

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -323,6 +323,7 @@ async function ensureSecurityBooted(): Promise<void> {
     worker: scanWorker,
     runPromise: runWithObservability,
     getMainWindow: () => mainWindow,
+    onSearchContentChanged: () => searchCache.clear(),
     pfCoordinator,
     pfRuntime,
     onPfEnabledChanged: (enabled) => {

--- a/packages/app/src/main/ipc/security.test.ts
+++ b/packages/app/src/main/ipc/security.test.ts
@@ -78,6 +78,7 @@ interface Fixture {
   /** Each call records `rescanAll` / `backfill` / `enqueue` /
    *  `getStatus` invocations so tests can assert dispatch. */
   workerCalls: { rescanAll: number; backfill: number; enqueue: number[]; getStatus: number }
+  searchInvalidations: { count: number }
 }
 
 function setupDb(): Database.Database {
@@ -101,6 +102,7 @@ function setupDb(): Database.Database {
 async function setupFixture(): Promise<Fixture> {
   const db = setupDb()
   const workerCalls = { rescanAll: 0, backfill: 0, enqueue: [] as number[], getStatus: 0 }
+  const searchInvalidations = { count: 0 }
   // PubSub-backed stream so we can assert change-event forwarding.
   const pubsub = await Effect.runPromise(PubSub.unbounded<FindingsChange>())
   const status: ScanStatus = { queued: 0, scanning: null, backfillRemaining: 0, backfillTotal: 0, manualBurstInFlight: false, currentProfile: 'regex@4' }
@@ -133,6 +135,7 @@ async function setupFixture(): Promise<Fixture> {
     worker,
     runPromise: <A, E>(eff: Effect.Effect<A, E>) => Effect.runPromise(eff as unknown as Effect.Effect<A>),
     getMainWindow: () => fakeWindow,
+    onSearchContentChanged: () => { searchInvalidations.count += 1 },
   })
 
   return {
@@ -141,6 +144,7 @@ async function setupFixture(): Promise<Fixture> {
     push: (change) => Effect.runPromise(PubSub.publish(pubsub, change)).then(() => { /* void */ }),
     dispose,
     workerCalls,
+    searchInvalidations,
   }
 }
 
@@ -329,6 +333,7 @@ describe('registerSecurityIpc', () => {
       )
       expect(result.findingId).toBe(findingId)
       expect(result.sessionId).toBe(1)
+      expect(fixture.searchInvalidations.count).toBe(1)
       const msg = fixture.db.prepare('SELECT content_text FROM messages WHERE id = 10')
         .get() as { content_text: string }
       expect(msg.content_text.includes('AKIAIOSFODNN7EXAMPLE')).toBe(false)
@@ -528,6 +533,7 @@ describe('registerSecurityIpc with mutationWorker', () => {
     // Track every call so we can assert the right proxy method was
     // hit and the in-process path was not.
     const calls: Array<{ method: string; args: unknown[] }> = []
+    let searchInvalidations = 0
     const fakeProxy: MutationWorkerProxy = {
       purgeFinding: async (id) => { calls.push({ method: 'purgeFinding', args: [id] }); return { findingId: id, sessionId: 1, maskUsed: '[redacted]', purgedAt: 'now' } },
       purgeFindings: async (ids) => { calls.push({ method: 'purgeFindings', args: [ids] }); return [] },
@@ -548,6 +554,7 @@ describe('registerSecurityIpc with mutationWorker', () => {
       worker,
       runPromise: <A, E>(eff: Effect.Effect<A, E>) => Effect.runPromise(eff as unknown as Effect.Effect<A>),
       getMainWindow: () => fakeWindow,
+      onSearchContentChanged: () => { searchInvalidations += 1 },
     })
     // Late-attach the fake proxy — mirrors how production wires the
     // mutation worker in after the IPC layer is already live.
@@ -569,6 +576,7 @@ describe('registerSecurityIpc with mutationWorker', () => {
         { method: 'dismissFindings', args: [[8, 9], 'global'] },
         { method: 'undismissFinding', args: [7] },
       ])
+      expect(searchInvalidations).toBe(3)
 
       // The proxy's per-mutation publishes ride a separate forwarder
       // (a Stream.empty proxy here emits nothing); the in-process

--- a/packages/app/src/main/ipc/security.ts
+++ b/packages/app/src/main/ipc/security.ts
@@ -163,6 +163,9 @@ export interface SecurityIpcDeps {
   runPromise: <A, E>(eff: Effect.Effect<A, E>) => Promise<A>
   /** Subscribe to per-window pushes; called once per main window. */
   getMainWindow: () => BrowserWindow | null
+  /** Purge rewrites indexed message content, so cached search results
+   *  must be discarded after the mutation commits. */
+  onSearchContentChanged?: () => void
   /** Privacy Filter download orchestrator. Optional in 5b — null means
    *  the PF channels return a default not-installed snapshot. PR 5c
    *  swaps in a real coordinator when the toggle flips on. */
@@ -206,7 +209,7 @@ export interface SecurityIpcHandle {
  *  worker is ready so the IPC layer becomes live before that boot
  *  completes. */
 export function registerSecurityIpc(deps: SecurityIpcDeps): SecurityIpcHandle {
-  const { db, worker, runPromise, getMainWindow, pfCoordinator, pfRuntime: hostRuntime, onPfEnabledChanged } = deps
+  const { db, worker, runPromise, getMainWindow, pfCoordinator, pfRuntime: hostRuntime, onPfEnabledChanged, onSearchContentChanged } = deps
   // Closure-local ref read by every mutation handler at call time —
   // lets `attachMutationWorker` swap the worker in after IPC has
   // already started taking calls. Until it's set the handlers fall
@@ -307,21 +310,31 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): SecurityIpcHandle {
     },
   )
   ipcMain.handle(SECURITY_IPC_CHANNELS.PURGE_FINDING, async (_e, findingId: number) => {
-    if (currentMutationWorker) return currentMutationWorker.purgeFinding(findingId)
+    if (currentMutationWorker) {
+      const result = await currentMutationWorker.purgeFinding(findingId)
+      onSearchContentChanged?.()
+      return result
+    }
     const publish = (change: Parameters<NonNullable<typeof getMainWindow extends () => infer R ? R : never>['webContents']['send']>[1]) =>
       Effect.sync(() => {
         getMainWindow()?.webContents.send(SECURITY_IPC_CHANNELS.EVT_FINDINGS_CHANGED, change)
-      })
+    })
     const result = await runPromise(purgeFinding(findingId, { db, publish: publish as never })) as PurgeResult
+    onSearchContentChanged?.()
     return result
   })
   ipcMain.handle(SECURITY_IPC_CHANNELS.PURGE_FINDINGS, async (_e, findingIds: number[]) => {
-    if (currentMutationWorker) return currentMutationWorker.purgeFindings(findingIds)
+    if (currentMutationWorker) {
+      const results = await currentMutationWorker.purgeFindings(findingIds)
+      onSearchContentChanged?.()
+      return results
+    }
     const publish = (change: unknown) =>
       Effect.sync(() => {
         getMainWindow()?.webContents.send(SECURITY_IPC_CHANNELS.EVT_FINDINGS_CHANGED, change)
-      })
+    })
     const results = await runPromise(purgeFindings(findingIds, { db, publish: publish as never })) as PurgeResult[]
+    onSearchContentChanged?.()
     return results
   })
   ipcMain.handle(
@@ -329,6 +342,7 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): SecurityIpcHandle {
     async (_e, args: { kind: SensitiveKind; valueHash: string }) => {
       if (currentMutationWorker) {
         const out = await currentMutationWorker.purgeEverywhere(args.kind, args.valueHash)
+        onSearchContentChanged?.()
         return { count: out.results.length, sessionIds: out.sessionIds }
       }
       const publish = (change: unknown) =>
@@ -338,6 +352,7 @@ export function registerSecurityIpc(deps: SecurityIpcDeps): SecurityIpcHandle {
       const out = await runPromise(
         purgeEverywhere(args.kind, args.valueHash, { db, publish: publish as never }),
       ) as { results: PurgeResult[]; sessionIds: number[] }
+      onSearchContentChanged?.()
       return { count: out.results.length, sessionIds: out.sessionIds }
     },
   )

--- a/packages/app/src/main/security/csp.test.ts
+++ b/packages/app/src/main/security/csp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { __cspFixtures, buildCsp } from './csp.js'
+import { __cspFixtures, buildCsp, buildPfInferenceCsp, isPfInferenceDocument } from './csp.js'
 
 // We don't import installRendererCsp itself in tests — wiring it would
 // require an Electron `session` stub. The string fixtures cover the
@@ -186,6 +186,29 @@ describe('Renderer CSP policy', () => {
         const img = directives(csp).get('img-src') ?? []
         expect(img).toContain('https://lh3.googleusercontent.com')
       }
+    })
+  })
+
+  describe('Privacy Filter inference document', () => {
+    it('selects only the dedicated inference HTML entry', () => {
+      expect(isPfInferenceDocument('file:///Applications/Spool.app/Contents/Resources/app.asar/out/renderer/pf-inference.html')).toBe(true)
+      expect(isPfInferenceDocument('http://localhost:5173/pf-inference.html')).toBe(true)
+      expect(isPfInferenceDocument('file:///Applications/Spool.app/Contents/Resources/app.asar/out/renderer/index.html')).toBe(false)
+    })
+
+    it('allows the local model protocol and WASM execution', () => {
+      for (const dev of [true, false]) {
+        const dirs = directives(buildPfInferenceCsp({ dev }))
+        expect(dirs.get('connect-src')).toContain('pf-model:')
+        expect(dirs.get('script-src')).toContain("'wasm-unsafe-eval'")
+        expect(dirs.get('worker-src')).toContain('blob:')
+      }
+    })
+
+    it('keeps production inference offline except for local schemes', () => {
+      const connect = directives(buildPfInferenceCsp({ dev: false })).get('connect-src') ?? []
+      expect(connect).toEqual(["'self'", 'pf-model:', 'blob:'])
+      expect(connect.every(source => !source.startsWith('http') && !source.startsWith('ws'))).toBe(true)
     })
   })
 })

--- a/packages/app/src/main/security/csp.ts
+++ b/packages/app/src/main/security/csp.ts
@@ -123,8 +123,40 @@ export function buildCsp(opts: { dev: boolean; backendOrigin?: string | null }):
   ].join('; ')
 }
 
+export function buildPfInferenceCsp(opts: { dev: boolean }): string {
+  const scriptSrc = opts.dev
+    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' blob: pf-model:"
+    : "script-src 'self' 'wasm-unsafe-eval' blob: pf-model:"
+  const connectSrc = opts.dev
+    ? "connect-src 'self' pf-model: blob: http://localhost:5173 ws://localhost:5173 ws://127.0.0.1:5173"
+    : "connect-src 'self' pf-model: blob:"
+  return [
+    "default-src 'self'",
+    scriptSrc,
+    "style-src 'self' 'unsafe-inline'",
+    "worker-src 'self' blob: pf-model:",
+    connectSrc,
+    "img-src 'none'",
+    "font-src 'none'",
+    "frame-src 'none'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+  ].join('; ')
+}
+
+export function isPfInferenceDocument(url: string): boolean {
+  try {
+    return new URL(url).pathname.endsWith('/pf-inference.html')
+  } catch {
+    return false
+  }
+}
+
 const DEV_CSP = buildCsp({ dev: true })
 const PROD_CSP = buildCsp({ dev: false })
+const PF_DEV_CSP = buildPfInferenceCsp({ dev: true })
+const PF_PROD_CSP = buildPfInferenceCsp({ dev: false })
 
 export function installRendererCsp(opts: { dev: boolean }): void {
   // Diagnostic escape hatch: setting SPOOL_DISABLE_CSP=1 skips the
@@ -133,6 +165,7 @@ export function installRendererCsp(opts: { dev: boolean }): void {
   // future Labs toggle could flip it via the renderer too.
   if (process.env['SPOOL_DISABLE_CSP'] === '1') return
   const policy = buildCsp({ dev: opts.dev, backendOrigin: overrideBackendOrigin() })
+  const pfPolicy = opts.dev ? PF_DEV_CSP : PF_PROD_CSP
   electronSession.defaultSession.webRequest.onHeadersReceived(
     (details, callback) => {
       // Only inject CSP into responses for the documents we actually
@@ -165,7 +198,7 @@ export function installRendererCsp(opts: { dev: boolean }): void {
           delete responseHeaders[key]
         }
       }
-      responseHeaders['Content-Security-Policy'] = [policy]
+      responseHeaders['Content-Security-Policy'] = [isPfInferenceDocument(url) ? pfPolicy : policy]
       callback({ responseHeaders })
     },
   )
@@ -173,4 +206,4 @@ export function installRendererCsp(opts: { dev: boolean }): void {
 
 // Exported for snapshot tests so policy drift gets caught in CI without
 // spinning up an Electron app.
-export const __cspFixtures = { DEV_CSP, PROD_CSP }
+export const __cspFixtures = { DEV_CSP, PROD_CSP, PF_DEV_CSP, PF_PROD_CSP }

--- a/packages/app/turbo.json
+++ b/packages/app/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "env": ["VITE_FEATURE_SECURITY", "VITE_FEATURE_SHARE", "VITE_FEATURE_SHAREPUBLISH"],
+      "env": ["VITE_FEATURE_SHAREPUBLISH"],
       "outputs": ["out/**"]
     }
   }

--- a/packages/app/turbo.json
+++ b/packages/app/turbo.json
@@ -3,6 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "env": ["VITE_FEATURE_SECURITY", "VITE_FEATURE_SHARE", "VITE_FEATURE_SHAREPUBLISH"],
       "outputs": ["out/**"]
     }
   }

--- a/packages/core/src/db/queries.ts
+++ b/packages/core/src/db/queries.ts
@@ -226,6 +226,39 @@ export function upsertSessionSearch(
   )
 }
 
+/** Rebuild the denormalized session-level search document from the authoritative
+ * session title and current message rows. Security purge calls this inside its
+ * transaction so raw values cannot survive in either session-level FTS index. */
+export function refreshSessionSearchFromMessages(
+  db: Database.Database,
+  sessionId: number,
+): void {
+  const session = db.prepare('SELECT title FROM sessions WHERE id = ?')
+    .get(sessionId) as { title: string | null } | undefined
+  if (!session) return
+
+  const rows = db.prepare(`
+    SELECT role, content_text AS contentText
+    FROM messages
+    WHERE session_id = ?
+      AND is_sidechain = 0
+      AND role IN ('user', 'assistant')
+    ORDER BY seq, id
+  `).all(sessionId) as Array<{ role: 'user' | 'assistant'; contentText: string }>
+  const byRole = { user: [] as string[], assistant: [] as string[] }
+  for (const row of rows) {
+    const text = row.contentText.trim()
+    if (text) byRole[row.role].push(text)
+  }
+
+  upsertSessionSearch(db, {
+    sessionId,
+    title: session.title ?? '',
+    userText: byRole.user.join('\n'),
+    assistantText: byRole.assistant.join('\n'),
+  })
+}
+
 /** Insert message rows, skipping any that collide with the partial
  *  UNIQUE index on (session_id, msg_uuid). Returns the count of rows
  *  actually inserted — callers use this to decide whether anything

--- a/packages/core/src/security/purge.test.ts
+++ b/packages/core/src/security/purge.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { Effect } from 'effect'
 import Database from 'better-sqlite3'
 import { runMigrations } from '../db/db.js'
+import { refreshSessionSearchFromMessages } from '../db/queries.js'
 import { insertFindings, listFindings, updateSessionCounts } from './repo.js'
 import { purgeFinding, purgeFindings, purgeEverywhere, orderForBulkPurge, PurgeError } from './purge.js'
 import { occurrencesByValueHash } from './repo.js'
@@ -65,7 +66,7 @@ describe('purgeFinding', () => {
     expect(counts.scan_high_count).toBe(0)
   })
 
-  it('removes the raw value from messages_fts so search no longer matches', async () => {
+  it('removes the raw value from message and session FTS indexes', async () => {
     const raw = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
     const content = `My token is ${raw} please rotate`
     insertMessage(db, 11, content)
@@ -75,12 +76,18 @@ describe('purgeFinding', () => {
       provider: 'regex', startOffset: start, endOffset: start + raw.length, state: 'active',
     }])
     const f = listFindings(db, { sessionId: 1 })[0]!
+    db.prepare('UPDATE sessions SET title = ? WHERE id = 1').run(`Token ${raw}`)
+    refreshSessionSearchFromMessages(db, 1)
 
     // FTS contains the raw value before purge
     const beforeHits = db.prepare(
       "SELECT COUNT(*) AS n FROM messages_fts WHERE messages_fts MATCH ?",
     ).get('"ghp_abcdefghijklmnopqrstuvwxyz0123456789"') as { n: number }
     expect(beforeHits.n).toBe(1)
+    const beforeSessionHits = db.prepare(
+      'SELECT COUNT(*) AS n FROM session_search_fts WHERE session_search_fts MATCH ?',
+    ).get('"ghp_abcdefghijklmnopqrstuvwxyz0123456789"') as { n: number }
+    expect(beforeSessionHits.n).toBe(1)
 
     await Effect.runPromise(purgeFinding(f.id, deps(db)))
 
@@ -88,6 +95,17 @@ describe('purgeFinding', () => {
       "SELECT COUNT(*) AS n FROM messages_fts WHERE messages_fts MATCH ?",
     ).get('"ghp_abcdefghijklmnopqrstuvwxyz0123456789"') as { n: number }
     expect(afterHits.n).toBe(0)
+    const afterSessionHits = db.prepare(
+      'SELECT COUNT(*) AS n FROM session_search_fts WHERE session_search_fts MATCH ?',
+    ).get('"ghp_abcdefghijklmnopqrstuvwxyz0123456789"') as { n: number }
+    expect(afterSessionHits.n).toBe(0)
+    const title = db.prepare(
+      'SELECT title, title_source AS titleSource FROM sessions WHERE id = 1',
+    ).get() as { title: string; titleSource: string }
+    expect(title).toEqual({
+      title: 'Token [redacted: GitHub key]',
+      titleSource: 'security',
+    })
   })
 
   it('refuses to re-purge an already purged finding', async () => {

--- a/packages/core/src/security/purge.ts
+++ b/packages/core/src/security/purge.ts
@@ -21,6 +21,7 @@ import type Database from 'better-sqlite3'
 import type { SensitiveKind } from '@spool-lab/redact'
 import { maskValueByKind } from '@spool-lab/redact'
 import { updateSessionCounts } from './repo.js'
+import { refreshSessionSearchFromMessages } from '../db/queries.js'
 import type { FindingsChange, FindingState } from './types.js'
 
 export class PurgeError extends Data.TaggedError('PurgeError')<{
@@ -321,6 +322,11 @@ function applyBulkPurgeTxn(
         SET state = 'purged', state_changed_at = ?
       WHERE id = ?`,
   )
+  const maskSessionTitle = db.prepare(
+    `UPDATE sessions
+        SET title = replace(title, ?, ?), title_source = 'security'
+      WHERE id = ? AND instr(title, ?) > 0`,
+  )
 
   // One transaction wraps the whole batch: a single fsync at COMMIT
   // instead of one per finding. This is the load-bearing change for
@@ -345,6 +351,7 @@ function applyBulkPurgeTxn(
           mask +
           text.slice(finding.end_offset)
         updateFinding.run(purgedAt, finding.id)
+        maskSessionTitle.run(original, mask, finding.session_id, original)
         results.push({
           findingId: finding.id,
           sessionId: finding.session_id,
@@ -365,6 +372,7 @@ function applyBulkPurgeTxn(
     // had a large fan-in, which on its own ran two SELECTs +
     // an UPDATE per call.
     for (const sessionId of sessionsToRecount) {
+      refreshSessionSearchFromMessages(db, sessionId)
       updateSessionCounts(db, sessionId)
     }
   })()
@@ -402,6 +410,12 @@ function applyPurgeTxn(
               state_changed_at = ?
         WHERE id = ?`,
     ).run(purgedAt, finding.id)
+    db.prepare(`
+      UPDATE sessions
+         SET title = replace(title, ?, ?), title_source = 'security'
+       WHERE id = ? AND instr(title, ?) > 0
+    `).run(original, mask, finding.session_id, original)
+    refreshSessionSearchFromMessages(db, finding.session_id)
     updateSessionCounts(db, finding.session_id)
   })()
 

--- a/packages/core/src/sync/syncer.test.ts
+++ b/packages/core/src/sync/syncer.test.ts
@@ -416,7 +416,7 @@ describe('Syncer', () => {
   //   4. A shrunk parse result is a strong rewrite signal — source
   //      file truncation must replay through the safe path.
 
-  it('append-only sync keeps Security Scan masks in session_search_fts after a content-changing re-sync (no raw leak)', async () => {
+  it('append-only sync keeps Security Scan masks in the title and session FTS after re-sync', async () => {
     // Regression for the gap the post-PR code review surfaced:
     // upsertSessionSearch used to read from parsed.messages (the raw
     // jsonl), so on every re-sync the session-level FTS index
@@ -440,17 +440,10 @@ describe('Syncer', () => {
       timestamp: ts,
       message: { role: 'user', content },
     })
-    // Two messages so the parser derives the title from the FIRST
-    // user message (a benign greeting) and the secret lives in a
-    // later message — this isolates the user_text/assistant_text leak
-    // the PR introduces from the title-derivation leak (pre-existing
-    // and out of scope here; the parser slices the first 120 chars of
-    // the first user message into sessions.title and that path has
-    // its own redaction story).
     const SECRET = 'AKIAIOSFODNN7EXAMPLE'
     writeFileSync(filePath, [
-      userRecord('m0', '2026-05-01T00:00:00Z', 'hello, please review my repo'),
-      userRecord('m1', '2026-05-01T00:01:00Z', `here is the credential: ${SECRET} thanks`),
+      userRecord('m0', '2026-05-01T00:00:00Z', `credential ${SECRET} needs rotation`),
+      userRecord('m1', '2026-05-01T00:01:00Z', 'please continue'),
     ].join('\n'))
 
     const { getDB, Syncer } = await loadCoreModules()
@@ -462,41 +455,52 @@ describe('Syncer', () => {
       "SELECT id FROM sessions WHERE session_uuid = 'session-search-mask-session'"
     ).get() as { id: number }).id
     const messageId = (db.prepare(
-      "SELECT id FROM messages WHERE session_id = ? AND msg_uuid = 'm1'"
+      "SELECT id FROM messages WHERE session_id = ? AND msg_uuid = 'm0'"
     ).get(sessionId) as { id: number }).id
 
-    // Simulate Security Scan purge of the m1 finding: mask
-    // content_text in place. The source jsonl still has the raw
-    // value — that's the threat model.
+    // Simulate the persisted result of Security Scan purge. Its own unit test
+    // verifies that this update is atomic; here the source JSONL deliberately
+    // retains the raw value so re-sync exercises the persistence boundary.
     db.prepare(
-      `UPDATE messages SET content_text = 'here is the credential: [redacted: AWS key] thanks' WHERE id = ?`,
+      `UPDATE messages SET content_text = 'credential [redacted: AWS key] needs rotation' WHERE id = ?`,
     ).run(messageId)
+    db.prepare(
+      `UPDATE sessions
+          SET title = 'credential [redacted: AWS key] needs rotation',
+              title_source = 'security'
+        WHERE id = ?`,
+    ).run(sessionId)
 
     // A real append at the source (claude session keeps growing).
     writeFileSync(filePath, [
-      userRecord('m0', '2026-05-01T00:00:00Z', 'hello, please review my repo'),
-      userRecord('m1', '2026-05-01T00:01:00Z', `here is the credential: ${SECRET} thanks`),
+      userRecord('m0', '2026-05-01T00:00:00Z', `credential ${SECRET} needs rotation`),
+      userRecord('m1', '2026-05-01T00:01:00Z', 'please continue'),
       userRecord('m2', '2026-05-01T00:02:00Z', 'a follow-up'),
     ].join('\n'))
     touchFile(filePath)
     expect(new Syncer(db).syncFile(filePath, 'claude')).toBe('updated')
 
-    // session_search.user_text must reflect what the DB holds (mask),
-    // not what parsed.messages saw (raw).
+    const session = db.prepare(
+      'SELECT title, title_source AS titleSource FROM sessions WHERE id = ?',
+    ).get(sessionId) as { title: string; titleSource: string }
+    expect(session).toEqual({
+      title: 'credential [redacted: AWS key] needs rotation',
+      titleSource: 'security',
+    })
+
     const search = db.prepare(
-      'SELECT user_text FROM session_search WHERE session_id = ?'
-    ).get(sessionId) as { user_text: string }
+      'SELECT title, user_text FROM session_search WHERE session_id = ?'
+    ).get(sessionId) as { title: string; user_text: string }
+    expect(search.title).toBe(session.title)
     expect(search.user_text.includes(SECRET)).toBe(false)
     expect(search.user_text.includes('[redacted: AWS key]')).toBe(true)
 
-    // And a column-restricted FTS search against user_text must not
-    // surface the raw value (assistant_text and title leaks would be
-    // separate paths — title derivation is the parser's job, not
-    // this PR's surface).
-    const ftsHits = db.prepare(
-      'SELECT COUNT(*) AS n FROM session_search_fts WHERE session_search_fts MATCH ?'
-    ).get(`user_text:"${SECRET}"`) as { n: number }
-    expect(ftsHits.n).toBe(0)
+    for (const table of ['session_search_fts', 'session_search_fts_trigram']) {
+      const ftsHits = db.prepare(
+        `SELECT COUNT(*) AS n FROM ${table} WHERE ${table} MATCH ?`
+      ).get(`"${SECRET}"`) as { n: number }
+      expect(ftsHits.n).toBe(0)
+    }
   })
 
   it('append-only sync preserves Security Scan purge state across a no-op re-sync (issue #344 follow-up)', async () => {

--- a/packages/core/src/sync/syncer.ts
+++ b/packages/core/src/sync/syncer.ts
@@ -22,7 +22,7 @@ import {
   getSessionMtime,
   getAllSessionMtimes,
   upsertSession,
-  upsertSessionSearch,
+  refreshSessionSearchFromMessages,
   insertMessages,
   getMessageSnapshot,
   recomputeMessageCount,
@@ -384,24 +384,13 @@ export class Syncer {
           recomputeMessageCount(this.db, sessionId)
         }
 
-        // Session-level search index. **Read content from the DB,
-        // not from `parsed.messages`** — Security Scan purge masks
-        // `messages.content_text` but never touches the source jsonl.
-        // Building search text from the parser output would re-index
-        // the raw secret in session_search_fts on every re-sync of an
-        // active session, leaking the purged value back into the
-        // "search across sessions" surface. Reading from DB instead
-        // makes session_search_fts a faithful projection of what
-        // messages_fts already protects. Skip on no-op re-syncs of an
-        // unchanged title — nothing to refresh.
+        // Session-level search is a projection of authoritative DB state,
+        // never parser output. Security purge masks both messages and a
+        // derived title while the source file remains unchanged; rebuilding
+        // from parsed data would leak either value back into search.
         const titleChanged = this.titleDiffersFromStored(sessionId, parsed.title)
         if (contentChanged || titleChanged) {
-          upsertSessionSearch(this.db, {
-            sessionId,
-            title: parsed.title,
-            userText: buildSessionSearchTextFromDb(this.db, sessionId, 'user'),
-            assistantText: buildSessionSearchTextFromDb(this.db, sessionId, 'assistant'),
-          })
+          refreshSessionSearchFromMessages(this.db, sessionId)
         }
 
         // Security Scan cascade — invalidate scan_profile so the
@@ -611,28 +600,6 @@ function loadCodexSessionIndex(): Map<string, string> {
     }
   } catch { /* file may not exist */ }
   return titles
-}
-
-/** Build the per-role text that backs `session_search_fts`, reading
- *  from `messages.content_text` so that Security Scan purge masks are
- *  honoured. The legacy `buildSessionSearchText(parsed.messages, …)`
- *  shape pulled directly from the parser output (i.e. from the source
- *  jsonl which still contains the raw secret), which leaked purged
- *  values back into the session-level FTS on every re-sync. */
-function buildSessionSearchTextFromDb(
-  db: Database.Database,
-  sessionId: number,
-  role: 'user' | 'assistant',
-): string {
-  const rows = db.prepare(
-    `SELECT content_text FROM messages
-      WHERE session_id = ? AND is_sidechain = 0 AND role = ?
-      ORDER BY seq, id`,
-  ).all(sessionId, role) as Array<{ content_text: string }>
-  return rows
-    .map(r => r.content_text.trim())
-    .filter(Boolean)
-    .join('\n')
 }
 
 function resolveProject(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
         specifier: ^5.0.3
         version: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     devDependencies:
+      '@electron/asar':
+        specifier: ^3.4.1
+        version: 3.4.1
       '@electron/rebuild':
         specifier: ^3.7.1
         version: 3.7.2


### PR DESCRIPTION
## Stack position

Part 6 of 7. Depends on #416; the final PR is #418.

## Why

The macOS bundle included `onnxruntime-node` even though Privacy Filter dynamically imports Transformers.js in the renderer and explicitly uses the WebGPU/WASM runtime from `onnxruntime-web`. The unused Node runtime contributed about 87.5 MB of packaged files, including binaries for other operating systems.

## What changed

- Added a package-size report for the logical app, frameworks, resources, asar, unpacked resources, and largest modules.
- Excluded only `onnxruntime-node` from electron-builder files.
- Added a clean-profile packaged-app smoke covering indexing/search, packaged SQLite, Claude/Codex ACP assets and protocol turns, ORT resource loading, Security Scan, and purge.
- Added an optional full Privacy Filter smoke that downloads the pinned model, initializes WebGPU, and completes a PF-enabled scan.
- Added a dedicated local-only CSP for the hidden Privacy Filter inference document.
- Made purge rebuild message/session FTS and derived titles, and invalidate the main-process search cache.
- Preserved a purged derived title across source re-sync with `title_source='security'`.
- Added renderer feature flags to the app Turbo cache key.

## Verification

- Before: 689.1 MB app, 210.1 MB asar, 246.9 MB unpacked.
- After: 601.7 MB app, 210.1 MB asar, 159.5 MB unpacked.
- Net reduction: 87.4 MB; no packaged `onnxruntime-node` entry remains.
- Clean-profile packaged smoke passed SQLite indexing/search, Claude/Codex ACP, ORT loading, Security scan/purge, and post-purge search.
- Full PF smoke installed the pinned model, initialized WebGPU in 12.1 seconds, completed a PF-profile scan, and reported runtime `ready`.
- App tests: 488 passed.
- Core tests: 410 passed, 1 skipped.
- Nine-package typecheck and type-aware lint passed.
- The packaged macOS app passed deep strict codesign verification.

## Review notes

`onnxruntime-web`, the platform ACP extension, and `better-sqlite3` remain packaged because they are exercised runtime dependencies. Release notarization remains CI-only verification.


## Known follow-ups

- Truncated-title residual: purge masks secrets in derived titles by exact match, so a secret cut off mid-value by title truncation leaves a partial prefix behind. Strict improvement over the pre-PR behavior (which left the whole secret), tracked for a follow-up.
- Bulk-purge throughput: `refreshSessionSearchFromMessages` re-reads each affected session's messages inside the batched purge transaction (once per session, not per finding). Re-measure at the #344 scale (~17k findings) before relying on it for mass purges.
- Historical purges: findings purged before this ships keep their raw stored title (re-purge is refused as already-purged, and re-sync cannot fix it since `title_source` stays `derived`). A one-time migration re-running title masking over `state='purged'` findings would close the gap.
