### PR TITLE
fix(release): fall back to Electron version for native ABI

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prepare": "vp config"
   },
   "devDependencies": {
+    "node-abi": "^4.33.0",
     "taze": "^19.14.1",
     "typescript": "7.0.2",
     "vite": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
 
   .:
     devDependencies:
+      node-abi:
+        specifier: ^4.33.0
+        version: 4.33.0
       taze:
         specifier: ^19.14.1
         version: 19.14.1

--- a/scripts/lib/electron-modules-abi.mjs
+++ b/scripts/lib/electron-modules-abi.mjs
@@ -1,0 +1,10 @@
+import { getAbi } from 'node-abi'
+
+export function electronModulesAbi({ result, electronVersion }) {
+  const modules = result.stdout?.trim()
+  if (result.status === 0 && modules && /^\d+$/.test(modules)) {
+    return modules
+  }
+
+  return getAbi(electronVersion, 'electron')
+}

--- a/scripts/lib/electron-modules-abi.test.mjs
+++ b/scripts/lib/electron-modules-abi.test.mjs
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vite-plus/test'
+
+import { electronModulesAbi } from './electron-modules-abi.mjs'
+
+describe('Electron ABI resolution', () => {
+  test('uses the running Electron ABI when the runtime is available', () => {
+    expect(
+      electronModulesAbi({
+        result: { status: 0, stdout: '148\n' },
+        electronVersion: '43.1.1',
+      }),
+    ).toBe('148')
+  })
+
+  test('resolves the ABI from the Electron version when the runtime cannot start', () => {
+    expect(
+      electronModulesAbi({
+        result: { status: 1, stdout: '', stderr: 'Electron failed to start' },
+        electronVersion: '43.1.1',
+      }),
+    ).toBe('148')
+  })
+})

--- a/scripts/with-electron-native.mjs
+++ b/scripts/with-electron-native.mjs
@@ -1,9 +1,13 @@
 import { spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { electronModulesAbi } from './lib/electron-modules-abi.mjs'
+
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(scriptDir, '..')
+const appRequire = createRequire(join(repoRoot, 'apps/app/package.json'))
 const pnpmBin = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 const command = process.argv[2]
 const args = process.argv.slice(3)
@@ -21,7 +25,7 @@ function run(program, programArgs, cwd = repoRoot) {
   })
 }
 
-function electronModulesAbi() {
+function electronModulesAbiForApp() {
   const result = spawnSync(
     pnpmBin,
     ['--filter', '@spool/app', 'exec', 'electron', '-p', 'process.versions.modules'],
@@ -31,11 +35,8 @@ function electronModulesAbi() {
       env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
     },
   )
-  const modules = result.stdout?.trim()
-  if (result.status !== 0 || !modules || !/^\d+$/.test(modules)) {
-    throw new Error('could not determine Electron NODE_MODULE_VERSION')
-  }
-  return modules
+  const electronVersion = appRequire('electron/package.json').version
+  return electronModulesAbi({ result, electronVersion })
 }
 
 let commandStatus = 1
@@ -53,7 +54,7 @@ try {
   if (electronRebuild.status === 0) {
     const cache = run(process.execPath, [
       join(scriptDir, 'cache-better-sqlite3-native.mjs'),
-      electronModulesAbi(),
+      electronModulesAbiForApp(),
     ])
     if (cache.status === 0) {
       const result = run(command, args, process.cwd())


### PR DESCRIPTION
The v0.6.1 Release workflow failed on both hosted runners because `with-electron-native.mjs` tried to launch Electron only to discover `NODE_MODULE_VERSION`. Hosted macOS could not start that probe, so packaging stopped before signing or publication. Add a tested `node-abi` fallback based on the installed Electron version; this is the same ABI registry used by `@electron/rebuild`.\n\nVerification:\n- `pnpm vp check`\n- `pnpm vp test run scripts/lib/electron-modules-abi.test.mjs`\n- forced Electron-start failure through the full `with-electron-native.mjs` wrapper caches ABI 148 and exits successfully\n\nNo GitHub release or npm package was created by the failed run. This PR is the v0.6.1 recovery checkpoint.