### PR TITLE
fix(app): verify Electron before dev setup

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -28,7 +28,7 @@
     "build:share-kit": "vp run --filter @spool/share-kit build",
     "build:session-view": "vp run --filter @spool-lab/session-view build",
     "build:deps": "pnpm run build:redact && pnpm run build:session-kit && pnpm run build:core && pnpm run build:cli && pnpm run build:share-kit && pnpm run build:session-view",
-    "dev": "pnpm run build:deps && node ../../scripts/with-electron-native.mjs node scripts/dev.mjs",
+    "dev": "pnpm run ensure:electron-runtime && pnpm run build:deps && node ../../scripts/with-electron-native.mjs node scripts/dev.mjs",
     "dev:reset-db": "node scripts/dev-reset-db.mjs",
     "dev:seed-from-prod": "node scripts/dev-seed-from-prod.mjs",
     "build": "electron-vite build && pnpm run build:workers",

--- a/apps/app/scripts/lib/dev-launch-plan.test.mjs
+++ b/apps/app/scripts/lib/dev-launch-plan.test.mjs
@@ -1,9 +1,17 @@
+import { readFileSync } from 'node:fs'
+
 import { describe, expect, test } from 'vite-plus/test'
 
 import electronViteConfig from '../../electron.vite.config.ts'
 import { DEV_LAUNCH_PLAN } from './dev-launch-plan.mjs'
 
+const appPackage = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8'))
+
 describe('Electron dev launch plan', () => {
+  test('ensures the Electron runtime before development setup', () => {
+    expect(appPackage.scripts.dev.split(' && ')[0]).toBe('pnpm run ensure:electron-runtime')
+  })
+
   test('builds isolated worker entries before starting Electron', () => {
     expect(DEV_LAUNCH_PLAN).toEqual([
       {


### PR DESCRIPTION
## Summary

- run the existing Electron runtime check before the more expensive development dependency builds
- add a regression test that keeps the runtime check first in the app development command

## Why

A missing or incomplete Electron installation should fail immediately when starting desktop development instead of surfacing only after the workspace dependency build finishes.

## Validation

- `pnpm --filter @spool/app run ensure:electron-runtime`
- `pnpm --filter @spool/app exec vp test run scripts/lib/dev-launch-plan.test.mjs --no-file-parallelism` (3 tests)
- `pnpm --filter @spool/app typecheck`
- focused format and lint checks
