### PR TITLE
Stacked features 7: dependency check + extra debounce search input

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,90 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10
+    groups:
+      # Keep routine developer-tool churn reviewable while excluding every
+      # runtime family that needs its own release or packaged-app validation.
+      tooling-patch-minor:
+        applies-to: version-updates
+        dependency-type: development
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@agentclientprotocol/*"
+          - "@anthropic-ai/claude-agent-sdk"
+          - "@electron/*"
+          - "@tailwindcss/*"
+          - "@types/better-sqlite3"
+          - "@types/react*"
+          - "@vitejs/*"
+          - "@void/*"
+          - "acp-extension-*"
+          - "better-sqlite3"
+          - "bindings"
+          - "electron*"
+          - "file-uri-to-path"
+          - "i18next"
+          - "react*"
+          - "rehype-*"
+          - "remark*"
+          - "shiki"
+          - "tailwindcss"
+          - "vite"
+          - "void"
+        update-types:
+          - patch
+          - minor
+
+      electron-native-patch-minor:
+        applies-to: version-updates
+        patterns:
+          - "@electron/*"
+          - "@types/better-sqlite3"
+          - "better-sqlite3"
+          - "bindings"
+          - "electron*"
+          - "file-uri-to-path"
+        update-types:
+          - patch
+          - minor
+
+      acp-patch-minor:
+        applies-to: version-updates
+        patterns:
+          - "@agentclientprotocol/*"
+          - "@anthropic-ai/claude-agent-sdk"
+          - "acp-extension-*"
+        update-types:
+          - patch
+          - minor
+
+      renderer-framework-patch-minor:
+        applies-to: version-updates
+        patterns:
+          - "@tailwindcss/*"
+          - "@types/react*"
+          - "@vitejs/*"
+          - "@void/*"
+          - "i18next"
+          - "react*"
+          - "rehype-*"
+          - "remark*"
+          - "shiki"
+          - "tailwindcss"
+          - "vite"
+          - "void"
+        update-types:
+          - patch
+          - minor
+
+    # Major updates intentionally match no group. Dependabot will open them
+    # separately so Electron, ACP, React/Vite, Shiki, Void, and i18next cannot
+    # be hidden inside a bulk upgrade. Security updates also remain separate.

--- a/docs/engineering-optimization-roadmap.md
+++ b/docs/engineering-optimization-roadmap.md
@@ -572,8 +572,9 @@ Implementation notes:
    not justify either change.
 7. Debounce session-local find by 120 ms while keeping the controlled input
    synchronous. The expensive Markdown-to-visible-text projection now runs
-   once after typing settles instead of once per keystroke; stale highlights
-   and counts are hidden during the debounce window.
+   once after typing settles instead of once per keystroke; the previous
+   query's highlights and count stay visible (dimmed) and navigable until
+   the new projection lands, and only "No matches" waits for the settle.
 
 Verification on 2026-07-12:
 

--- a/docs/engineering-optimization-roadmap.md
+++ b/docs/engineering-optimization-roadmap.md
@@ -1,7 +1,7 @@
 # Spool Engineering Optimization Roadmap
 
-> Status: Implemented  
-> Updated: 2026-07-12  
+> Status: Implemented
+> Updated: 2026-07-12
 > Base: `main@049c4b2`  
 > Implementation: stacked branches `feat/typecheck-baseline` through
 > `feat/dependency-maintenance`
@@ -570,6 +570,10 @@ Implementation notes:
 6. Do not split orchestration modules or add React memoization without a
    functional ownership boundary or profiler evidence. File size alone does
    not justify either change.
+7. Debounce session-local find by 120 ms while keeping the controlled input
+   synchronous. The expensive Markdown-to-visible-text projection now runs
+   once after typing settles instead of once per keystroke; stale highlights
+   and counts are hidden during the debounce window.
 
 Verification on 2026-07-12:
 
@@ -584,6 +588,10 @@ Verification on 2026-07-12:
 - CLI build passed, the packaged macOS app passed deep strict codesign
   verification, and the globally linked `sp status` read the 393.6 MB local
   index after the final Node ABI restore.
+- App passed all 488 unit tests after the session-local debounce change. The 22
+  focused Electron E2E cases for global search and session detail passed,
+  including rendered-Markdown matching, keyboard navigation, and the
+  1,500-message deep-find fixture.
 
 Changes:
 
@@ -613,6 +621,7 @@ Acceptance criteria:
 - [x] Renderer/framework updates have an explicit risk lane.
 - [x] High-risk major and security updates remain independently reviewable.
 - [x] No unprofiled module split, memoization, or bulk major upgrade is added.
+- [x] Session-local find does not reparse every loaded message per keystroke.
 
 ## 4. Required Verification Matrix
 

--- a/docs/engineering-optimization-roadmap.md
+++ b/docs/engineering-optimization-roadmap.md
@@ -1,9 +1,10 @@
 # Spool Engineering Optimization Roadmap
 
-> Status: Proposed  
+> Status: Implemented  
 > Updated: 2026-07-12  
 > Base: `main@049c4b2`  
-> Intended implementer: `sol high`
+> Implementation: stacked branches `feat/typecheck-baseline` through
+> `feat/dependency-maintenance`
 
 ## 1. Objective
 
@@ -547,6 +548,43 @@ Acceptance criteria:
 
 Goal: make future upgrades smaller and safer.
 
+Implementation status: complete on `feat/dependency-maintenance`.
+
+Implementation notes:
+
+1. Add weekly Dependabot version updates at the pnpm workspace root. Dependabot
+   uses the `npm` ecosystem for pnpm lockfiles and discovers all workspace
+   manifests from that root.
+2. Group patch/minor updates into four explicit risk lanes: tooling,
+   Electron/native, ACP, and renderer/framework. The tooling catch-all excludes
+   every higher-risk runtime family, so a dependency can never drift into the
+   broad group because of manifest placement.
+3. Leave major updates and security updates ungrouped. Electron, ACP, React,
+   Vite, Shiki, Void, and i18next therefore produce independently reviewable
+   PRs with their own release, E2E, or migration evidence.
+4. Set the open PR limit to ten so the four routine groups and isolated majors
+   can coexist without creating an unbounded maintenance queue.
+5. Do not perform the audited Electron 34-to-43 jump in this roadmap. It needs a
+   dedicated branch with staged Electron release notes, native ABI validation,
+   packaged E2E, signing, and CI notarization evidence.
+6. Do not split orchestration modules or add React memoization without a
+   functional ownership boundary or profiler evidence. File size alone does
+   not justify either change.
+
+Verification on 2026-07-12:
+
+- `.github/dependabot.yml` parses as YAML and contains one pnpm-root update
+  entry with four non-overlapping patch/minor risk groups.
+- Every explicitly high-risk package family excluded from the tooling catch-all
+  is owned by exactly one narrower group.
+- Major and security updates have no matching bulk group and remain isolated.
+- Frozen install, nine-package typecheck, type-aware Oxlint, and all unit tests
+  passed. The complete serial app E2E run finished with 166 passed, two
+  retry-passed flaky tests, and one fixture-dependent skip.
+- CLI build passed, the packaged macOS app passed deep strict codesign
+  verification, and the globally linked `sp status` read the 393.6 MB local
+  index after the final Node ABI restore.
+
 Changes:
 
 1. Add automated dependency update PRs grouped by risk:
@@ -567,6 +605,14 @@ Changes:
    - `packages/core/src/db/queries.ts`
 5. Use React profiling before adding memoization. File size alone is not proof
    of a render bottleneck.
+
+Acceptance criteria:
+
+- [x] Routine patch/minor tooling updates are grouped.
+- [x] Electron/native and ACP updates are separated from general tooling.
+- [x] Renderer/framework updates have an explicit risk lane.
+- [x] High-risk major and security updates remain independently reviewable.
+- [x] No unprofiled module split, memoization, or bulk major upgrade is added.
 
 ## 4. Required Verification Matrix
 

--- a/packages/app/e2e/session-detail.spec.ts
+++ b/packages/app/e2e/session-detail.spec.ts
@@ -124,6 +124,88 @@ test('find-in-page matches rendered text, not markdown source', async () => {
   await expect(window.locator('[data-testid="session-find-status"]')).toContainText('No matches')
 })
 
+test('find keeps the previous result visible and navigable while retyping', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  await window.locator('[data-testid="sidebar-project-row"]').first().click()
+  await window
+    .locator('[data-testid="session-row"][data-session-uuid="test-session-uuid-001"]')
+    .click()
+  await expect(window.locator('[data-testid="session-detail"]')).toBeVisible({ timeout: 5000 })
+
+  const isMac = process.platform === 'darwin'
+  await window.keyboard.press(isMac ? 'Meta+f' : 'Control+f')
+
+  const input = window.locator('[data-testid="session-find-input"]')
+  const status = window.locator('[data-testid="session-find-status"]')
+
+  await input.fill('XYZMARKDOWN')
+  await expect(status).toContainText(/^\d+ of \d+$/)
+  const settled = await status.textContent()
+
+  // Record every status transition in-page: the previous count must stay
+  // visible through the debounce window (no blank flash) until the new
+  // result replaces it. A MutationObserver sees each DOM change
+  // synchronously, so this cannot race the 120 ms debounce.
+  await window.evaluate(() => {
+    const el = document.querySelector('[data-testid="session-find-status"]')
+    if (!el) throw new Error('find status missing')
+    const w = window as unknown as { __findLog?: (string | null)[]; __findObs?: MutationObserver }
+    w.__findLog = [el.textContent]
+    w.__findObs = new MutationObserver(() => { w.__findLog?.push(el.textContent) })
+    w.__findObs.observe(el, { childList: true, characterData: true, subtree: true })
+  })
+
+  await input.fill('XYZMARKDOWN-no-such-text')
+  // Enter during the debounce window must act on the still-visible previous
+  // result instead of being swallowed.
+  await window.keyboard.press('Enter')
+  await expect(status).toContainText('No matches', { timeout: 5000 })
+
+  const log = await window.evaluate(() => {
+    const w = window as unknown as { __findLog?: (string | null)[]; __findObs?: MutationObserver }
+    w.__findObs?.disconnect()
+    return w.__findLog ?? []
+  })
+  expect(log[0]).toBe(settled)
+  expect(log).not.toContain('')
+})
+
+test('find refocuses after its own buttons but not after clicks into the list', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  await window.locator('[data-testid="sidebar-project-row"]').first().click()
+  await window
+    .locator(`[data-testid="session-row"][data-session-uuid="${LARGE_SESSION_UUID}"]`)
+    .click()
+  await expect(window.locator('[data-testid="session-detail"]')).toBeVisible({ timeout: 10000 })
+
+  const isMac = process.platform === 'darwin'
+  await window.keyboard.press(isMac ? 'Meta+f' : 'Control+f')
+
+  const status = window.locator('[data-testid="session-find-status"]')
+  await window.locator('[data-testid="session-find-input"]').fill('Message 14')
+  await expect(status).toContainText(/^1 of \d+$/, { timeout: 5000 })
+
+  const focusedTestId = () =>
+    window.evaluate(() => (document.activeElement as HTMLElement | null)?.dataset?.['testid'] ?? document.activeElement?.tagName ?? '')
+
+  // Clicking the bar's own next button advances and hands focus back to the
+  // input so typing stays seamless.
+  await window.locator('[data-testid="session-find-next"]').click()
+  await expect(status).toContainText(/^2 of \d+$/)
+  await expect.poll(focusedTestId).toBe('session-find-input')
+
+  // Focus moved into the message list stays there: navigating via the
+  // hotkey must not yank it back to the find input.
+  await window.locator('[data-testid="message-list-scroll"]').click({ position: { x: 10, y: 10 } })
+  await window.keyboard.press(isMac ? 'Meta+ArrowRight' : 'Control+ArrowRight')
+  await expect(status).toContainText(/^3 of \d+$/)
+  await expect.poll(focusedTestId).not.toBe('session-find-input')
+})
+
 test('handles 1500-message session: virtualization + deep find', async () => {
   const { window } = ctx
   await waitForSync(window)

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -48,6 +48,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
   const [findFocusNonce, setFindFocusNonce] = useState(0)
   const [findResultNonce, setFindResultNonce] = useState(0)
   const [findQuery, setFindQuery] = useState('')
+  const [settledFindQuery, setSettledFindQuery] = useState('')
   const [activeMatchIndex, setActiveMatchIndex] = useState(0)
   const listRef = useRef<MessageListHandle>(null)
   const activeFindMatchRef = useRef<HTMLElement | null>(null)
@@ -55,6 +56,20 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
   const hasDraft = useDraftCountForSession(sessionUuid) > 0
 
   const normalizedFindQuery = findQuery.trim().toLocaleLowerCase()
+  const normalizedSettledFindQuery = settledFindQuery.trim().toLocaleLowerCase()
+  const findPending = normalizedFindQuery !== normalizedSettledFindQuery
+  const effectiveFindQuery = findPending ? '' : normalizedSettledFindQuery
+
+  useEffect(() => {
+    if (!normalizedFindQuery) {
+      setSettledFindQuery('')
+      return undefined
+    }
+    const timer = window.setTimeout(() => {
+      setSettledFindQuery(findQuery)
+    }, 120)
+    return () => window.clearTimeout(timer)
+  }, [findQuery, normalizedFindQuery])
 
   const {
     messageFindRanges,
@@ -65,11 +80,11 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
 
     // Only project markdown → rendered text when a query is active. For a 1500-message
     // session this saves ~1500 remark.parse calls on session open.
-    if (normalizedFindQuery) {
+    if (effectiveFindQuery) {
       for (const message of messages) {
         const source = message.contentText || (message.role === 'system' ? '(summary)' : '')
         const text = extractRenderedText(source)
-        const ranges = getFindRanges(text, normalizedFindQuery)
+        const ranges = getFindRanges(text, effectiveFindQuery)
         if (ranges.length > 0) {
           rangesByMessage.set(message.id, { ranges, offset })
           offset += ranges.length
@@ -81,12 +96,13 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
       messageFindRanges: rangesByMessage,
       totalFindMatches: offset,
     }
-  }, [messages, normalizedFindQuery])
+  }, [messages, effectiveFindQuery])
 
   const activeMatchOrdinal = totalFindMatches > 0 ? activeMatchIndex + 1 : 0
 
   const clearFind = useCallback(() => {
     setFindQuery('')
+    setSettledFindQuery('')
     setActiveMatchIndex(0)
   }, [])
 
@@ -181,13 +197,13 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
   }, [sessionUuid, clearFind])
 
   useEffect(() => {
-    if (!normalizedFindQuery || totalFindMatches === 0) {
+    if (!effectiveFindQuery || totalFindMatches === 0) {
       setActiveMatchIndex(0)
       return
     }
 
     setActiveMatchIndex((value) => Math.min(value, totalFindMatches - 1))
-  }, [normalizedFindQuery, totalFindMatches])
+  }, [effectiveFindQuery, totalFindMatches])
 
   useEffect(() => {
     if (!showFindBar) return
@@ -411,6 +427,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
         focusNonce={findFocusNonce}
         resultNonce={findResultNonce}
         query={findQuery}
+        pending={findPending}
         matches={totalFindMatches}
         activeMatchOrdinal={activeMatchOrdinal}
         onChange={runFind}

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -27,6 +27,10 @@ type Props = {
   onShare: (session: Session, messages: Message[]) => void
 }
 
+// Keystrokes inside this window coalesce into one find projection — the
+// projection re-parses every message's markdown, so it must not run per key.
+const FIND_DEBOUNCE_MS = 120
+
 export default function SessionDetail({ sessionUuid, targetMessageId, onCopySessionId, onBack, onShare }: Props) {
   const { t } = useTranslation()
   const [session, setSession] = useState<Session | null>(null)
@@ -58,7 +62,10 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
   const normalizedFindQuery = findQuery.trim().toLocaleLowerCase()
   const normalizedSettledFindQuery = settledFindQuery.trim().toLocaleLowerCase()
   const findPending = normalizedFindQuery !== normalizedSettledFindQuery
-  const effectiveFindQuery = findPending ? '' : normalizedSettledFindQuery
+  // While a new query is pending, the previous query's highlights and count
+  // stay visible and navigable (Chrome-style) instead of blanking for the
+  // debounce window.
+  const effectiveFindQuery = normalizedSettledFindQuery
 
   useEffect(() => {
     if (!normalizedFindQuery) {
@@ -67,7 +74,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
     }
     const timer = window.setTimeout(() => {
       setSettledFindQuery(findQuery)
-    }, 120)
+    }, FIND_DEBOUNCE_MS)
     return () => window.clearTimeout(timer)
   }, [findQuery, normalizedFindQuery])
 

--- a/packages/app/src/renderer/components/SessionFindBar.tsx
+++ b/packages/app/src/renderer/components/SessionFindBar.tsx
@@ -7,6 +7,7 @@ type Props = {
   focusNonce: number
   resultNonce: number
   query: string
+  pending: boolean
   matches: number
   activeMatchOrdinal: number
   onChange: (query: string) => void
@@ -20,6 +21,7 @@ export default function SessionFindBar({
   focusNonce,
   resultNonce,
   query,
+  pending,
   matches,
   activeMatchOrdinal,
   onChange,
@@ -80,9 +82,11 @@ export default function SessionFindBar({
   const hasMatches = matches > 0
   const statusLabel = !hasQuery
     ? ''
-    : hasMatches
-      ? t('session.find_matches_other', { current: activeMatchOrdinal, total: matches })
-      : t('session.find_noMatch')
+    : pending
+      ? ''
+      : hasMatches
+        ? t('session.find_matches_other', { current: activeMatchOrdinal, total: matches })
+        : t('session.find_noMatch')
 
   return (
     <div
@@ -130,7 +134,7 @@ export default function SessionFindBar({
       <button
         type="button"
         onClick={onPrevious}
-        disabled={!hasQuery || !hasMatches}
+        disabled={pending || !hasQuery || !hasMatches}
         className="flex-none inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted transition-colors enabled:hover:bg-warm-surface enabled:hover:text-warm-text enabled:dark:hover:bg-dark-surface enabled:dark:hover:text-dark-text disabled:opacity-40"
         aria-label={`${t('session.find_prev')} (${previousShortcutLabel})`}
         title={`${t('session.find_prev')} (${previousShortcutLabel})`}
@@ -140,7 +144,7 @@ export default function SessionFindBar({
       <button
         type="button"
         onClick={onNext}
-        disabled={!hasQuery || !hasMatches}
+        disabled={pending || !hasQuery || !hasMatches}
         className="flex-none inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted transition-colors enabled:hover:bg-warm-surface enabled:hover:text-warm-text enabled:dark:hover:bg-dark-surface enabled:dark:hover:text-dark-text disabled:opacity-40"
         aria-label={`${t('session.find_next')} (${nextShortcutLabel})`}
         title={`${t('session.find_next')} (${nextShortcutLabel})`}

--- a/packages/app/src/renderer/components/SessionFindBar.tsx
+++ b/packages/app/src/renderer/components/SessionFindBar.tsx
@@ -30,6 +30,7 @@ export default function SessionFindBar({
   onClose,
 }: Props) {
   const { t } = useTranslation()
+  const containerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const selectionRef = useRef<{ start: number; end: number } | null>(null)
   const isMacLike = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform)
@@ -71,6 +72,10 @@ export default function SessionFindBar({
     if (!visible) return
     const input = inputRef.current
     if (!input || document.activeElement === input) return
+    // Reclaim focus only when it sits on the bar's own controls (prev/next
+    // button clicks) so typing stays seamless — focus the user moved into
+    // the message list must stay there.
+    if (!containerRef.current?.contains(document.activeElement)) return
     requestAnimationFrame(() => {
       focusInput('preserve')
     })
@@ -80,16 +85,20 @@ export default function SessionFindBar({
 
   const hasQuery = query.trim().length > 0
   const hasMatches = matches > 0
+  // While a new query is pending the previous count stays visible (dimmed)
+  // and navigable; only "No matches" waits for the settle, so it never
+  // flashes mid-typing.
   const statusLabel = !hasQuery
     ? ''
-    : pending
-      ? ''
-      : hasMatches
-        ? t('session.find_matches_other', { current: activeMatchOrdinal, total: matches })
+    : hasMatches
+      ? t('session.find_matches_other', { current: activeMatchOrdinal, total: matches })
+      : pending
+        ? ''
         : t('session.find_noMatch')
 
   return (
     <div
+      ref={containerRef}
       className="absolute top-8 right-4 z-20 flex items-center gap-0.5 rounded-md border border-warm-border dark:border-dark-border bg-warm-bg/95 dark:bg-dark-surface2/95 backdrop-blur-sm shadow-[0_4px_12px_rgba(0,0,0,0.06)] dark:shadow-[0_4px_12px_rgba(0,0,0,0.4)] pl-2 pr-1 py-0.5 w-[320px] animate-in fade-in transition-[border-color,box-shadow] focus-within:border-accent/55 dark:focus-within:border-accent-dark/60 focus-within:shadow-[0_0_0_3px_rgba(200,90,0,0.10),0_4px_12px_rgba(0,0,0,0.06)] dark:focus-within:shadow-[0_0_0_3px_rgba(240,112,32,0.15),0_4px_12px_rgba(0,0,0,0.4)]"
       role="search"
     >
@@ -125,8 +134,9 @@ export default function SessionFindBar({
         data-testid="session-find-input"
       />
       <span
-        className="flex-none font-mono text-[11px] tabular-nums text-warm-muted dark:text-dark-muted whitespace-nowrap pl-1"
+        className={`flex-none font-mono text-[11px] tabular-nums text-warm-muted dark:text-dark-muted whitespace-nowrap pl-1 transition-opacity ${pending ? 'opacity-60' : ''}`}
         data-testid="session-find-status"
+        data-pending={pending ? 'true' : undefined}
       >
         {statusLabel}
       </span>
@@ -134,20 +144,22 @@ export default function SessionFindBar({
       <button
         type="button"
         onClick={onPrevious}
-        disabled={pending || !hasQuery || !hasMatches}
+        disabled={!hasQuery || !hasMatches}
         className="flex-none inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted transition-colors enabled:hover:bg-warm-surface enabled:hover:text-warm-text enabled:dark:hover:bg-dark-surface enabled:dark:hover:text-dark-text disabled:opacity-40"
         aria-label={`${t('session.find_prev')} (${previousShortcutLabel})`}
         title={`${t('session.find_prev')} (${previousShortcutLabel})`}
+        data-testid="session-find-prev"
       >
         <ChevronUp size={12} strokeWidth={1.8} aria-hidden />
       </button>
       <button
         type="button"
         onClick={onNext}
-        disabled={pending || !hasQuery || !hasMatches}
+        disabled={!hasQuery || !hasMatches}
         className="flex-none inline-flex items-center justify-center w-6 h-6 rounded text-warm-muted dark:text-dark-muted transition-colors enabled:hover:bg-warm-surface enabled:hover:text-warm-text enabled:dark:hover:bg-dark-surface enabled:dark:hover:text-dark-text disabled:opacity-40"
         aria-label={`${t('session.find_next')} (${nextShortcutLabel})`}
         title={`${t('session.find_next')} (${nextShortcutLabel})`}
+        data-testid="session-find-next"
       >
         <ChevronDown size={12} strokeWidth={1.8} aria-hidden />
       </button>


### PR DESCRIPTION
## Stack position

Part 7 of 7. Depends on #417 and completes the stack.

## Why

Future dependency upgrades need smaller risk boundaries, and session-local find still reparsed every loaded Markdown message on each keystroke in long sessions.

## What changed

### Dependency maintenance

- Added weekly Dependabot updates at the pnpm workspace root.
- Grouped patch/minor updates into four explicit lanes: tooling, Electron/native, ACP, and renderer/framework.
- Excluded every high-risk runtime family from the broad tooling group.
- Left major and security updates ungrouped so Electron, ACP, React/Vite, Shiki, Void, and i18next remain independently reviewable.
- Did not perform the Electron 34-to-43 upgrade, unprofiled module splitting, or speculative React memoization.

### Session-local find

- Kept the controlled find input synchronous.
- Added a 120 ms trailing debounce before the expensive Markdown-to-visible-text projection.
- Cleared stale highlights/counts while a new query is pending.
- Disabled previous/next navigation until the debounced result is current.

## Verification

- Dependabot YAML parsed successfully and its four groups passed a semantic overlap check.
- Every high-risk pattern owned by a narrow group is excluded from the tooling catch-all.
- `pnpm install --frozen-lockfile`, 9-package typecheck, type-aware lint, and all unit tests passed.
- App unit tests after the debounce change: 488/488.
- Focused Electron E2E for search and session detail: 22/22, including rendered-Markdown matching, keyboard navigation, and a 1,500-message deep-find fixture.
- Complete serial Electron E2E: 166 passed, 2 retry-passed flaky tests, and 1 fixture-dependent skip.
- CLI build, deep strict macOS codesign verification, and `sp status` passed after the final Node ABI restore.

## Review follow-up (maintainer)

The debounce originally hid all find state for its 120 ms window, which made Enter a silent no-op, flashed highlights on every pause, and could yank focus back from the message list. The follow-up commit keeps the previous query's matches visible (dimmed) and navigable until the new projection lands — only "No matches" waits for the settle — and scopes the find bar's focus reclaim to its own controls. Two e2e tests pin the semantics: a MutationObserver asserts the status text never blanks across a retype (immune to debounce timing), and a focus test covers both reclaim-after-button and stay-in-list paths.

## Review notes

The debounce is deliberately scoped to the current session's in-memory find. It does not change the cross-session SQLite/FTS search implemented in #416.

