### PR TITLE
fix: publish session-kit to npm in the release chain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,18 +191,21 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # Build dist for every package we publish so the prepack step has a tree
-      # to ship. Order matters only for redact → core → cli because the upstream
-      # consumer reads dist/index.d.ts at typecheck time during downstream build.
+      # to ship. Order matters for redact/session-kit → core → cli because the
+      # upstream consumer reads dist/index.d.ts at typecheck time during
+      # downstream build.
       - name: Build publish targets
         run: |
           pnpm -F @spool-lab/redact build
+          pnpm -F @spool-lab/session-kit build
           pnpm -F @spool-lab/core build
           pnpm -F @spool-lab/cli build
 
       # Publish in dependency order. Each step is idempotent: if the registry
       # already has this version (re-run after a partial-fail), we skip rather
-      # than error. redact is bumped in lockstep with core/cli by release.sh,
-      # so a fresh release always produces a new version per package.
+      # than error. redact and session-kit are bumped in lockstep with core/cli
+      # by release.sh, so a fresh release always produces a new version per
+      # package.
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
@@ -221,5 +224,6 @@ jobs:
             fi
           }
           publish_if_missing packages/redact
+          publish_if_missing packages/session-kit
           publish_if_missing packages/core
           publish_if_missing apps/cli

--- a/packages/session-kit/package.json
+++ b/packages/session-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/session-kit",
-  "version": "0.0.1",
+  "version": "0.6.0",
   "description": "Browser-safe canonical records, sequence hashing, edit extraction, views, and session diffs for Spool v2.",
   "type": "module",
   "main": "./dist/index.js",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -60,7 +60,7 @@ NEW_VERSION="$major.$minor.$patch"
 TAG="v$NEW_VERSION"
 green "Bumping to $NEW_VERSION"
 
-for f in package.json apps/app/package.json packages/core/package.json apps/cli/package.json apps/web/package.json packages/redact/package.json; do
+for f in package.json apps/app/package.json packages/core/package.json apps/cli/package.json apps/web/package.json packages/redact/package.json packages/session-kit/package.json; do
   if [[ -f "$f" ]]; then
     jq --arg v "$NEW_VERSION" '.version = $v' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
   fi


### PR DESCRIPTION
The v2 share flow made `@spool-lab/core` and `@spool-lab/cli` depend on `@spool-lab/session-kit` at runtime, but the Release workflow neither built nor published it. The v0.6.0 `publish-npm` job failed with TS2307 in `packages/core`; even a green publish would have shipped a dependency that doesn't exist on npm.

- **release.yml**: build session-kit before core; publish it with the same idempotent `publish_if_missing` guard
- **release.sh**: bump session-kit in lockstep (same treatment as redact)
- **session-kit**: `0.0.1` → `0.6.0` so its first publish matches the already-tagged release

After merge, re-dispatching the Release workflow on `main` completes the v0.6.0 npm publish (build artifacts + GitHub release already succeeded and re-upload idempotently).