### PR TITLE
release: v0.6.1

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/app",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "homepage": "https://github.com/spool-lab/spool#readme",
   "bugs": {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "homepage": "https://github.com/spool-lab/spool#readme",
   "bugs": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/web",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "homepage": "https://github.com/spool-lab/spool#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spool",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "homepage": "https://github.com/spool-lab/spool#readme",
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "homepage": "https://github.com/spool-lab/spool#readme",
   "bugs": {

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/redact",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Local, pure-TS sensitive-data detection for Spool sessions. Pattern + checksum + entropy pipeline today; pluggable provider boundary for future on-device ML (e.g. OpenAI Privacy Filter via transformers.js).",
   "homepage": "https://github.com/spool-lab/spool#readme",
   "bugs": {

--- a/packages/session-kit/package.json
+++ b/packages/session-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/session-kit",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Browser-safe canonical records, sequence hashing, edit extraction, views, and Session diffs for Spool.",
   "homepage": "https://github.com/spool-lab/spool#readme",
   "bugs": {


### PR DESCRIPTION
Version bump for the v0.6.1 release train. Cut by scripts/release.sh; direct push to main is blocked by repository rules, so the synchronized version checkpoint rides the required PR and merge queue. Tag and Release workflow dispatch follow once this merges.