### PR TITLE
release: v0.6.2

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/app",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "homepage": "https://github.com/spool-lab/spool#readme",
   "bugs": {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": false,
   "homepage": "https://github.com/spool-lab/spool#readme",
   "bugs": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/web",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "homepage": "https://github.com/spool-lab/spool#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spool",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "homepage": "https://github.com/spool-lab/spool#readme",
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": false,
   "homepage": "https://github.com/spool-lab/spool#readme",
   "bugs": {

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/redact",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Local, pure-TS sensitive-data detection for Spool sessions. Pattern + checksum + entropy pipeline today; pluggable provider boundary for future on-device ML (e.g. OpenAI Privacy Filter via transformers.js).",
   "homepage": "https://github.com/spool-lab/spool#readme",
   "bugs": {

--- a/packages/session-kit/package.json
+++ b/packages/session-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/session-kit",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Browser-safe canonical records, sequence hashing, edit extraction, views, and Session diffs for Spool.",
   "homepage": "https://github.com/spool-lab/spool#readme",
   "bugs": {


### PR DESCRIPTION
Patch release for the CLI current-project list behavior.\n\nThis synchronizes the release train at 0.6.2 because the CLI change depends on the matching `@spool-lab/core` API.