### PR TITLE
chore(app): declare __SPOOL_E2E__ build constant so bare tsc typechecks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ packages/*/src/**/*.js
 packages/*/src/**/*.d.ts
 packages/*/src/**/*.js.map
 packages/*/src/**/*.d.ts.map
+# Hand-written ambient declarations (exempt from the rule above)
+!packages/app/src/env.d.ts
 # Playwright
 test-results/
 playwright-report/

--- a/packages/app/src/env.d.ts
+++ b/packages/app/src/env.d.ts
@@ -1,0 +1,6 @@
+// Build-time constants injected via `define` in electron.vite.config.ts.
+// esbuild replaces them with literals at build time; this declaration is
+// what lets bare `tsc --noEmit` typecheck the sources that reference them.
+
+/** True only in e2e builds (SPOOL_E2E_TEST=1) — see electron.vite.config.ts. */
+declare const __SPOOL_E2E__: boolean


### PR DESCRIPTION
## What

`__SPOOL_E2E__` is injected via `define` in `electron.vite.config.ts` (esbuild replaces it with a literal at build time), but the repo had no ambient declaration for it. Running bare `tsc --noEmit -p packages/app` therefore always failed with one error:

```
src/main/index.ts(732,7): error TS2304: Cannot find name '__SPOOL_E2E__'.
```

CI never surfaces this (no tsc step; electron-vite/esbuild transpiles without typechecking, vitest doesn't typecheck either), so it only bites people running tsc by hand as a verification step — every such run has to mentally filter out this known error.

## How

- `packages/app/src/env.d.ts` with `declare const __SPOOL_E2E__: boolean` and a pointer to the define site.
- One `.gitignore` exemption: `packages/*/src/**/*.d.ts` ignores compiled artifacts that land in src by mistake; the new hand-written ambient declaration is explicitly un-ignored.

## Test plan

- `npx tsc --noEmit -p packages/app/tsconfig.json` is now fully clean (was: 1 error on main).
- Declaration-only change, no runtime impact; the build-time define is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)