### PR TITLE
release: v0.6.0

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/app",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "private": true,
   "productName": "Spool",
   "main": "./out/main/index.js",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/cli",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "private": false,
   "type": "module",
   "bin": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/web",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spool",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/core",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/redact",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Local, pure-TS sensitive-data detection for Spool sessions. Pattern + checksum + entropy pipeline today; pluggable provider boundary for future on-device ML (e.g. OpenAI Privacy Filter via transformers.js).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump for the v0.6.0 desktop release (Spool v2 share flow). Cut by scripts/release.sh; direct push to main is blocked by repo rules, so the bump rides a PR. Tag + Release workflow dispatch follow once this merges.