### PR TITLE
Fix Cloudflare Worker route cutover

### DIFF
--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -1,6 +1,8 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
-  "name": "spool-web",
+  // Keep the existing production service name so the first direct deploy can
+  // replace its script without trying to steal the already-bound route.
+  "name": "spool-pro-router",
   "main": "src/server.ts",
   "compatibility_date": "2026-07-17",
   "compatibility_flags": ["nodejs_compat"],
@@ -21,7 +23,7 @@
   },
   "env": {
     "staging": {
-      "name": "spool-web-staging",
+      "name": "spool-pro-router-staging",
       "routes": [
         {
           "pattern": "staging.spool.pro/*",


### PR DESCRIPTION
## Problem

The first direct deployment uploaded `spool-web`, then failed when attaching `spool.pro/*` because that route is still owned by `spool-pro-router`.

## Fix

Deploy the new web entry bundle under the existing Worker service name. This replaces the script and assets in place, preserving the route for a zero-downtime cutover.

## Validation

- generated deploy config names `spool-pro-router`
- `pnpm --filter @spool/web typecheck`
- `wrangler types --check`
- `pnpm --filter @spool/web build`
- `wrangler deploy --dry-run`
