### PR TITLE
fix(release): build npm targets through prepack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,10 +196,10 @@ jobs:
       # downstream build.
       - name: Build publish targets
         run: |
-          pnpm -F @spool-lab/redact build
-          pnpm -F @spool-lab/session-kit build
-          pnpm -F @spool-lab/core build
-          pnpm -F @spool-lab/cli build
+          pnpm -F @spool-lab/redact run prepack
+          pnpm -F @spool-lab/session-kit run prepack
+          pnpm -F @spool-lab/core run prepack
+          pnpm -F @spool-lab/cli run prepack
 
       # Publish in dependency order. Each step is idempotent: if the registry
       # already has this version (re-run after a partial-fail), we skip rather

--- a/scripts/lib/release-workflow.test.mjs
+++ b/scripts/lib/release-workflow.test.mjs
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, test } from 'vite-plus/test'
+
+const repoRoot = new URL('../..', import.meta.url)
+const releaseWorkflow = readFileSync(new URL('.github/workflows/release.yml', repoRoot), 'utf8')
+
+describe('npm release workflow', () => {
+  test('builds every publish target through its prepack script', () => {
+    const buildBlock = releaseWorkflow.match(
+      /- name: Build publish targets[\s\S]*?(?=\n      - name:)/,
+    )?.[0]
+    const publishDirectories = [
+      ...releaseWorkflow.matchAll(/^\s+publish_if_missing ([^\s]+)$/gm),
+    ].map((match) => match[1])
+
+    expect(buildBlock).toBeDefined()
+    expect(publishDirectories.length).toBeGreaterThan(0)
+
+    for (const packageDirectory of publishDirectories) {
+      const manifest = JSON.parse(
+        readFileSync(new URL(`${packageDirectory}/package.json`, repoRoot), 'utf8'),
+      )
+      expect(buildBlock).toContain(`pnpm -F ${manifest.name} run prepack`)
+    }
+  })
+})


### PR DESCRIPTION
The v0.6.1 recovery run built and uploaded every desktop artifact, then npm publication stopped before publishing because the workflow invoked nonexistent package `build` scripts. All publish targets intentionally expose `prepack: vp run build`. Invoke those scripts in dependency order and add a workflow regression test derived from the actual publish target list.\n\nVerification:\n- `pnpm -F <each publish target> run prepack` produces every expected `dist/index.js`\n- `pnpm vp test run scripts/lib/release-workflow.test.mjs`\n- `pnpm vp check`\n\nThe GitHub release exists with desktop assets; no npm package reached 0.6.1, so the workflow re-run remains idempotent.