### PR TITLE
chore(settings): move Account tab to the top, drop duplicate local-data footer

### DIFF
--- a/packages/app/e2e/settings.spec.ts
+++ b/packages/app/e2e/settings.spec.ts
@@ -37,6 +37,26 @@ test('cmd/ctrl+K opens search overlay on home', async () => {
   await expect(window.locator('[data-testid="search-overlay"]')).toBeHidden()
 })
 
+test('Account leads the settings rail; the local-data footer is gone', async () => {
+  const { window } = ctx
+  await waitForSync(window)
+
+  await window.locator('[data-testid="settings-button"]').click()
+  await expect(window.locator('[data-testid="settings-panel"]')).toBeVisible()
+
+  const sidebar = window.locator('[data-testid="settings-sidebar"]')
+  await expect(sidebar.locator('[aria-pressed]').first()).toHaveAttribute(
+    'data-testid',
+    'settings-tab-account',
+  )
+  // Every locale's footer copy contained the literal ~/.spool/ path,
+  // so this probe is locale-independent.
+  await expect(sidebar.getByText('~/.spool/')).toHaveCount(0)
+
+  await window.keyboard.press('Escape')
+  await expect(window.locator('[data-testid="settings-panel"]')).toBeHidden()
+})
+
 test('cmd/ctrl+K is suppressed while Settings is open', async () => {
   const { window } = ctx
   await waitForSync(window)

--- a/packages/app/src/renderer/components/SettingsPanel.tsx
+++ b/packages/app/src/renderer/components/SettingsPanel.tsx
@@ -48,6 +48,19 @@ const TAB_DEFS: {
   fallbackLabel?: string
   icon: ReactNode
 }[] = [
+  // Account leads the rail; it stays hidden while the `sharePublish`
+  // flag is off (see visibleTabs), so flag-off builds start at General.
+  {
+    id: 'account',
+    labelKey: 'settings.tab_account',
+    fallbackLabel: 'Account',
+    icon: (
+      <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/>
+        <circle cx="12" cy="7" r="4"/>
+      </svg>
+    ),
+  },
   {
     id: 'general',
     labelKey: 'settings.tab_general',
@@ -129,21 +142,6 @@ const TAB_DEFS: {
       </svg>
     ),
   },
-  // Account is pinned to the bottom of the rail (after feature tabs) so
-  // toggling the `sharePublish` flag — which conditionally hides this
-  // row — doesn't shift Labs/Security up and down. Matches the GitHub
-  // and Slack settings convention: identity sits below configuration.
-  {
-    id: 'account',
-    labelKey: 'settings.tab_account',
-    fallbackLabel: 'Account',
-    icon: (
-      <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/>
-        <circle cx="12" cy="7" r="4"/>
-      </svg>
-    ),
-  },
 ]
 
 // ── Main component ─────────────────────────────────────────────────────────
@@ -188,7 +186,7 @@ export default function SettingsPanel({
       <div className="w-[960px] h-[680px] max-w-[calc(100vw-48px)] max-h-[calc(100vh-48px)] bg-warm-bg dark:bg-dark-bg border border-warm-border dark:border-dark-border rounded-[10px] shadow-xl overflow-hidden flex">
         {/* Sidebar — width + paddings tuned to match the desktop handoff
             (220px rail, 22px vertical padding, 14px horizontal). */}
-        <div className="w-[220px] flex-none bg-warm-surface dark:bg-dark-surface border-r border-warm-border dark:border-dark-border flex flex-col pt-[22px] pb-3">
+        <div data-testid="settings-sidebar" className="w-[220px] flex-none bg-warm-surface dark:bg-dark-surface border-r border-warm-border dark:border-dark-border flex flex-col pt-[22px] pb-3">
           <div className="px-[14px] mb-[18px]">
             <h2 className="text-[22px] font-bold text-warm-text dark:text-dark-text leading-none">{t('settings.title')}</h2>
           </div>
@@ -197,6 +195,7 @@ export default function SettingsPanel({
               <button
                 key={def.id}
                 type="button"
+                data-testid={`settings-tab-${def.id}`}
                 aria-pressed={activeTab === def.id}
                 onClick={() => setTab(def.id)}
                 className={`flex w-full items-center gap-[11px] rounded-lg h-9 px-3 text-[13.5px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent focus-visible:ring-offset-0 ${
@@ -212,8 +211,6 @@ export default function SettingsPanel({
               </button>
             ))}
           </div>
-          <div className="flex-1" />
-          <FooterPath text={t('settings.localData_footer')} />
         </div>
 
         {/* Content */}
@@ -632,19 +629,6 @@ function SmallSelect({ value, onChange, options }: { value: string; onChange: (v
         </button>
       )}
     />
-  )
-}
-
-function FooterPath({ text }: { text: string }) {
-  const path = '~/.spool/'
-  const idx = text.indexOf(path)
-  const lead = idx >= 0 ? text.slice(0, idx).replace(/[\s,，:：]+$/, '').trim() : text
-  const trail = idx >= 0 ? text.slice(idx + path.length).trim() : ''
-  return (
-    <div className="px-4 py-2 text-[11px] leading-snug text-warm-faint dark:text-dark-muted">
-      <span className="block">{lead}{trail ? ` ${trail}` : ''}</span>
-      {idx >= 0 && <span className="block mt-0.5 font-mono">{path}</span>}
-    </div>
   )
 }
 

--- a/packages/app/src/renderer/i18n/locales/de.json
+++ b/packages/app/src/renderer/i18n/locales/de.json
@@ -205,7 +205,6 @@
     "about_section": "Über",
     "about_tagline": "Spool – eine lokale Suchmaschine für Ihre Gedanken.",
     "about_trademark": "Spool™ ist eine Marke von TypeSafe Limited.",
-    "localData_footer": "Alle Daten bleiben lokal in ~/.spool/",
     "shortcuts_group_global": "Global",
     "shortcuts_group_search": "Suche",
     "shortcuts_group_session": "Sitzung",

--- a/packages/app/src/renderer/i18n/locales/en.json
+++ b/packages/app/src/renderer/i18n/locales/en.json
@@ -205,7 +205,6 @@
     "about_section": "About",
     "about_tagline": "Spool — a local search engine for your thinking.",
     "about_trademark": "Spool™ is a trademark of TypeSafe Limited.",
-    "localData_footer": "All data stays local in ~/.spool/",
     "shortcuts_group_global": "Global",
     "shortcuts_group_search": "Search",
     "shortcuts_group_session": "Session",

--- a/packages/app/src/renderer/i18n/locales/fr.json
+++ b/packages/app/src/renderer/i18n/locales/fr.json
@@ -205,7 +205,6 @@
     "about_section": "À propos",
     "about_tagline": "Spool — un moteur de recherche local pour votre réflexion.",
     "about_trademark": "Spool™ est une marque de TypeSafe Limited.",
-    "localData_footer": "Toutes les données restent en local dans ~/.spool/",
     "shortcuts_group_global": "Global",
     "shortcuts_group_search": "Recherche",
     "shortcuts_group_session": "Session",

--- a/packages/app/src/renderer/i18n/locales/ja.json
+++ b/packages/app/src/renderer/i18n/locales/ja.json
@@ -199,7 +199,6 @@
     "about_section": "Spool について",
     "about_tagline": "Spool — あなたの思考のためのローカル検索エンジン。",
     "about_trademark": "Spool™ は TypeSafe Limited の商標です。",
-    "localData_footer": "すべてのデータは ~/.spool/ にローカル保存されます",
     "shortcuts_group_global": "グローバル",
     "shortcuts_group_search": "検索",
     "shortcuts_group_session": "セッション",

--- a/packages/app/src/renderer/i18n/locales/ko.json
+++ b/packages/app/src/renderer/i18n/locales/ko.json
@@ -199,7 +199,6 @@
     "about_section": "정보",
     "about_tagline": "Spool — 당신의 사고를 위한 로컬 검색 엔진.",
     "about_trademark": "Spool™은 TypeSafe Limited의 상표입니다.",
-    "localData_footer": "모든 데이터는 ~/.spool/에 로컬로 저장됩니다",
     "shortcuts_group_global": "전역",
     "shortcuts_group_search": "검색",
     "shortcuts_group_session": "세션",

--- a/packages/app/src/renderer/i18n/locales/zh-CN.json
+++ b/packages/app/src/renderer/i18n/locales/zh-CN.json
@@ -199,7 +199,6 @@
     "about_section": "关于",
     "about_tagline": "Spool —— 一个本地的思维搜索引擎。",
     "about_trademark": "Spool™ 是 TypeSafe Limited 的商标。",
-    "localData_footer": "所有数据本地保存在 ~/.spool/",
     "shortcuts_group_global": "全局",
     "shortcuts_group_search": "搜索",
     "shortcuts_group_session": "会话",

--- a/packages/app/src/renderer/i18n/locales/zh-TW.json
+++ b/packages/app/src/renderer/i18n/locales/zh-TW.json
@@ -199,7 +199,6 @@
     "about_section": "關於",
     "about_tagline": "Spool —— 一個本機的思維搜尋引擎。",
     "about_trademark": "Spool™ 是 TypeSafe Limited 的商標。",
-    "localData_footer": "所有資料本機保存在 ~/.spool/",
     "shortcuts_group_global": "全域",
     "shortcuts_group_search": "搜尋",
     "shortcuts_group_session": "會話",


### PR DESCRIPTION
## What

Two small Settings-panel cleanups ahead of the share launch:

- **Account tab now leads the sidebar rail.** It was pinned to the bottom to avoid tab-shift when the `sharePublish` flag flips, but the flag is build-time (Vite-inlined), so the rail can never shift within a running session — the rationale no longer applies. With sign-in becoming a first-class part of the app, identity belongs at the top. The tab is still hidden in builds without `VITE_FEATURE_SHAREPUBLISH=1`.
- **Removed the sidebar footer** ("All data stays local in ~/.spool/"). It duplicated the General → Data section, which already shows the database path. The `settings.localData_footer` key is removed from all 7 locales to keep key parity.

## How

- `TAB_DEFS` reordered; the `FooterPath` component and its only call site deleted.
- Tab buttons gained `data-testid="settings-tab-<id>"` so tests can address tabs without text-matching (per the e2e selector discipline).

## Test plan

- New e2e in `settings.spec.ts`: first rail entry is `settings-tab-account`, and the sidebar no longer contains the `~/.spool/` footer probe (locale-independent).
- App unit suite: 482 passed (includes locale key-parity).
- e2e: `settings.spec.ts` + full `share-publish.spec.ts` (Account-tab flow) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)