### PR TITLE
feat: scope spool list to current project

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -47,7 +47,7 @@ spool show <session> --json       # machine-readable output
 
 ```bash
 spool sync [--watch]
-spool list [-s <source>] [-n <count>] [--json]
+spool list [-s <source>] [-p <path>] [-n <count>] [-a|--all] [--json]
 spool projects [name] [-n <count>] [--json]
 spool search <query> [-s <source>] [--since 7d] [-n 10] [--json]
 spool status

--- a/apps/cli/src/cli.test.ts
+++ b/apps/cli/src/cli.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { existsSync, statSync, rmSync, mkdtempSync } from 'node:fs'
+import { existsSync, statSync, rmSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { resolve, join } from 'node:path'
 
@@ -11,6 +11,7 @@ const BIN = resolve(import.meta.dirname, '..', 'bin', 'spool.js')
 
 const SESSION_UUID_1 = '00000000-aaaa-bbbb-cccc-000000000001'
 const SESSION_UUID_2 = '11111111-aaaa-bbbb-cccc-000000000002'
+const CWD_SESSION_UUID = '22222222-aaaa-bbbb-cccc-000000000003'
 const AMBIGUOUS_SESSION_UUID = '00000000-dddd-eeee-ffff-000000000003'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -23,10 +24,11 @@ const ISOLATED_ENV = {
   SPOOL_PI_DIR: '/nonexistent/pi',
 }
 
-function run(args: string[], env?: Record<string, string>): string {
+function run(args: string[], env?: Record<string, string>, cwd?: string): string {
   return execFileSync('node', [BIN, ...args], {
     encoding: 'utf8',
     env: { ...process.env, ...ISOLATED_ENV, ...env },
+    cwd,
     timeout: 15_000,
   })
 }
@@ -362,41 +364,93 @@ describe('share session-id prefixes', () => {
 
 describe('list', () => {
   let seeded: ReturnType<typeof createSeededDir>
+  let currentProjectDir: string
   beforeAll(() => {
     seeded = createSeededDir()
+    currentProjectDir = join(seeded.dir, 'current-project')
+    mkdirSync(join(currentProjectDir, 'packages', 'cli'), { recursive: true })
+    writeFileSync(join(currentProjectDir, 'package.json'), '{"name":"current-project"}')
+
+    const db = new Database(join(seeded.dir, 'spool.db'))
+    db.prepare(
+      'INSERT INTO projects (source_id, slug, display_path, display_name) VALUES (?, ?, ?, ?)',
+    ).run(1, 'current-project', currentProjectDir, 'current-project')
+    db.prepare(`
+      INSERT INTO sessions (
+        project_id, source_id, session_uuid, file_path, title, started_at,
+        ended_at, message_count, cwd, model, raw_file_mtime
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      2,
+      1,
+      CWD_SESSION_UUID,
+      '/fake/current-project-session.jsonl',
+      'Current project session',
+      '2026-04-08T10:00:00Z',
+      '2026-04-08T11:00:00Z',
+      1,
+      currentProjectDir,
+      'claude-4',
+      '2026-04-08',
+    )
+    db.close()
   })
   afterAll(() => {
     seeded.cleanup()
   })
 
