### PR TITLE
fix(release): set a safe packaged executable name

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -116,6 +116,7 @@
   "build": {
     "appId": "com.linkclaw.spool",
     "productName": "Spool",
+    "executableName": "Spool",
     "npmRebuild": false,
     "publish": [
       {

--- a/apps/app/scripts/lib/dev-launch-plan.test.mjs
+++ b/apps/app/scripts/lib/dev-launch-plan.test.mjs
@@ -12,6 +12,10 @@ describe('Electron dev launch plan', () => {
     expect(appPackage.scripts.dev.split(' && ')[0]).toBe('pnpm run ensure:electron-runtime')
   })
 
+  test('uses a path-safe executable name for packaged apps', () => {
+    expect(appPackage.build.executableName).toBe('Spool')
+  })
+
   test('builds isolated worker entries before starting Electron', () => {
     expect(DEV_LAUNCH_PLAN).toEqual([
       {


### PR DESCRIPTION
The recovered v0.6.1 workflow passed native ABI preparation, then Electron Builder 26.15 rejected the scoped package-derived Linux executable name `@spoolapp`. Set the explicit packaged executable name to `Spool` and lock the configuration down with a regression test.\n\nVerification:\n- `pnpm vp test run apps/app/scripts/lib/dev-launch-plan.test.mjs`\n- `pnpm vp check`\n\nThe failed run produced no release or npm publication; this is the next same-version recovery checkpoint.