### PR TITLE
chore(share): make share callback props required now that the flag is gone

### DIFF
--- a/packages/app/src/renderer/components/FragmentResults.tsx
+++ b/packages/app/src/renderer/components/FragmentResults.tsx
@@ -17,7 +17,7 @@ type Props = {
   onOpenSession: (uuid: string, messageId?: number) => void
   defaultSortOrder: SearchSortOrder
   onCopySessionId: (source: FragmentResult['source']) => void
-  onShareSession?: (uuid: string) => void
+  onShareSession: (uuid: string) => void
 }
 
 export default function FragmentResults({ results, query, onOpenSession, defaultSortOrder, onCopySessionId, onShareSession }: Props) {
@@ -119,7 +119,7 @@ export default function FragmentResults({ results, query, onOpenSession, default
               result={result}
               onOpenSession={onOpenSession}
               onCopySessionId={onCopySessionId}
-              {...(onShareSession ? { onShareSession } : {})}
+              onShareSession={onShareSession}
             />
           ))}
         </div>
@@ -144,7 +144,7 @@ function FragmentRow({
   result: FragmentRowResult
   onOpenSession: (uuid: string, messageId?: number) => void
   onCopySessionId: (source: FragmentResult['source']) => void
-  onShareSession?: (uuid: string) => void
+  onShareSession: (uuid: string) => void
 }) {
   const { t } = useTranslation()
   const snippet = snippetToStrongHtml(result.snippet)
@@ -168,7 +168,7 @@ function FragmentRow({
           result={result}
           onOpenSession={onOpenSession}
           onCopySessionId={onCopySessionId}
-          {...(onShareSession ? { onShare: () => onShareSession(result.sessionUuid) } : {})}
+          onShare={() => onShareSession(result.sessionUuid)}
         />
       </div>
 

--- a/packages/app/src/renderer/components/LibraryLanding.tsx
+++ b/packages/app/src/renderer/components/LibraryLanding.tsx
@@ -12,7 +12,7 @@ type Props = {
   onSelectProject: (identityKey: string) => void
   onOpenSession: (uuid: string) => void
   onCopySessionId: (source: Session['source']) => void
-  onShare?: (uuid: string) => void
+  onShare: (uuid: string) => void
 }
 
 type DateBucket = {
@@ -243,7 +243,7 @@ export default function LibraryLanding({ onOpenSession, onCopySessionId, onShare
           onPinChange={handlePinChange}
           onOpenSession={onOpenSession}
           onCopySessionId={onCopySessionId}
-          {...(onShare ? { onShare } : {})}
+          onShare={onShare}
           testId="library-landing-scroll"
         />
       )}

--- a/packages/app/src/renderer/components/ProjectView.tsx
+++ b/packages/app/src/renderer/components/ProjectView.tsx
@@ -16,7 +16,7 @@ type Props = {
   onSortOrderChange: (next: ProjectSessionSortOrder) => void
   onOpenSession: (uuid: string) => void
   onCopySessionId: (source: Session['source']) => void
-  onShare?: (uuid: string) => void
+  onShare: (uuid: string) => void
 }
 
 const PAGE_SIZE = 50
@@ -544,7 +544,7 @@ export default function ProjectView({
           onPinChange={handlePinChange}
           onOpenSession={onOpenSession}
           onCopySessionId={onCopySessionId}
-          {...(onShare ? { onShare } : {})}
+          onShare={onShare}
           testId="project-view-scroll"
         />
       )}

--- a/packages/app/src/renderer/components/SecurityPage.tsx
+++ b/packages/app/src/renderer/components/SecurityPage.tsx
@@ -54,7 +54,7 @@ import { formatRelativeDate } from '../../shared/formatDate.js'
 interface Props {
   onOpenSession: (sessionUuid: string) => void
   /** Share-draft starter; rendered as a menu item. */
-  onShareSession?: (sessionUuid: string) => void
+  onShareSession: (sessionUuid: string) => void
   /** Open Settings panel pre-focused on the Security tab. Wired from
    *  App.tsx; used by the EmptyState "Detector settings" affordance so
    *  a clean archive isn't a dead end. */
@@ -829,7 +829,7 @@ function SecurityPageInner({ onOpenSession, onShareSession, onOpenSettings }: Pr
                         activeKinds={activeKinds}
                         valuesHidden={valuesHidden}
                         onOpen={() => onOpenSession(s.sessionUuid)}
-                        {...(onShareSession ? { onShare: () => onShareSession(s.sessionUuid) } : {})}
+                        onShare={() => onShareSession(s.sessionUuid)}
                         onRefresh={refresh}
                       />
                     ))}
@@ -1242,7 +1242,7 @@ function SessionCard({
   activeKinds: readonly string[]
   valuesHidden: boolean
   onOpen: () => void
-  onShare?: () => void
+  onShare: () => void
   onRefresh: () => void
 }) {
   const { t } = useTranslation()

--- a/packages/app/src/renderer/components/SessionDetail.tsx
+++ b/packages/app/src/renderer/components/SessionDetail.tsx
@@ -24,7 +24,7 @@ type Props = {
   targetMessageId?: number | null
   onCopySessionId: (source: Session['source']) => void
   onBack?: () => void
-  onShare?: (session: Session, messages: Message[]) => void
+  onShare: (session: Session, messages: Message[]) => void
 }
 
 export default function SessionDetail({ sessionUuid, targetMessageId, onCopySessionId, onBack, onShare }: Props) {
@@ -345,7 +345,7 @@ export default function SessionDetail({ sessionUuid, targetMessageId, onCopySess
             onChange={setPinned}
           />
 
-          {onShare && session && (
+          {session && (
             <button
               data-testid="detail-share"
               onClick={() => onShare(session, messages)}

--- a/packages/app/src/renderer/components/SharesPage.tsx
+++ b/packages/app/src/renderer/components/SharesPage.tsx
@@ -28,8 +28,8 @@ type Props = {
   /** Open a draft by id alone — used by the Published tab's revoked
    *  rows, which only carry the draft_id stored at publish time. */
   onOpenDraftById?: ((draftId: string) => void | Promise<void>) | undefined
-  onImportSpool?: ((file: File) => void | Promise<void>) | undefined
-  onStartNewDraft?: ((sessionUuid: string) => void | Promise<void>) | undefined
+  onImportSpool: (file: File) => void | Promise<void>
+  onStartNewDraft: (sessionUuid: string) => void | Promise<void>
 }
 
 type SharesTab = 'drafts' | 'published'
@@ -48,11 +48,11 @@ export default function SharesPage({ onOpenDraft, onOpenDraftById, onImportSpool
   const handleClosePicker = useCallback(() => setPickerOpen(false), [])
   const handlePickSession = useCallback((uuid: string) => {
     setPickerOpen(false)
-    void onStartNewDraft?.(uuid)
+    void onStartNewDraft(uuid)
   }, [onStartNewDraft])
 
   const onImport = useCallback(
-    (file: File) => onImportSpool?.(file),
+    (file: File) => onImportSpool(file),
     [onImportSpool],
   )
   const onRejectDrop = useCallback((files: File[]) => {
@@ -62,7 +62,7 @@ export default function SharesPage({ onOpenDraft, onOpenDraftById, onImportSpool
     })
   }, [t])
   const { isDragActive, dragHandlers } = useSpoolDrop({
-    enabled: Boolean(onImportSpool),
+    enabled: true,
     onImport,
     onReject: onRejectDrop,
   })
@@ -111,7 +111,7 @@ export default function SharesPage({ onOpenDraft, onOpenDraftById, onImportSpool
             )}
           </div>
         )}
-        {(tab === 'drafts' || !publishEnabled) && onStartNewDraft && (
+        {(tab === 'drafts' || !publishEnabled) && (
           <button
             type="button"
             data-testid="shares-new-draft"
@@ -132,13 +132,13 @@ export default function SharesPage({ onOpenDraft, onOpenDraftById, onImportSpool
             error={error}
             onOpenDraft={onOpenDraft}
             onDeleteDraft={handleDelete}
-            {...(onStartNewDraft ? { onStartNewDraft: handleOpenPicker } : {})}
+            onStartNewDraft={handleOpenPicker}
           />
         ) : (
           <PublishedList onOpenDraftById={onOpenDraftById} />
         )}
       </div>
-      {pickerOpen && onStartNewDraft && (
+      {pickerOpen && (
         <NewDraftPicker onSelect={handlePickSession} onClose={handleClosePicker} />
       )}
     </div>
@@ -757,7 +757,7 @@ function DraftsList({
   error: string | null
   onOpenDraft?: ((draft: ShareDraftListItem) => void) | undefined
   onDeleteDraft: (draft: ShareDraftListItem) => void
-  onStartNewDraft?: (() => void) | undefined
+  onStartNewDraft: () => void
 }) {
   const { t } = useTranslation()
   const [skeletonCount] = useState(readSkeletonCount)
@@ -796,19 +796,17 @@ function DraftsList({
         icon={<Newspaper size={22} strokeWidth={1.5} />}
         title={t('shares.empty_title')}
         hint={t('shares.empty_body')}
-        {...(onStartNewDraft ? {
-          action: (
-            <button
-              type="button"
-              data-testid="shares-empty-start"
-              onClick={onStartNewDraft}
-              className="inline-flex items-center gap-1.5 h-8 px-3 rounded text-sm font-medium text-white bg-accent dark:bg-accent-dark hover:opacity-90 transition-opacity"
-            >
-              <Plus size={14} strokeWidth={2} aria-hidden />
-              <span>{t('shares.newDraft')}</span>
-            </button>
-          ),
-        } : {})}
+        action={(
+          <button
+            type="button"
+            data-testid="shares-empty-start"
+            onClick={onStartNewDraft}
+            className="inline-flex items-center gap-1.5 h-8 px-3 rounded text-sm font-medium text-white bg-accent dark:bg-accent-dark hover:opacity-90 transition-opacity"
+          >
+            <Plus size={14} strokeWidth={2} aria-hidden />
+            <span>{t('shares.newDraft')}</span>
+          </button>
+        )}
       />
     )
   }

--- a/packages/app/src/renderer/components/Sidebar.tsx
+++ b/packages/app/src/renderer/components/Sidebar.tsx
@@ -24,9 +24,9 @@ type Props = {
   onSelectSession?: (sessionUuid: string) => void
   onSelectHome?: () => void
   isLibraryActive?: boolean
-  onSelectShares?: () => void
+  onSelectShares: () => void
   isSharesActive?: boolean
-  onSelectSecurity?: () => void
+  onSelectSecurity: () => void
   isSecurityActive?: boolean
   onOpenSearch?: () => void
   syncStatus?: { phase: string; count: number; total: number } | null
@@ -39,7 +39,7 @@ type Props = {
   pinnedSortOrder?: PinnedSortOrder
   onPinnedSortOrderChange?: (next: PinnedSortOrder) => void
   onCopySessionId?: (source: SessionSource) => void
-  onShareSession?: (uuid: string) => void
+  onShareSession: (uuid: string) => void
   sidebarToggle?: {
     collapsed: boolean
     onToggle: () => void
@@ -145,24 +145,20 @@ export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, o
             onClick={onSelectHome}
           />
         )}
-        {onSelectSecurity && (
-          <NavRow
-            testId="sidebar-security"
-            icon={<SecurityIcon size={14} strokeWidth={1.75} />}
-            label={t('sidebar.security')}
-            active={isSecurityActive}
-            onClick={onSelectSecurity}
-          />
-        )}
-        {onSelectShares && (
-          <NavRow
-            testId="sidebar-shares"
-            icon={<SharesIcon size={14} strokeWidth={1.75} />}
-            label={t('sidebar.shares')}
-            active={isSharesActive}
-            onClick={onSelectShares}
-          />
-        )}
+        <NavRow
+          testId="sidebar-security"
+          icon={<SecurityIcon size={14} strokeWidth={1.75} />}
+          label={t('sidebar.security')}
+          active={isSecurityActive}
+          onClick={onSelectSecurity}
+        />
+        <NavRow
+          testId="sidebar-shares"
+          icon={<SharesIcon size={14} strokeWidth={1.75} />}
+          label={t('sidebar.shares')}
+          active={isSharesActive}
+          onClick={onSelectShares}
+        />
         {onOpenSearch && (
           <NavRow
             testId="sidebar-search"
@@ -220,7 +216,7 @@ export default function Sidebar({ activeIdentityKey, activeSessionUuid = null, o
                   active={session.sessionUuid === activeSessionUuid}
                   onClick={() => onSelectSession(session.sessionUuid)}
                   {...(onCopySessionId ? { onCopySessionId } : {})}
-                  {...(onShareSession ? { onShare: onShareSession } : {})}
+                  onShare={onShareSession}
                 />
               ))}
             </div>
@@ -664,7 +660,7 @@ function PinnedRow({
   active: boolean
   onClick: () => void
   onCopySessionId?: (source: SessionSource) => void
-  onShare?: (uuid: string) => void
+  onShare: (uuid: string) => void
 }) {
   const { t } = useTranslation()
   const [resuming, setResuming] = useState(false)


### PR DESCRIPTION
## What

Follow-up to #422 completing the flag removal. With the `share` flag gone, `App.tsx` always passes the share callbacks, but the consuming components still declared them optional and kept `{prop && ...}` hide-branches whose condition could never be false — dead code, and inverted type safety (a future call site that forgets to wire a callback would silently hide the affordance instead of failing to compile).

`onSelectShares` / `onSelectSecurity` / `onShareSession` (Sidebar, SecurityPage, FragmentResults), `onShare` (SessionDetail, LibraryLanding, ProjectView), and `onImportSpool` / `onStartNewDraft` (SharesPage) are now required, including the file-local subcomponents they feed (PinnedRow, SessionCard, FragmentRow, DraftsList). The always-true guards and conditional prop spreads are unwrapped; `useSpoolDrop` is always enabled.

Shared multi-caller components (`SessionRow`, `ContinueActions`) keep their optional props — their optionality is a reusable-component contract, not flag residue.

## Why now

Surfaced as a CONFIRMED cleanup finding in the #422 high-effort review; deferred from that PR to keep the launch-gating change and the type refactor separately revertable.

## Test plan

- Behavior-identical refactor: typecheck is the primary gate (it now proves every caller wires every share callback).
- App unit suite green (447); full e2e suite green locally on macOS (166 passed, 1 pre-existing skip) — covers Sidebar nav, SharesPage tabs/empty-state, SecurityPage rows, session-detail share entry, and search-result share actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)