-  it('lists sessions', () => {
-    const out = run(['list'], { SPOOL_DATA_DIR: seeded.dir })
+  it('defaults to sessions for the current cwd project', () => {
+    const out = run(
+      ['list'],
+      { SPOOL_DATA_DIR: seeded.dir },
+      join(currentProjectDir, 'packages', 'cli'),
+    )
+    expect(out).toContain('Current project session')
+    expect(out).not.toContain('Debugging authentication flow')
+    expect(out).not.toContain('Refactoring database queries')
+  })
+
+  it('--all ignores cwd and lists sessions from every project', () => {
+    const out = run(['list', '--all'], { SPOOL_DATA_DIR: seeded.dir })
+    expect(out).toContain('Current project session')
     expect(out).toContain('Debugging authentication flow')
     expect(out).toContain('Refactoring database queries')
   })
 
   it('prints an actionable short id per row (what spool share/show consume)', () => {
-    const out = run(['list'], { SPOOL_DATA_DIR: seeded.dir })
+    const out = run(['list', '--all'], { SPOOL_DATA_DIR: seeded.dir })
     expect(out).toContain(SESSION_UUID_1.slice(0, 8))
     expect(out).not.toMatch(/^#[0-9a-f]{8}\b/m)
   })
 
   it('limits results with -n', () => {
-    const out = run(['list', '-n', '1'], { SPOOL_DATA_DIR: seeded.dir })
+    const out = run(['list', '--all', '-n', '1'], { SPOOL_DATA_DIR: seeded.dir })
     expect(out).toContain('Refactoring database queries')
     expect(out).not.toContain('Debugging authentication flow')
   })
 
   it('filters by source', () => {
-    const out = run(['list', '-s', 'codex'], { SPOOL_DATA_DIR: seeded.dir })
+    const out = run(['list', '--all', '-s', 'codex'], { SPOOL_DATA_DIR: seeded.dir })
     expect(out).toContain('No sessions found')
   })
 
+  it('hints at --all when the current project has no matching sessions', () => {
+    const out = run(['list'], { SPOOL_DATA_DIR: seeded.dir })
+    expect(out).toContain('spool list --all')
+    expect(out).not.toContain('spool sync')
+  })
+
+  it('does not treat a child project as the project containing cwd', () => {
+    const out = run(['list'], { SPOOL_DATA_DIR: seeded.dir }, seeded.dir)
+    expect(out).not.toContain('Current project session')
+    expect(out).toContain('spool list --all')
+  })
+
   it('outputs JSON', () => {
-    const out = run(['list', '--json'], { SPOOL_DATA_DIR: seeded.dir })
+    const out = run(['list', '--all', '--json'], { SPOOL_DATA_DIR: seeded.dir })
     const parsed = JSON.parse(out)
     expect(Array.isArray(parsed)).toBe(true)
-    expect(parsed.length).toBe(2)
+    expect(parsed.length).toBe(3)
     expect(parsed[0].sessionUuid).toBeTruthy()
   })
 

--- a/apps/cli/src/commands/list.ts
+++ b/apps/cli/src/commands/list.ts
@@ -1,4 +1,9 @@
-import { getDB, listRecentSessionsPage } from '@spool-lab/core'
+import {
+  getDB,
+  listRecentSessionsPage,
+  listSessionsByIdentity,
+  resolveLocalProjectIdentity,
+} from '@spool-lab/core'
 import { Command } from 'commander'
 
 import { printSession } from '../format.js'
@@ -10,32 +15,47 @@ export const listCommand = new Command('list')
   .option('-n, --limit <n>', 'Max results', '20')
   .option('-s, --source <name>', 'Filter by source: claude|codex|gemini|opencode|pi')
   .option('-p, --project <path>', 'Filter by project path substring')
+  .option('-a, --all', 'List across all projects (ignore cwd)')
   .option('--json', 'Output as JSON')
-  .action((opts: { limit: string; source?: string; project?: string; json?: boolean }) => {
-    const db = getDB(true)
-    let sessions = listRecentSessionsPage(db, { limit: parseInt(opts.limit, 10) * 2 }).sessions
+  .action(
+    (opts: { limit: string; source?: string; project?: string; all?: boolean; json?: boolean }) => {
+      const db = getDB(true)
+      const limit = parseInt(opts.limit, 10)
+      const queryLimit = limit * 2
+      let sessions = opts.all
+        ? listRecentSessionsPage(db, { limit: queryLimit }).sessions
+        : listSessionsByIdentity(db, resolveLocalProjectIdentity(db, process.cwd()).key, {
+            limit: queryLimit,
+          }).sessions
 
-    if (opts.source && SESSION_SOURCES.has(opts.source)) {
-      sessions = sessions.filter((s) => s.source === opts.source)
-    }
-    if (opts.project) {
-      const needle = opts.project.toLowerCase()
-      sessions = sessions.filter((s) => s.projectDisplayPath.toLowerCase().includes(needle))
-    }
+      if (opts.source && SESSION_SOURCES.has(opts.source)) {
+        sessions = sessions.filter((s) => s.source === opts.source)
+      }
+      if (opts.project) {
+        const needle = opts.project.toLowerCase()
+        sessions = sessions.filter((s) => s.projectDisplayPath.toLowerCase().includes(needle))
+      }
 
-    sessions = sessions.slice(0, parseInt(opts.limit, 10))
+      sessions = sessions.slice(0, limit)
 
-    if (opts.json) {
-      console.log(JSON.stringify(sessions, null, 2))
-      return
-    }
+      if (opts.json) {
+        console.log(JSON.stringify(sessions, null, 2))
+        return
+      }
 
-    if (sessions.length === 0) {
-      console.log('No sessions found. Run `spool sync` to index sessions.')
-      return
-    }
+      if (sessions.length === 0) {
+        if (!opts.all && listRecentSessionsPage(db, { limit: 1 }).sessions.length > 0) {
+          console.log(
+            'No sessions found for the current project. Run `spool list --all` to search all projects.',
+          )
+          return
+        }
+        console.log('No sessions found. Run `spool sync` to index sessions.')
+        return
+      }
 
-    for (const s of sessions) {
-      printSession(s)
-    }
-  })
+      for (const s of sessions) {
+        printSession(s)
+      }
+    },
+  )

--- a/apps/web/src/content/docs/quick-start.md
+++ b/apps/web/src/content/docs/quick-start.md
@@ -36,6 +36,9 @@ spool list -n 10
 spool share <session-uuid>
 ```
 
+`spool list` uses the current project by default. Run `spool list --all` to see recent Sessions
+from every indexed project.
+
 Only Claude Code and Codex CLI Sessions can currently be shared and resumed.
 
 ## 4. Review before sharing

--- a/apps/web/src/content/docs/reference/cli.md
+++ b/apps/web/src/content/docs/reference/cli.md
@@ -99,13 +99,17 @@ Sync is local and does not publish anything.
 
 ## `spool list`
 
-List recent local Sessions:
+List recent local Sessions for the project containing the current working directory:
 
 ```bash
 spool list
 spool list -s codex -n 10
 spool list --json
+spool list --all
 ```
+
+`--all` ignores the current-project scope and lists recent Sessions across every project. It
+still respects `--limit`; combine it with `--project <path>` to query a different project.
 
 ## `spool projects`
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export * from './parsers/spool-prelude.js'
 export * from './sync/syncer.js'
 export * from './sync/watcher.js'
 export * from './projects/groups.js'
+export * from './projects/local-identity.js'
 export * from './projects/sessions.js'
 export {
   resolveSystemBinary,

--- a/packages/core/src/projects/display-name.test.ts
+++ b/packages/core/src/projects/display-name.test.ts
@@ -9,6 +9,7 @@ describe('fallbackDisplayName', () => {
   })
   it('handles trailing slash', () => {
     expect(fallbackDisplayName('/Users/chen/Code/spool/')).toBe('spool')
+    expect(fallbackDisplayName('/Users/chen/Code/spool///')).toBe('spool')
   })
   it('returns "(root)" for /', () => {
     expect(fallbackDisplayName('/')).toBe('(root)')

--- a/packages/core/src/projects/display-name.ts
+++ b/packages/core/src/projects/display-name.ts
@@ -1,6 +1,8 @@
 export function fallbackDisplayName(input: string): string {
   if (input === '/') return '(root)'
-  const trimmed = input.replace(/\/+$/, '')
+  let end = input.length
+  while (end > 0 && input[end - 1] === '/') end -= 1
+  const trimmed = input.slice(0, end)
   const parts = trimmed.split('/').filter(Boolean)
   return parts[parts.length - 1] ?? trimmed
 }

--- a/packages/core/src/projects/local-identity.ts
+++ b/packages/core/src/projects/local-identity.ts
@@ -1,0 +1,89 @@
+import { realpathSync } from 'node:fs'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
+
+import type Database from 'better-sqlite3'
+
+import type { ProjectIdentity } from '../types.js'
+import { realFs } from './fs.js'
+import { listProjectGroups } from './groups.js'
+import { computeIdentity } from './identity.js'
+
+/** Match a live cwd to an identity already present in the local index. */
+export function resolveLocalProjectIdentity(db: Database.Database, cwd: string): ProjectIdentity {
+  const computed = computeIdentity(cwd, realFs)
+  const groups = listProjectGroups(db, { withPaths: true })
+
+  const direct = groups.find(
+    (group) => group.identityKind === computed.kind && group.identityKey === computed.key,
+  )
+  if (direct) return identityFromGroup(direct)
+
+  if (isAbsolute(computed.key)) {
+    const canonicalKey = canonicalPath(computed.key)
+    const canonical = groups.find(
+      (group) =>
+        group.identityKind === computed.kind &&
+        isAbsolute(group.identityKey) &&
+        canonicalPath(group.identityKey) === canonicalKey,
+    )
+    if (canonical) return identityFromGroup(canonical)
+  }
+
+  const canonicalCwd = canonicalPath(cwd)
+  const nearby = groups
+    .map((group) => ({
+      group,
+      distance: closestPathDistance(canonicalCwd, [...group.displayPaths, ...group.cwds]),
+    }))
+    .filter(
+      (candidate): candidate is typeof candidate & { distance: number } =>
+        candidate.distance !== null,
+    )
+    .sort((a, b) => a.distance - b.distance)[0]
+
+  return nearby ? identityFromGroup(nearby.group) : computed
+}
+
+function identityFromGroup(group: {
+  identityKind: ProjectIdentity['kind']
+  identityKey: string
+  displayName: string
+}): ProjectIdentity {
+  return {
+    kind: group.identityKind,
+    key: group.identityKey,
+    displayName: group.displayName,
+  }
+}
+
+function closestPathDistance(cwd: string, paths: string[]): number | null {
+  let closest: number | null = null
+  for (const path of paths) {
+    if (!isAbsolute(path)) continue
+    const candidate = canonicalPath(path)
+    const distance = containingPathDistance(cwd, candidate)
+    if (distance !== null && (closest === null || distance < closest)) closest = distance
+  }
+  return closest
+}
+
+function containingPathDistance(cwd: string, projectPath: string): number | null {
+  const projectToCwd = relative(projectPath, cwd)
+  return isContainedRelativePath(projectToCwd) ? pathDepth(projectToCwd) : null
+}
+
+function isContainedRelativePath(path: string): boolean {
+  return path === '' || (path !== '..' && !path.startsWith(`..${sep}`) && !isAbsolute(path))
+}
+
+function pathDepth(path: string): number {
+  return path === '' ? 0 : path.split(sep).filter(Boolean).length
+}
+
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path)
+  } catch {
+    return resolve(path)
+  }
+}

--- a/skills/spool/SKILL.md
+++ b/skills/spool/SKILL.md
@@ -105,16 +105,16 @@ Fold what you found into your reply as ordinary context, citing the source per c
 
 ## Command reference
 
-| Command                                             | Does                                                                                                               |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `spool sync [--watch]`                              | Index new sessions; `--watch` stays running                                                                        |
-| `spool search <query> [-s <source>] [--since 7d]`   | Full-text search; add `--json` for machine-readable results                                                        |
-| `spool list [-s <source>] [-p <path>] [-n <count>]` | Recent sessions; filters apply to a recent window, so raise `-n` when filtering                                    |
-| `spool projects [query] [-n <count>]`               | Project groups, or sessions for a name, identity key, path, or cwd                                                 |
-| `spool show <uuid\|sid\|url>`                       | Local transcript / shared Summary; `--log` timeline, `--diff` net change, `@r<n>` record, `--json` structured data |
-| `spool pin <uuid>` / `unpin <uuid>` / `pinned`      | Bookmark and list sessions; state is shared with the Spool app Library                                             |
-| `spool status` / `spool doctor [checkId] [--fix]`   | Index stats / diagnostics; `doctor --fix --force` also permits destructive fixes                                   |
-| `spool login [--token <t>]` / `spool logout`        | Hub browser-device auth (or token for automation) / revoke and clear credentials                                   |
-| `spool share [<uuid>[@<n>]] [--summary <markdown>]` | Publish selected Claude/Codex records; also supports `--no-agent-summary`, `--yes`, and `--spool-file`             |
-| `spool withdraw <sid\|url>`                         | Tombstone a share so its URL stops resolving                                                                       |
-| `spool resume <sid\|url>[@<n>] [--workspace <dir>]` | Materialize and natively fork a share; `--no-exec` prints the command without launching                            |
+| Command                                                     | Does                                                                                                                                |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `spool sync [--watch]`                                      | Index new sessions; `--watch` stays running                                                                                         |
+| `spool search <query> [-s <source>] [--since 7d]`           | Full-text search; add `--json` for machine-readable results                                                                         |
+| `spool list [-s <source>] [-p <path>] [-n <count>] [--all]` | Current-project Sessions by default; `--all` searches every project. Filters apply to a recent window, so raise `-n` when filtering |
+| `spool projects [query] [-n <count>]`                       | Project groups, or sessions for a name, identity key, path, or cwd                                                                  |
+| `spool show <uuid\|sid\|url>`                               | Local transcript / shared Summary; `--log` timeline, `--diff` net change, `@r<n>` record, `--json` structured data                  |
+| `spool pin <uuid>` / `unpin <uuid>` / `pinned`              | Bookmark and list sessions; state is shared with the Spool app Library                                                              |
+| `spool status` / `spool doctor [checkId] [--fix]`           | Index stats / diagnostics; `doctor --fix --force` also permits destructive fixes                                                    |
+| `spool login [--token <t>]` / `spool logout`                | Hub browser-device auth (or token for automation) / revoke and clear credentials                                                    |
+| `spool share [<uuid>[@<n>]] [--summary <markdown>]`         | Share selected Claude/Codex records as Link-only; also supports `--no-agent-summary`, `--yes`, and `--spool-file`                   |
+| `spool withdraw <sid\|url>`                                 | Tombstone a share so its URL stops resolving                                                                                        |
+| `spool resume <sid\|url>[@<n>] [--workspace <dir>]`         | Materialize and natively fork a share; `--no-exec` prints the command without launching                                             |


### PR DESCRIPTION
## What changed

- Make `spool list` default to Sessions associated with the current working directory's project identity.
- Add `-a, --all` to ignore cwd and list Sessions across all projects.
- Preserve `--source`, `--project`, `--limit`, and `--json` filtering on top of the selected scope.
- Add cwd identity resolution for canonical and indexed project paths.
- Update CLI documentation, quick start material, and the Spool skill reference.

## Why

A global recent-Session list becomes noisy when users work across multiple repositories. Defaulting to the current project makes `spool list` context-aware, while `--all` preserves the existing cross-project workflow explicitly.

## User impact

Running `spool list` inside a project now shows that project's Sessions. Users who want the previous global behavior can run `spool list --all`.

## Validation

- `pnpm --filter @spool-lab/core test` — 450 passed, 1 skipped
- `pnpm --filter @spool-lab/cli test` — 147 passed
- `pnpm --filter @spool-lab/core typecheck`
- `pnpm --filter @spool-lab/cli typecheck`

E2E tests were not run, per the repository's local-development guidance.
