### PR TITLE
chore: configure low-noise dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+      time: "04:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 2
+    groups:
+      # Keep routine version churn to one reviewable lockfile diff. Minor and
+      # major upgrades stay manual so runtime migrations keep their own tests.
+      routine-patches:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "better-sqlite3"
+        update-types:
+          - patch
+    ignore:
+      # Security alerts remain available even when version-update PRs are
+      # intentionally suppressed. Review minor and major upgrades manually.
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-major
+
+      # better-sqlite3 is pinned exactly because the workspace alternates one
+      # installed binary between the Node and Electron ABIs.
+      - dependency-name: better-sqlite3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,14 @@ node packages/app/scripts/smoke-packaged.mjs packages/app/dist/mac-arm64/Spool.a
 node packages/app/scripts/package-size-report.mjs packages/app/dist/mac-arm64/Spool.app
 ```
 
+## Dependency maintenance
+
+Dependabot deliberately opens one grouped patch update each month. Minor and major upgrades are manual so framework and runtime migrations do not share a lockfile diff with routine maintenance. One dependency is also manual at every version:
+
+- `better-sqlite3`, which must be validated against both the Node and Electron ABIs
+
+Review grouped ACP patches as a coordinated lockfile change: the Codex extension publishes exact-version platform binaries, while the ACP SDK and Claude extension have independent version lines. For Electron or native-module changes, run the full verification matrix above plus the packaged smoke, code-signing check, and package-size report. Dependabot security alerts remain enabled separately from version updates.
+
 ## What to work on
 
 - Check [Issues](https://github.com/spool-lab/spool/issues) for bugs and feature requests


### PR DESCRIPTION
## Why

The first Dependabot version-update configuration was paused in #440 after its initial run opened ten PRs, including upgrades against an intentionally pinned native dependency. The useful part of dependency automation can be restored with much tighter volume and scope.

## What changed

- Run npm/pnpm workspace version updates monthly instead of weekly.
- Limit open version-update PRs to two.
- Group all eligible patch updates into one reviewable lockfile diff.
- Suppress automatic minor and major version updates so framework/runtime migrations remain manual changes with their own validation.
- Ignore `better-sqlite3` at every version because its exact pin participates in the Node/Electron ABI switching scheme.
- Allow type-package and ACP patch updates back into the monthly group. The ACP SDK and Claude extension have independent version lines; the Codex extension's exact-version platform packages are reviewed together in the grouped lockfile diff.
- Document the policy and the additional packaged-app gates required for Electron/native changes.

Dependabot security alerts remain available independently. As with any Dependabot `ignore` rule, an automated security-fix PR for the explicitly ignored `better-sqlite3` package may be suppressed; its alert still requires manual review.

## Verification

- Parsed `.github/dependabot.yml` with Ruby/Psych.
- Ran a semantic policy check confirming:
  - monthly cadence;
  - open PR limit of two;
  - one `version-updates` patch-only group;
  - global minor/major suppression;
  - `better-sqlite3` as the only permanent package ignore.
- `git diff --check` passed.
- Ubuntu unit, Ubuntu E2E, and macOS E2E passed in PR CI.
