### PR TITLE
fix: drop [triggers] block from backend Pages config

### DIFF
--- a/apps/backend/wrangler.toml
+++ b/apps/backend/wrangler.toml
@@ -61,12 +61,12 @@ bucket_name = "spool-hub"
 [vars]
 ENV = "development"
 
-# Cron trigger for the deletion sweep. Pages Functions ignore this in
-# the Pages runtime — the deletion worker is intended to run as a
+# Cron cadence for the deletion sweep ("0 */6 * * *"). Pages configs
+# reject a [triggers] block outright (wrangler ≥4.9x validates it), so
+# this lives here as documentation only — the deletion worker is a
 # companion Worker (functions/_scheduled/deletion-worker.ts) sharing the
-# same D1/KV/R2 bindings. Kept here for documentation.
-[triggers]
-crons = ["0 */6 * * *"]
+# same D1/KV/R2 bindings, and its cron is set in
+# workers/spool-share-deletion/wrangler.toml.
 
 # Secrets (set ONCE per environment via wrangler — never commit):
 #   wrangler pages secret put WORKOS_CLIENT_ID         --project-name spool-share-backend


### PR DESCRIPTION
wrangler ≥4.9x treats `apps/backend/wrangler.toml` as a Pages config (it has `pages_build_output_dir`) and rejects the `[triggers]` block outright — every `wrangler pages deploy` fails validation before upload. Found during the first production launch of the share backend.

The block was documentation only (Pages Functions never ran the cron). The cadence stays documented in a comment pointing at `workers/spool-share-deletion/wrangler.toml`, where the cron actually lives.

Note for a follow-up: the same wrangler versions also require binding `id` fields in config-based Pages deploys, so `pnpm run deploy:staging/prod` no longer works with the id-less checked-in config — this launch used local id-carrying configs (`wrangler.{staging,prod}.toml`, untracked) swapped in at deploy time. Worth deciding whether to script that swap or gitignore the local configs.