### PR TITLE
feat: launch spool.new with session route maps

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,4 +1,4 @@
-name: Deploy Web
+name: Deploy Production
 
 on:
   push:
@@ -33,7 +33,16 @@ jobs:
       - name: Build workspace dependencies
         run: pnpm vp run --filter '@spool/web^...' build
 
-      - name: Deploy to Cloudflare Workers
+      # The router proxies every /api request to Pages, so publish the backend
+      # first. If that deployment fails, the existing Worker stays pointed at
+      # the last healthy production backend.
+      - name: Deploy backend to Cloudflare Pages
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: pnpm --filter @spool/backend run deploy:prod
+
+      - name: Deploy web router to Cloudflare Workers
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
             echo ""
             echo '**macOS (Apple Silicon)**'
             echo '```bash'
-            echo 'curl -fsSL https://spool.pro/install.sh | bash'
+            echo 'curl -fsSL https://spool.new/install.sh | bash'
             echo '```'
             echo ""
             echo '**Linux (x86_64)**'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,9 @@ Key rules at a glance:
 - Public web is content-first: show real Sessions and authors before feature explanations
 - `Share` publishes supported Sessions as Public by default; providers not yet supported by Explore remain Link-only
 - Public metadata is author-attributed (`@handle · published 2h ago`), never first-person
-- Warm amber accent `#C85A00` (light) / `#F07020` (dark) — never blue or purple
-- Warm near-black `#141410` for dark mode — never pure `#000` or cold `#0A0A0A`
+- Paperboy electric blue accent `#1387FF` (light) / `#5BB1F0` (dark) is the sole product accent; amber is reserved for warning semantics, never primary branding
+- Void palette: `#000000` background with `#090909` surfaces in dark mode; white with neutral-gray surfaces in light mode
+- The homepage may use the approved WebGL knowledge-space hero and share → server → resume animation; product and reading surfaces keep motion minimal and functional
 - Geist Sans for UI chrome; Geist Mono for Session records, commands, URLs, and paths
 - Session pages separate interpretive Summary from machine-derived evidence
 - Visibility and continuation lineage must remain explicit trust signals

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Requires Apple Silicon. The script quits any running Spool instance before repla
 apps/
   app/          Electron desktop app for preparing and sharing Sessions
   cli/          CLI for Session preparation, sharing, reading, and Resume
-  web/          spool.pro website, docs, Profiles, account pages, and Session reader
+  web/          spool.new website, docs, Profiles, account pages, and Session reader
   backend/      Hub, identity, publication, and media API on Cloudflare
 packages/
   core/         Local Session ingestion, organization, SQLite, and search

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,9 +12,9 @@
 ## Aesthetic Direction
 
 - **Direction:** Void Index — Framer-derived void black + electric blue over the Warm Index structure. Function-first but with personality.
-- **Decoration level:** Minimal. Typography, authentic Session content, and color warmth carry the page. No gradients or decorative blobs.
+- **Decoration level:** Minimal on product and reading surfaces. The marketing homepage may use one cinematic WebGL knowledge-space scene plus the choreographed share → server → resume flow; particles, bloom, and restrained light bands must explain that narrative rather than become generic decoration. No gradient buttons or interchangeable CSS blobs.
 - **Mood:** The feeling of finding a thoughtful piece of work in a well-kept public index. Intimate, focused, and trustworthy; never corporate or clinical.
-- **Differentiation:** Developer platforms default to cold grays, dense dashboards, or social-feed gloss. Spool's warm near-blacks and amber accent frame technical work as something worth reading without disguising its provenance.
+- **Differentiation:** Developer platforms default to undifferentiated gray dashboards or social-feed gloss. Spool's void palette and Paperboy electric blue frame technical work as something worth reading without disguising its provenance.
 
 ## Layout Philosophy
 
@@ -29,7 +29,7 @@ The public web must show the artifact before explaining the product. Real Sessio
 
 ### Public web
 
-- **Header:** Compact and persistent. Wordmark on the left; `Explore`, `Docs`, and search in the primary navigation; `Publish` and account state on the right. `Publish` uses the amber accent.
+- **Header:** Compact and persistent. Wordmark on the left; `Explore`, `Docs`, and search in the primary navigation; `Publish` and account state on the right. `Publish` uses the Paperboy blue accent.
 - **Homepage:** Featured-first editorial layout. The hero pairs a concise promise with one real featured Session—never a screenshot of the desktop app. Primary CTA is `Explore sessions`; secondary CTA is `Publish yours`. Search stays compact until the public corpus is large enough to make search-first discovery useful.
 - **Homepage feed:** Public Sessions appear immediately after the hero. Use information-rich rows or cards with author, agent, topic/project, Summary excerpt, evidence, and continuation state. Avoid equal-weight feature tiles.
 - **Discovery:** Search is prominent at the top, followed by clear filters for topic, agent, author, and recency. Results remain readable without opening each Session.
@@ -43,7 +43,7 @@ The public web must show the artifact before explaining the product. Real Sessio
 
 - **Core principle:** The desktop app is the author’s private preparation surface. Projects and Sessions are the home; search and publishing are actions within that context.
 - **Shell:** Persistent left sidebar (240px) + main pane. Sidebar lists projects derived from `project_groups_v` and remains visible across every main-pane state.
-- **Sidebar:** Warm surface background, soft right border. Top-left wordmark `Spool.`, then a `PROJECTS` section label with a sort menu, then project rows. A divider separates derived projects from the always-last `Loose` entry.
+- **Sidebar:** Neutral surface background, soft right border. Top-left wordmark `Spool.`, then a `PROJECTS` section label with a sort menu, then project rows. A divider separates derived projects from the always-last `Loose` entry.
 - **Project row:** Display name on the left, faint source-color dots in the middle, monospace count on the right. Active and hover states use `surface2`.
 - **Home:** Pinned Sessions above a recent feed bucketed by date. Entry to search is ⌘K or the top-right trigger.
 - **Project view:** Recent feed of one project with sort and source filters. A `PINNED` segment surfaces project-pinned Sessions on top.
@@ -85,7 +85,7 @@ Border radius remains restrained: 10px for cards, 8px for inputs, 6px for rows a
 
 ## Color
 
-- **Approach:** Restrained — one amber accent, warm neutrals, color is rare and meaningful.
+- **Approach:** Restrained — one Paperboy blue accent over a black/white void palette; color is rare and meaningful.
 
 ### Light Mode
 
@@ -114,8 +114,8 @@ Border radius remains restrained: 10px for cards, 8px for inputs, 6px for rows a
 | `--text`      | `#FFFFFF` | Primary text                               |
 | `--muted`     | `#A6A6A6` | Secondary text                             |
 | `--faint`     | `#555555` | Placeholder, disabled                      |
-| `--accent`    | `#0099FF` | Accent brightened for dark — electric blue |
-| `--accent-bg` | `#002A44` | Accent backgrounds on dark                 |
+| `--accent`    | `#5BB1F0` | Accent brightened for dark — Paperboy blue |
+| `--accent-bg` | `#0E2740` | Accent backgrounds on dark                 |
 
 ### Source Badge Colors
 
@@ -132,13 +132,13 @@ Only currently-supported agent sources are listed. Add a row when a new source s
 
 ### Semantic States
 
-Status colors are warm-tuned to match the rest of the palette — never use Tailwind defaults (`green-500`, `red-500`).
+Semantic colors are tuned for contrast against the void palette — never use Tailwind defaults (`green-500`, `red-500`).
 
 | State                | Light                  | Dark      |
 | -------------------- | ---------------------- | --------- |
 | Success / synced     | `#6BAF6B` (warm green) | `#7DC07D` |
 | Warning / stale      | `#E4A640` (warm amber) | `#F0B854` |
-| Error / disconnected | `#C95A4F` (terracotta) | `#D67259` |
+| Error / disconnected | `#E5484D`              | `#FF6369` |
 
 ## Spacing
 
@@ -180,13 +180,14 @@ Status colors are warm-tuned to match the rest of the palette — never use Tail
 
 ## Motion
 
-- **Approach:** Minimal-functional — only transitions that aid comprehension.
+- **Approach:** Minimal-functional on product surfaces. The homepage is the exception: its WebGL hero and share → server → resume sequence may use continuous, narrative motion to make cross-machine Session flow legible.
+- **Homepage motion:** Theme-aware particles, bloom, and light bands must remain visually subordinate to the promise and CTAs. Respect `prefers-reduced-motion` with a stable composed frame and no essential information hidden behind animation timing.
 - **⌘K overlay open/close:** Backdrop fades in (120ms), overlay card scales from 0.98 → 1 + fades in (140ms ease-out). Reverse on close.
 - **Main-pane state changes (Library Home ↔ Project View ↔ Session Detail):** Instant. No slide or crossfade — sidebar context already tells the user where they are.
 - **Results appear:** Fade + translate-y(4px) → 0. Duration 150ms, ease-out, staggered 20ms per item.
 - **Mode switch (Fast ↔ AI):** Overlay content area crossfade 200ms.
 - **Hover states:** Background 80ms, border-color 80ms — fast enough to feel instant.
-- **Nothing else moves.** No scroll-driven animations, no decorative motion.
+- **Nothing else moves on product surfaces.** No scroll-driven animation in readers, Discovery, Profiles, desktop preparation, or account flows.
 
 ## UI States
 
@@ -196,7 +197,7 @@ Status colors are warm-tuned to match the rest of the palette — never use Tail
 - **Session result:** Author avatar + handle, title or first-prompt-derived label, Summary excerpt, agent/source badge, publication time, touched-file or diff evidence, and fork/resume state.
 - **Empty query:** Show recent and featured Sessions, not an empty search page.
 - **Empty filter:** Explain which filters produced no results and offer one-click clearing.
-- **Loading:** Preserve card/row geometry with warm-neutral skeletons; do not replace the entire feed with a centered spinner.
+- **Loading:** Preserve card/row geometry with neutral skeletons; do not replace the entire feed with a centered spinner.
 
 ### Profile
 
@@ -378,7 +379,7 @@ In dense lists, prefer compact facts over repeated pronouns:
 - Ambiguous visibility controls, icon-only publish actions, or language that calls a Link-only URL private
 - Uniform bubbly border-radius on all elements
 - Gradient buttons
-- Cold grays (`#0A0A0A`, `#111111`)—always use warm near-blacks
+- Introducing dark-mode surface values outside the documented void token scale (`#000000`, `#090909`, `#111111`)
 - Inter, Roboto, or system fonts as primary UI typeface
 - Emoji in production UI—replace all with vector icons
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The current Share-focused surfaces are:
 ```text
 apps/
   cli/          CLI for indexing, sharing, reading, resuming, and automation
-  web/          spool.pro: homepage, docs, Profiles, account pages, and Session reader
+  web/          spool.new: homepage, docs, Profiles, account pages, and Session reader
   backend/      Hub, identity, publication, and media API on Cloudflare
 packages/
   core/         Local Session ingestion, organization, SQLite, and full-text search

--- a/apps/app/.env.development.local.example
+++ b/apps/app/.env.development.local.example
@@ -34,7 +34,7 @@ SPOOL_WORKOS_CLIENT_ID=
 # ── Main-process backend origin ────────────────────────────────────
 # Where main posts to (sign-in-with-code, me, publish IPC, etc.).
 # In dev this is the wrangler pages dev on 8788. In prod the binary
-# defaults to https://spool.pro (DEFAULT_BACKEND in backend-url.ts);
+# defaults to https://spool.new (DEFAULT_BACKEND in backend-url.ts);
 # leave this blank in prod builds unless you're pointing at a staging
 # environment.
 SPOOL_SHARE_BACKEND=http://localhost:8788
@@ -43,5 +43,5 @@ SPOOL_SHARE_BACKEND=http://localhost:8788
 # The origin the renderer uses when constructing /s/<id> links shown
 # to the user (Published row in Shares page, etc.). In dev this is
 # the share-web vite server on 3002. In prod defaults to
-# https://spool.pro via the resolver helper. Vite-inlined.
+# https://spool.new via the resolver helper. Vite-inlined.
 VITE_SPOOL_SHARE_PUBLIC_URL=http://localhost:3002

--- a/apps/app/e2e/helpers/share-publish-mock-backend.ts
+++ b/apps/app/e2e/helpers/share-publish-mock-backend.ts
@@ -1,4 +1,4 @@
-// Minimal in-process HTTP server that stands in for the spool.pro backend
+// Minimal in-process HTTP server that stands in for the spool.new backend
 // during e2e runs of the publish flow.
 //
 // The real backend (apps/backend) is a Cloudflare Pages Functions project: D1, KV, R2,
@@ -287,7 +287,7 @@ async function routeRequest(
         return json(res, 200, {
           id: s.id,
           version: s.version,
-          url: `https://mock.spool.pro/s/${s.id}`,
+          url: `https://mock.spool.new/s/${s.id}`,
         })
       }
     }
@@ -328,7 +328,7 @@ async function routeRequest(
     return json(res, 200, {
       id: slug,
       version,
-      url: `https://mock.spool.pro/s/${slug}`,
+      url: `https://mock.spool.new/s/${slug}`,
     })
   }
 

--- a/apps/app/electron.vite.config.ts
+++ b/apps/app/electron.vite.config.ts
@@ -63,8 +63,8 @@ const MAIN_INLINE_ENV: readonly string[] = [
   'SPOOL_WORKOS_CLIENT_ID',
   // Backend origin for `/api/auth/sign-in-with-code`, `/api/me`, etc.
   // In dev this is the local wrangler `http://localhost:8788`; in prod
-  // it's the spool.pro Pages deployment. Without this inlined the main
-  // bundle defaults to https://spool.pro and dev sign-in 404s.
+  // it's the spool.new Pages deployment. Without this inlined the main
+  // bundle defaults to https://spool.new and dev sign-in 404s.
   'SPOOL_SHARE_BACKEND',
 ]
 

--- a/apps/app/src/main/index.ts
+++ b/apps/app/src/main/index.ts
@@ -10,6 +10,7 @@ import {
   nativeTheme,
   nativeImage,
   net,
+  session,
   shell,
 } from 'electron'
 import type { MenuItemConstructorOptions } from 'electron'
@@ -529,7 +530,7 @@ function createWindow(): BrowserWindow {
     height: 740,
     minWidth: 800,
     minHeight: 520,
-    backgroundColor: nativeTheme.shouldUseDarkColors ? '#141410' : '#FAFAF8',
+    backgroundColor: nativeTheme.shouldUseDarkColors ? '#000000' : '#FFFFFF',
     autoHideMenuBar: !isMac,
     // hiddenInset keeps the traffic lights but lets the renderer paint
     // up to y=0, so the app's top bar sits flush with the close/min/max
@@ -664,7 +665,7 @@ app
     // otherwise the first response slips through with whatever Vite (or
     // the bundled file:// loader) emits and Electron's "Insecure CSP"
     // warning fires once before our header takes over.
-    installRendererCsp({ dev: isDevMode })
+    installRendererCsp({ dev: isDevMode }, session.defaultSession)
 
     // Hydrate the agent-binary path cache from disk before anything has a
     // chance to call `cachedResolveAsync`. Without this every cold launch
@@ -772,7 +773,7 @@ app
     registerSharePublishIpc()
     // Share-profile IPC (display name + avatar upload / delete / visibility)
     registerShareProfileIpc()
-    // v2 hub share IPC (one-click records share to spool.pro)
+    // v2 hub share IPC (one-click records share to spool.new)
     registerHubShareIpc()
 
     // Auto-updater (only runs in packaged builds)

--- a/apps/app/src/main/ipc/share-publish.test.ts
+++ b/apps/app/src/main/ipc/share-publish.test.ts
@@ -120,7 +120,7 @@ describe('share-publish:publish size gate', () => {
     const body = makeBody('hello world')
     authedFetch.mockResolvedValue({
       ok: true,
-      json: async () => ({ id: 's1', url: 'https://spool.pro/s/s1', version: 1 }),
+      json: async () => ({ id: 's1', url: 'https://spool.new/s/s1', version: 1 }),
     })
 
     const res = (await publish(body)) as { ok: boolean }

--- a/apps/app/src/main/net/robust-fetch.test.ts
+++ b/apps/app/src/main/net/robust-fetch.test.ts
@@ -160,7 +160,7 @@ describe('loopback handling', () => {
   )
 
   it('public hosts are not loopback', () => {
-    expect(isLoopbackUrl('https://spool.pro/api')).toBe(false)
+    expect(isLoopbackUrl('https://spool.new/api')).toBe(false)
   })
 
   it('loopback targets skip the provided chain and go direct', async () => {

--- a/apps/app/src/main/security/csp.test.ts
+++ b/apps/app/src/main/security/csp.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vite-plus/test'
 
 import { __cspFixtures, buildCsp, buildPfInferenceCsp, isPfInferenceDocument } from './csp.js'
 
-// We don't import installRendererCsp itself in tests — wiring it would
-// require an Electron `session` stub. The string fixtures cover the
-// actual product surface (drift in directives) without the harness.
+// `installRendererCsp` receives its Electron Session from the main-process
+// composition root, so importing this policy module does not load Electron.
+// The string fixtures cover directive drift without a runtime harness.
 const { DEV_CSP, PROD_CSP } = __cspFixtures
 
 function directives(csp: string): Map<string, string[]> {
@@ -101,8 +101,10 @@ describe('Renderer CSP policy', () => {
       expect(connect.every((src) => !src.includes('localhost'))).toBe(true)
     })
 
-    it('allows the spool.pro origin family on connect-src', () => {
+    it('allows both the canonical and legacy Spool origin families on connect-src', () => {
       const connect = directives(PROD_CSP).get('connect-src') ?? []
+      expect(connect).toContain('https://spool.new')
+      expect(connect).toContain('https://*.spool.new')
       expect(connect).toContain('https://spool.pro')
       expect(connect).toContain('https://*.spool.pro')
     })
@@ -158,11 +160,13 @@ describe('Renderer CSP policy', () => {
       })
     }
 
-    it('prod keeps the canonical spool.pro family alongside the override', () => {
-      // Published-share URLs and avatar links keep pointing at
-      // spool.pro even when the API origin is overridden.
+    it('prod keeps canonical and legacy Spool families alongside the override', () => {
+      // New published links point at spool.new while existing links and
+      // avatar URLs may still point at spool.pro.
       const connect =
         directives(buildCsp({ dev: false, backendOrigin: origin })).get('connect-src') ?? []
+      expect(connect).toContain('https://spool.new')
+      expect(connect).toContain('https://*.spool.new')
       expect(connect).toContain('https://spool.pro')
       expect(connect).toContain('https://*.spool.pro')
     })

--- a/apps/app/src/main/security/csp.ts
+++ b/apps/app/src/main/security/csp.ts
@@ -1,4 +1,4 @@
-import { session as electronSession } from 'electron'
+import type { Session } from 'electron'
 
 import { backendUrl, DEFAULT_BACKEND } from '../share/backend-url.js'
 
@@ -36,12 +36,12 @@ import { backendUrl, DEFAULT_BACKEND } from '../share/backend-url.js'
 
 // Backend origins: the renderer renders user-uploaded avatars served
 // from `/api/avatars/<id>` on the share-backend. In dev that's the
-// local wrangler at :8788; in prod it's spool.pro. Without these
+// local wrangler at :8788; in prod it's spool.new. Without these
 // origins in img-src Chromium silently drops the request — the
 // network tab shows nothing and the <img> renders as broken.
 const IMG_ALLOW_DEV = "'self' data: blob: https://lh3.googleusercontent.com http://localhost:8788"
 const IMG_ALLOW_PROD =
-  "'self' data: blob: https://lh3.googleusercontent.com https://spool.pro https://*.spool.pro"
+  "'self' data: blob: https://lh3.googleusercontent.com https://spool.new https://*.spool.new https://spool.pro https://*.spool.pro"
 
 // The editor's PDF preview renders a generated `blob:` URL inside an
 // `<iframe>` and lets Chromium's built-in PDF MIME handler take over.
@@ -71,14 +71,14 @@ const CONNECT_BLOB = 'blob:'
 // different backend (staging, local mock, future domain move) — the
 // renderer's direct fetches (avatars in img-src, api calls in
 // connect-src) must follow the same override or they silently 404
-// behind CSP while main happily talks to the new host. The canonical
-// spool.pro family stays in the prod allow-list unconditionally:
-// published-share URLs and avatar links keep pointing there even when
-// the API origin is overridden.
+// behind CSP while main happily talks to the new host. Both the
+// canonical spool.new family and the legacy spool.pro family
+// stay in the prod allow-list unconditionally. Existing published-share
+// URLs and avatar links may still point at spool.pro during migration.
 function overrideBackendOrigin(): string | null {
   try {
     // Compare normalized origins, not raw strings — an override of
-    // `https://spool.pro/` (trailing slash) is still the default and
+    // `https://spool.new/` (trailing slash) is still the default and
     // must not duplicate the origin in the policy.
     const origin = new URL(backendUrl()).origin
     return origin === new URL(DEFAULT_BACKEND).origin ? null : origin
@@ -114,7 +114,7 @@ export function buildCsp(opts: { dev: boolean; backendOrigin?: string | null }):
     "style-src 'self' 'unsafe-inline'",
     "font-src 'self' data:",
     `img-src ${IMG_ALLOW_PROD}${extra}`,
-    `connect-src 'self' ${CONNECT_BLOB} https://spool.pro https://*.spool.pro${extra}`,
+    `connect-src 'self' ${CONNECT_BLOB} https://spool.new https://*.spool.new https://spool.pro https://*.spool.pro${extra}`,
     `frame-src ${FRAME_ALLOW}`,
     `object-src ${OBJECT_ALLOW}`,
     "frame-ancestors 'none'",
@@ -157,7 +157,7 @@ const PROD_CSP = buildCsp({ dev: false })
 const PF_DEV_CSP = buildPfInferenceCsp({ dev: true })
 const PF_PROD_CSP = buildPfInferenceCsp({ dev: false })
 
-export function installRendererCsp(opts: { dev: boolean }): void {
+export function installRendererCsp(opts: { dev: boolean }, rendererSession: Session): void {
   // Diagnostic escape hatch: setting SPOOL_DISABLE_CSP=1 skips the
   // installation entirely so we can A/B which directive is gating a
   // surface. Kept inside the module rather than at the call site so a
@@ -165,7 +165,7 @@ export function installRendererCsp(opts: { dev: boolean }): void {
   if (process.env['SPOOL_DISABLE_CSP'] === '1') return
   const policy = buildCsp({ dev: opts.dev, backendOrigin: overrideBackendOrigin() })
   const pfPolicy = opts.dev ? PF_DEV_CSP : PF_PROD_CSP
-  electronSession.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+  rendererSession.webRequest.onHeadersReceived((details, callback) => {
     // Only inject CSP into responses for the documents we actually
     // ship. Chromium's built-in PDF viewer extension serves its UI
     // off `chrome-extension://`; if we replace that response's CSP

--- a/apps/app/src/main/share/backend-url.test.ts
+++ b/apps/app/src/main/share/backend-url.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from 'vite-plus/test'
+
+import { backendUrl, DEFAULT_BACKEND } from './backend-url.js'
+
+const originalBackend = process.env['SPOOL_SHARE_BACKEND']
+
+afterEach(() => {
+  if (originalBackend === undefined) delete process.env['SPOOL_SHARE_BACKEND']
+  else process.env['SPOOL_SHARE_BACKEND'] = originalBackend
+})
+
+describe('backendUrl', () => {
+  it('uses spool.new as the production backend', () => {
+    delete process.env['SPOOL_SHARE_BACKEND']
+    expect(DEFAULT_BACKEND).toBe('https://spool.new')
+    expect(backendUrl()).toBe('https://spool.new')
+  })
+
+  it('keeps explicit local and staging overrides', () => {
+    process.env['SPOOL_SHARE_BACKEND'] = 'https://staging.spool.new'
+    expect(backendUrl()).toBe('https://staging.spool.new')
+  })
+})

--- a/apps/app/src/main/share/backend-url.ts
+++ b/apps/app/src/main/share/backend-url.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_BACKEND = 'https://spool.pro'
+export const DEFAULT_BACKEND = 'https://spool.new'
 
 export function backendUrl(): string {
   return process.env['SPOOL_SHARE_BACKEND'] ?? DEFAULT_BACKEND

--- a/apps/app/src/renderer/components/AppToaster.tsx
+++ b/apps/app/src/renderer/components/AppToaster.tsx
@@ -3,8 +3,8 @@ import { Toaster } from 'sonner'
 
 /**
  * App-wide toast surface. Wraps sonner's <Toaster /> with DESIGN.md tokens:
- * elevated warm card, type-specific tints + Lucide icons so status reads
- * at a glance, amber accent only on the action button.
+ * elevated neutral card, type-specific tints + Lucide icons so status reads
+ * at a glance, with the product accent reserved for the action button.
  */
 export default function AppToaster() {
   return (
@@ -24,14 +24,14 @@ export default function AppToaster() {
             'min-w-[260px] max-w-[380px] w-max px-3.5 py-2.5',
             'rounded-[10px]',
             // Default (neutral / non-typed) — elevated white card.
-            'bg-white dark:bg-[#2A2A24]',
+            'bg-white dark:bg-dark-surface2',
             'ring-1 ring-warm-border/70 dark:ring-white/[0.06]',
-            'shadow-[0_1px_2px_rgba(20,20,16,0.04),0_8px_28px_rgba(20,20,16,0.10)]',
+            'shadow-[0_1px_2px_rgba(0,0,0,0.04),0_8px_28px_rgba(0,0,0,0.10)]',
             'dark:shadow-[0_2px_8px_rgba(0,0,0,0.35),0_16px_40px_rgba(0,0,0,0.45)]',
             'font-sans text-warm-text dark:text-dark-text',
           ].join(' '),
           // Per-type tints: light wash + tinted ring. Subtle enough to
-          // sit alongside warm palette, strong enough to read as status.
+          // stay subordinate to the product accent while still reading as status.
           success: [
             'bg-[#F1F8F1] dark:bg-[#1F2A1F]',
             'ring-[color:var(--color-status-success)]/30 dark:ring-[color:var(--color-status-success-dark)]/30',

--- a/apps/app/src/renderer/components/SessionFindBar.tsx
+++ b/apps/app/src/renderer/components/SessionFindBar.tsx
@@ -99,7 +99,7 @@ export default function SessionFindBar({
   return (
     <div
       ref={containerRef}
-      className="border-warm-border dark:border-dark-border bg-warm-bg/95 dark:bg-dark-surface2/95 animate-in fade-in focus-within:border-accent/55 dark:focus-within:border-accent-dark/60 absolute top-8 right-4 z-20 flex w-[320px] items-center gap-0.5 rounded-md border py-0.5 pr-1 pl-2 shadow-[0_4px_12px_rgba(0,0,0,0.06)] backdrop-blur-sm transition-[border-color,box-shadow] focus-within:shadow-[0_0_0_3px_rgba(200,90,0,0.10),0_4px_12px_rgba(0,0,0,0.06)] dark:shadow-[0_4px_12px_rgba(0,0,0,0.4)] dark:focus-within:shadow-[0_0_0_3px_rgba(240,112,32,0.15),0_4px_12px_rgba(0,0,0,0.4)]"
+      className="border-warm-border dark:border-dark-border bg-warm-bg/95 dark:bg-dark-surface2/95 animate-in fade-in focus-within:border-accent/55 dark:focus-within:border-accent-dark/60 absolute top-8 right-4 z-20 flex w-[320px] items-center gap-0.5 rounded-md border py-0.5 pr-1 pl-2 shadow-[0_4px_12px_rgba(0,0,0,0.06)] backdrop-blur-sm transition-[border-color,box-shadow] focus-within:shadow-[0_0_0_3px_rgba(19,135,255,0.10),0_4px_12px_rgba(0,0,0,0.06)] dark:shadow-[0_4px_12px_rgba(0,0,0,0.4)] dark:focus-within:shadow-[0_0_0_3px_rgba(91,177,240,0.15),0_4px_12px_rgba(0,0,0,0.4)]"
       role="search"
     >
       <input

--- a/apps/app/src/renderer/components/SettingsPanel.tsx
+++ b/apps/app/src/renderer/components/SettingsPanel.tsx
@@ -235,7 +235,7 @@ export default function SettingsPanel({
 }: Props) {
   const [tab, setTab] = useState<SettingsTab>(initialTab)
   const { t } = useTranslation()
-  // Account tab is the spool.pro identity surface (sign-in, handle,
+  // Account tab is the spool.new identity surface (sign-in, handle,
   // delete-account schedule). Sub-gated behind the share-publish flag
   // so the tab doesn't appear in pre-launch dev builds that don't
   // opt into the publish stack.

--- a/apps/app/src/renderer/components/SharesPage.tsx
+++ b/apps/app/src/renderer/components/SharesPage.tsx
@@ -312,7 +312,7 @@ function PublishedList({
               void handleSignIn()
             }}
             disabled={signingIn}
-            className="dark:bg-dark-surface2 dark:text-dark-text border-warm-border2 dark:border-dark-border2 hover:border-accent hover:dark:border-accent-dark inline-flex h-8 items-center gap-2 rounded-md border bg-white px-3 text-[12px] font-medium text-[#1C1C18] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+            className="dark:bg-dark-surface2 text-warm-text dark:text-dark-text border-warm-border2 dark:border-dark-border2 hover:border-accent hover:dark:border-accent-dark inline-flex h-8 items-center gap-2 rounded-md border bg-white px-3 text-[12px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60"
           >
             <svg width={15} height={15} viewBox="0 0 18 18" fill="none" aria-hidden>
               <path

--- a/apps/app/src/renderer/components/SharesPage.tsx
+++ b/apps/app/src/renderer/components/SharesPage.tsx
@@ -241,7 +241,7 @@ function PublishedList({
   )
 
   // Re-fetch the published list when this window regains focus — picks up
-  // remote revocations (user opened spool.pro/me on the web and revoked)
+  // remote revocations (user opened spool.new/me on the web and revoked)
   // that the desktop wouldn't otherwise see until a manual restart.
   useEffect(() => {
     if (!user) return
@@ -361,7 +361,7 @@ function PublishedList({
 
   // Stale banner — the last remote fetch failed, so the rows below are
   // the local cache and may be behind the backend (e.g. a revoke done
-  // on spool.pro/me). A persistent inline strip, not a toast: the
+  // on spool.new/me). A persistent inline strip, not a toast: the
   // condition persists until a refresh succeeds, and the focus-driven
   // refresh would re-toast on every window switch.
   const handleRetry = async () => {

--- a/apps/app/src/renderer/components/hub-share-dialog.tsx
+++ b/apps/app/src/renderer/components/hub-share-dialog.tsx
@@ -110,7 +110,7 @@ export default function HubShareDialog({ open, sessionUuid, initialSummary = '',
     >
       <div
         className="bg-warm-bg dark:bg-dark-bg border-warm-border dark:border-dark-border w-[480px] max-w-[90vw] overflow-hidden rounded-[10px] border font-sans"
-        style={{ boxShadow: '0 18px 48px rgba(28,28,24,0.18), 0 2px 6px rgba(28,28,24,0.08)' }}
+        style={{ boxShadow: '0 18px 48px rgba(10,10,10,0.18), 0 2px 6px rgba(10,10,10,0.08)' }}
       >
         <div className="px-6 pt-5 pb-5">
           <div className="text-accent dark:text-accent-dark flex items-center gap-1.5 text-[12px] font-medium">

--- a/apps/app/src/renderer/components/hub-share-dialog.tsx
+++ b/apps/app/src/renderer/components/hub-share-dialog.tsx
@@ -1,4 +1,4 @@
-// One-click share to spool.pro (the v2 records share). Prepare runs
+// One-click share to spool.new (the v2 records share). Prepare runs
 // locally and shows the honesty gate — record count, diffstat, redact
 // findings — before anything leaves the machine; Share runs the same
 // 3-step handshake the CLI uses. Mirrors RefreshFromSourceDialog's outer

--- a/apps/app/src/renderer/components/security/AllowlistManageModal.tsx
+++ b/apps/app/src/renderer/components/security/AllowlistManageModal.tsx
@@ -115,7 +115,7 @@ export default function AllowlistManageModal({ onClose }: Props) {
     >
       <div
         className="bg-warm-bg dark:bg-dark-bg border-warm-border dark:border-dark-border flex max-h-[70vh] min-h-[240px] w-[720px] max-w-[calc(100vw-64px)] flex-col overflow-hidden rounded-[10px] border"
-        style={{ boxShadow: '0 18px 48px rgba(28,28,24,0.18), 0 2px 6px rgba(28,28,24,0.08)' }}
+        style={{ boxShadow: '0 18px 48px rgba(10,10,10,0.18), 0 2px 6px rgba(10,10,10,0.08)' }}
       >
         <header className="flex items-center justify-between gap-4 px-5 pt-4 pb-2">
           <h2 className="text-warm-text dark:text-dark-text min-w-0 text-[15px] leading-[20px] font-semibold tracking-[-0.005em]">

--- a/apps/app/src/renderer/components/security/PurgeConfirmDialog.tsx
+++ b/apps/app/src/renderer/components/security/PurgeConfirmDialog.tsx
@@ -101,7 +101,7 @@ export default function PurgeConfirmDialog({
     >
       <div
         className={`bg-warm-bg dark:bg-dark-bg rounded-[10px] font-sans ${bulk ? 'w-[520px]' : 'w-[460px]'} border-warm-border dark:border-dark-border max-w-[90vw] overflow-hidden border`}
-        style={{ boxShadow: '0 18px 48px rgba(28,28,24,0.18), 0 2px 6px rgba(28,28,24,0.08)' }}
+        style={{ boxShadow: '0 18px 48px rgba(10,10,10,0.18), 0 2px 6px rgba(10,10,10,0.08)' }}
       >
         <div className="px-6 pt-5 pb-4">
           <div className="text-accent dark:text-accent-dark flex items-center gap-1.5 text-[12px] font-medium">

--- a/apps/app/src/renderer/components/session/RefreshFromSourceDialog.tsx
+++ b/apps/app/src/renderer/components/session/RefreshFromSourceDialog.tsx
@@ -45,7 +45,7 @@ export default function RefreshFromSourceDialog({ open, busy, onConfirm, onCance
     >
       <div
         className="bg-warm-bg dark:bg-dark-bg border-warm-border dark:border-dark-border w-[460px] max-w-[90vw] overflow-hidden rounded-[10px] border font-sans"
-        style={{ boxShadow: '0 18px 48px rgba(28,28,24,0.18), 0 2px 6px rgba(28,28,24,0.08)' }}
+        style={{ boxShadow: '0 18px 48px rgba(10,10,10,0.18), 0 2px 6px rgba(10,10,10,0.08)' }}
       >
         <div className="px-6 pt-5 pb-4">
           <div className="text-accent dark:text-accent-dark flex items-center gap-1.5 text-[12px] font-medium">

--- a/apps/app/src/renderer/components/share-editor/ConnectCard.tsx
+++ b/apps/app/src/renderer/components/share-editor/ConnectCard.tsx
@@ -50,7 +50,7 @@ export function ConnectCard({ onSignedIn }: { onSignedIn?: () => void }) {
         }}
         disabled={busy}
         data-testid="connect-card-signin"
-        className="dark:bg-dark-surface2 dark:text-dark-text border-warm-border2 dark:border-dark-border2 hover:border-accent hover:dark:border-accent-dark inline-flex h-7 items-center justify-center gap-2 rounded-md border bg-white px-3 text-[12px] font-medium text-[#1C1C18] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+        className="dark:bg-dark-surface2 text-warm-text dark:text-dark-text border-warm-border2 dark:border-dark-border2 hover:border-accent hover:dark:border-accent-dark inline-flex h-7 items-center justify-center gap-2 rounded-md border bg-white px-3 text-[12px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60"
       >
         {busy ? (
           <>

--- a/apps/app/src/renderer/components/share-editor/ShareMenu.tsx
+++ b/apps/app/src/renderer/components/share-editor/ShareMenu.tsx
@@ -57,7 +57,7 @@ type Props = {
  * Single editor-topbar entry point for sharing. Replaces the separate
  * Publish + Export buttons with one Share popover that carries two tabs:
  *
- *   - Publish — the full spool.pro publish flow (visibility / expiry /
+ *   - Publish — the full spool.new publish flow (visibility / expiry /
  *     PII gate / errors) plus the post-publish manage surface (URL,
  *     copy, view, republish, unpublish).
  *   - Export — the four local-only formats (PNG / PDF / Markdown /

--- a/apps/app/src/renderer/i18n/locales/de.json
+++ b/apps/app/src/renderer/i18n/locales/de.json
@@ -354,7 +354,7 @@
       "deleteConfirm_item_shares_prefix": "Jede veröffentlichte Freigabe liefert",
       "deleteConfirm_item_shares_emphasis": "410 Gone",
       "deleteConfirm_item_handle": "Ihr Handle wird freigegeben und kann von beliebigen Nutzern beansprucht werden",
-      "deleteConfirm_item_record": "Ihr Kontodatensatz wird von spool.pro entfernt",
+      "deleteConfirm_item_record": "Ihr Kontodatensatz wird von spool.new entfernt",
       "deleteConfirm_footnote": "Sie können dies jederzeit vor Ablauf der Abkühlphase abbrechen. Entwürfe auf diesem Gerät bleiben unverändert — sie liegen lokal.",
       "deleteConfirm_confirm": "Löschung planen",
       "deleteConfirm_scheduling": "Plane…",
@@ -636,7 +636,7 @@
       "publishUnredacted": "Mit sichtbaren Geheimnissen veröffentlichen",
       "publishing": "Veröffentliche…",
       "tryAgain": "Erneut versuchen",
-      "footerHint": "Ein Snapshot wird auf spool.pro hochgeladen. Jederzeit widerrufbar.",
+      "footerHint": "Ein Snapshot wird auf spool.new hochgeladen. Jederzeit widerrufbar.",
       "footerHint_published": "Der Snapshot lebt unter dem Link oben. Jederzeit widerrufbar.",
       "error_sessionExpired": "Ihre Sitzung ist abgelaufen — bitte erneut anmelden, um zu veröffentlichen.",
       "error_rateLimited": "Zu viele Veröffentlichungen. Bitte in wenigen Minuten erneut versuchen.",
@@ -670,7 +670,7 @@
       "downloading": "Exportiere…"
     },
     "connectCard": {
-      "title": "Bei spool.pro anmelden",
+      "title": "Bei spool.new anmelden",
       "body": "Spool lädt nur Snapshots hoch, die Sie ausdrücklich veröffentlichen. Entwürfe und Ihre Bibliothek verlassen diesen Rechner nie.",
       "signInWithGoogle": "Mit Google anmelden",
       "waitingForBrowser": "Warte auf Browser…",
@@ -680,7 +680,7 @@
       "title": "Diese Freigabe zurückziehen?",
       "body_prefix": "Dies ist endgültig. Der Link liefert",
       "body_emphasis": "410 Gone",
-      "body_suffix": ", der Snapshot wird aus dem spool.pro-Speicher gelöscht und die URL kann nicht wiederverwendet werden. Um diese Konversation erneut zu teilen, müssen Sie eine neue Kopie veröffentlichen — sie erhält eine neue URL.",
+      "body_suffix": ", der Snapshot wird aus dem spool.new-Speicher gelöscht und die URL kann nicht wiederverwendet werden. Um diese Konversation erneut zu teilen, müssen Sie eine neue Kopie veröffentlichen — sie erhält eine neue URL.",
       "confirm": "Ja, endgültig zurückziehen",
       "confirming": "Ziehe zurück…"
     }
@@ -912,10 +912,10 @@
     "toggleOptions": "Optionen anzeigen"
   },
   "hubShare": {
-    "menuLabel": "Auf spool.pro teilen",
-    "pretitle": "Auf spool.pro teilen",
+    "menuLabel": "Auf spool.new teilen",
+    "pretitle": "Auf spool.new teilen",
     "title": "Diese Session veröffentlichen?",
-    "lead": "Veröffentlicht das vollständige Transkript ({{records}} Einträge) als Public Session auf spool.pro. Sie kann in Explore und der Suche erscheinen; die Quell-Session bleibt unverändert.",
+    "lead": "Veröffentlicht das vollständige Transkript ({{records}} Einträge) als Public Session auf spool.new. Sie kann in Explore und der Suche erscheinen; die Quell-Session bleibt unverändert.",
     "secretsWarning": "{{total}} mögliche Geheimnisse erkannt ({{high}} mit hohem Risiko). Beim Teilen werden diese Werte übertragen.",
     "summaryLabel": "Zusammenfassung (Markdown)",
     "publish": "Session veröffentlichen",
@@ -923,7 +923,7 @@
     "doneTitle": "Session veröffentlicht",
     "doneLead": "Diese Session ist Public und kann in Explore und der Suche erscheinen. Die Quell-Session bleibt unverändert.",
     "linkOnlyTitle": "Einen nur per Link erreichbaren Share erstellen?",
-    "linkOnlyLead": "Dieser Anbieter wird in Explore noch nicht unterstützt. Teilt das vollständige Transkript ({{records}} Einträge) über eine nur per Link erreichbare URL auf spool.pro; die Quell-Session bleibt unverändert.",
+    "linkOnlyLead": "Dieser Anbieter wird in Explore noch nicht unterstützt. Teilt das vollständige Transkript ({{records}} Einträge) über eine nur per Link erreichbare URL auf spool.new; die Quell-Session bleibt unverändert.",
     "linkOnlyPublish": "Link teilen",
     "linkOnlyPublishing": "Wird geteilt…",
     "linkOnlyDoneTitle": "Link geteilt",

--- a/apps/app/src/renderer/i18n/locales/en.json
+++ b/apps/app/src/renderer/i18n/locales/en.json
@@ -354,7 +354,7 @@
       "deleteConfirm_item_shares_prefix": "Every published share returns",
       "deleteConfirm_item_shares_emphasis": "410 Gone",
       "deleteConfirm_item_handle": "Your handle is released and can be re-claimed by anyone",
-      "deleteConfirm_item_record": "Your account record is removed from spool.pro",
+      "deleteConfirm_item_record": "Your account record is removed from spool.new",
       "deleteConfirm_footnote": "You can cancel from this screen any time before the cool-off expires. Drafts on this device are unaffected — they live locally.",
       "deleteConfirm_confirm": "Schedule deletion",
       "deleteConfirm_scheduling": "Scheduling…",
@@ -636,7 +636,7 @@
       "publishUnredacted": "Publish with secrets visible",
       "publishing": "Publishing…",
       "tryAgain": "Try again",
-      "footerHint": "A snapshot uploads to spool.pro. Revoke any time.",
+      "footerHint": "A snapshot uploads to spool.new. Revoke any time.",
       "footerHint_published": "Snapshot lives at the link above. Revoke any time.",
       "error_sessionExpired": "Your session expired — sign in again to publish.",
       "error_rateLimited": "Too many publishes. Try again in a few minutes.",
@@ -670,7 +670,7 @@
       "downloading": "Exporting…"
     },
     "connectCard": {
-      "title": "Sign in to spool.pro",
+      "title": "Sign in to spool.new",
       "body": "Spool only ever uploads snapshots you explicitly publish. Drafts and your library never leave this machine.",
       "signInWithGoogle": "Sign in with Google",
       "waitingForBrowser": "Waiting for browser…",
@@ -680,7 +680,7 @@
       "title": "Unpublish this share?",
       "body_prefix": "This is permanent. The link will return",
       "body_emphasis": "410 Gone",
-      "body_suffix": ", the snapshot is deleted from spool.pro storage, and the URL can't be reused. To share this conversation again you'll need to publish a fresh copy — it will have a new URL.",
+      "body_suffix": ", the snapshot is deleted from spool.new storage, and the URL can't be reused. To share this conversation again you'll need to publish a fresh copy — it will have a new URL.",
       "confirm": "Yes, unpublish permanently",
       "confirming": "Unpublishing…"
     }
@@ -912,10 +912,10 @@
     "toggleOptions": "Show options"
   },
   "hubShare": {
-    "menuLabel": "Share to spool.pro",
-    "pretitle": "Share to spool.pro",
+    "menuLabel": "Share to spool.new",
+    "pretitle": "Share to spool.new",
     "title": "Publish this Session?",
-    "lead": "Publishes the full transcript ({{records}} records) as a Public Session on spool.pro. It can appear in Explore and search, and the source Session stays unchanged.",
+    "lead": "Publishes the full transcript ({{records}} records) as a Public Session on spool.new. It can appear in Explore and search, and the source Session stays unchanged.",
     "secretsWarning": "{{total}} potential secrets detected ({{high}} high severity). Sharing sends these values — review with Security Scan first if unsure.",
     "summaryLabel": "Summary (Markdown)",
     "publish": "Publish Session",
@@ -923,7 +923,7 @@
     "doneTitle": "Session published",
     "doneLead": "This Session is Public and can appear in Explore and search. The source Session stays unchanged.",
     "linkOnlyTitle": "Create a Link-only share?",
-    "linkOnlyLead": "This provider is not supported in Explore yet. Shares the full transcript ({{records}} records) at a Link-only URL on spool.pro; the source Session stays unchanged.",
+    "linkOnlyLead": "This provider is not supported in Explore yet. Shares the full transcript ({{records}} records) at a Link-only URL on spool.new; the source Session stays unchanged.",
     "linkOnlyPublish": "Share link",
     "linkOnlyPublishing": "Sharing…",
     "linkOnlyDoneTitle": "Link shared",

--- a/apps/app/src/renderer/i18n/locales/fr.json
+++ b/apps/app/src/renderer/i18n/locales/fr.json
@@ -354,7 +354,7 @@
       "deleteConfirm_item_shares_prefix": "Chaque partage publié renverra",
       "deleteConfirm_item_shares_emphasis": "410 Gone",
       "deleteConfirm_item_handle": "Votre handle est libéré et peut être réservé par n'importe qui",
-      "deleteConfirm_item_record": "Votre enregistrement de compte est supprimé de spool.pro",
+      "deleteConfirm_item_record": "Votre enregistrement de compte est supprimé de spool.new",
       "deleteConfirm_footnote": "Vous pouvez annuler depuis cet écran à tout moment avant la fin du délai. Les brouillons sur cet appareil ne sont pas affectés — ils restent locaux.",
       "deleteConfirm_confirm": "Programmer la suppression",
       "deleteConfirm_scheduling": "Programmation…",
@@ -636,7 +636,7 @@
       "publishUnredacted": "Publier avec les secrets visibles",
       "publishing": "Publication…",
       "tryAgain": "Réessayer",
-      "footerHint": "Un instantané est envoyé vers spool.pro. Révocable à tout moment.",
+      "footerHint": "Un instantané est envoyé vers spool.new. Révocable à tout moment.",
       "footerHint_published": "L'instantané se trouve au lien ci-dessus. Révocable à tout moment.",
       "error_sessionExpired": "Votre session a expiré — reconnectez-vous pour publier.",
       "error_rateLimited": "Trop de publications. Réessayez dans quelques minutes.",
@@ -670,7 +670,7 @@
       "downloading": "Export en cours…"
     },
     "connectCard": {
-      "title": "Se connecter à spool.pro",
+      "title": "Se connecter à spool.new",
       "body": "Spool n'envoie que les instantanés que vous publiez explicitement. Vos brouillons et votre bibliothèque ne quittent jamais cette machine.",
       "signInWithGoogle": "Se connecter avec Google",
       "waitingForBrowser": "En attente du navigateur…",
@@ -680,7 +680,7 @@
       "title": "Dépublier ce partage ?",
       "body_prefix": "Action irréversible. Le lien renverra",
       "body_emphasis": "410 Gone",
-      "body_suffix": ", l'instantané est supprimé du stockage spool.pro et l'URL ne peut pas être réutilisée. Pour partager à nouveau cette conversation, vous devrez publier une nouvelle copie — elle aura une nouvelle URL.",
+      "body_suffix": ", l'instantané est supprimé du stockage spool.new et l'URL ne peut pas être réutilisée. Pour partager à nouveau cette conversation, vous devrez publier une nouvelle copie — elle aura une nouvelle URL.",
       "confirm": "Oui, dépublier définitivement",
       "confirming": "Dépublication…"
     }
@@ -912,10 +912,10 @@
     "toggleOptions": "Options"
   },
   "hubShare": {
-    "menuLabel": "Partager sur spool.pro",
-    "pretitle": "Partager sur spool.pro",
+    "menuLabel": "Partager sur spool.new",
+    "pretitle": "Partager sur spool.new",
     "title": "Publier cette Session ?",
-    "lead": "Publie la transcription complète ({{records}} enregistrements) comme Session publique sur spool.pro. Elle peut apparaître dans Explore et la recherche, et la Session source reste inchangée.",
+    "lead": "Publie la transcription complète ({{records}} enregistrements) comme Session publique sur spool.new. Elle peut apparaître dans Explore et la recherche, et la Session source reste inchangée.",
     "secretsWarning": "{{total}} secrets potentiels détectés (dont {{high}} à haut risque). Le partage envoie ces valeurs.",
     "summaryLabel": "Résumé (Markdown)",
     "publish": "Publier la Session",
@@ -923,7 +923,7 @@
     "doneTitle": "Session publiée",
     "doneLead": "Cette Session est publique et peut apparaître dans Explore et la recherche. La Session source reste inchangée.",
     "linkOnlyTitle": "Créer un partage accessible par lien ?",
-    "linkOnlyLead": "Ce fournisseur n’est pas encore pris en charge dans Explore. Partage la transcription complète ({{records}} enregistrements) via une URL accessible par lien sur spool.pro ; la Session source reste inchangée.",
+    "linkOnlyLead": "Ce fournisseur n’est pas encore pris en charge dans Explore. Partage la transcription complète ({{records}} enregistrements) via une URL accessible par lien sur spool.new ; la Session source reste inchangée.",
     "linkOnlyPublish": "Partager le lien",
     "linkOnlyPublishing": "Partage…",
     "linkOnlyDoneTitle": "Lien partagé",

--- a/apps/app/src/renderer/i18n/locales/ja.json
+++ b/apps/app/src/renderer/i18n/locales/ja.json
@@ -347,7 +347,7 @@
       "deleteConfirm_item_shares_prefix": "公開済みのすべての共有は",
       "deleteConfirm_item_shares_emphasis": "410 Gone",
       "deleteConfirm_item_handle": "ハンドルは解放され、誰でも再取得できます",
-      "deleteConfirm_item_record": "アカウントレコードは spool.pro から削除されます",
+      "deleteConfirm_item_record": "アカウントレコードは spool.new から削除されます",
       "deleteConfirm_footnote": "クールオフ終了前であればこの画面からいつでもキャンセルできます。このデバイス上の下書きは影響を受けません — ローカルに保存されています。",
       "deleteConfirm_confirm": "削除を予約",
       "deleteConfirm_scheduling": "予約中…",
@@ -606,7 +606,7 @@
       "publishUnredacted": "秘密情報を表示したまま公開",
       "publishing": "公開中…",
       "tryAgain": "再試行",
-      "footerHint": "スナップショットは spool.pro にアップロードされます。いつでも取り消せます。",
+      "footerHint": "スナップショットは spool.new にアップロードされます。いつでも取り消せます。",
       "footerHint_published": "スナップショットは上のリンクにあります。いつでも取り消せます。",
       "error_sessionExpired": "セッションの有効期限が切れました — 公開するには再度サインインしてください。",
       "error_rateLimited": "公開回数が多すぎます。数分後に再試行してください。",
@@ -637,7 +637,7 @@
       "downloading": "エクスポート中…"
     },
     "connectCard": {
-      "title": "spool.pro にサインイン",
+      "title": "spool.new にサインイン",
       "body": "Spool は明示的に公開したスナップショットのみをアップロードします。下書きとライブラリはこのマシンから出ることはありません。",
       "signInWithGoogle": "Google でサインイン",
       "waitingForBrowser": "ブラウザを待機中…",
@@ -647,7 +647,7 @@
       "title": "この共有の公開を取り消しますか？",
       "body_prefix": "この操作は取り消せません。リンクは",
       "body_emphasis": "410 Gone",
-      "body_suffix": " を返し、スナップショットは spool.pro のストレージから削除され、URL は再利用できなくなります。この会話を再度共有するには新しいコピーを公開する必要があり — 新しい URL になります。",
+      "body_suffix": " を返し、スナップショットは spool.new のストレージから削除され、URL は再利用できなくなります。この会話を再度共有するには新しいコピーを公開する必要があり — 新しい URL になります。",
       "confirm": "はい、永久に公開を取り消す",
       "confirming": "取り消し中…"
     }
@@ -870,10 +870,10 @@
     "toggleOptions": "オプション"
   },
   "hubShare": {
-    "menuLabel": "spool.pro に共有",
-    "pretitle": "spool.pro に共有",
+    "menuLabel": "spool.new に共有",
+    "pretitle": "spool.new に共有",
     "title": "このセッションを公開しますか？",
-    "lead": "完全なトランスクリプト（{{records}} 件のレコード）を spool.pro の公開セッションとして公開します。Explore と検索に表示される可能性があり、元のセッションは変更されません。",
+    "lead": "完全なトランスクリプト（{{records}} 件のレコード）を spool.new の公開セッションとして公開します。Explore と検索に表示される可能性があり、元のセッションは変更されません。",
     "secretsWarning": "{{total}} 件の機密情報の可能性が検出されました(うち {{high}} 件が高リスク)。共有するとこれらの値が送信されます。",
     "summaryLabel": "要約（Markdown）",
     "publish": "セッションを公開",
@@ -881,7 +881,7 @@
     "doneTitle": "セッションを公開しました",
     "doneLead": "このセッションは公開され、Explore と検索に表示される可能性があります。元のセッションは変更されません。",
     "linkOnlyTitle": "このセッションのリンク限定共有を作成しますか？",
-    "linkOnlyLead": "このプロバイダーはまだ Explore に対応していません。完全なトランスクリプト（{{records}} 件のレコード）を spool.pro のリンク限定 URL で共有し、元のセッションは変更されません。",
+    "linkOnlyLead": "このプロバイダーはまだ Explore に対応していません。完全なトランスクリプト（{{records}} 件のレコード）を spool.new のリンク限定 URL で共有し、元のセッションは変更されません。",
     "linkOnlyPublish": "リンクを共有",
     "linkOnlyPublishing": "共有中…",
     "linkOnlyDoneTitle": "リンクを共有しました",

--- a/apps/app/src/renderer/i18n/locales/ko.json
+++ b/apps/app/src/renderer/i18n/locales/ko.json
@@ -347,7 +347,7 @@
       "deleteConfirm_item_shares_prefix": "게시된 모든 공유가 다음을 반환합니다:",
       "deleteConfirm_item_shares_emphasis": "410 Gone",
       "deleteConfirm_item_handle": "핸들이 해제되어 누구나 다시 등록할 수 있습니다",
-      "deleteConfirm_item_record": "계정 기록이 spool.pro에서 제거됩니다",
+      "deleteConfirm_item_record": "계정 기록이 spool.new에서 제거됩니다",
       "deleteConfirm_footnote": "쿨오프 만료 전에는 이 화면에서 언제든지 취소할 수 있습니다. 이 기기의 초안은 영향을 받지 않으며 — 로컬에 보관됩니다.",
       "deleteConfirm_confirm": "삭제 예약",
       "deleteConfirm_scheduling": "예약 중…",
@@ -606,7 +606,7 @@
       "publishUnredacted": "비밀 정보를 노출한 채 게시",
       "publishing": "게시 중…",
       "tryAgain": "다시 시도",
-      "footerHint": "스냅샷이 spool.pro에 업로드됩니다. 언제든 취소할 수 있습니다.",
+      "footerHint": "스냅샷이 spool.new에 업로드됩니다. 언제든 취소할 수 있습니다.",
       "footerHint_published": "스냅샷은 위 링크에 있습니다. 언제든 취소할 수 있습니다.",
       "error_sessionExpired": "세션이 만료되었습니다 — 게시하려면 다시 로그인하세요.",
       "error_rateLimited": "게시 횟수가 너무 많습니다. 몇 분 후 다시 시도하세요.",
@@ -637,7 +637,7 @@
       "downloading": "내보내는 중…"
     },
     "connectCard": {
-      "title": "spool.pro에 로그인",
+      "title": "spool.new에 로그인",
       "body": "Spool은 사용자가 명시적으로 게시한 스냅샷만 업로드합니다. 초안과 라이브러리는 이 기기를 벗어나지 않습니다.",
       "signInWithGoogle": "Google로 로그인",
       "waitingForBrowser": "브라우저를 기다리는 중…",
@@ -647,7 +647,7 @@
       "title": "이 공유의 게시를 취소하시겠어요?",
       "body_prefix": "되돌릴 수 없습니다. 링크는",
       "body_emphasis": "410 Gone",
-      "body_suffix": " 을 반환하며, 스냅샷은 spool.pro 저장소에서 삭제되고 URL은 재사용할 수 없습니다. 이 대화를 다시 공유하려면 새 사본을 게시해야 하며 — 새 URL이 생성됩니다.",
+      "body_suffix": " 을 반환하며, 스냅샷은 spool.new 저장소에서 삭제되고 URL은 재사용할 수 없습니다. 이 대화를 다시 공유하려면 새 사본을 게시해야 하며 — 새 URL이 생성됩니다.",
       "confirm": "예, 영구적으로 게시 취소",
       "confirming": "취소하는 중…"
     }
@@ -870,10 +870,10 @@
     "toggleOptions": "옵션"
   },
   "hubShare": {
-    "menuLabel": "spool.pro에 공유",
-    "pretitle": "spool.pro에 공유",
+    "menuLabel": "spool.new에 공유",
+    "pretitle": "spool.new에 공유",
     "title": "이 세션을 공개할까요?",
-    "lead": "전체 트랜스크립트({{records}}개 레코드)를 spool.pro의 공개 세션으로 게시합니다. Explore와 검색에 표시될 수 있으며 원본 세션은 변경되지 않습니다.",
+    "lead": "전체 트랜스크립트({{records}}개 레코드)를 spool.new의 공개 세션으로 게시합니다. Explore와 검색에 표시될 수 있으며 원본 세션은 변경되지 않습니다.",
     "secretsWarning": "민감 정보로 의심되는 항목 {{total}}건이 감지되었습니다(고위험 {{high}}건). 공유하면 해당 값이 전송됩니다.",
     "summaryLabel": "요약 (Markdown)",
     "publish": "세션 게시",
@@ -881,7 +881,7 @@
     "doneTitle": "세션 게시됨",
     "doneLead": "이 세션은 공개 상태이며 Explore와 검색에 표시될 수 있습니다. 원본 세션은 변경되지 않습니다.",
     "linkOnlyTitle": "이 세션의 링크 전용 공유를 만들까요?",
-    "linkOnlyLead": "이 제공자는 아직 Explore에서 지원되지 않습니다. 전체 트랜스크립트({{records}}개 레코드)를 spool.pro의 링크 전용 URL로 공유하며 원본 세션은 변경되지 않습니다.",
+    "linkOnlyLead": "이 제공자는 아직 Explore에서 지원되지 않습니다. 전체 트랜스크립트({{records}}개 레코드)를 spool.new의 링크 전용 URL로 공유하며 원본 세션은 변경되지 않습니다.",
     "linkOnlyPublish": "링크 공유",
     "linkOnlyPublishing": "공유 중…",
     "linkOnlyDoneTitle": "링크 공유됨",

--- a/apps/app/src/renderer/i18n/locales/zh-CN.json
+++ b/apps/app/src/renderer/i18n/locales/zh-CN.json
@@ -347,7 +347,7 @@
       "deleteConfirm_item_shares_prefix": "所有已发布的分享将返回",
       "deleteConfirm_item_shares_emphasis": "410 Gone",
       "deleteConfirm_item_handle": "你的 handle 将被释放，任何人都可以重新认领",
-      "deleteConfirm_item_record": "你的账户记录将从 spool.pro 删除",
+      "deleteConfirm_item_record": "你的账户记录将从 spool.new 删除",
       "deleteConfirm_footnote": "在冷却期结束前你可以随时在此界面取消。本机的草稿不受影响——它们保存在本地。",
       "deleteConfirm_confirm": "安排删除",
       "deleteConfirm_scheduling": "安排中…",
@@ -606,7 +606,7 @@
       "publishUnredacted": "公开发布敏感信息",
       "publishing": "发布中…",
       "tryAgain": "重试",
-      "footerHint": "快照将上传至 spool.pro，随时可撤销。",
+      "footerHint": "快照将上传至 spool.new，随时可撤销。",
       "footerHint_published": "快照位于上方链接，随时可撤销。",
       "error_sessionExpired": "登录已过期——请重新登录后再发布。",
       "error_rateLimited": "发布次数过多，请几分钟后重试。",
@@ -637,7 +637,7 @@
       "downloading": "导出中…"
     },
     "connectCard": {
-      "title": "登录 spool.pro",
+      "title": "登录 spool.new",
       "body": "Spool 只会上传你主动发布的快照。草稿和你的资料库永远不会离开本机。",
       "signInWithGoogle": "使用 Google 登录",
       "waitingForBrowser": "正在等待浏览器…",
@@ -647,7 +647,7 @@
       "title": "取消发布此分享？",
       "body_prefix": "此操作无法撤销。链接将返回",
       "body_emphasis": "410 Gone",
-      "body_suffix": "，快照将从 spool.pro 存储中删除，URL 无法重新使用。要再次分享此对话，需要重新发布一份——链接将是全新的。",
+      "body_suffix": "，快照将从 spool.new 存储中删除，URL 无法重新使用。要再次分享此对话，需要重新发布一份——链接将是全新的。",
       "confirm": "确认永久取消发布",
       "confirming": "取消发布中…"
     }
@@ -870,10 +870,10 @@
     "toggleOptions": "选项"
   },
   "hubShare": {
-    "menuLabel": "分享到 spool.pro",
-    "pretitle": "分享到 spool.pro",
+    "menuLabel": "分享到 spool.new",
+    "pretitle": "分享到 spool.new",
     "title": "发布这个会话？",
-    "lead": "将完整转录（{{records}} 条记录）作为公开会话发布到 spool.pro。它可以出现在 Explore 和搜索中，源会话不会被更改。",
+    "lead": "将完整转录（{{records}} 条记录）作为公开会话发布到 spool.new。它可以出现在 Explore 和搜索中，源会话不会被更改。",
     "secretsWarning": "检测到 {{total}} 处疑似敏感信息(其中 {{high}} 处高危)。分享会发送这些内容——不确定时请先用安全扫描检查。",
     "summaryLabel": "摘要（Markdown）",
     "publish": "发布会话",
@@ -881,7 +881,7 @@
     "doneTitle": "会话已发布",
     "doneLead": "该会话已公开，可以出现在 Explore 和搜索中。源会话不会被更改。",
     "linkOnlyTitle": "创建这个会话的仅链接分享？",
-    "linkOnlyLead": "Explore 尚未支持此提供商。将完整转录（{{records}} 条记录）通过 spool.pro 的仅链接 URL 分享；源会话不会被更改。",
+    "linkOnlyLead": "Explore 尚未支持此提供商。将完整转录（{{records}} 条记录）通过 spool.new 的仅链接 URL 分享；源会话不会被更改。",
     "linkOnlyPublish": "分享链接",
     "linkOnlyPublishing": "分享中…",
     "linkOnlyDoneTitle": "已分享链接",

--- a/apps/app/src/renderer/i18n/locales/zh-TW.json
+++ b/apps/app/src/renderer/i18n/locales/zh-TW.json
@@ -347,7 +347,7 @@
       "deleteConfirm_item_shares_prefix": "所有已發布的分享將回傳",
       "deleteConfirm_item_shares_emphasis": "410 Gone",
       "deleteConfirm_item_handle": "你的 handle 將被釋放，任何人都可以重新認領",
-      "deleteConfirm_item_record": "你的帳號記錄將從 spool.pro 刪除",
+      "deleteConfirm_item_record": "你的帳號記錄將從 spool.new 刪除",
       "deleteConfirm_footnote": "在冷卻期結束前你可以隨時在此畫面取消。本機的草稿不受影響——它們儲存在本地。",
       "deleteConfirm_confirm": "安排刪除",
       "deleteConfirm_scheduling": "安排中…",
@@ -606,7 +606,7 @@
       "publishUnredacted": "公開發布敏感資訊",
       "publishing": "發布中…",
       "tryAgain": "重試",
-      "footerHint": "快照將上傳至 spool.pro，隨時可撤銷。",
+      "footerHint": "快照將上傳至 spool.new，隨時可撤銷。",
       "footerHint_published": "快照位於上方連結，隨時可撤銷。",
       "error_sessionExpired": "登入已過期——請重新登入後再發布。",
       "error_rateLimited": "發布次數過多，請幾分鐘後重試。",
@@ -637,7 +637,7 @@
       "downloading": "匯出中…"
     },
     "connectCard": {
-      "title": "登入 spool.pro",
+      "title": "登入 spool.new",
       "body": "Spool 只會上傳你主動發布的快照。草稿和你的資料庫永遠不會離開本機。",
       "signInWithGoogle": "使用 Google 登入",
       "waitingForBrowser": "正在等待瀏覽器…",
@@ -647,7 +647,7 @@
       "title": "取消發布此分享？",
       "body_prefix": "此操作無法復原。連結將回傳",
       "body_emphasis": "410 Gone",
-      "body_suffix": "，快照將從 spool.pro 儲存空間中刪除，URL 無法重複使用。要再次分享此對話，需要重新發布一份——連結將是全新的。",
+      "body_suffix": "，快照將從 spool.new 儲存空間中刪除，URL 無法重複使用。要再次分享此對話，需要重新發布一份——連結將是全新的。",
       "confirm": "確認永久取消發布",
       "confirming": "取消發布中…"
     }
@@ -870,10 +870,10 @@
     "toggleOptions": "選項"
   },
   "hubShare": {
-    "menuLabel": "分享到 spool.pro",
-    "pretitle": "分享到 spool.pro",
+    "menuLabel": "分享到 spool.new",
+    "pretitle": "分享到 spool.new",
     "title": "發佈這個會話？",
-    "lead": "將完整轉錄（{{records}} 條記錄）作為公開會話發佈到 spool.pro。它可以出現在 Explore 和搜尋中，來源會話不會被變更。",
+    "lead": "將完整轉錄（{{records}} 條記錄）作為公開會話發佈到 spool.new。它可以出現在 Explore 和搜尋中，來源會話不會被變更。",
     "secretsWarning": "偵測到 {{total}} 處疑似敏感資訊(其中 {{high}} 處高風險)。分享會傳送這些內容——不確定時請先用安全掃描檢查。",
     "summaryLabel": "摘要（Markdown）",
     "publish": "發佈會話",
@@ -881,7 +881,7 @@
     "doneTitle": "會話已發佈",
     "doneLead": "此會話已公開，可以出現在 Explore 和搜尋中。來源會話不會被變更。",
     "linkOnlyTitle": "建立這個會話的僅連結分享？",
-    "linkOnlyLead": "Explore 尚未支援此供應商。透過 spool.pro 的僅連結 URL 分享完整轉錄（{{records}} 條記錄）；來源會話不會被變更。",
+    "linkOnlyLead": "Explore 尚未支援此供應商。透過 spool.new 的僅連結 URL 分享完整轉錄（{{records}} 條記錄）；來源會話不會被變更。",
     "linkOnlyPublish": "分享連結",
     "linkOnlyPublishing": "分享中…",
     "linkOnlyDoneTitle": "已分享連結",

--- a/apps/app/src/renderer/lib/sharePublicUrl.test.ts
+++ b/apps/app/src/renderer/lib/sharePublicUrl.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { resolveAvatarUrl, sharePublicOrigin, sharePublicUrl } from './sharePublicUrl'
+
+describe('public share URL defaults', () => {
+  it('uses spool.new for production links', () => {
+    expect(sharePublicOrigin({})).toBe('https://spool.new')
+    expect(sharePublicUrl('abc 123', {})).toBe('https://spool.new/s/abc%20123')
+  })
+
+  it('keeps explicit staging and backend origins', () => {
+    const env = {
+      VITE_SPOOL_SHARE_PUBLIC_URL: 'https://staging.spool.new/',
+      VITE_SPOOL_SHARE_BACKEND: 'https://api.staging.example/',
+    }
+    expect(sharePublicOrigin(env)).toBe('https://staging.spool.new')
+    expect(resolveAvatarUrl('/api/avatars/u1', env)).toBe(
+      'https://api.staging.example/api/avatars/u1',
+    )
+  })
+})

--- a/apps/app/src/renderer/lib/sharePublicUrl.ts
+++ b/apps/app/src/renderer/lib/sharePublicUrl.ts
@@ -6,7 +6,7 @@
  * time. In dev set this to `http://localhost:3002` (the web app
  * vite server) via `apps/app/.env.development.local`. In prod
  * builds the env is unset and the function returns
- * `https://spool.pro`.
+ * `https://spool.new`.
  *
  * Why this is a renderer concern (and not just a `published.url` echo):
  * the Published-tab list draws from a local cache of slugs and titles,
@@ -15,7 +15,7 @@
  * runtime-known on this side.
  */
 
-const DEFAULT_PUBLIC_URL = 'https://spool.pro'
+const DEFAULT_PUBLIC_URL = 'https://spool.new'
 
 export function sharePublicOrigin(
   env: Record<string, string | undefined> = import.meta.env as Record<string, string | undefined>,
@@ -38,7 +38,7 @@ export function sharePublicUrl(slug: string, env?: Record<string, string | undef
  *   - an absolute URL to the provider CDN (e.g. lh3.googleusercontent.com)
  *
  * Relative `/api/*` paths must hit the backend origin directly.
- * In prod the backend and public web share an origin (spool.pro) so
+ * In prod the backend and public web share an origin (spool.new) so
  * `sharePublicOrigin()` works as a fallback, but in dev they're split
  * (3002 = web-app vite, 8788 = wrangler) and the web app vite proxy
  * only exists when that dev server is actually running. Prefer the

--- a/apps/app/src/renderer/styles.css
+++ b/apps/app/src/renderer/styles.css
@@ -241,7 +241,7 @@ body {
   content: '';
   position: absolute;
   inset: 0;
-  background-color: #f07020;
+  background-color: var(--sp-accent);
   pointer-events: none;
   border-radius: inherit;
   animation: spool-share-jump-flash 1600ms ease-out forwards;

--- a/apps/app/src/renderer/theme/editorTypes.test.ts
+++ b/apps/app/src/renderer/theme/editorTypes.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { defaultThemeEditorState, normalizeThemeEditorState } from './editorTypes'
+
+describe('Spool theme defaults', () => {
+  it('uses the Paperboy blue and void palette', () => {
+    expect(defaultThemeEditorState()).toMatchObject({
+      light: { accent: '#1387FF', background: '#FFFFFF', foreground: '#0A0A0A' },
+      dark: { accent: '#5BB1F0', background: '#000000', foreground: '#FFFFFF' },
+    })
+  })
+
+  it('migrates exact pre-rebrand defaults without replacing custom themes', () => {
+    const legacy = {
+      v: 1,
+      light: {
+        ...defaultThemeEditorState().light,
+        contrast: 73,
+        accent: '#C85A00',
+        background: '#FAFAF8',
+        foreground: '#1C1C18',
+      },
+      dark: {
+        ...defaultThemeEditorState().dark,
+        accent: '#F07020',
+        background: '#141410',
+        foreground: '#F2F2EC',
+      },
+    }
+    expect(normalizeThemeEditorState(legacy)).toEqual({
+      ...defaultThemeEditorState(),
+      light: { ...defaultThemeEditorState().light, contrast: 73 },
+    })
+
+    legacy.light.accent = '#123456'
+    expect(normalizeThemeEditorState(legacy)?.light.accent).toBe('#123456')
+  })
+})

--- a/apps/app/src/renderer/theme/editorTypes.ts
+++ b/apps/app/src/renderer/theme/editorTypes.ts
@@ -32,6 +32,16 @@ export const LIGHT_PRESETS = THEME_PRESETS
 export const DARK_PRESETS = THEME_PRESETS
 
 const KNOWN_PRESETS = new Set<string>(THEME_PRESETS)
+const LEGACY_SPOOL_LIGHT = {
+  accent: '#C85A00',
+  background: '#FAFAF8',
+  foreground: '#1C1C18',
+} as const
+const LEGACY_SPOOL_DARK = {
+  accent: '#F07020',
+  background: '#141410',
+  foreground: '#F2F2EC',
+} as const
 
 export function normalizePresetId(raw: string): string {
   const preset = raw === 'forest' ? 'everforest' : raw
@@ -69,22 +79,56 @@ export function normalizeThemeEditorState(raw: unknown): ThemeEditorStateV1 | nu
   if (record['v'] !== 1) return null
 
   const defaults = defaultThemeEditorState()
-  return {
+  const normalized = {
     v: 1,
     light: normalizeThemeSide(
       record['light'] as Partial<ThemeSideConfig> | undefined,
       defaults.light,
     ),
     dark: normalizeThemeSide(record['dark'] as Partial<ThemeSideConfig> | undefined, defaults.dark),
+  } satisfies ThemeEditorStateV1
+
+  // The Paperboy rebrand changed the built-in Spool preset. Migrate only
+  // exact legacy defaults so a genuinely customized palette remains intact.
+  if (matchesLegacySpoolPreset(normalized.light, LEGACY_SPOOL_LIGHT)) {
+    const next = defaultLightSide()
+    normalized.light = {
+      ...normalized.light,
+      accent: next.accent,
+      background: next.background,
+      foreground: next.foreground,
+    }
   }
+  if (matchesLegacySpoolPreset(normalized.dark, LEGACY_SPOOL_DARK)) {
+    const next = defaultDarkSide()
+    normalized.dark = {
+      ...normalized.dark,
+      accent: next.accent,
+      background: next.background,
+      foreground: next.foreground,
+    }
+  }
+  return normalized
+}
+
+function matchesLegacySpoolPreset(
+  side: ThemeSideConfig,
+  legacy: typeof LEGACY_SPOOL_LIGHT | typeof LEGACY_SPOOL_DARK,
+): boolean {
+  return (
+    side.preset === 'spool' &&
+    side.accent.toUpperCase() === legacy.accent &&
+    side.background.toUpperCase() === legacy.background &&
+    side.foreground.toUpperCase() === legacy.foreground
+  )
 }
 
 export function defaultLightSide(): ThemeSideConfig {
   return {
     preset: 'spool',
-    accent: '#C85A00',
-    background: '#FAFAF8',
-    foreground: '#1C1C18',
+    accent: '#1387FF',
+    background: '#FFFFFF',
+    foreground: '#0A0A0A',
     uiFont: 'Geist Variable',
     codeFont: 'Geist Mono',
     translucentChrome: false,
@@ -95,9 +139,9 @@ export function defaultLightSide(): ThemeSideConfig {
 export function defaultDarkSide(): ThemeSideConfig {
   return {
     preset: 'spool',
-    accent: '#F07020',
-    background: '#141410',
-    foreground: '#F2F2EC',
+    accent: '#5BB1F0',
+    background: '#000000',
+    foreground: '#FFFFFF',
     uiFont: 'Geist Variable',
     codeFont: 'Geist Mono',
     translucentChrome: false,

--- a/apps/backend/.dev.vars.example
+++ b/apps/backend/.dev.vars.example
@@ -30,7 +30,7 @@
 #   WorkOS. The checked-in development config defaults to the share-web
 #   Vite server below; keep this explicit when copying the file so custom
 #   local environments can override it. It must match the redirect URI
-#   registered in WorkOS. Unset in prod (defaults to https://spool.pro).
+#   registered in WorkOS. Unset in prod (defaults to https://spool.new).
 
 # DEV_WORKOS_API_URL (optional — normally injected by share-dev.sh)
 #   workerd ignores proxy envs (workers-sdk#4515); on proxy-only dev

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,6 +1,6 @@
 # @spool/backend
 
-Cloudflare Pages Functions backing spool.pro identity, Hub storage, Session reads, publication documents, Profiles, account management, media, and audit surfaces.
+Cloudflare Pages Functions backing spool.new identity, Hub storage, Session reads, publication documents, Profiles, account management, media, and audit surfaces.
 
 ## Responsibilities
 
@@ -86,7 +86,7 @@ For Backend + Web + Desktop together:
 Run the manual probe against staging before production promotion:
 
 ```bash
-TARGET=https://staging.spool.pro ./apps/backend/tests/pentest.sh
+TARGET=https://staging.spool.new ./apps/backend/tests/pentest.sh
 ```
 
 It checks security headers, unauthenticated access, identifier enumeration, and redirect handling.

--- a/apps/backend/functions/api/auth/[provider]/callback.ts
+++ b/apps/backend/functions/api/auth/[provider]/callback.ts
@@ -17,7 +17,7 @@ import { safeNext } from '../../../../src/auth/next'
 import { getProvider } from '../../../../src/auth/providers/registry'
 import { MAX_TTL_SEC, createSession } from '../../../../src/auth/session'
 import { ApiError, jsonError } from '../../../../src/errors'
-import { publicBaseUrl } from '../../../../src/public-url'
+import { oauthPublicBaseUrl } from '../../../../src/public-url'
 import { checkRate } from '../../../../src/rate-limit'
 import { clientIp } from '../../../../src/request'
 import { CC_NO_STORE } from '../../../../src/security/cache-control'
@@ -66,7 +66,7 @@ export const onRequestGet: PagesFunction<Env, 'provider'> = async (ctx) => {
     const next = safeNext(rawNext)
 
     // Must match /api/auth/[provider]/start's redirect_uri exactly.
-    const redirectUri = `${publicBaseUrl(ctx.env)}/api/auth/${provider.id}/callback`
+    const redirectUri = `${oauthPublicBaseUrl(ctx.request, ctx.env)}/api/auth/${provider.id}/callback`
     const claim = await provider.exchangeCode(
       { code, codeVerifier: verifier, redirectUri },
       ctx.env,

--- a/apps/backend/functions/api/auth/[provider]/start.ts
+++ b/apps/backend/functions/api/auth/[provider]/start.ts
@@ -20,7 +20,7 @@ type Env = {
   WORKOS_CLIENT_ID?: string
   // Public origin the provider must redirect back to — must exactly
   // match the value registered with the provider. Defaults to
-  // spool.pro; dev sets it to the web app's origin (e.g. http://localhost:3002).
+  // spool.new; dev sets it to the web app's origin (e.g. http://localhost:3002).
   PUBLIC_BASE_URL?: string
 }
 

--- a/apps/backend/functions/api/auth/[provider]/start.ts
+++ b/apps/backend/functions/api/auth/[provider]/start.ts
@@ -14,7 +14,7 @@ import { safeNext } from '../../../../src/auth/next'
 import { pkceChallenge, randomUrlSafe } from '../../../../src/auth/pkce'
 import { getProvider } from '../../../../src/auth/providers/registry'
 import { jsonError } from '../../../../src/errors'
-import { publicBaseUrl } from '../../../../src/public-url'
+import { oauthPublicBaseUrl } from '../../../../src/public-url'
 
 type Env = {
   WORKOS_CLIENT_ID?: string
@@ -49,7 +49,7 @@ export const onRequestGet: PagesFunction<Env, 'provider'> = async (ctx) => {
     // arrives at the backend (8788) but the URI registered with the
     // provider is the web app's origin (3002). Using ctx.request.url
     // here causes a 400 redirect_uri_mismatch on every dev sign-in.
-    const redirectUri = `${publicBaseUrl(ctx.env)}/api/auth/${provider.id}/callback`
+    const redirectUri = `${oauthPublicBaseUrl(ctx.request, ctx.env)}/api/auth/${provider.id}/callback`
     const authorizeUrl = provider.buildAuthRequestUrl(
       { state, codeChallenge: challenge, redirectUri },
       ctx.env,

--- a/apps/backend/functions/api/publish.ts
+++ b/apps/backend/functions/api/publish.ts
@@ -17,7 +17,7 @@ type Env = {
   SNAPSHOTS: R2Bucket
   OG: R2Bucket
   // Origin returned in the published share URL. Dev points this at the
-  // local web-app vite server; prod defaults to spool.pro.
+  // local web-app vite server; prod defaults to spool.new.
   PUBLIC_BASE_URL?: string
 }
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -19,8 +19,8 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler pages dev ./public --inspector-port 9230 --d1 DB --kv SESSIONS --kv META --kv RATE --kv NONCE --r2 SNAPSHOTS --r2 OG --r2 AVATARS --r2 HUB",
-    "deploy:staging": "wrangler pages deploy public --project-name spool-share-backend-staging",
-    "deploy:prod": "wrangler pages deploy public --project-name spool-share-backend",
+    "deploy:staging": "node scripts/deploy-pages.mjs staging",
+    "deploy:prod": "node scripts/deploy-pages.mjs production",
     "test": "vp test run",
     "typecheck": "tsc --noEmit",
     "d1:migrate:local": "wrangler d1 migrations apply spool-share-db --local",

--- a/apps/backend/scripts/deploy-pages.mjs
+++ b/apps/backend/scripts/deploy-pages.mjs
@@ -1,0 +1,87 @@
+import { spawn } from 'node:child_process'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const PAPERBOY_ACCOUNT_ID = '6898ecdad1e8341d3e09d4b46124d72e'
+const targets = {
+  production: {
+    branch: 'main',
+    config: 'wrangler.prod.toml',
+    project: 'spool-share-backend',
+  },
+  staging: {
+    branch: 'main',
+    config: 'wrangler.staging.toml',
+    project: 'spool-share-backend-staging',
+  },
+}
+
+const targetName = process.argv[2]
+const target = targets[targetName]
+if (target === undefined) {
+  console.error('Usage: node scripts/deploy-pages.mjs <production|staging>')
+  process.exit(2)
+}
+
+const appDir = dirname(dirname(fileURLToPath(import.meta.url)))
+const redirectPath = join(appDir, '.wrangler', 'deploy', 'config.json')
+let previousRedirect = null
+
+try {
+  previousRedirect = await readFile(redirectPath)
+} catch (error) {
+  if (error?.code !== 'ENOENT') throw error
+}
+
+await mkdir(dirname(redirectPath), { recursive: true })
+await writeFile(
+  redirectPath,
+  `${JSON.stringify({ configPath: `../../${target.config}` }, null, 2)}\n`,
+)
+
+let child
+let signal = null
+try {
+  child = spawn(
+    process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm',
+    [
+      'exec',
+      'wrangler',
+      'pages',
+      'deploy',
+      'public',
+      '--project-name',
+      target.project,
+      '--branch',
+      target.branch,
+    ],
+    {
+      cwd: appDir,
+      env: {
+        ...process.env,
+        CLOUDFLARE_ACCOUNT_ID: PAPERBOY_ACCOUNT_ID,
+      },
+      stdio: 'inherit',
+    },
+  )
+
+  const forwardSignal = (received) => {
+    signal = received
+    child.kill(received)
+  }
+  process.once('SIGINT', forwardSignal)
+  process.once('SIGTERM', forwardSignal)
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.once('error', reject)
+    child.once('exit', (code, childSignal) => {
+      signal ??= childSignal
+      resolve(code ?? 1)
+    })
+  })
+  process.exitCode = signal === 'SIGINT' ? 130 : signal === 'SIGTERM' ? 143 : exitCode
+} finally {
+  if (previousRedirect === null) await rm(redirectPath, { force: true })
+  else await writeFile(redirectPath, previousRedirect)
+}

--- a/apps/backend/src/handles.ts
+++ b/apps/backend/src/handles.ts
@@ -18,7 +18,7 @@ export function profilesEnabled(env: { PROFILES_ENABLED?: string }): boolean {
 }
 
 // Two flavours of reserved name, merged into one set:
-//   1) URL-routing words that already mean something on spool.pro
+//   1) URL-routing words that already mean something on spool.new
 //      (collide with /api/*, /me, /settings, etc.)
 //   2) Brand / impersonation guards. Cheap to add now; expensive to
 //      take back from a squatter after launch.

--- a/apps/backend/src/public-url.ts
+++ b/apps/backend/src/public-url.ts
@@ -10,9 +10,30 @@
 export const DEFAULT_PUBLIC_BASE_URL = 'https://spool.new'
 export const LOCAL_PUBLIC_BASE_URL = 'http://localhost:3002'
 
-export function publicBaseUrl(env: { PUBLIC_BASE_URL?: string; ENV?: string }): string {
+type PublicUrlEnv = { PUBLIC_BASE_URL?: string; ENV?: string }
+
+export function publicBaseUrl(env: PublicUrlEnv): string {
   return (
     env.PUBLIC_BASE_URL ??
     (env.ENV === 'development' ? LOCAL_PUBLIC_BASE_URL : DEFAULT_PUBLIC_BASE_URL)
   )
+}
+
+/**
+ * OAuth state and verifier cookies are host-only. During the spool.pro →
+ * spool.new migration, a sign-in started on the legacy host must therefore
+ * return to that same host; otherwise the callback cannot read its cookies.
+ * Only the two owned production hosts are accepted from the edge's forwarded
+ * header. All other requests use the deployment's canonical base URL.
+ */
+export function oauthPublicBaseUrl(request: Request, env: PublicUrlEnv): string {
+  const forwardedHost = request.headers
+    .get('x-forwarded-host')
+    ?.split(',', 1)[0]
+    ?.trim()
+    .toLowerCase()
+  if (forwardedHost === 'spool.new' || forwardedHost === 'spool.pro') {
+    return `https://${forwardedHost}`
+  }
+  return publicBaseUrl(env)
 }

--- a/apps/backend/src/public-url.ts
+++ b/apps/backend/src/public-url.ts
@@ -6,8 +6,8 @@
 // Dev runs the OAuth callback through the web app's Vite proxy (port 3002),
 // so development defaults to that origin even though Wrangler listens on
 // 8788. PUBLIC_BASE_URL can override any environment; production inherits
-// the spool.pro default.
-export const DEFAULT_PUBLIC_BASE_URL = 'https://spool.pro'
+// the spool.new default.
+export const DEFAULT_PUBLIC_BASE_URL = 'https://spool.new'
 export const LOCAL_PUBLIC_BASE_URL = 'http://localhost:3002'
 
 export function publicBaseUrl(env: { PUBLIC_BASE_URL?: string; ENV?: string }): string {

--- a/apps/backend/src/publish/og.ts
+++ b/apps/backend/src/publish/og.ts
@@ -48,19 +48,19 @@ export function buildOgHtml(snap: SnapshotForOg): string {
   // text-node siblings between elements.
   // Satori does NOT resolve `width: 100%` to the canvas dimensions the
   // way a browser would — flex column children collapse to content width
-  // instead. Hard-code the 1200×630 dimensions so the cream paper fills
+  // instead. Hard-code the 1200×630 dimensions so the canvas fills
   // the whole OG image rather than leaving a grey gutter on the right.
   //
-  // Font-family chain: Inter → Noto Sans SC → system-ui. Satori walks
-  // the chain per glyph, so Latin chars resolve to Inter and CJK chars
+  // Font-family chain: Geist → Noto Sans SC → sans-serif. Satori walks
+  // the chain per glyph, so Latin chars resolve to Geist and CJK chars
   // fall through to Noto Sans SC. Without Noto Sans SC in the loaded
   // fonts list, CJK glyphs render as black "NO GLYPH" placeholder
   // boxes (the Satori default for unmapped codepoints).
   return (
-    `<div style="display:flex;flex-direction:column;justify-content:space-between;width:1200px;height:630px;padding:60px;background:#FAF7F0;font-family:Inter,'Noto Sans SC',system-ui,sans-serif">` +
-    `<div style="display:flex;font-size:28px;color:#C85A00;letter-spacing:0.12em;text-transform:uppercase">spool · share</div>` +
-    `<div style="display:flex;font-size:64px;color:#141410;line-height:1.15;font-weight:500">${title}</div>` +
-    `<div style="display:flex;font-size:22px;color:#6b6857">${template} · ${date}</div>` +
+    `<div style="display:flex;flex-direction:column;justify-content:space-between;width:1200px;height:630px;padding:60px;background:#FFFFFF;font-family:Geist,'Noto Sans SC',sans-serif">` +
+    `<div style="display:flex;font-size:28px;color:#1387FF;letter-spacing:0.12em;text-transform:uppercase">spool · share</div>` +
+    `<div style="display:flex;font-size:64px;color:#0A0A0A;line-height:1.15;font-weight:500">${title}</div>` +
+    `<div style="display:flex;font-size:22px;color:#666666">${template} · ${date}</div>` +
     `</div>`
   )
 }
@@ -87,12 +87,12 @@ export async function renderOgPng(snap: SnapshotForOg): Promise<ArrayBuffer> {
   // "NO GLYPH" boxes for the missing script — same as the pre-fix
   // behaviour). Worst case: Google Fonts is down, we get an OG image
   // that says "Shared conversation" in default sans with no glyphs.
-  const [inter, cjk] = await Promise.all([
-    loadGoogleFont({ family: 'Inter', weight: 500, text }).catch(() => null),
+  const [geist, cjk] = await Promise.all([
+    loadGoogleFont({ family: 'Geist', weight: 500, text }).catch(() => null),
     loadGoogleFont({ family: 'Noto Sans SC', weight: 500, text }).catch(() => null),
   ])
   const fonts: { name: string; data: ArrayBuffer; weight: 500; style: 'normal' }[] = []
-  if (inter) fonts.push({ name: 'Inter', data: inter, weight: 500, style: 'normal' })
+  if (geist) fonts.push({ name: 'Geist', data: geist, weight: 500, style: 'normal' })
   if (cjk) fonts.push({ name: 'Noto Sans SC', data: cjk, weight: 500, style: 'normal' })
 
   const res = new ImageResponse(html, {

--- a/apps/backend/tests/cli-auth.test.ts
+++ b/apps/backend/tests/cli-auth.test.ts
@@ -53,7 +53,7 @@ async function sessionCookie(env: Env, userId = 'u1'): Promise<string> {
 }
 
 async function startRequest(env: Env, label = 'devbox.local') {
-  const req = new Request('https://spool.pro/api/cli-auth/start', {
+  const req = new Request('https://spool.new/api/cli-auth/start', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ label }),
@@ -74,7 +74,7 @@ async function approveRequest(
   cookie: string,
   body: Record<string, unknown>,
 ): Promise<Response> {
-  const req = new Request('https://spool.pro/api/cli-auth/approve', {
+  const req = new Request('https://spool.new/api/cli-auth/approve', {
     method: 'POST',
     headers: { 'content-type': 'application/json', cookie },
     body: JSON.stringify(body),
@@ -83,7 +83,7 @@ async function approveRequest(
 }
 
 async function pollRequest(env: Env, deviceCode: string): Promise<Response> {
-  const req = new Request('https://spool.pro/api/cli-auth/poll', {
+  const req = new Request('https://spool.new/api/cli-auth/poll', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ device_code: deviceCode }),
@@ -109,7 +109,7 @@ describe('POST /api/cli-auth/start', () => {
     expect(body.device_code.length).toBeGreaterThanOrEqual(43)
     expect(body.user_code).toMatch(/^[BCDFGHJKMNPQRSTWXZ2-9]{4}-[BCDFGHJKMNPQRSTWXZ2-9]{4}$/)
     expect(body.verification_uri).toBe(
-      `https://spool.pro/cli-auth?code=${encodeURIComponent(body.user_code)}`,
+      `https://spool.new/cli-auth?code=${encodeURIComponent(body.user_code)}`,
     )
     expect(body.expires_in).toBe(15 * 60)
     expect(body.interval).toBe(3)
@@ -121,7 +121,7 @@ describe('POST /api/cli-auth/start', () => {
     await env.RATE.put(`rate/cli-auth-start/1.2.3.4/${slot}`, String(CLI_AUTH_START_RATE_MAX), {
       expirationTtl: CLI_AUTH_START_RATE_WINDOW_SEC,
     })
-    const req = new Request('https://spool.pro/api/cli-auth/start', {
+    const req = new Request('https://spool.new/api/cli-auth/start', {
       method: 'POST',
       headers: { 'cf-connecting-ip': '1.2.3.4' },
     })
@@ -134,7 +134,7 @@ describe('GET /api/cli-auth/approve (page metadata)', () => {
   it('401 without a session', async () => {
     const env = envFor()
     const { user_code } = await startRequest(env)
-    const req = new Request(`https://spool.pro/api/cli-auth/approve?code=${user_code}`)
+    const req = new Request(`https://spool.new/api/cli-auth/approve?code=${user_code}`)
     const res = await invoke(approveGet, req, env)
     expect(res.status).toBe(401)
   })
@@ -144,7 +144,7 @@ describe('GET /api/cli-auth/approve (page metadata)', () => {
     const cookie = await sessionCookie(env)
     const { user_code } = await startRequest(env)
     const req = new Request(
-      `https://spool.pro/api/cli-auth/approve?code=${user_code.toLowerCase()}`,
+      `https://spool.new/api/cli-auth/approve?code=${user_code.toLowerCase()}`,
       { headers: { cookie } },
     )
     const res = await invoke(approveGet, req, env)
@@ -157,7 +157,7 @@ describe('GET /api/cli-auth/approve (page metadata)', () => {
   it('404 on an unknown code', async () => {
     const env = envFor(stateWithUser())
     const cookie = await sessionCookie(env)
-    const req = new Request('https://spool.pro/api/cli-auth/approve?code=BBBB-BBBB', {
+    const req = new Request('https://spool.new/api/cli-auth/approve?code=BBBB-BBBB', {
       headers: { cookie },
     })
     const res = await invoke(approveGet, req, env)
@@ -234,7 +234,7 @@ describe('deny + failure modes', () => {
   it('401 approving without a session', async () => {
     const env = envFor(stateWithUser())
     const { user_code } = await startRequest(env)
-    const req = new Request('https://spool.pro/api/cli-auth/approve', {
+    const req = new Request('https://spool.new/api/cli-auth/approve', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ user_code, decision: 'approve' }),
@@ -258,7 +258,7 @@ describe('deny + failure modes', () => {
     })
     const env = envFor(state)
     const { user_code } = await startRequest(env)
-    const req = new Request('https://spool.pro/api/cli-auth/approve', {
+    const req = new Request('https://spool.new/api/cli-auth/approve', {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -286,7 +286,7 @@ describe('deny + failure modes', () => {
     const env = envFor()
     const bad = await invoke(
       pollPost,
-      new Request('https://spool.pro/api/cli-auth/poll', {
+      new Request('https://spool.new/api/cli-auth/poll', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({}),

--- a/apps/backend/tests/discovery.test.ts
+++ b/apps/backend/tests/discovery.test.ts
@@ -97,7 +97,7 @@ function seedDiscovery(
 }
 
 function engagementRequest(sid: string, body: unknown = { kind: 'qualified_read' }): Request {
-  return new Request(`https://spool.pro/api/discovery/v1/sessions/${sid}/engagement`, {
+  return new Request(`https://spool.new/api/discovery/v1/sessions/${sid}/engagement`, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
@@ -218,7 +218,7 @@ describe('GET /api/discovery/v1/sessions', () => {
 
     const response = await invoke(
       sessionsGet,
-      new Request('https://spool.pro/api/discovery/v1/sessions?sort=recent'),
+      new Request('https://spool.new/api/discovery/v1/sessions?sort=recent'),
       env,
     )
     const body = (await response.json()) as {
@@ -247,7 +247,7 @@ describe('GET /api/discovery/v1/sessions', () => {
     env.state.users[0]!.avatar_visible = 0
     const hiddenAvatarResponse = await invoke(
       sessionsGet,
-      new Request('https://spool.pro/api/discovery/v1/sessions?sort=recent'),
+      new Request('https://spool.new/api/discovery/v1/sessions?sort=recent'),
       env,
     )
     const hiddenAvatarBody = (await hiddenAvatarResponse.json()) as {
@@ -281,7 +281,7 @@ describe('GET /api/discovery/v1/sessions', () => {
 
     const recommended = await invoke(
       sessionsGet,
-      new Request('https://spool.pro/api/discovery/v1/sessions?sort=recommended'),
+      new Request('https://spool.new/api/discovery/v1/sessions?sort=recommended'),
       env,
     )
     const recommendedItems = (await recommended.json()) as { items: Array<{ sid: string }> }
@@ -289,7 +289,7 @@ describe('GET /api/discovery/v1/sessions', () => {
 
     const search = await invoke(
       sessionsGet,
-      new Request('https://spool.pro/api/discovery/v1/sessions?q=refresh%20tokens&sort=trending'),
+      new Request('https://spool.new/api/discovery/v1/sessions?q=refresh%20tokens&sort=trending'),
       env,
     )
     const searchItems = (await search.json()) as { items: Array<{ sid: string }> }
@@ -304,7 +304,7 @@ describe('GET /api/discovery/v1/sessions', () => {
 
     const first = await invoke(
       sessionsGet,
-      new Request('https://spool.pro/api/discovery/v1/sessions?sort=recent&limit=1'),
+      new Request('https://spool.new/api/discovery/v1/sessions?sort=recent&limit=1'),
       env,
     )
     const firstBody = (await first.json()) as {
@@ -317,7 +317,7 @@ describe('GET /api/discovery/v1/sessions', () => {
     const second = await invoke(
       sessionsGet,
       new Request(
-        `https://spool.pro/api/discovery/v1/sessions?sort=recent&limit=1&cursor=${firstBody.nextCursor}`,
+        `https://spool.new/api/discovery/v1/sessions?sort=recent&limit=1&cursor=${firstBody.nextCursor}`,
       ),
       env,
     )
@@ -329,12 +329,12 @@ describe('GET /api/discovery/v1/sessions', () => {
     expect(secondBody.nextCursor).toBeNull()
 
     const invalidUrls = [
-      'https://spool.pro/api/discovery/v1/sessions?q=',
-      'https://spool.pro/api/discovery/v1/sessions?sort=popular',
-      'https://spool.pro/api/discovery/v1/sessions?agent=gemini',
-      'https://spool.pro/api/discovery/v1/sessions?limit=0',
-      'https://spool.pro/api/discovery/v1/sessions?cursor=not.valid',
-      `https://spool.pro/api/discovery/v1/sessions?sort=trending&cursor=${firstBody.nextCursor}`,
+      'https://spool.new/api/discovery/v1/sessions?q=',
+      'https://spool.new/api/discovery/v1/sessions?sort=popular',
+      'https://spool.new/api/discovery/v1/sessions?agent=gemini',
+      'https://spool.new/api/discovery/v1/sessions?limit=0',
+      'https://spool.new/api/discovery/v1/sessions?cursor=not.valid',
+      `https://spool.new/api/discovery/v1/sessions?sort=trending&cursor=${firstBody.nextCursor}`,
     ]
     for (const url of invalidUrls) {
       const response = await invoke(sessionsGet, new Request(url), env)
@@ -357,7 +357,7 @@ describe('GET /api/discovery/v1/sessions', () => {
 
     const response = await invoke(
       sessionsGet,
-      new Request('https://spool.pro/api/discovery/v1/sessions?q=maya&agent=claude'),
+      new Request('https://spool.new/api/discovery/v1/sessions?q=maya&agent=claude'),
       env,
     )
     const body = (await response.json()) as { items: Array<{ sid: string }> }
@@ -365,7 +365,7 @@ describe('GET /api/discovery/v1/sessions', () => {
 
     const none = await invoke(
       sessionsGet,
-      new Request('https://spool.pro/api/discovery/v1/sessions?q=does-not-match'),
+      new Request('https://spool.new/api/discovery/v1/sessions?q=does-not-match'),
       env,
     )
     await expect(none.json()).resolves.toMatchObject({ items: [] })

--- a/apps/backend/tests/endpoints.test.ts
+++ b/apps/backend/tests/endpoints.test.ts
@@ -48,21 +48,21 @@ afterEach(() => {
 describe('GET /api/auth/workos/callback — plumbing edges', () => {
   it('400 when code or state query params are missing', async () => {
     const env = envFor()
-    const req = new Request('https://spool.pro/api/auth/workos/callback?code=abc')
+    const req = new Request('https://spool.new/api/auth/workos/callback?code=abc')
     const res = await invoke(callbackGet, req, env, { provider: 'workos' })
     expect(res.status).toBe(400)
   })
 
   it('400 when state cookie is absent', async () => {
     const env = envFor()
-    const req = new Request('https://spool.pro/api/auth/workos/callback?code=abc&state=xyz')
+    const req = new Request('https://spool.new/api/auth/workos/callback?code=abc&state=xyz')
     const res = await invoke(callbackGet, req, env, { provider: 'workos' })
     expect(res.status).toBe(400)
   })
 
   it('403 when state cookie does not match query state', async () => {
     const env = envFor()
-    const req = new Request('https://spool.pro/api/auth/workos/callback?code=abc&state=fromUrl', {
+    const req = new Request('https://spool.new/api/auth/workos/callback?code=abc&state=fromUrl', {
       headers: {
         cookie: '__spool_oauth_state=otherState|/; __spool_oauth_verifier=v',
       },
@@ -82,7 +82,7 @@ describe('GET /api/auth/workos/callback — plumbing edges', () => {
     await env.RATE.put(`rate/oauth-callback/8.8.8.8/${slot}`, String(RATE_MAX), {
       expirationTtl: RATE_WINDOW_SEC * 2,
     })
-    const req = new Request('https://spool.pro/api/auth/workos/callback?code=abc&state=xyz', {
+    const req = new Request('https://spool.new/api/auth/workos/callback?code=abc&state=xyz', {
       headers: { 'CF-Connecting-IP': '8.8.8.8' },
     })
     const res = await invoke(callbackGet, req, env, { provider: 'workos' })
@@ -94,7 +94,7 @@ describe('GET /api/auth/workos/callback — plumbing edges', () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response('{"error":"invalid_grant"}', { status: 400 }),
     )
-    const req = new Request('https://spool.pro/api/auth/workos/callback?code=bad&state=S', {
+    const req = new Request('https://spool.new/api/auth/workos/callback?code=bad&state=S', {
       headers: { cookie: '__spool_oauth_state=S|/me; __spool_oauth_verifier=v' },
     })
     const res = await invoke(callbackGet, req, env, { provider: 'workos' })
@@ -114,7 +114,7 @@ describe('GET /api/auth/workos/callback — plumbing edges', () => {
       if (!res) throw new Error(`unexpected fetch: ${String(input)}`)
       return res
     })
-    const req = new Request('https://spool.pro/api/auth/workos/callback?code=c&state=S', {
+    const req = new Request('https://spool.new/api/auth/workos/callback?code=c&state=S', {
       headers: {
         cookie: '__spool_oauth_state=S|/me%E3%80%82%E8%BF%99%E6%AC%A1; __spool_oauth_verifier=v',
       },
@@ -164,7 +164,7 @@ describe('POST /api/auth/sign-out', () => {
 describe('start endpoint', () => {
   it('redirects to AuthKit and sets both oauth cookies', async () => {
     const env = envFor()
-    const req = new Request('https://spool.pro/api/auth/workos/start?next=/me')
+    const req = new Request('https://spool.new/api/auth/workos/start?next=/me')
     const res = await invoke(startGet, req, env, { provider: 'workos' })
     expect(res.status).toBe(302)
     const loc = res.headers.get('location') ?? ''
@@ -177,7 +177,7 @@ describe('start endpoint', () => {
 
   it('coerces an unsafe next param back to /', async () => {
     const env = envFor()
-    const req = new Request('https://spool.pro/api/auth/workos/start?next=//evil.example.com')
+    const req = new Request('https://spool.new/api/auth/workos/start?next=//evil.example.com')
     const res = await invoke(startGet, req, env, { provider: 'workos' })
     const stateCookie = getSetCookies(res).find((c) => c.includes('__spool_oauth_state=')) ?? ''
     // The cookie value is `${state}|${next}`. Ensure the next half is `/`.
@@ -187,7 +187,7 @@ describe('start endpoint', () => {
   it('404s on an unknown provider (no scanner enumeration)', async () => {
     const env = envFor()
     for (const provider of ['github', 'google']) {
-      const req = new Request(`https://spool.pro/api/auth/${provider}/start`)
+      const req = new Request(`https://spool.new/api/auth/${provider}/start`)
       const res = await invoke(startGet, req, env, { provider })
       expect(res.status).toBe(404)
     }
@@ -196,7 +196,7 @@ describe('start endpoint', () => {
   it('callback 404s on an unknown provider', async () => {
     const env = envFor()
     for (const provider of ['github', 'google']) {
-      const req = new Request(`https://spool.pro/api/auth/${provider}/callback?code=x&state=y`)
+      const req = new Request(`https://spool.new/api/auth/${provider}/callback?code=x&state=y`)
       const res = await invoke(callbackGet, req, env, { provider })
       expect(res.status).toBe(404)
     }

--- a/apps/backend/tests/health.test.ts
+++ b/apps/backend/tests/health.test.ts
@@ -23,7 +23,7 @@ async function runWithMiddleware(
 
 describe('GET /api/health', () => {
   it('returns 200 + ok + version + time and the global security headers', async () => {
-    const r = await runWithMiddleware(new Request('https://spool.pro/api/health'))
+    const r = await runWithMiddleware(new Request('https://spool.new/api/health'))
     expect(r.status).toBe(200)
     expect(r.headers.get('x-robots-tag')).toBe('noindex')
     expect(r.headers.get('x-content-type-options')).toBe('nosniff')
@@ -37,7 +37,7 @@ describe('GET /api/health', () => {
   })
 
   it('surfaces BUILD_VERSION when set by the deploy', async () => {
-    const r = await runWithMiddleware(new Request('https://spool.pro/api/health'), {
+    const r = await runWithMiddleware(new Request('https://spool.new/api/health'), {
       BUILD_VERSION: 'abc1234',
     })
     const body = (await r.json()) as { version: string }

--- a/apps/backend/tests/native-signin.test.ts
+++ b/apps/backend/tests/native-signin.test.ts
@@ -25,7 +25,7 @@ function envFor(dbState?: FakeDbState) {
 }
 
 function request(body: unknown): Request {
-  return new Request('https://spool.pro/api/auth/sign-in-with-code', {
+  return new Request('https://spool.new/api/auth/sign-in-with-code', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
@@ -156,7 +156,7 @@ describe('POST /api/auth/sign-in-with-code', () => {
     await env.RATE.put(`rate/signin/9.9.9.9/${slot}`, String(SIGNIN_RATE_MAX), {
       expirationTtl: SIGNIN_RATE_WINDOW_SEC * 2,
     })
-    const req = new Request('https://spool.pro/api/auth/sign-in-with-code', {
+    const req = new Request('https://spool.new/api/auth/sign-in-with-code', {
       method: 'POST',
       headers: { 'content-type': 'application/json', 'cf-connecting-ip': '9.9.9.9' },
       body: JSON.stringify({ provider: 'workos', code: 'c', code_verifier: 'v' }),

--- a/apps/backend/tests/og.test.ts
+++ b/apps/backend/tests/og.test.ts
@@ -224,6 +224,20 @@ describe('renderOgPng', () => {
     expect(html).toMatch(/<\/div>$/)
     expect(html.match(/<div /g)?.length).toBe(4)
   })
+
+  it('uses the Paperboy blue and void light palette', async () => {
+    const { buildOgHtml } = await import('../src/publish/og')
+    const html = buildOgHtml({
+      conversation: { title: 'hello' },
+      publish: { published_at: new Date().toISOString() },
+      editor_opts: { template: 'forum', paper: 'cream', colorway: 'amber' },
+    })
+
+    expect(html).toContain('background:#FFFFFF')
+    expect(html).toContain('color:#1387FF')
+    expect(html).toContain('font-family:Geist')
+    expect(html).not.toMatch(/#C85A00|#141410|font-family:Inter/)
+  })
 })
 
 describe('GET /api/og/[id].png', () => {

--- a/apps/backend/tests/pentest.sh
+++ b/apps/backend/tests/pentest.sh
@@ -3,7 +3,7 @@
 # NOT run in CI. Run it before flipping a prod deploy. Set TARGET to the
 # base URL (no trailing slash):
 #
-#   TARGET=https://staging.spool.pro ./tests/pentest.sh
+#   TARGET=https://staging.spool.new ./tests/pentest.sh
 #
 # Exits non-zero if any required check fails.
 

--- a/apps/backend/tests/public-url.test.ts
+++ b/apps/backend/tests/public-url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test'
 
-import { publicBaseUrl } from '../src/public-url'
+import { oauthPublicBaseUrl, publicBaseUrl } from '../src/public-url'
 
 describe('publicBaseUrl', () => {
   it('uses the local Web origin for the checked-in development environment', () => {
@@ -12,5 +12,28 @@ describe('publicBaseUrl', () => {
       'https://staging.spool.new',
     )
     expect(publicBaseUrl({ ENV: 'production' })).toBe('https://spool.new')
+  })
+})
+
+describe('oauthPublicBaseUrl', () => {
+  it.each(['spool.new', 'spool.pro'])(
+    'keeps OAuth callbacks on the owned start host %s',
+    (host) => {
+      const request = new Request('https://spool-share-backend.pages.dev/api/auth/workos/start', {
+        headers: { 'x-forwarded-host': host },
+      })
+      expect(oauthPublicBaseUrl(request, { PUBLIC_BASE_URL: 'https://spool.new' })).toBe(
+        `https://${host}`,
+      )
+    },
+  )
+
+  it('ignores untrusted forwarded hosts and falls back to the configured origin', () => {
+    const request = new Request('https://spool-share-backend.pages.dev/api/auth/workos/start', {
+      headers: { 'x-forwarded-host': 'attacker.example' },
+    })
+    expect(oauthPublicBaseUrl(request, { PUBLIC_BASE_URL: 'https://spool.new' })).toBe(
+      'https://spool.new',
+    )
   })
 })

--- a/apps/backend/tests/public-url.test.ts
+++ b/apps/backend/tests/public-url.test.ts
@@ -8,9 +8,9 @@ describe('publicBaseUrl', () => {
   })
 
   it('keeps explicit deployment origins and the production fallback', () => {
-    expect(publicBaseUrl({ ENV: 'staging', PUBLIC_BASE_URL: 'https://staging.spool.pro' })).toBe(
-      'https://staging.spool.pro',
+    expect(publicBaseUrl({ ENV: 'staging', PUBLIC_BASE_URL: 'https://staging.spool.new' })).toBe(
+      'https://staging.spool.new',
     )
-    expect(publicBaseUrl({ ENV: 'production' })).toBe('https://spool.pro')
+    expect(publicBaseUrl({ ENV: 'production' })).toBe('https://spool.new')
   })
 })

--- a/apps/backend/tests/publish.test.ts
+++ b/apps/backend/tests/publish.test.ts
@@ -431,7 +431,7 @@ describe('POST /api/publish', () => {
     const body = (await res.json()) as { id: string; version: number; url: string }
     expect(isValidSlug(body.id)).toBe(true)
     expect(body.version).toBe(1)
-    expect(body.url).toBe(`https://spool.pro/s/${body.id}`)
+    expect(body.url).toBe(`https://spool.new/s/${body.id}`)
 
     expect(env._snapshots.has(`${body.id}.json`)).toBe(true)
     const metaRaw = await env.META.get(`meta/${body.id}`)

--- a/apps/backend/tests/router-routes.test.ts
+++ b/apps/backend/tests/router-routes.test.ts
@@ -1,4 +1,4 @@
-// Route-table guard for the spool.pro entry Worker (same cross-package
+// Route-table guard for the spool.new entry Worker (same cross-package
 // pattern as deletion-worker-deploy.test.ts). /api/* goes to the Pages
 // backend; marketing, docs, readers, and account pages stay in apps/web.
 

--- a/apps/backend/tests/share-visibility.test.ts
+++ b/apps/backend/tests/share-visibility.test.ts
@@ -72,7 +72,7 @@ function patchReq(id: string, body: unknown, token: string | null = TOKEN): Requ
     'CF-Connecting-IP': '1.2.3.4',
   }
   if (token) headers['authorization'] = `Bearer ${token}`
-  return new Request(`https://spool.pro/api/me/shares/${id}`, {
+  return new Request(`https://spool.new/api/me/shares/${id}`, {
     method: 'PATCH',
     headers,
     body: typeof body === 'string' ? body : JSON.stringify(body),

--- a/apps/backend/tests/workos.test.ts
+++ b/apps/backend/tests/workos.test.ts
@@ -43,7 +43,7 @@ describe('workosProvider.buildAuthRequestUrl', () => {
         {
           state: 'S1',
           codeChallenge: 'unused-challenge',
-          redirectUri: 'https://spool.pro/api/auth/workos/callback',
+          redirectUri: 'https://spool.new/api/auth/workos/callback',
         },
         ENV,
       ),
@@ -53,7 +53,7 @@ describe('workosProvider.buildAuthRequestUrl', () => {
     expect(url.searchParams.get('provider')).toBe('authkit')
     expect(url.searchParams.get('response_type')).toBe('code')
     expect(url.searchParams.get('state')).toBe('S1')
-    expect(url.searchParams.get('redirect_uri')).toBe('https://spool.pro/api/auth/workos/callback')
+    expect(url.searchParams.get('redirect_uri')).toBe('https://spool.new/api/auth/workos/callback')
     // Confidential client: the PKCE challenge from /start must NOT be
     // forwarded — WorkOS rejects mixing code_challenge with client_secret.
     expect(url.searchParams.get('code_challenge')).toBeNull()
@@ -259,11 +259,11 @@ describe('workos web flow endpoints', () => {
   }
 
   it('returns a structured error instead of throwing when WorkOS is not configured', async () => {
-    const req = new Request('https://spool.pro/api/auth/workos/start?next=/me')
+    const req = new Request('https://spool.new/api/auth/workos/start?next=/me')
     const res = await invoke(
       startGet,
       req,
-      { PUBLIC_BASE_URL: 'https://spool.pro' },
+      { PUBLIC_BASE_URL: 'https://spool.new' },
       { provider: 'workos' },
     )
 
@@ -277,7 +277,7 @@ describe('workos web flow endpoints', () => {
 
   it('start 302s to AuthKit with state + next baked into cookies', async () => {
     const env = envFor()
-    const req = new Request('https://spool.pro/api/auth/workos/start?next=/me')
+    const req = new Request('https://spool.new/api/auth/workos/start?next=/me')
     const res = await invoke(startGet, req, env, { provider: 'workos' })
     expect(res.status).toBe(302)
     const loc = new URL(res.headers.get('location') ?? '')
@@ -318,7 +318,7 @@ describe('workos web flow endpoints', () => {
       throw new Error(`unexpected fetch: ${url}`)
     })
 
-    const req = new Request('https://spool.pro/api/auth/workos/callback?code=goodcode&state=S', {
+    const req = new Request('https://spool.new/api/auth/workos/callback?code=goodcode&state=S', {
       headers: {
         cookie: '__spool_oauth_state=S|/me; __spool_oauth_verifier=v',
       },
@@ -348,7 +348,7 @@ describe('workos web flow endpoints', () => {
       }
       return jsonResponse({}, 500)
     })
-    const req = new Request('https://spool.pro/api/auth/workos/callback?code=c&state=S', {
+    const req = new Request('https://spool.new/api/auth/workos/callback?code=c&state=S', {
       headers: {
         cookie: '__spool_oauth_state=S|/me; __spool_oauth_verifier=v',
       },

--- a/apps/backend/wrangler.prod.toml
+++ b/apps/backend/wrangler.prod.toml
@@ -1,14 +1,8 @@
 # Production Pages deployment config with concrete resource identifiers.
 # Resource ids are not credentials; Wrangler authentication remains external.
 # Wrangler ≥4.9x refuses config-based Pages deploys without ids.
-# Deploy by temporarily swapping this in as wrangler.toml (Pages rejects
-# --config custom paths):
-#   mv wrangler.toml wrangler.toml.checked-in
-#   cp wrangler.prod.toml wrangler.toml
-#   wrangler pages deploy public
-#   mv -f wrangler.toml.checked-in wrangler.toml
-# PUBLIC_BASE_URL is deliberately unset in prod (code defaults to
-# https://spool.pro).
+# `pnpm run deploy:prod` selects this file through Wrangler's ephemeral
+# deploy-config redirect; the checked-in local wrangler.toml is never replaced.
 name = "spool-share-backend"
 pages_build_output_dir = "public"
 compatibility_date = "2026-05-01"
@@ -54,4 +48,5 @@ bucket_name = "spool-hub"
 
 [vars]
 ENV = "production"
+PUBLIC_BASE_URL = "https://spool.new"
 ABUSE_NOTIFY_EMAIL = "abuse@spool.pro"

--- a/apps/backend/wrangler.staging.toml
+++ b/apps/backend/wrangler.staging.toml
@@ -1,9 +1,8 @@
 # Staging Pages deployment config with concrete resource identifiers.
 # Resource ids are not credentials; Wrangler authentication remains external.
 # Wrangler ≥4.9x refuses config-based Pages deploys without ids, so
-# `pnpm run deploy:staging` can no longer ride the id-less wrangler.toml.
-# Deploy with:
-#   wrangler pages deploy public --config wrangler.staging.toml
+# `pnpm run deploy:staging` selects this file through Wrangler's ephemeral
+# deploy-config redirect; the checked-in local wrangler.toml is never replaced.
 name = "spool-share-backend-staging"
 pages_build_output_dir = "public"
 compatibility_date = "2026-05-01"
@@ -49,5 +48,5 @@ bucket_name = "spool-hub-staging"
 
 [vars]
 ENV = "staging"
-PUBLIC_BASE_URL = "https://staging.spool.pro"
+PUBLIC_BASE_URL = "https://staging.spool.new"
 ABUSE_NOTIFY_EMAIL = "abuse@spool.pro"

--- a/apps/backend/wrangler.toml
+++ b/apps/backend/wrangler.toml
@@ -71,7 +71,7 @@ ENV = "development"
 # Secrets (set ONCE per environment via wrangler — never commit):
 #   wrangler pages secret put WORKOS_CLIENT_ID         --project-name spool-share-backend
 #       (WorkOS AuthKit environment client id — web sign-in via /api/auth/workos/*;
-#        register https://spool.pro/api/auth/workos/callback as a redirect URI
+#        register https://spool.new/api/auth/workos/callback as a redirect URI
 #        in the WorkOS dashboard)
 #   wrangler pages secret put WORKOS_API_KEY           --project-name spool-share-backend
 #       (doubles as the OAuth client_secret and the identities-API Bearer key)

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,6 +1,6 @@
 # @spool-lab/cli
 
-CLI for publishing, reading, resuming, and managing agent Sessions with [Spool](https://spool.pro).
+CLI for publishing, reading, resuming, and managing agent Sessions with [Spool](https://spool.new).
 
 ## Run
 

--- a/apps/cli/src/commands/hub.test.ts
+++ b/apps/cli/src/commands/hub.test.ts
@@ -64,7 +64,7 @@ describe('login command handler', () => {
           JSON.stringify({
             device_code: 'dev-secret',
             user_code: 'XKCD-2941',
-            verification_uri: 'https://spool.pro/cli-auth?code=XKCD-2941',
+            verification_uri: 'https://spool.new/cli-auth?code=XKCD-2941',
             expires_in: 900,
             interval: 3,
           }),
@@ -101,10 +101,10 @@ describe('login command handler', () => {
     ).resolves.toBe(0)
 
     expect(JSON.parse(readFileSync(join(home, '.spool', 'hub-credentials.json'), 'utf8'))).toEqual({
-      hubUrl: 'https://spool.pro',
+      hubUrl: 'https://spool.new',
       token: 'sph_browser',
     })
-    expect(opened).toEqual(['https://spool.pro/cli-auth?code=XKCD-2941'])
+    expect(opened).toEqual(['https://spool.new/cli-auth?code=XKCD-2941'])
     expect(output[0]).toContain('XKCD-2941')
     // The start call carries the approval-page label.
     const startCall = fetchMock.mock.calls.find(([u]) => String(u).endsWith('/api/cli-auth/start'))!
@@ -123,7 +123,7 @@ describe('login command handler', () => {
           JSON.stringify({
             device_code: 'dev-secret',
             user_code: 'XKCD-2941',
-            verification_uri: 'https://spool.pro/cli-auth?code=XKCD-2941',
+            verification_uri: 'https://spool.new/cli-auth?code=XKCD-2941',
             expires_in: 900,
             interval: 3,
           }),
@@ -166,7 +166,7 @@ describe('login command handler', () => {
           JSON.stringify({
             device_code: 'dev-secret',
             user_code: 'XKCD-2941',
-            verification_uri: 'https://spool.pro/cli-auth?code=XKCD-2941',
+            verification_uri: 'https://spool.new/cli-auth?code=XKCD-2941',
             expires_in: 0, // deadline already passed → zero poll iterations
             interval: 3,
           }),
@@ -360,7 +360,7 @@ describe('withdraw command handler', () => {
     [410, `Session already withdrawn: ${SID}`],
   ])('prints a friendly HTTP %s error', async (status, expected) => {
     const home = tempHome()
-    saveHubCredentials({ hubUrl: 'https://spool.pro', token: 'owner-token' }, { homeDir: home })
+    saveHubCredentials({ hubUrl: 'https://spool.new', token: 'owner-token' }, { homeDir: home })
     const errors: string[] = []
     const fetchMock = vi.fn(async () => Response.json({ message: 'server detail' }, { status }))
 

--- a/apps/cli/src/hub/client.test.ts
+++ b/apps/cli/src/hub/client.test.ts
@@ -63,7 +63,7 @@ describe('HubClient', () => {
   it('uploads object batches as NDJSON', async () => {
     const fetchMock = vi.fn(async () => Response.json({ stored: 2 }))
     const client = new HubClient({
-      hubUrl: 'https://spool.pro',
+      hubUrl: 'https://spool.new',
       token: 'token',
       fetch: fetchMock as typeof fetch,
     })
@@ -76,7 +76,7 @@ describe('HubClient', () => {
     ).resolves.toEqual({ stored: 2 })
 
     const [input, init] = fetchMock.mock.calls[0]!
-    expect(String(input)).toBe('https://spool.pro/api/hub/v1/objects/batch')
+    expect(String(input)).toBe('https://spool.new/api/hub/v1/objects/batch')
     expect(init?.body).toBe(
       '{"oid":"oid-a","data":"{\\"a\\":1}"}\n' + '{"oid":"oid-b","data":"{\\"b\\":2}"}\n',
     )
@@ -94,7 +94,7 @@ describe('HubClient', () => {
     })
     const fetchMock = vi.fn(async () => new Response(body, { status: 200 }))
     const client = new HubClient({
-      hubUrl: 'https://spool.pro',
+      hubUrl: 'https://spool.new',
       fetch: fetchMock as typeof fetch,
     })
 
@@ -108,20 +108,20 @@ describe('HubClient', () => {
       { i: 1, oid: 'b', data: 'two' },
     ])
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
-      `https://spool.pro/api/hub/v1/sessions/${SID}/records?from=0&to=2`,
+      `https://spool.new/api/hub/v1/sessions/${SID}/records?from=0&to=2`,
     )
   })
 
   it('POSTs to the contract token endpoint without requiring a request body', async () => {
     const fetchMock = vi.fn(async () => Response.json({ token: 'new-token' }))
     const client = new HubClient({
-      hubUrl: 'https://spool.pro',
+      hubUrl: 'https://spool.new',
       fetch: fetchMock as typeof fetch,
     })
 
     await expect(client.createToken()).resolves.toEqual({ token: 'new-token' })
     const [input, init] = fetchMock.mock.calls[0]!
-    expect(String(input)).toBe('https://spool.pro/api/hub/v1/tokens')
+    expect(String(input)).toBe('https://spool.new/api/hub/v1/tokens')
     expect(init).toMatchObject({ method: 'POST' })
     expect(init?.body).toBeUndefined()
   })
@@ -135,7 +135,7 @@ describe('HubClient', () => {
       async () => new Response(typeof body === 'string' ? body : JSON.stringify(body), { status }),
     )
     const client = new HubClient({
-      hubUrl: 'https://spool.pro',
+      hubUrl: 'https://spool.new',
       token: 'bad-token',
       fetch: fetchMock as typeof fetch,
     })

--- a/apps/cli/src/hub/credentials.test.ts
+++ b/apps/cli/src/hub/credentials.test.ts
@@ -79,6 +79,7 @@ describe('hub credentials', () => {
   it('uses the production hub URL when no credentials exist', () => {
     const home = tempHome()
 
+    expect(DEFAULT_HUB_URL).toBe('https://spool.new')
     expect(hubCredentialsPath({ homeDir: home })).toBe(join(home, '.spool', 'hub-credentials.json'))
     expect(loadHubCredentials({ homeDir: home, env: {} })).toEqual({
       hubUrl: DEFAULT_HUB_URL,

--- a/apps/cli/src/hub/credentials.ts
+++ b/apps/cli/src/hub/credentials.ts
@@ -2,7 +2,7 @@ import { chmodSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'n
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 
-export const DEFAULT_HUB_URL = 'https://spool.pro'
+export const DEFAULT_HUB_URL = 'https://spool.new'
 
 export interface StoredHubCredentials {
   hubUrl: string

--- a/apps/cli/src/hub/redact-gate.ts
+++ b/apps/cli/src/hub/redact-gate.ts
@@ -34,6 +34,6 @@ export function formatRedactSummary(summary: RedactGateSummary): string {
   for (const [kind, count] of summary.byKind.slice(0, 10)) {
     lines.push(`  - ${kind}: ${count}`)
   }
-  lines.push('Sharing sends the full transcript, including these values, to spool.pro.')
+  lines.push('Sharing sends the full transcript, including these values, to spool.new.')
   return lines.join('\n')
 }

--- a/apps/cli/src/hub/ref.test.ts
+++ b/apps/cli/src/hub/ref.test.ts
@@ -16,8 +16,8 @@ describe('resolveSessionRef', () => {
     ],
     [
       'share URL',
-      `https://spool.pro/session/${CLAUDE_SID}`,
-      { sid: CLAUDE_SID, provider: 'claude', hubUrl: 'https://spool.pro' },
+      `https://spool.new/session/${CLAUDE_SID}`,
+      { sid: CLAUDE_SID, provider: 'claude', hubUrl: 'https://spool.new' },
     ],
     [
       'share URL with position',
@@ -29,6 +29,14 @@ describe('resolveSessionRef', () => {
     expect(resolveSessionRef(input)).toEqual(expected)
   })
 
+  it('keeps legacy spool.pro Session URLs resumable', () => {
+    expect(resolveSessionRef(`https://spool.pro/session/${CLAUDE_SID}`)).toEqual({
+      sid: CLAUDE_SID,
+      provider: 'claude',
+      hubUrl: 'https://spool.pro',
+    })
+  })
+
   it.each([
     '',
     '11111111-2222-4333-8444-555555555555',
@@ -36,10 +44,10 @@ describe('resolveSessionRef', () => {
     'claude_not!a!uuid',
     `${CLAUDE_SID}@-1`,
     `${CLAUDE_SID}@1.5`,
-    `http://spool.pro/session/${CLAUDE_SID}`,
-    `https://spool.pro/s/${CLAUDE_SID}`,
-    `https://spool.pro/session/${CLAUDE_SID}?position=1`,
-    `https://spool.pro/session/${CLAUDE_SID}/extra`,
+    `http://spool.new/session/${CLAUDE_SID}`,
+    `https://spool.new/s/${CLAUDE_SID}`,
+    `https://spool.new/session/${CLAUDE_SID}?position=1`,
+    `https://spool.new/session/${CLAUDE_SID}/extra`,
   ])('rejects bad input: %s', (input) => {
     expect(() => resolveSessionRef(input)).toThrow('Invalid session reference')
   })

--- a/apps/cli/src/hub/share-pipeline.test.ts
+++ b/apps/cli/src/hub/share-pipeline.test.ts
@@ -178,7 +178,7 @@ describe('prepareShare', () => {
 
 describe('materialize → share lineage round-trip', () => {
   const birth: BirthPayload = {
-    source: { sid: 'claude_abc-123', position: 4, url: 'https://spool.pro/session/claude_abc-123' },
+    source: { sid: 'claude_abc-123', position: 4, url: 'https://spool.new/session/claude_abc-123' },
   }
 
   it('materializes with rewritten sessionId, restored paths, and one birth record', async () => {

--- a/apps/cli/vite.config.ts
+++ b/apps/cli/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
       build: {
         command: 'pnpm run clean && tsc && chmod +x bin/spool.js',
         input: [{ auto: true }, '!dist/**', '!node_modules/**'],
+        output: ['dist/**'],
       },
     },
   },

--- a/apps/web/public/install-daemon.sh
+++ b/apps/web/public/install-daemon.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Spool Daemon installer — downloads the latest release and installs to /Applications
-# Usage: curl -fsSL https://spool.pro/install-daemon.sh | bash
+# Usage: curl -fsSL https://spool.new/install-daemon.sh | bash
 
 REPO="spool-lab/spool-daemon"
 APP_NAME="Spool Daemon.app"

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Spool installer — downloads the latest release and installs to /Applications
-# Usage: curl -fsSL https://spool.pro/install.sh | bash
+# Usage: curl -fsSL https://spool.new/install.sh | bash
 
 REPO="spool-lab/spool"
 APP_NAME="Spool.app"

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://spool.pro/sitemap-index.xml
+Sitemap: https://spool.new/sitemap-index.xml

--- a/apps/web/src/components/Chrome.tsx
+++ b/apps/web/src/components/Chrome.tsx
@@ -1,4 +1,4 @@
-// Shared chrome composition for the spool.pro share-web pages. All five
+// Shared chrome composition for the spool.new share-web pages. All five
 // routes (Reader, Tombstone, Profile, Me, SignIn) compose Page + Header
 // + Footer here while reusable visual primitives come from @spool-lab/ui.
 //

--- a/apps/web/src/components/session/cli-resume-dialog.tsx
+++ b/apps/web/src/components/session/cli-resume-dialog.tsx
@@ -65,7 +65,7 @@ export function CliResumeDialog({ open, resumeCommand, onClose }: Props) {
 
   return (
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center overflow-y-auto bg-[rgba(20,20,16,0.48)] p-4 [[data-theme=dark]_&]:bg-[rgba(20,20,16,0.72)]"
+      className="fixed inset-0 z-[100] flex items-center justify-center overflow-y-auto bg-black/50 p-4 [[data-theme=dark]_&]:bg-black/75"
       role="dialog"
       aria-modal="true"
       aria-labelledby="cli-resume-title"

--- a/apps/web/src/components/session/route-map.test.tsx
+++ b/apps/web/src/components/session/route-map.test.tsx
@@ -1,0 +1,106 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vite-plus/test'
+
+import type { SessionRoute } from '../../lib/session-route'
+import { SessionRouteMap } from './route-map'
+
+const route: SessionRoute = {
+  goal: 'Make the public Session route understandable on every device',
+  phases: [
+    {
+      recordIndex: 12,
+      timestamp: '2026-07-22T07:00:00.000Z',
+      isPrompt: true,
+      label: 'Inspect the existing reader',
+      tools: 3,
+      edits: 0,
+      commands: 1,
+      agents: 0,
+      errors: 0,
+      checkRuns: 0,
+      checkFails: 0,
+    },
+    {
+      recordIndex: 28,
+      timestamp: '2026-07-22T07:15:00.000Z',
+      isPrompt: true,
+      label: 'Adapt the map for touch and keyboard input',
+      tools: 5,
+      edits: 2,
+      commands: 1,
+      agents: 1,
+      errors: 1,
+      checkRuns: 1,
+      checkFails: 1,
+    },
+  ],
+  totalErrors: 2,
+  prUrl: 'https://github.com/paperboytm/spool/pull/99',
+  prLabel: 'PR #99 · paperboytm/spool',
+}
+
+function render(): string {
+  return renderToStaticMarkup(<SessionRouteMap route={route} onJump={vi.fn()} />)
+}
+
+describe('SessionRouteMap', () => {
+  it('labels the route and preserves its full goal on narrow layouts', () => {
+    const html = render()
+
+    expect(html).toContain('aria-labelledby="session-route-title"')
+    expect(html).toContain('id="session-route-title"')
+    expect(html).toContain(route.goal)
+    expect(html).toContain('break-words')
+    expect(html).toContain('lg:hidden')
+    expect(html).toContain('hidden overflow-x-auto')
+  })
+
+  it('uses native buttons with on-scale 48px touch targets for every phase', () => {
+    const html = render()
+    const buttons = html.match(/<button\b[^>]*>/g) ?? []
+
+    // Each responsive presentation has one control per phase; CSS exposes only
+    // the presentation matching the active breakpoint.
+    expect(buttons).toHaveLength(route.phases.length * 2)
+    expect(buttons.every((button) => button.includes('type="button"'))).toBe(true)
+    expect(buttons.every((button) => /(?:min-h-12|size-12)/.test(button))).toBe(true)
+    expect(html).toContain('aria-label="Phase 2 of 2: Adapt the map for touch and keyboard input')
+    expect(html).toContain('focus-visible:outline-[var(--accent)]')
+    expect(html).not.toContain('role="button"')
+    expect(html).not.toContain('tabindex="0"')
+  })
+
+  it('keeps route metadata at the design-system type floor', () => {
+    const html = render()
+
+    expect(html).toContain('text-xs')
+    expect(html).toContain('text-[11px]')
+    expect(html).not.toContain('text-[9px]')
+    expect(html).not.toContain('py-2.5')
+    expect(html).toContain('2 dead ends')
+    expect(html).not.toContain('3 dead ends')
+    expect(html).not.toContain('var(--faint)')
+    expect(html).toContain('Outcome: PR #99 · paperboytm/spool')
+  })
+
+  it('renders the pull request as an explicit, safe external link', () => {
+    const html = render()
+    const anchor = html.match(/<a\b[^>]*>/)?.[0]
+
+    expect(anchor).toContain(`href="${route.prUrl}"`)
+    expect(anchor).toContain('target="_blank"')
+    expect(anchor).toMatch(/\brel="[^"]*\bnoopener\b[^"]*"/)
+    expect(anchor).toMatch(/\brel="[^"]*\bnoreferrer\b[^"]*"/)
+    expect(anchor).toContain('min-h-12')
+    expect(html).toContain('(opens in a new tab)')
+  })
+
+  it('does not render an untrusted outcome URL', () => {
+    const html = renderToStaticMarkup(
+      <SessionRouteMap route={{ ...route, prUrl: 'javascript:alert(1)' }} onJump={vi.fn()} />,
+    )
+
+    expect(html).not.toContain('<a')
+    expect(html).not.toContain('javascript:')
+  })
+})

--- a/apps/web/src/components/session/route-map.tsx
+++ b/apps/web/src/components/session/route-map.tsx
@@ -1,0 +1,333 @@
+import { ExternalLink } from 'lucide-react'
+
+/* The Session's route map: the derived trajectory from prompt to
+ * outcome rendered as a winding path — steering prompts are waypoints,
+ * friction (tool errors / failed checks) branches off as dead-end
+ * stubs, and the recorded PR closes the route. Clicking a waypoint
+ * jumps the conversation to that prompt. */
+import type { SessionRoute } from '../../lib/session-route'
+
+const MIN_WIDTH = 640
+const POINT_GAP = 96
+const PAD_X = 64
+const BASE_Y = 96
+const WAVE = 32
+const HEIGHT = 192
+
+interface Point {
+  x: number
+  y: number
+}
+
+function phasePoints(count: number, width: number): Point[] {
+  const usable = width - PAD_X * 2
+  return Array.from({ length: count }, (_, i) => {
+    const t = count === 1 ? 0.5 : i / (count - 1)
+    return {
+      x: PAD_X + t * usable,
+      y: BASE_Y + (i % 2 === 0 ? -WAVE : WAVE) * (count === 1 ? 0 : 1),
+    }
+  })
+}
+
+function routePath(points: Point[]): string {
+  if (points.length === 0) return ''
+  let d = `M${points[0]!.x} ${points[0]!.y}`
+  for (let i = 1; i < points.length; i++) {
+    const a = points[i - 1]!
+    const b = points[i]!
+    const mx = (a.x + b.x) / 2
+    d += ` C${mx} ${a.y} ${mx} ${b.y} ${b.x} ${b.y}`
+  }
+  return d
+}
+
+function countLabel(count: number, singular: string): string {
+  return `${count} ${singular}${count === 1 ? '' : 's'}`
+}
+
+function phaseActivity(phase: SessionRoute['phases'][number]): string[] {
+  return [
+    phase.tools > 0 ? countLabel(phase.tools, 'tool') : null,
+    phase.edits > 0 ? countLabel(phase.edits, 'edit') : null,
+    phase.agents > 0 ? countLabel(phase.agents, 'agent') : null,
+  ].filter((part): part is string => part !== null)
+}
+
+function phaseDeadEnds(phase: SessionRoute['phases'][number]): number {
+  return phase.errors + phase.checkFails
+}
+
+function safePullRequestUrl(value: string | null): string | null {
+  if (value === null) return null
+  try {
+    const url = new URL(value)
+    return url.origin === 'https://github.com' &&
+      /^\/[^/]+\/[^/]+\/pull\/\d+\/?$/.test(url.pathname)
+      ? value
+      : null
+  } catch {
+    return null
+  }
+}
+
+function phaseAccessibleLabel(
+  phase: SessionRoute['phases'][number],
+  index: number,
+  phaseCount: number,
+): string {
+  const details = phaseActivity(phase)
+  const deadEnds = phaseDeadEnds(phase)
+  if (deadEnds > 0) details.push(countLabel(deadEnds, 'dead end'))
+
+  return [
+    `Phase ${index + 1} of ${phaseCount}: ${phase.label}`,
+    details.length > 0 ? details.join(', ') : null,
+    'Jump to this point in the session',
+  ]
+    .filter((part): part is string => part !== null)
+    .join('. ')
+}
+
+export function SessionRouteMap({
+  route,
+  onJump,
+}: {
+  route: SessionRoute
+  onJump: (recordIndex: number) => void
+}) {
+  const { phases } = route
+  const width = Math.max(MIN_WIDTH, phases.length * POINT_GAP + PAD_X * 2)
+  const points = phasePoints(phases.length + 1, width)
+  const outcome = points[points.length - 1]!
+  const path = routePath(points)
+  const prUrl = safePullRequestUrl(route.prUrl)
+
+  return (
+    <section
+      aria-labelledby="session-route-title"
+      className="mb-6 overflow-hidden rounded-[10px] border border-[var(--border)] bg-[var(--card,var(--bg))]"
+    >
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-2 border-b border-[var(--border)] px-4 py-3">
+        <h3
+          id="session-route-title"
+          className="m-0 shrink-0 text-[10px] font-semibold tracking-[0.08em] text-[var(--muted)] uppercase"
+        >
+          Route
+        </h3>
+        {route.goal !== null && (
+          <span className="order-3 w-full min-w-0 font-mono text-[11px] break-words text-[var(--text)] sm:order-none sm:w-auto sm:flex-1 sm:truncate">
+            <span className="font-semibold text-[var(--accent)]">/goal</span> {route.goal}
+          </span>
+        )}
+        <span className="ml-auto shrink-0 font-mono text-[11px] text-[var(--muted)] tabular-nums">
+          {countLabel(phases.length, 'phase')}
+          {route.totalErrors > 0 ? ` · ${countLabel(route.totalErrors, 'dead end')}` : ''}
+        </span>
+      </div>
+
+      <div className="px-3 py-3 lg:hidden">
+        <ol className="m-0 list-none space-y-2 p-0">
+          {phases.map((phase, index) => {
+            const activity = phaseActivity(phase)
+            const deadEnds = phaseDeadEnds(phase)
+            return (
+              <li key={phase.recordIndex}>
+                <button
+                  type="button"
+                  aria-label={phaseAccessibleLabel(phase, index, phases.length)}
+                  onClick={() => onJump(phase.recordIndex)}
+                  className="flex min-h-12 w-full cursor-pointer items-start gap-3 rounded-[6px] border border-[var(--border)] bg-[var(--card)] p-3 text-left transition-colors duration-[80ms] hover:border-[var(--border-strong)] hover:bg-[var(--card-2)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)] active:bg-[var(--accent-bg)]"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="mt-1 size-2 shrink-0 rounded-full border-2 border-[var(--accent)] bg-[var(--bg)]"
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block font-mono text-xs leading-5 break-words text-[var(--text)]">
+                      {phase.label}
+                    </span>
+                    {(activity.length > 0 || deadEnds > 0) && (
+                      <span className="mt-1 block font-mono text-[11px] leading-4 text-[var(--muted)] tabular-nums">
+                        {[...activity, deadEnds > 0 ? countLabel(deadEnds, 'dead end') : null]
+                          .filter((part): part is string => part !== null)
+                          .join(' · ')}
+                      </span>
+                    )}
+                  </span>
+                </button>
+              </li>
+            )
+          })}
+          <li className="flex min-h-12 items-center gap-3 px-3 py-2">
+            <span
+              aria-hidden="true"
+              className="flex size-4 shrink-0 items-center justify-center rounded-full border border-[var(--accent)]"
+            >
+              <span className="size-2 rounded-full bg-[var(--accent)]" />
+            </span>
+            <span className="min-w-0 font-mono text-[11px] leading-4 font-semibold break-words text-[var(--accent)]">
+              {route.prLabel ?? 'Session end'}
+            </span>
+          </li>
+        </ol>
+      </div>
+
+      <div className="hidden lg:block">
+        <span className="sr-only">Outcome: {route.prLabel ?? 'Session end'}</span>
+      </div>
+
+      <div className="hidden overflow-x-auto px-2 py-3 lg:block">
+        <div className="relative w-full" style={{ minWidth: `${width}px` }}>
+          <svg
+            viewBox={`0 0 ${width} ${HEIGHT}`}
+            className="pointer-events-none block h-auto w-full"
+            aria-hidden="true"
+          >
+            {/* route */}
+            <path
+              d={path}
+              fill="none"
+              stroke="color-mix(in srgb, var(--accent) 18%, transparent)"
+              strokeWidth={8}
+              strokeLinecap="round"
+            />
+            <path
+              d={path}
+              fill="none"
+              stroke="var(--accent)"
+              strokeWidth={2}
+              strokeLinecap="round"
+            />
+
+            {phases.map((phase, i) => {
+              const p = points[i]!
+              const above = p.y <= BASE_Y
+              const labelY = above ? p.y - 32 : p.y + 32
+              const metaY = above ? p.y - 16 : p.y + 48
+              const stubY = above ? p.y + 32 : p.y - 32
+              const anchor = p.x < 96 ? 'start' : p.x > width - 96 ? 'end' : 'middle'
+              const anchorX = anchor === 'start' ? p.x - 8 : anchor === 'end' ? p.x + 8 : p.x
+              const meta = phaseActivity(phase).join(' · ')
+              const deadEnds = phaseDeadEnds(phase)
+              return (
+                <g key={phase.recordIndex}>
+                  {deadEnds > 0 && (
+                    <>
+                      <path
+                        d={`M${p.x} ${p.y} C${p.x + 16} ${(p.y + stubY) / 2} ${p.x + 8} ${(p.y + stubY) / 2} ${p.x + 24} ${stubY}`}
+                        fill="none"
+                        stroke="var(--muted)"
+                        strokeWidth={1.6}
+                        strokeDasharray="4 4"
+                      />
+                      <circle
+                        cx={p.x + 24}
+                        cy={stubY}
+                        r={8}
+                        fill="var(--bg)"
+                        stroke="var(--muted)"
+                        strokeWidth={1.6}
+                      />
+                      <path
+                        d={`M${p.x + 21} ${stubY - 3} L${p.x + 27} ${stubY + 3} M${p.x + 27} ${stubY - 3} L${p.x + 21} ${stubY + 3}`}
+                        stroke="var(--muted)"
+                        strokeWidth={1.6}
+                        strokeLinecap="round"
+                      />
+                      <text
+                        x={p.x + 40}
+                        y={stubY + 4}
+                        className="fill-[var(--muted)] font-mono text-[11px]"
+                      >
+                        {deadEnds}
+                      </text>
+                    </>
+                  )}
+                  <circle
+                    cx={p.x}
+                    cy={p.y}
+                    r={6}
+                    fill="var(--bg)"
+                    stroke="var(--accent)"
+                    strokeWidth={2}
+                  />
+                  <text
+                    x={anchorX}
+                    y={labelY}
+                    textAnchor={anchor}
+                    className="fill-[var(--text)] font-mono text-xs"
+                  >
+                    {phase.label.length > 26 ? `${phase.label.slice(0, 25)}…` : phase.label}
+                  </text>
+                  {meta && (
+                    <text
+                      x={anchorX}
+                      y={metaY}
+                      textAnchor={anchor}
+                      className="fill-[var(--muted)] font-mono text-[11px]"
+                    >
+                      {meta}
+                    </text>
+                  )}
+                </g>
+              )
+            })}
+
+            {/* outcome */}
+            <g>
+              <circle
+                cx={outcome.x}
+                cy={outcome.y}
+                r={12}
+                fill="none"
+                stroke="var(--accent)"
+                strokeWidth={1.6}
+                opacity={0.6}
+              />
+              <circle cx={outcome.x} cy={outcome.y} r={6} fill="var(--accent)" />
+              <text
+                x={width - 32}
+                y={outcome.y <= BASE_Y ? outcome.y - 24 : outcome.y + 32}
+                textAnchor="end"
+                className="fill-[var(--accent)] font-mono text-[11px] font-semibold"
+              >
+                {route.prLabel ?? 'Session end'}
+              </text>
+            </g>
+          </svg>
+
+          {phases.map((phase, index) => {
+            const point = points[index]!
+            return (
+              <button
+                key={phase.recordIndex}
+                type="button"
+                title={phase.label}
+                aria-label={phaseAccessibleLabel(phase, index, phases.length)}
+                onClick={() => onJump(phase.recordIndex)}
+                className="absolute size-12 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-[6px] border border-transparent bg-transparent transition-colors duration-[80ms] hover:bg-[var(--accent-weak)] focus-visible:bg-[var(--accent-weak)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)] active:bg-[var(--accent-bg)]"
+                style={{ left: `${(point.x / width) * 100}%`, top: `${(point.y / HEIGHT) * 100}%` }}
+              />
+            )
+          })}
+        </div>
+      </div>
+
+      {prUrl !== null && (
+        <div className="border-t border-[var(--border)] px-4">
+          <a
+            href={prUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex min-h-12 items-center gap-2 font-mono text-[11px] text-[var(--accent)] no-underline hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+          >
+            <span>{route.prLabel ?? 'Open pull request'}</span>
+            <ExternalLink size={12} strokeWidth={1.7} aria-hidden="true" />
+            <span className="sr-only">(opens in a new tab)</span>
+          </a>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/web/src/components/session/workbench.test.ts
+++ b/apps/web/src/components/session/workbench.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from 'vite-plus/test'
 
 import type { HubSessionMeta } from '../../lib/hub-api'
 import type { ParsedConversation } from '../../lib/session-messages'
+import type { SessionRoute } from '../../lib/session-route'
 
 vi.mock('@spool-lab/session-view', () => ({
   MessageList: ({ useWindowScroll }: { useWindowScroll?: boolean }) =>
@@ -253,6 +254,7 @@ function renderWorkbench(
     view?: SessionViewV1 | null
     provider?: SessionProvider
     visibility?: HubSessionMeta['visibility']
+    route?: SessionRoute | null
   } = {},
 ): string {
   return renderToStaticMarkup(
@@ -266,6 +268,7 @@ function renderWorkbench(
       view: options.view === undefined ? view : options.view,
       provider: options.provider ?? 'claude',
       conversation: options.messages ?? conversation,
+      ...(options.route === undefined ? {} : { route: options.route }),
       isDark: false,
       initialRecordIndex: null,
       spoolDocument:
@@ -291,6 +294,69 @@ describe('SessionWorkbench', () => {
     expect(html).toContain('Published full prompt')
     expect(html).toContain('<h1>Purpose</h1>')
     expect(html).not.toContain('>Files<')
+  })
+
+  it('never falls back to raw metadata when a curated title is blank', () => {
+    const document = spoolDocument([{ role: 'user', body: 'Published prompt' }])
+    document.conversation.title = '   '
+    const html = renderWorkbench({
+      spool: document,
+      messages: { ...conversation, title: 'Unpublished private title' },
+    })
+
+    expect(html).toContain('Shared session')
+    expect(html).not.toContain('Unpublished private title')
+  })
+
+  it('renders a projected route for a curated .spool timeline', () => {
+    const html = renderWorkbench({
+      spool: spoolDocument([
+        { role: 'user', body: 'Published first phase' },
+        { role: 'assistant', body: 'Work' },
+        { role: 'user', body: 'Published second phase' },
+      ]),
+      route: {
+        goal: 'Published first phase',
+        phases: [
+          {
+            recordIndex: 2,
+            turnIndex: 0,
+            timestamp: null,
+            isPrompt: true,
+            label: 'Published first phase',
+            tools: 1,
+            edits: 0,
+            commands: 0,
+            agents: 0,
+            errors: 0,
+            checkRuns: 0,
+            checkFails: 0,
+          },
+          {
+            recordIndex: 8,
+            turnIndex: 2,
+            timestamp: null,
+            isPrompt: true,
+            label: 'Published second phase',
+            tools: 2,
+            edits: 1,
+            commands: 0,
+            agents: 0,
+            errors: 0,
+            checkRuns: 0,
+            checkFails: 0,
+          },
+        ],
+        totalErrors: 0,
+        prUrl: null,
+        prLabel: null,
+      },
+    })
+
+    expect(html).toContain('id="session-route-title"')
+    expect(html).toContain('/goal')
+    expect(html).toContain('Published second phase')
+    expect(html).toContain('data-testid="timeline-body"')
   })
 
   it('uses update time only for Link-only sharing metadata', () => {

--- a/apps/web/src/components/session/workbench.tsx
+++ b/apps/web/src/components/session/workbench.tsx
@@ -40,7 +40,9 @@ import {
   repositoryUrlForRemote,
   resumeCommandFor,
 } from '../../lib/session-page'
+import type { SessionRoute } from '../../lib/session-route'
 import { CliResumeDialog } from './cli-resume-dialog'
+import { SessionRouteMap } from './route-map'
 import { SessionSummary } from './session-summary'
 
 interface Props {
@@ -48,6 +50,7 @@ interface Props {
   view: SessionViewV1 | null
   provider: SessionProvider
   conversation: ParsedConversation
+  route?: SessionRoute | null
   isDark: boolean
   initialRecordIndex: number | null
   spoolDocument: SpoolDocument | null
@@ -135,6 +138,7 @@ export function SessionWorkbench({
   view,
   provider,
   conversation,
+  route,
   isDark,
   initialRecordIndex,
   spoolDocument,
@@ -151,7 +155,6 @@ export function SessionWorkbench({
   const listRef = useRef<MessageListHandle>(null)
   const timelineRef = useRef<HTMLDivElement>(null)
   const focusedTurnRef = useRef<HTMLElement | null>(null)
-  const focusTimerRef = useRef<number | null>(null)
   const jumpFrameRef = useRef<number | null>(null)
 
   const card = parseWorkspaceCard(meta.cardJson)
@@ -180,11 +183,10 @@ export function SessionWorkbench({
   )
   const spoolTitle = spoolDocument?.conversation.title.trim() ?? ''
   const fullTitle =
-    (spoolDocument !== null && spoolDocument.opts.redact
-      ? redactPlainText(spoolTitle, spoolRedactList)
-      : spoolTitle) ||
-    conversation.title.trim() ||
-    'Shared session'
+    spoolDocument === null
+      ? conversation.title.trim() || 'Shared session'
+      : (spoolDocument.opts.redact ? redactPlainText(spoolTitle, spoolRedactList) : spoolTitle) ||
+        'Shared session'
   const title = compactSessionTitle(fullTitle)
   const spoolPrompts = useMemo(
     () => (spoolDocument === null ? [] : getSpoolPromptEntries(spoolDocument, spoolRedactList)),
@@ -230,27 +232,26 @@ export function SessionWorkbench({
       jumpFrameRef.current = null
 
       if (focusedTurnRef.current !== null && focusedTurnRef.current !== turn) {
-        focusedTurnRef.current.blur()
         focusedTurnRef.current.removeAttribute('tabindex')
       }
       focusedTurnRef.current = turn
       turn.tabIndex = -1
+      turn.addEventListener(
+        'blur',
+        () => {
+          turn.removeAttribute('tabindex')
+          if (focusedTurnRef.current === turn) focusedTurnRef.current = null
+        },
+        { once: true },
+      )
       turn.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'nearest' })
       turn.focus({ preventScroll: true })
-      if (focusTimerRef.current !== null) window.clearTimeout(focusTimerRef.current)
-      focusTimerRef.current = window.setTimeout(() => {
-        turn.blur()
-        turn.removeAttribute('tabindex')
-        if (focusedTurnRef.current === turn) focusedTurnRef.current = null
-        focusTimerRef.current = null
-      }, 1600)
     }
     focusTurn()
   }, [])
 
   useEffect(
     () => () => {
-      if (focusTimerRef.current !== null) window.clearTimeout(focusTimerRef.current)
       if (jumpFrameRef.current !== null) window.cancelAnimationFrame(jumpFrameRef.current)
       focusedTurnRef.current?.removeAttribute('tabindex')
     },
@@ -384,6 +385,27 @@ export function SessionWorkbench({
                       : 'turns'}
                 </span>
               </div>
+
+              {route && route.phases.length > 1 && (
+                <SessionRouteMap
+                  route={route}
+                  onJump={(recordIndex) => {
+                    if (spoolDocument !== null) {
+                      const turnIndex = route.phases.find(
+                        (phase) => phase.recordIndex === recordIndex,
+                      )?.turnIndex
+                      if (turnIndex !== undefined) jumpToTurn(turnIndex)
+                      return
+                    }
+                    const messageId = conversation.recordToMessageId.get(recordIndex)
+                    if (messageId !== undefined) {
+                      setTargetTurnIndex(null)
+                      setTargetMessageId(messageId)
+                      listRef.current?.scrollToMessageId(messageId)
+                    }
+                  }}
+                />
+              )}
 
               <div className="min-w-0 lg:grid lg:grid-cols-[24px_minmax(0,1fr)] lg:gap-4">
                 {prompts.length > 0 && (

--- a/apps/web/src/components/site/daemon.tsx
+++ b/apps/web/src/components/site/daemon.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 
 import registry from '../../../data/registry.json'
 
-const INSTALL_CMD = 'curl -fsSL https://spool.pro/install-daemon.sh | bash'
+const INSTALL_CMD = 'curl -fsSL https://spool.new/install-daemon.sh | bash'
 const REPO_URL = 'https://github.com/paperboytm/spool-daemon'
 
 // ─── Tray cells (hero specimen, 8 cells × 2 cols) ──────────────────────

--- a/apps/web/src/components/site/hero-space.tsx
+++ b/apps/web/src/components/site/hero-space.tsx
@@ -7,7 +7,7 @@
  * Laptops on a ground ring emit Session comets that fly along 3D arcs
  * and join the galaxy on arrival. UnrealBloom + exponential fog carry
  * the look; thin CSS light beams sweep the band on top (see .hs-band)
- * while the base stays the same warm near-black as the rest of the
+ * while the base stays the same void black as the rest of the
  * page, so scrolling out of the hero has no color jump.
  *
  * three.js loads lazily inside the effect so the initial page chunk
@@ -48,7 +48,7 @@ function mixRgb(a: Rgb, b: Rgb, t: number): Rgb {
 }
 
 const WHITE: Rgb = { r: 255, g: 255, b: 255 }
-const NEAR_BLACK: Rgb = { r: 20, g: 20, b: 16 }
+const VOID_BLACK: Rgb = { r: 0, g: 0, b: 0 }
 
 function rgbaOf(c: Rgb, a: number): string {
   return `rgba(${c.r},${c.g},${c.b},${a})`
@@ -61,8 +61,8 @@ function hexIntOf(c: Rgb): number {
 function readPalette(el: Element) {
   const css = getComputedStyle(el)
   const read = (name: string, fallback: Rgb) => parseCssColor(css.getPropertyValue(name), fallback)
-  const accent = read('--accent', { r: 0, g: 153, b: 255 })
-  const bgc = read('--bg', NEAR_BLACK)
+  const accent = read('--accent', { r: 19, g: 135, b: 255 })
+  const bgc = read('--bg', VOID_BLACK)
   const dark = bgc.r + bgc.g + bgc.b < 3 * 128
   return {
     accent,
@@ -70,18 +70,18 @@ function readPalette(el: Element) {
     codex: read('--src-codex', { r: 124, g: 201, b: 162 }),
     gemini: read('--src-gemini', { r: 138, g: 176, b: 229 }),
     /* Scene neutrals follow the active design system. */
-    bg: read('--bg', NEAR_BLACK),
-    surface: read('--surface', { r: 28, g: 28, b: 24 }),
-    border: read('--border', { r: 46, g: 46, b: 40 }),
-    border2: read('--border2', { r: 58, g: 58, b: 52 }),
-    muted: read('--muted', { r: 138, g: 138, b: 128 }),
+    bg: read('--bg', VOID_BLACK),
+    surface: read('--surface', { r: 9, g: 9, b: 9 }),
+    border: read('--border', { r: 31, g: 31, b: 31 }),
+    border2: read('--border2', { r: 46, g: 46, b: 46 }),
+    muted: read('--muted', { r: 166, g: 166, b: 166 }),
     /* Derived tints: toward white on dark themes; saturated and deep on
      * light so particles read as ink, not haze. */
     bright: mixRgb(accent, dark ? WHITE : { r: 0, g: 40, b: 110 }, dark ? 0.3 : 0.2),
     soft: mixRgb(accent, dark ? WHITE : { r: 0, g: 40, b: 110 }, dark ? 0.55 : 0.35),
     sparkle: mixRgb(accent, dark ? WHITE : { r: 0, g: 40, b: 110 }, dark ? 0.45 : 0.1),
     pale: mixRgb(accent, dark ? WHITE : bgc, dark ? 0.82 : 0.3),
-    dimmed: mixRgb(accent, dark ? NEAR_BLACK : WHITE, 0.45),
+    dimmed: mixRgb(accent, dark ? VOID_BLACK : WHITE, 0.45),
   }
 }
 type Palette = ReturnType<typeof readPalette>
@@ -115,7 +115,7 @@ function makeSoftDot(THREE: typeof import('three')) {
   return tex
 }
 
-/** Radial amber glow for the floor under the space. */
+/** Radial accent glow for the floor under the space. */
 function makeFloorGlow(THREE: typeof import('three'), accent: Rgb) {
   const c = document.createElement('canvas')
   c.width = c.height = 256
@@ -129,7 +129,7 @@ function makeFloorGlow(THREE: typeof import('three'), accent: Rgb) {
   return new THREE.CanvasTexture(c)
 }
 
-/** Terminal screen texture: a dark warm display running an agent
+/** Terminal screen texture: a void display running an agent
  * session — glowing code lines in the machine's source color, a divider,
  * and a bright cursor block. Reads as "an agent at work", not flat color. */
 function makeScreenTexture(THREE: typeof import('three'), color: Rgb, seed: number) {
@@ -138,7 +138,7 @@ function makeScreenTexture(THREE: typeof import('three'), color: Rgb, seed: numb
   c.width = 256
   c.height = 160
   const g = c.getContext('2d')!
-  g.fillStyle = '#0c0c0a'
+  g.fillStyle = '#090909'
   g.fillRect(0, 0, 256, 160)
   /* Soft glow pooling at the bottom of the display. */
   const r = color.r
@@ -160,7 +160,7 @@ function makeScreenTexture(THREE: typeof import('three'), color: Rgb, seed: numb
       const bright = 0.28 + rnd() * 0.5
       const dim = rnd() > 0.72
       g.fillStyle = dim
-        ? `rgba(138,138,128,${0.3 + rnd() * 0.2})`
+        ? `rgba(166,166,166,${0.3 + rnd() * 0.2})`
         : `rgba(${r},${gr},${b},${bright})`
       g.beginPath()
       g.roundRect(x, y, wSeg, 7, 3.5)
@@ -175,7 +175,7 @@ function makeScreenTexture(THREE: typeof import('three'), color: Rgb, seed: numb
   g.beginPath()
   g.roundRect(14, y + 2, 8, 9, 2)
   g.fill()
-  g.fillStyle = 'rgba(242,242,236,0.8)'
+  g.fillStyle = 'rgba(255,255,255,0.8)'
   g.beginPath()
   g.roundRect(28, y + 2, 30, 9, 3)
   g.fill()
@@ -622,7 +622,7 @@ export function HeroSpace({
       const screenGeo = new THREE.PlaneGeometry(68, 42)
       const edgeMat = new THREE.LineBasicMaterial({
         color: hexIntOf(
-          darkMode ? mixRgb(pal.border2, WHITE, 0.18) : mixRgb(pal.muted, NEAR_BLACK, 0.3),
+          darkMode ? mixRgb(pal.border2, WHITE, 0.18) : mixRgb(pal.muted, VOID_BLACK, 0.3),
         ),
         transparent: true,
         opacity: 0.5,

--- a/apps/web/src/components/site/home-pieces.tsx
+++ b/apps/web/src/components/site/home-pieces.tsx
@@ -239,7 +239,7 @@ export function FlowShow() {
           </span>
         </div>
         <div className="fs-pill">
-          <span className="fs-url">spool.pro/session/claude_7a55b1ee</span>
+          <span className="fs-url">spool.new/session/claude_7a55b1ee</span>
           <span className="fs-vis">Public</span>
         </div>
       </div>

--- a/apps/web/src/components/site/logo-lab.tsx
+++ b/apps/web/src/components/site/logo-lab.tsx
@@ -103,8 +103,8 @@ const VARIANTS: ReadonlyArray<{
 ]
 
 const THEMES = [
-  { key: 'dark', bg: '#141410', fg: '#f2f2ec', border: '#2e2e28', accent: '#f07020' },
-  { key: 'light', bg: '#fafaf8', fg: '#1c1c18', border: '#e8e8e2', accent: '#c85a00' },
+  { key: 'dark', bg: '#000000', fg: '#ffffff', border: '#1f1f1f', accent: '#5bb1f0' },
+  { key: 'light', bg: '#ffffff', fg: '#0a0a0a', border: '#e5e5e5', accent: '#1387ff' },
 ] as const
 
 export default function LogoLab() {

--- a/apps/web/src/content/docs/guides/agent-integration.md
+++ b/apps/web/src/content/docs/guides/agent-integration.md
@@ -32,7 +32,7 @@ Claude Code and Codex CLI Sessions are Public by default. Gemini CLI, OpenCode, 
 
 ## Continue a Spool Session
 
-Give the agent a spool.pro Session URL and ask it to continue the work. The skill routes the URL to:
+Give the agent a spool.new Session URL and ask it to continue the work. Legacy spool.pro Session URLs remain supported. The skill routes the URL to:
 
 ```bash
 npx @spool-lab/cli resume <session-url>

--- a/apps/web/src/content/docs/quick-start.md
+++ b/apps/web/src/content/docs/quick-start.md
@@ -50,7 +50,7 @@ For a CLI share, Spool can ask a detected local Agent to draft the Summary with 
 A successful share returns a URL such as:
 
 ```text
-https://spool.pro/session/claude_…
+https://spool.new/session/claude_…
 ```
 
 Anyone with the URL can read the Shared Session without installing Spool. Claude Code and Codex CLI Shares are Public in Explore and search by default.

--- a/apps/web/src/edge-router.test.ts
+++ b/apps/web/src/edge-router.test.ts
@@ -18,12 +18,12 @@ describe('edge router', () => {
       expect(request.url).toBe('https://spool-share-backend.pages.dev/api/health?full=1')
       expect(request.method).toBe('POST')
       expect(request.headers.get('authorization')).toBe('Bearer test')
-      expect(request.headers.get('x-forwarded-host')).toBe('spool.pro')
+      expect(request.headers.get('x-forwarded-host')).toBe('spool.new')
       expect(request.headers.get('x-forwarded-proto')).toBe('https')
       expect(await request.text()).toBe('payload')
       return new Response('api', { status: 201, headers: { 'x-upstream': 'backend' } })
     })
-    const request = new Request('https://spool.pro/api/health?full=1', {
+    const request = new Request('https://spool.new/api/health?full=1', {
       method: 'POST',
       headers: { authorization: 'Bearer test' },
       body: 'payload',
@@ -44,7 +44,7 @@ describe('edge router', () => {
   })
 
   it('passes web requests to TanStack Start unchanged', async () => {
-    const request = new Request('https://spool.pro/docs/installation')
+    const request = new Request('https://spool.new/docs/installation')
     const webFetch = vi.fn(async (received: Request) => {
       expect(received).toBe(request)
       return new Response('page', { headers: { 'cache-control': 'public, max-age=60' } })

--- a/apps/web/src/edge-router.ts
+++ b/apps/web/src/edge-router.ts
@@ -1,4 +1,4 @@
-// Public edge dispatch for spool.pro. The web Worker is the entry Worker so
+// Public edge dispatch for spool.new. The web Worker is the entry Worker so
 // Cloudflare can serve its Vite-built static assets directly; only /api/* is
 // forwarded to the existing Pages backend.
 

--- a/apps/web/src/lib/hub-api.ts
+++ b/apps/web/src/lib/hub-api.ts
@@ -112,11 +112,14 @@ export function parseNdjsonRecords(text: string): HubRecordLine[] {
 
 export type RangeFetcher = (from: number, to: number) => Promise<HubRecordLine[]>
 
-export function makeRangeFetcher(sid: string): RangeFetcher {
+export function makeRangeFetcher(sid: string, signal?: AbortSignal): RangeFetcher {
   return async (from, to) => {
     const r = await fetch(
       `/api/hub/v1/sessions/${encodeURIComponent(sid)}/records?from=${from}&to=${to}`,
-      { headers: { accept: 'application/x-ndjson' } },
+      {
+        headers: { accept: 'application/x-ndjson' },
+        ...(signal === undefined ? {} : { signal }),
+      },
     )
     if (r.status !== 200) throw new Error(`records fetch failed: HTTP ${r.status}`)
     return parseNdjsonRecords(await r.text())

--- a/apps/web/src/lib/mailto.test.ts
+++ b/apps/web/src/lib/mailto.test.ts
@@ -6,15 +6,15 @@ const ID = 'K7s4F3pQz1mB9XnLrV8aE'
 
 describe('reportMailto', () => {
   it('targets abuse@spool.pro', () => {
-    expect(reportMailto(ID, 'https://spool.pro').startsWith('mailto:abuse@spool.pro?')).toBe(true)
+    expect(reportMailto(ID, 'https://spool.new').startsWith('mailto:abuse@spool.pro?')).toBe(true)
   })
 
   it('encodes the share id into both subject and body using the given origin', () => {
-    const href = reportMailto(ID, 'https://spool.pro')
+    const href = reportMailto(ID, 'https://spool.new')
     const url = new URL(href)
-    expect(url.searchParams.get('subject')).toBe(`Report spool.pro/s/${ID}`)
+    expect(url.searchParams.get('subject')).toBe(`Report spool.new/s/${ID}`)
     const body = url.searchParams.get('body') ?? ''
-    expect(body).toContain(`Share URL: https://spool.pro/s/${ID}`)
+    expect(body).toContain(`Share URL: https://spool.new/s/${ID}`)
     expect(body).toContain(
       'Reason (please pick one): copyright | privacy | harassment | illegal | spam | other',
     )
@@ -30,15 +30,15 @@ describe('reportMailto', () => {
 
   it('percent-encodes spaces in the query string (not "+")', () => {
     // Some mail clients don't decode "+" as space in mailto bodies; %20 is safer.
-    const href = reportMailto('x'.repeat(21), 'https://spool.pro')
+    const href = reportMailto('x'.repeat(21), 'https://spool.new')
     expect(href).not.toContain('?subject=Report+')
     expect(href).toContain('?subject=Report%20')
   })
 
-  it('falls back to spool.pro when no window and no origin override', () => {
+  it('falls back to spool.new when no window and no origin override', () => {
     // node test environment — `window` is undefined; the helper should
     // pick the prod default rather than emit an empty origin string.
     const url = new URL(reportMailto(ID))
-    expect(url.searchParams.get('subject')).toBe(`Report spool.pro/s/${ID}`)
+    expect(url.searchParams.get('subject')).toBe(`Report spool.new/s/${ID}`)
   })
 })

--- a/apps/web/src/lib/mailto.ts
+++ b/apps/web/src/lib/mailto.ts
@@ -8,7 +8,9 @@
 // just rely on the default — window.location.origin already gives the
 // right value at runtime.
 
-const DEFAULT_ORIGIN = 'https://spool.pro'
+import { PUBLIC_SITE_ORIGIN } from './site'
+
+const DEFAULT_ORIGIN = PUBLIC_SITE_ORIGIN
 
 function currentOrigin(): string {
   if (typeof window !== 'undefined' && window.location?.origin) {

--- a/apps/web/src/lib/og-meta.test.ts
+++ b/apps/web/src/lib/og-meta.test.ts
@@ -14,32 +14,32 @@ describe('snapshotOgHead', () => {
   it('emits a title, canonical link, and the OG + Twitter Card set', () => {
     const out = snapshotOgHead({
       title: 'My great chat',
-      ogImageUrl: 'https://spool.pro/api/og/abc.png',
-      canonicalUrl: 'https://spool.pro/s/abc',
+      ogImageUrl: 'https://spool.new/api/og/abc.png',
+      canonicalUrl: 'https://spool.new/s/abc',
     })
-    expect(out.meta[0]).toEqual({ title: 'My great chat · spool.pro' })
-    expect(out.links).toEqual([{ rel: 'canonical', href: 'https://spool.pro/s/abc' }])
+    expect(out.meta[0]).toEqual({ title: 'My great chat · spool.new' })
+    expect(out.links).toEqual([{ rel: 'canonical', href: 'https://spool.new/s/abc' }])
     expect(metaValue(out, 'property', 'og:type')).toBe('article')
     expect(metaValue(out, 'property', 'og:title')).toBe('My great chat')
-    expect(metaValue(out, 'property', 'og:image')).toBe('https://spool.pro/api/og/abc.png')
+    expect(metaValue(out, 'property', 'og:image')).toBe('https://spool.new/api/og/abc.png')
     expect(metaValue(out, 'property', 'og:image:width')).toBe('1200')
     expect(metaValue(out, 'property', 'og:image:height')).toBe('630')
-    expect(metaValue(out, 'property', 'og:url')).toBe('https://spool.pro/s/abc')
+    expect(metaValue(out, 'property', 'og:url')).toBe('https://spool.new/s/abc')
     expect(metaValue(out, 'name', 'twitter:card')).toBe('summary_large_image')
     expect(metaValue(out, 'name', 'twitter:title')).toBe('My great chat')
-    expect(metaValue(out, 'name', 'twitter:image')).toBe('https://spool.pro/api/og/abc.png')
+    expect(metaValue(out, 'name', 'twitter:image')).toBe('https://spool.new/api/og/abc.png')
   })
 
   it('truncates pathological titles to 200 chars', () => {
     const long = 'a'.repeat(500)
     const out = snapshotOgHead({ title: long, ogImageUrl: 'x', canonicalUrl: 'y' })
     expect(metaValue(out, 'property', 'og:title')).toHaveLength(200)
-    expect(out.meta[0]?.['title']).toBe(`${'a'.repeat(200)} · spool.pro`)
+    expect(out.meta[0]?.['title']).toBe(`${'a'.repeat(200)} · spool.new`)
   })
 
   it('falls back to a default title when the snapshot title is empty', () => {
     const out = snapshotOgHead({ title: '', ogImageUrl: 'x', canonicalUrl: 'y' })
-    expect(out.meta[0]).toEqual({ title: 'Shared conversation · spool.pro' })
+    expect(out.meta[0]).toEqual({ title: 'Shared conversation · spool.new' })
     expect(metaValue(out, 'property', 'og:title')).toBe('Shared conversation')
   })
 
@@ -65,19 +65,19 @@ describe('sessionOgHead', () => {
     const out = sessionOgHead({
       title: 'Fix the auth flow',
       description: 'A coding-agent session shared by @xy — 12 records.',
-      canonicalUrl: 'https://spool.pro/session/claude_abc12345',
+      canonicalUrl: 'https://spool.new/session/claude_abc12345',
     })
-    expect(out.meta[0]).toEqual({ title: 'Fix the auth flow · spool.pro' })
+    expect(out.meta[0]).toEqual({ title: 'Fix the auth flow · spool.new' })
     expect(metaValue(out, 'name', 'twitter:card')).toBe('summary')
     expect(out.meta.some((m) => m['property'] === 'og:image')).toBe(false)
     expect(out.links).toEqual([
-      { rel: 'canonical', href: 'https://spool.pro/session/claude_abc12345' },
+      { rel: 'canonical', href: 'https://spool.new/session/claude_abc12345' },
     ])
   })
 
   it('falls back to generic title and description', () => {
     const out = sessionOgHead({ title: '', description: '', canonicalUrl: 'x' })
-    expect(out.meta[0]).toEqual({ title: 'Shared session · spool.pro' })
+    expect(out.meta[0]).toEqual({ title: 'Shared session · spool.new' })
     expect(metaValue(out, 'name', 'description')).toBe('A shared coding-agent session on Spool.')
   })
 })

--- a/apps/web/src/lib/og-meta.ts
+++ b/apps/web/src/lib/og-meta.ts
@@ -6,6 +6,8 @@
 // the escaping. Kept pure (values in, values out, no fetch) so the
 // capping/fallback behaviour stays unit-testable in node.
 
+import { PUBLIC_SITE_HOST } from './site'
+
 export interface OgMeta {
   /** Snapshot conversation.title — gets length-capped. */
   title: string
@@ -35,7 +37,7 @@ export function snapshotOgHead(og: OgMeta): HeadFragment {
   const desc = og.description ?? DEFAULT_DESC
   return {
     meta: [
-      { title: `${title} · spool.pro` },
+      { title: `${title} · ${PUBLIC_SITE_HOST}` },
       { name: 'description', content: desc },
       { property: 'og:type', content: 'article' },
       { property: 'og:title', content: title },
@@ -69,7 +71,7 @@ export function sessionOgHead(og: SessionOgMeta): HeadFragment {
   const desc = og.description || 'A shared coding-agent session on Spool.'
   return {
     meta: [
-      { title: `${title} · spool.pro` },
+      { title: `${title} · ${PUBLIC_SITE_HOST}` },
       { name: 'description', content: desc },
       { property: 'og:type', content: 'article' },
       { property: 'og:title', content: title },

--- a/apps/web/src/lib/security-headers.test.ts
+++ b/apps/web/src/lib/security-headers.test.ts
@@ -10,5 +10,7 @@ describe('Explore security headers', () => {
     expect(headers?.['X-Robots-Tag']).toBeUndefined()
     expect(headers?.['Content-Security-Policy']).toContain("script-src 'self' 'nonce-nonce-value'")
     expect(headers?.['Content-Security-Policy']).toContain("form-action 'self'")
+    expect(headers?.['Content-Security-Policy']).toContain('https://spool.new')
+    expect(headers?.['Content-Security-Policy']).toContain('https://spool.pro')
   })
 })

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -18,7 +18,8 @@
 // generated in src/start.ts and threaded to the router (router ssr
 // option) so the framework stamps it onto every inline script it emits.
 
-const IMG_SRC_READER = "'self' data: https://spool.pro https://lh3.googleusercontent.com"
+const IMG_SRC_READER =
+  "'self' data: https://spool.new https://spool.pro https://lh3.googleusercontent.com"
 
 function csp(
   nonce: string | undefined,

--- a/apps/web/src/lib/server-api-origin.ts
+++ b/apps/web/src/lib/server-api-origin.ts
@@ -5,7 +5,7 @@ import { createServerOnlyFn } from '@tanstack/react-start'
 const readBackendOrigin = createServerOnlyFn(() => process.env.ORIGIN_BACKEND)
 
 /** SSR calls the Pages backend directly rather than recursively fetching the
- * public spool.pro Worker route. */
+ * public spool.new Worker route. */
 export function apiOriginFor(backendOrigin: string): string {
   return new URL(backendOrigin).origin
 }

--- a/apps/web/src/lib/session-messages.ts
+++ b/apps/web/src/lib/session-messages.ts
@@ -1,6 +1,6 @@
 // Hub records → the exact message list the desktop renders. The parsing
 // brain is @spool-lab/session-kit's provider parsers (the same code the
-// desktop indexer wraps), so what you read on spool.pro is what you'd see
+// desktop indexer wraps), so what you read on spool.new is what you'd see
 // opening the session in the app.
 
 import { parseSessionText, type ParsedMessage, type SessionProvider } from '@spool-lab/session-kit'

--- a/apps/web/src/lib/session-page.ts
+++ b/apps/web/src/lib/session-page.ts
@@ -41,7 +41,7 @@ export function deepLinkHash(index: number): string {
   return `#r/${index}`
 }
 
-/** The sid alone resumes against the reader's configured hub (spool.pro
+/** The sid alone resumes against the reader's configured hub (spool.new
  *  by default) — shorter to copy than the full page URL, which stays
  *  accepted by the CLI for cross-hub cases. */
 export function resumeCommandFor(sid: string): string {

--- a/apps/web/src/lib/session-reader.test.ts
+++ b/apps/web/src/lib/session-reader.test.ts
@@ -5,6 +5,7 @@ import {
   batchEventRanges,
   fetchHubSpoolFile,
   fetchRecordsExact,
+  makeRangeFetcher,
   parseNdjsonRecords,
   type HubRecordLine,
   type RangeFetcher,
@@ -74,6 +75,19 @@ describe('record fetching', () => {
   it('aborts instead of looping when the server makes no progress', async () => {
     const fetchRange: RangeFetcher = async () => []
     await expect(fetchRecordsExact(fetchRange, 0, 3)).rejects.toThrow(/no records/)
+  })
+
+  it('forwards AbortSignal to record fetches', async () => {
+    const abortController = new AbortController()
+    const fetchMock = vi.fn(async () => new Response(`${JSON.stringify(record(0))}\n`))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await makeRangeFetcher('claude_12345678', abortController.signal)(0, 1)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/hub/v1/sessions/claude_12345678/records?from=0&to=1',
+      expect.objectContaining({ signal: abortController.signal }),
+    )
   })
 
   it('batches event indices into ranges, bridging small gaps only', () => {
@@ -295,9 +309,9 @@ describe('session OG tags', () => {
     const fragment = sessionOgHead({
       title: 'Fix <PKCE> handling',
       description: 'A coding-agent session shared by @xy — 42 records.',
-      canonicalUrl: 'https://spool.pro/session/claude_x',
+      canonicalUrl: 'https://spool.new/session/claude_x',
     })
-    expect(fragment.meta[0]).toEqual({ title: 'Fix <PKCE> handling · spool.pro' })
+    expect(fragment.meta[0]).toEqual({ title: 'Fix <PKCE> handling · spool.new' })
     expect(fragment.meta.find((m) => m['name'] === 'twitter:card')?.['content']).toBe('summary')
     expect(fragment.meta.some((m) => m['property'] === 'og:image')).toBe(false)
   })

--- a/apps/web/src/lib/session-route.test.ts
+++ b/apps/web/src/lib/session-route.test.ts
@@ -1,0 +1,417 @@
+import type { SpoolDocument } from '@spool/share-kit'
+import { describe, expect, it } from 'vite-plus/test'
+
+import type { HubRecordLine } from './hub-api'
+import { deriveSessionRoute, projectSessionRouteToSpool } from './session-route'
+
+let seq = 0
+function rec(data: object): HubRecordLine {
+  return { i: seq++, oid: `oid-${seq}`, data: JSON.stringify(data) }
+}
+
+function claudePrompt(text: string, timestamp?: string): HubRecordLine {
+  return rec({
+    type: 'user',
+    ...(timestamp === undefined ? {} : { timestamp }),
+    message: { role: 'user', content: text },
+  })
+}
+
+function claudeToolUse(name: string, input: object = {}, id = `tool-${seq}`): HubRecordLine {
+  return rec({
+    type: 'assistant',
+    message: { role: 'assistant', content: [{ type: 'tool_use', name, id, input }] },
+  })
+}
+
+function claudeToolResult(
+  toolUseId: string,
+  options: { isError?: boolean; content?: string } = {},
+): HubRecordLine {
+  return rec({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: toolUseId,
+          is_error: options.isError ?? false,
+          content: options.content ?? 'ok',
+        },
+      ],
+    },
+  })
+}
+
+function codexEventPrompt(text: string, timestamp: string): HubRecordLine {
+  return rec({ timestamp, type: 'event_msg', payload: { type: 'user_message', message: text } })
+}
+
+function codexResponsePrompt(text: string, timestamp: string): HubRecordLine {
+  return rec({
+    timestamp,
+    type: 'response_item',
+    payload: {
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_text', text }],
+    },
+  })
+}
+
+function codexCall(
+  name: string,
+  args: object | string,
+  id: string,
+  type: 'function_call' | 'custom_tool_call' = 'function_call',
+): HubRecordLine {
+  return rec({
+    type: 'response_item',
+    payload: {
+      type,
+      name,
+      call_id: id,
+      ...(type === 'function_call'
+        ? { arguments: typeof args === 'string' ? args : JSON.stringify(args) }
+        : { input: typeof args === 'string' ? args : JSON.stringify(args) }),
+    },
+  })
+}
+
+function codexOutput(id: string, output: unknown): HubRecordLine {
+  return rec({
+    type: 'response_item',
+    payload: { type: 'function_call_output', call_id: id, output: JSON.stringify(output) },
+  })
+}
+
+function spoolDocument(
+  turns: SpoolDocument['conversation']['turns'],
+  selected?: number[],
+): SpoolDocument {
+  return {
+    version: 2,
+    exportedAt: '2026-07-22T00:00:00.000Z',
+    conversation: {
+      source: 'claude-code',
+      sourceLabel: 'Claude Code',
+      origin: { kind: 'agent-session', agent: 'claude' },
+      title: 'Curated session',
+      shareUrl: null,
+      createdAt: '2026-07-22T00:00:00.000Z',
+      wordCount: 10,
+      readMin: 1,
+      turns,
+    },
+    opts: {
+      template: 'chat',
+      paper: 'snow',
+      typeface: 'geist',
+      colorway: 'amber',
+      accentHex: '#C85A00',
+      density: 'compact',
+      redact: false,
+      showGaps: true,
+      showMasthead: false,
+      showColophon: false,
+      hideEmptyTurns: true,
+      ...(selected === undefined ? {} : { selected }),
+    },
+  }
+}
+
+describe('deriveSessionRoute — Claude Code', () => {
+  it('returns null for sessions with no authored or tool activity', () => {
+    seq = 0
+    expect(deriveSessionRoute([rec({ type: 'mode' })])).toBeNull()
+  })
+
+  it('segments authored prompts and keeps check failures out of generic errors', () => {
+    seq = 0
+    const route = deriveSessionRoute([
+      claudePrompt('Fix the refresh race between tabs', '2026-07-22T00:00:00Z'),
+      claudeToolUse('Read'),
+      claudeToolUse('Edit'),
+      claudePrompt('Now make the tests pass', '2026-07-22T00:01:00Z'),
+      claudeToolUse('Bash', { command: 'pnpm --filter @spool/web test' }, 'check-1'),
+      claudeToolResult('check-1', { isError: true, content: 'Exit code 1' }),
+      claudeToolUse('Bash', { command: 'pnpm test' }, 'check-2'),
+      claudeToolResult('check-2'),
+      claudeToolUse('WebFetch', {}, 'fetch-1'),
+      claudeToolResult('fetch-1', { isError: true, content: 'network denied' }),
+    ])
+
+    expect(route).not.toBeNull()
+    expect(route!.goal).toBe('Fix the refresh race between tabs')
+    expect(route!.phases).toHaveLength(2)
+    expect(route!.phases[0]).toMatchObject({
+      timestamp: '2026-07-22T00:00:00Z',
+      isPrompt: true,
+      tools: 2,
+      edits: 1,
+    })
+    expect(route!.phases[1]).toMatchObject({
+      checkRuns: 2,
+      checkFails: 1,
+      errors: 1,
+    })
+    expect(route!.totalErrors).toBe(2)
+  })
+
+  it('recognizes a failed piped check from its test summary when the tool flag is false', () => {
+    seq = 0
+    const route = deriveSessionRoute([
+      claudePrompt('Run the suite'),
+      claudeToolUse('Bash', { command: 'pnpm test 2>&1 | tail -8' }, 'check-1'),
+      claudeToolResult('check-1', {
+        isError: false,
+        content: ' Test Files  1 failed | 26 passed (27)\n[ELIFECYCLE] Test failed.',
+      }),
+    ])
+
+    expect(route!.phases[0]).toMatchObject({ checkRuns: 1, checkFails: 1, errors: 0 })
+    expect(route!.totalErrors).toBe(1)
+  })
+
+  it('skips tool results, sidechains, and tag-like payloads when finding prompts', () => {
+    seq = 0
+    const route = deriveSessionRoute([
+      rec({ type: 'user', message: { role: 'user', content: '<task-notification>x' } }),
+      rec({ type: 'user', isSidechain: true, message: { role: 'user', content: 'sidechain' } }),
+      claudePrompt('The real goal'),
+      claudeToolUse('Bash', { command: 'ls' }),
+    ])
+    expect(route!.phases).toHaveLength(1)
+    expect(route!.goal).toBe('The real goal')
+    expect(route!.phases[0]).toMatchObject({ commands: 1, checkRuns: 0 })
+  })
+
+  it('keeps legitimate markup prompts and repeated prompts as distinct steering phases', () => {
+    seq = 0
+    const route = deriveSessionRoute([
+      claudePrompt('<main>Fix this JSX layout</main>'),
+      claudePrompt('继续'),
+      claudeToolUse('Read'),
+      claudePrompt('继续'),
+      claudeToolUse('Edit'),
+    ])
+
+    expect(route!.phases.map((phase) => phase.label)).toEqual([
+      '<main>Fix this JSX layout</main>',
+      '继续',
+      '继续',
+    ])
+    expect(route!.phases[1]).toMatchObject({ tools: 1, edits: 0 })
+    expect(route!.phases[2]).toMatchObject({ tools: 1, edits: 1 })
+  })
+
+  it('captures a recorded PR as the outcome', () => {
+    seq = 0
+    const route = deriveSessionRoute([
+      claudePrompt('Ship it'),
+      rec({
+        type: 'pr-link',
+        prUrl: 'https://github.com/paperboytm/spool/pull/9',
+        prNumber: 9,
+        prRepository: 'paperboytm/spool',
+      }),
+    ])
+    expect(route!.prUrl).toBe('https://github.com/paperboytm/spool/pull/9')
+    expect(route!.prLabel).toBe('PR #9 · paperboytm/spool')
+  })
+
+  it('captures the validated URL emitted by a normal gh pr create command', () => {
+    seq = 0
+    const route = deriveSessionRoute([
+      claudePrompt('Open the pull request'),
+      claudeToolUse('Bash', { command: 'gh pr create --fill' }, 'pr-create'),
+      claudeToolResult('pr-create', {
+        content: 'https://github.com/paperboytm/spool/pull/11\n',
+      }),
+    ])
+
+    expect(route!.prUrl).toBe('https://github.com/paperboytm/spool/pull/11')
+    expect(route!.prLabel).toBe('PR #11 · paperboytm/spool')
+  })
+
+  it('ignores unsafe or non-GitHub PR links and derives labels from the URL', () => {
+    seq = 0
+    const route = deriveSessionRoute([
+      claudePrompt('Ship it'),
+      rec({
+        type: 'pr-link',
+        prUrl: 'javascript:alert(1)',
+        prNumber: 1,
+        prRepository: 'spoofed/repository',
+      }),
+      rec({
+        type: 'pr-link',
+        prUrl: 'https://github.com/paperboytm/spool/pull/10',
+        prNumber: 999,
+        prRepository: 'spoofed/repository',
+      }),
+    ])
+
+    expect(route!.prUrl).toBe('https://github.com/paperboytm/spool/pull/10')
+    expect(route!.prLabel).toBe('PR #10 · paperboytm/spool')
+  })
+
+  it('collects pre-prompt activity into an implicit opening phase', () => {
+    seq = 0
+    const route = deriveSessionRoute([claudeToolUse('Read'), claudeToolUse('Read')])
+    expect(route!.phases).toHaveLength(1)
+    expect(route!.phases[0]).toMatchObject({ label: 'Session start', isPrompt: false })
+    expect(route!.goal).toBeNull()
+  })
+})
+
+describe('deriveSessionRoute — Codex', () => {
+  it('uses event messages as authored prompts and parses Codex calls and outputs', () => {
+    seq = 0
+    const firstTimestamp = '2026-07-22T01:00:00Z'
+    const secondTimestamp = '2026-07-22T01:01:00Z'
+    const route = deriveSessionRoute([
+      codexResponsePrompt('# AGENTS.md instructions for /workspace\ninternal', firstTimestamp),
+      codexResponsePrompt('Implement the route map', firstTimestamp),
+      codexEventPrompt('Implement the route map', firstTimestamp),
+      codexCall('apply_patch', '*** Begin Patch', 'edit-1', 'custom_tool_call'),
+      codexOutput('edit-1', { output: 'Success.', metadata: { exit_code: 0 } }),
+      codexResponsePrompt('Make the tests pass', secondTimestamp),
+      codexEventPrompt('Make the tests pass', secondTimestamp),
+      codexCall('exec_command', { cmd: 'pnpm --filter @spool/web test' }, 'check-1'),
+      codexOutput('check-1', { output: 'failed', metadata: { exit_code: 1 } }),
+      // Some Codex versions emit a second result shape for the same call.
+      rec({
+        type: 'event_msg',
+        payload: { type: 'patch_apply_end', call_id: 'check-1', success: false },
+      }),
+      codexCall('web_search', { query: 'docs' }, 'web-1'),
+      rec({
+        type: 'response_item',
+        payload: {
+          type: 'function_call_output',
+          call_id: 'web-1',
+          is_error: true,
+          output: 'network denied',
+        },
+      }),
+    ])
+
+    expect(route!.goal).toBe('Implement the route map')
+    expect(route!.phases).toHaveLength(2)
+    expect(route!.phases[0]).toMatchObject({ edits: 1, tools: 1 })
+    expect(route!.phases[1]).toMatchObject({
+      commands: 1,
+      checkRuns: 1,
+      checkFails: 1,
+      errors: 1,
+      tools: 2,
+    })
+    expect(route!.totalErrors).toBe(2)
+  })
+
+  it('falls back to response-item user messages for older response-only rollouts', () => {
+    seq = 0
+    const route = deriveSessionRoute([
+      codexResponsePrompt(
+        '# AGENTS.md instructions for /workspace\ninternal',
+        '2026-01-01T00:00:00Z',
+      ),
+      codexResponsePrompt('Actual old-format prompt', '2026-01-01T00:00:01Z'),
+      codexCall('exec', 'pnpm typecheck', 'check-1', 'custom_tool_call'),
+      codexOutput('check-1', { output: 'ok', metadata: { exit_code: 0 } }),
+    ])
+
+    expect(route!.goal).toBe('Actual old-format prompt')
+    expect(route!.phases).toHaveLength(1)
+    expect(route!.phases[0]).toMatchObject({ commands: 1, checkRuns: 1, checkFails: 0 })
+  })
+})
+
+describe('projectSessionRouteToSpool', () => {
+  it('uses only visible curated labels and supplies exact timeline turn anchors', () => {
+    seq = 0
+    const rawRoute = deriveSessionRoute([
+      claudePrompt('Secret first phase', '2026-07-22T02:00:00Z'),
+      claudeToolUse('Bash', { command: 'pnpm test' }, 'hidden-check'),
+      claudeToolResult('hidden-check', { isError: true }),
+      claudePrompt('Raw second phase', '2026-07-22T02:01:00Z'),
+      claudeToolUse('Edit'),
+      claudePrompt('Raw third phase', '2026-07-22T02:02:00Z'),
+      claudeToolUse('Read'),
+    ])
+    const document = spoolDocument(
+      [
+        { role: 'user', body: 'Secret first phase', timestamp: '2026-07-22T02:00:00Z' },
+        { role: 'assistant', body: 'Hidden answer', timestamp: '2026-07-22T02:00:30Z' },
+        { role: 'user', body: 'Published second phase', timestamp: '2026-07-22T02:01:00Z' },
+        { role: 'assistant', body: 'Visible answer', timestamp: '2026-07-22T02:01:30Z' },
+        { role: 'user', body: 'Published third phase', timestamp: '2026-07-22T02:02:00Z' },
+        { role: 'assistant', body: 'Done', timestamp: '2026-07-22T02:02:30Z' },
+      ],
+      [2, 3, 4, 5],
+    )
+
+    const projected = projectSessionRouteToSpool(rawRoute, document)
+
+    expect(projected!.goal).toBe('Published second phase')
+    expect(projected!.phases.map(({ label, turnIndex }) => [label, turnIndex])).toEqual([
+      ['Published second phase', 2],
+      ['Published third phase', 4],
+    ])
+    expect(projected!.phases.map((phase) => phase.label)).not.toContain('Secret first phase')
+    expect(projected!.totalErrors).toBe(0)
+    expect(projected!.prUrl).toBeNull()
+  })
+
+  it('falls back to prompt order when legacy .spool turns have no timestamps', () => {
+    seq = 0
+    const rawRoute = deriveSessionRoute([
+      claudePrompt('Raw first'),
+      claudePrompt('Raw second'),
+      claudePrompt('Raw third'),
+    ])
+    const document = spoolDocument(
+      [
+        { role: 'user', body: 'Hidden first' },
+        { role: 'user', body: 'Visible second' },
+        { role: 'user', body: 'Visible third' },
+      ],
+      [1, 2],
+    )
+
+    const projected = projectSessionRouteToSpool(rawRoute, document)
+    expect(projected!.phases.map(({ label, turnIndex }) => [label, turnIndex])).toEqual([
+      ['Visible second', 1],
+      ['Visible third', 2],
+    ])
+  })
+
+  it('renders a stable curated route before raw evidence arrives', () => {
+    const projected = projectSessionRouteToSpool(
+      null,
+      spoolDocument(
+        [
+          { role: 'user', body: 'Hidden first' },
+          { role: 'assistant', body: 'Hidden answer' },
+          { role: 'user', body: 'Visible second' },
+          { role: 'assistant', body: 'Visible answer' },
+          { role: 'user', body: 'Visible third' },
+        ],
+        [2, 3, 4],
+      ),
+    )
+
+    expect(projected).toMatchObject({
+      goal: 'Visible second',
+      totalErrors: 0,
+      prUrl: null,
+      prLabel: null,
+    })
+    expect(projected!.phases.map(({ label, turnIndex }) => [label, turnIndex])).toEqual([
+      ['Visible second', 2],
+      ['Visible third', 4],
+    ])
+  })
+})

--- a/apps/web/src/lib/session-route.ts
+++ b/apps/web/src/lib/session-route.ts
@@ -1,0 +1,588 @@
+/* Derive the public "route map" from provider-native hub records.
+ *
+ * Raw records remain the source of machine evidence (tool/check/error counts).
+ * When a curated .spool document is rendered, project the authored labels and
+ * anchors through that document before exposing the route: this keeps selected
+ * turns and redaction rules authoritative while retaining the raw evidence. */
+
+import type { SpoolDocument } from '@spool/share-kit'
+import { collectRedactList, redactPlainText, selectSegments } from '@spool/share-kit/timeline'
+
+import type { HubRecordLine } from './hub-api'
+
+export interface RoutePhase {
+  /** Record index of the steering prompt — jump anchor for legacy sessions. */
+  recordIndex: number
+  /** Original .spool turn index when the route is projected onto a publication. */
+  turnIndex?: number
+  /** Provider timestamp, used to align raw prompts with curated turns. */
+  timestamp: string | null
+  /** False only for the synthetic phase used when tools precede the first prompt. */
+  isPrompt: boolean
+  label: string
+  tools: number
+  edits: number
+  commands: number
+  agents: number
+  /** Non-check tool failures inside this phase. */
+  errors: number
+  checkRuns: number
+  /** Failed check commands. Kept separate from errors so the UI counts once. */
+  checkFails: number
+}
+
+export interface SessionRoute {
+  goal: string | null
+  phases: RoutePhase[]
+  /** Unique failed tool calls, including failed checks. */
+  totalErrors: number
+  prUrl: string | null
+  prLabel: string | null
+}
+
+const EDIT_TOOLS = new Set(['edit', 'write', 'multiedit', 'notebookedit', 'apply_patch'])
+const AGENT_TOOLS = new Set(['agent', 'task', 'spawn_agent', 'spawn-agent'])
+const COMMAND_TOOLS = new Set([
+  'bash',
+  'shell',
+  'command',
+  'exec',
+  'exec_command',
+  'run_command',
+  'terminal',
+])
+const CHECK_CMD = /\b(?:test|vitest|jest|pytest|typecheck|tsc|lint|check|build)\b/i
+const MAX_LABEL = 64
+
+type UnknownRecord = Record<string, unknown>
+
+interface PromptDetails {
+  text: string
+  timestamp: string | null
+}
+
+interface ToolCallDetails {
+  id: string | null
+  name: string
+  command: string
+}
+
+interface ToolResultDetails {
+  id: string | null
+  failed: boolean
+  checkFailed: boolean
+  pr: { prUrl: string; prLabel: string } | null
+}
+
+interface PendingCall {
+  phase: RoutePhase
+  isCheck: boolean
+  createsPr: boolean
+}
+
+function isObject(value: unknown): value is UnknownRecord {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function stringAt(record: UnknownRecord | null, key: string): string | null {
+  const value = record?.[key]
+  return typeof value === 'string' ? value : null
+}
+
+function objectAt(record: UnknownRecord | null, key: string): UnknownRecord | null {
+  const value = record?.[key]
+  return isObject(value) ? value : null
+}
+
+function contentText(content: unknown, acceptedTypes: readonly string[]): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  const accepted = new Set(acceptedTypes)
+  return content
+    .filter(isObject)
+    .filter((entry) => accepted.has(stringAt(entry, 'type') ?? ''))
+    .map((entry) => stringAt(entry, 'text') ?? '')
+    .filter(Boolean)
+    .join('\n')
+}
+
+function cleanPrompt(text: string): string | null {
+  const administrativeTags = [
+    'spool-system-prelude',
+    'local-command-stdout',
+    'local-command-caveat',
+    'system-reminder',
+    'command-name',
+    'command-message',
+    'command-args',
+  ]
+  let trimmed = text.trim()
+  for (const tag of administrativeTags) {
+    trimmed = trimmed.replace(new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?<\\/${tag}>`, 'gi'), ' ')
+  }
+  trimmed = trimmed.trim()
+  if (!trimmed || /^<task-notification\b[^>]*>/i.test(trimmed)) return null
+  // Codex persists injected workspace instructions as a user-role response
+  // item. event_msg is preferred when present, but old response-only sessions
+  // still need this guard.
+  if (/^# AGENTS\.md instructions for\s/i.test(trimmed)) return null
+  return trimmed
+}
+
+function claudePrompt(record: UnknownRecord): PromptDetails | null {
+  if (record['type'] !== 'user' || record['isSidechain'] === true) return null
+  const message = objectAt(record, 'message')
+  const content = message?.['content']
+  if (
+    Array.isArray(content) &&
+    content.some((entry) => isObject(entry) && entry['type'] === 'tool_result')
+  ) {
+    return null
+  }
+  const text = cleanPrompt(contentText(content, ['text']))
+  if (text === null) return null
+  return { text, timestamp: stringAt(record, 'timestamp') }
+}
+
+function codexPrompt(record: UnknownRecord, preferEventMessages: boolean): PromptDetails | null {
+  const payload = objectAt(record, 'payload')
+  if (record['type'] === 'event_msg' && payload?.['type'] === 'user_message') {
+    const text = cleanPrompt(stringAt(payload, 'message') ?? '')
+    return text === null ? null : { text, timestamp: stringAt(record, 'timestamp') }
+  }
+  if (
+    preferEventMessages ||
+    record['type'] !== 'response_item' ||
+    payload?.['type'] !== 'message' ||
+    payload['role'] !== 'user'
+  ) {
+    return null
+  }
+  const text = cleanPrompt(contentText(payload['content'], ['input_text', 'text']))
+  return text === null ? null : { text, timestamp: stringAt(record, 'timestamp') }
+}
+
+function promptOf(record: UnknownRecord, preferCodexEvents: boolean): PromptDetails | null {
+  return claudePrompt(record) ?? codexPrompt(record, preferCodexEvents)
+}
+
+function labelOf(text: string): string {
+  const firstLine = (text.split('\n').find((line) => line.trim()) ?? text).trim()
+  return firstLine.length <= MAX_LABEL
+    ? firstLine
+    : `${firstLine.slice(0, MAX_LABEL - 1).trimEnd()}…`
+}
+
+function parseInput(input: unknown): UnknownRecord | null {
+  if (isObject(input)) return input
+  if (typeof input !== 'string') return null
+  try {
+    const parsed = JSON.parse(input) as unknown
+    return isObject(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function commandFromInput(input: unknown): string {
+  const parsed = parseInput(input)
+  if (parsed !== null) {
+    return (
+      stringAt(parsed, 'command') ?? stringAt(parsed, 'cmd') ?? stringAt(parsed, 'script') ?? ''
+    )
+  }
+  return typeof input === 'string' ? input : ''
+}
+
+function claudeToolCalls(record: UnknownRecord): ToolCallDetails[] {
+  if (record['type'] !== 'assistant') return []
+  const message = objectAt(record, 'message')
+  if (!Array.isArray(message?.['content'])) return []
+  return message['content'].flatMap((entry) => {
+    if (!isObject(entry) || entry['type'] !== 'tool_use') return []
+    const name = stringAt(entry, 'name') ?? ''
+    const input = entry['input']
+    return [
+      {
+        id: stringAt(entry, 'id'),
+        name,
+        command: commandFromInput(input),
+      },
+    ]
+  })
+}
+
+function codexToolCalls(record: UnknownRecord): ToolCallDetails[] {
+  if (record['type'] !== 'response_item') return []
+  const payload = objectAt(record, 'payload')
+  if (
+    payload === null ||
+    (payload['type'] !== 'function_call' && payload['type'] !== 'custom_tool_call')
+  ) {
+    return []
+  }
+  const name = stringAt(payload, 'name') ?? ''
+  const input = payload['arguments'] ?? payload['input']
+  return [
+    {
+      id: stringAt(payload, 'call_id') ?? stringAt(payload, 'id'),
+      name,
+      command: commandFromInput(input),
+    },
+  ]
+}
+
+function toolCalls(record: UnknownRecord): ToolCallDetails[] {
+  return [...claudeToolCalls(record), ...codexToolCalls(record)]
+}
+
+function outputExitCode(value: unknown): number | null {
+  if (isObject(value)) {
+    const direct = value['exit_code']
+    if (typeof direct === 'number') return direct
+    const metadata = objectAt(value, 'metadata')
+    const nested = metadata?.['exit_code']
+    if (typeof nested === 'number') return nested
+    return null
+  }
+  if (typeof value === 'string') {
+    try {
+      return outputExitCode(JSON.parse(value) as unknown)
+    } catch {
+      const explicit = value.match(
+        /(?:process exited with code|exit(?:ed)?(?: code)?[:=]?)[\s`]*(\d+)/i,
+      )
+      if (explicit?.[1]) return Number(explicit[1])
+    }
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      if (!isObject(entry)) continue
+      const code = outputExitCode(stringAt(entry, 'text'))
+      if (code !== null) return code
+    }
+  }
+  return null
+}
+
+function outputSignalsFailure(value: unknown): boolean {
+  const exitCode = outputExitCode(value)
+  if (exitCode !== null) return exitCode !== 0
+  if (typeof value === 'string') return /^\s*(?:script|command|tool) failed\b/i.test(value)
+  if (Array.isArray(value)) {
+    return value.some(
+      (entry) => isObject(entry) && outputSignalsFailure(stringAt(entry, 'text') ?? ''),
+    )
+  }
+  return false
+}
+
+function outputText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) {
+    return value
+      .filter(isObject)
+      .map((entry) => stringAt(entry, 'text') ?? '')
+      .filter(Boolean)
+      .join('\n')
+  }
+  if (isObject(value)) {
+    return [stringAt(value, 'stdout'), stringAt(value, 'stderr'), stringAt(value, 'output')]
+      .filter((part): part is string => part !== null)
+      .join('\n')
+  }
+  return ''
+}
+
+function outputSignalsCheckFailure(value: unknown): boolean {
+  if (outputSignalsFailure(value)) return true
+  const text = outputText(value)
+  return (
+    /(?:^|\n)\s*(?:Test Files|Tests|Suites?)\s+\d+\s+failed\b/im.test(text) ||
+    /(?:^|\n)\s*FAIL(?:ED)?\s+/m.test(text) ||
+    /(?:^|\n).*\bELIFECYCLE\b.*\bfailed\b/im.test(text) ||
+    /(?:^|\n).*\berror TS\d+:/i.test(text) ||
+    /(?:^|\n).*\bFound \d+ errors?\b/i.test(text)
+  )
+}
+
+function githubPr(value: string): { prUrl: string; prLabel: string } | null {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    return null
+  }
+  if (url.origin !== 'https://github.com' || url.username || url.password) return null
+  const match = url.pathname.match(/^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?$/)
+  if (match === null) return null
+  const [, owner, repository, number] = match
+  return {
+    prUrl: `https://github.com/${owner}/${repository}/pull/${number}`,
+    prLabel: `PR #${number} · ${owner}/${repository}`,
+  }
+}
+
+function githubPrFromOutput(value: unknown): { prUrl: string; prLabel: string } | null {
+  const match = outputText(value).match(/https:\/\/github\.com\/[^\s/]+\/[^\s/]+\/pull\/\d+\/?/i)
+  return match?.[0] ? githubPr(match[0]) : null
+}
+
+function claudeToolResults(record: UnknownRecord): ToolResultDetails[] {
+  if (record['type'] !== 'user') return []
+  const message = objectAt(record, 'message')
+  if (!Array.isArray(message?.['content'])) return []
+  return message['content'].flatMap((entry) => {
+    if (!isObject(entry) || entry['type'] !== 'tool_result') return []
+    const content = entry['content']
+    const toolUseResult = record['toolUseResult']
+    return [
+      {
+        id: stringAt(entry, 'tool_use_id'),
+        failed:
+          entry['is_error'] === true ||
+          outputSignalsFailure(content) ||
+          outputSignalsFailure(toolUseResult),
+        checkFailed: outputSignalsCheckFailure(content) || outputSignalsCheckFailure(toolUseResult),
+        pr: githubPrFromOutput(content) ?? githubPrFromOutput(toolUseResult),
+      },
+    ]
+  })
+}
+
+function codexToolResults(record: UnknownRecord): ToolResultDetails[] {
+  const payload = objectAt(record, 'payload')
+  if (payload === null) return []
+  const payloadType = payload['type']
+  if (
+    (record['type'] !== 'response_item' ||
+      (payloadType !== 'function_call_output' && payloadType !== 'custom_tool_call_output')) &&
+    (record['type'] !== 'event_msg' || payloadType !== 'patch_apply_end')
+  ) {
+    return []
+  }
+  const status = stringAt(payload, 'status')?.toLowerCase()
+  const failed =
+    payload['success'] === false ||
+    payload['is_error'] === true ||
+    status === 'failed' ||
+    status === 'error' ||
+    outputSignalsFailure(payload['output'])
+  return [
+    {
+      id: stringAt(payload, 'call_id') ?? stringAt(payload, 'id'),
+      failed,
+      checkFailed: outputSignalsCheckFailure(payload['output']),
+      pr: githubPrFromOutput(payload['output']),
+    },
+  ]
+}
+
+function toolResults(record: UnknownRecord): ToolResultDetails[] {
+  return [...claudeToolResults(record), ...codexToolResults(record)]
+}
+
+function isCodexEventPrompt(record: UnknownRecord): boolean {
+  const payload = objectAt(record, 'payload')
+  return record['type'] === 'event_msg' && payload?.['type'] === 'user_message'
+}
+
+function capturePrLink(record: UnknownRecord): { prUrl: string; prLabel: string } | null {
+  if (record['type'] !== 'pr-link') return null
+  const rawUrl = stringAt(record, 'prUrl')
+  return rawUrl === null ? null : githubPr(rawUrl)
+}
+
+export function deriveSessionRoute(records: readonly HubRecordLine[]): SessionRoute | null {
+  const parsed = records.flatMap((line) => {
+    try {
+      const record = JSON.parse(line.data) as unknown
+      return isObject(record) ? [{ line, record }] : []
+    } catch {
+      return []
+    }
+  })
+  const preferCodexEvents = parsed.some(({ record }) => isCodexEventPrompt(record))
+
+  let goal: string | null = null
+  const phases: RoutePhase[] = []
+  let current: RoutePhase | null = null
+  let totalErrors = 0
+  let prUrl: string | null = null
+  let prLabel: string | null = null
+  const pendingCalls = new Map<string, PendingCall>()
+  const seenCalls = new Set<string>()
+  const countedFailures = new Set<string>()
+
+  const ensurePhase = (
+    recordIndex: number,
+    label: string,
+    timestamp: string | null,
+    isPrompt: boolean,
+  ): RoutePhase => {
+    const phase: RoutePhase = {
+      recordIndex,
+      timestamp,
+      isPrompt,
+      label,
+      tools: 0,
+      edits: 0,
+      commands: 0,
+      agents: 0,
+      errors: 0,
+      checkRuns: 0,
+      checkFails: 0,
+    }
+    phases.push(phase)
+    return phase
+  }
+
+  for (const { line, record } of parsed) {
+    const pr = capturePrLink(record)
+    if (pr !== null) {
+      prUrl = pr.prUrl
+      prLabel = pr.prLabel
+      continue
+    }
+
+    const prompt = promptOf(record, preferCodexEvents)
+    if (prompt !== null) {
+      if (goal === null) goal = labelOf(prompt.text)
+      current = ensurePhase(line.i, labelOf(prompt.text), prompt.timestamp, true)
+      continue
+    }
+
+    for (const call of toolCalls(record)) {
+      const callKey = call.id ?? `record:${line.i}`
+      if (seenCalls.has(callKey)) continue
+      seenCalls.add(callKey)
+      const phase = current ?? (current = ensurePhase(line.i, 'Session start', null, false))
+      phase.tools += 1
+      const normalizedName = call.name.toLowerCase()
+      if (EDIT_TOOLS.has(normalizedName)) phase.edits += 1
+      else if (AGENT_TOOLS.has(normalizedName)) phase.agents += 1
+      else if (COMMAND_TOOLS.has(normalizedName)) phase.commands += 1
+
+      const isCheck = COMMAND_TOOLS.has(normalizedName) && CHECK_CMD.test(call.command)
+      if (isCheck) phase.checkRuns += 1
+      if (call.id !== null) {
+        pendingCalls.set(call.id, {
+          phase,
+          isCheck,
+          createsPr:
+            COMMAND_TOOLS.has(normalizedName) &&
+            /(?:^|\s)gh\s+pr\s+create(?:\s|$)/i.test(call.command),
+        })
+      }
+    }
+
+    let resultOffset = 0
+    for (const result of toolResults(record)) {
+      const pending = result.id === null ? null : (pendingCalls.get(result.id) ?? null)
+      if (pending?.createsPr === true && result.pr !== null) {
+        prUrl = result.pr.prUrl
+        prLabel = result.pr.prLabel
+      }
+      const failed = result.failed || (pending?.isCheck === true && result.checkFailed)
+      const failureKey = result.id ?? `record:${line.i}:result:${resultOffset}`
+      resultOffset += 1
+      if (!failed) continue
+      if (countedFailures.has(failureKey)) continue
+      countedFailures.add(failureKey)
+
+      const phase = pending?.phase ?? current ?? ensurePhase(line.i, 'Session start', null, false)
+      current ??= phase
+      totalErrors += 1
+      if (pending?.isCheck === true) phase.checkFails += 1
+      else phase.errors += 1
+    }
+  }
+
+  if (phases.length === 0) return null
+  return { goal, phases, totalErrors, prUrl, prLabel }
+}
+
+/**
+ * Replace raw authored labels with the exact visible .spool prompt projection
+ * and attach TimelineBody turn indices. Hidden turns never leak through the
+ * route, and clicks always target a turn that the publication actually shows.
+ */
+export function projectSessionRouteToSpool(
+  route: SessionRoute | null,
+  document: SpoolDocument,
+): SessionRoute | null {
+  const redactList = document.opts.redact
+    ? collectRedactList(document.conversation.turns, document.opts)
+    : []
+  const visibleTurns = selectSegments(document.conversation, document.opts).turns
+  const visibleIndices = new Set(visibleTurns.map((turn) => turn.origIndex))
+  const promptTurns = document.conversation.turns.flatMap((turn, turnIndex) => {
+    if (turn.role !== 'user' || !turn.body.trim()) return []
+    const body = document.opts.redact ? redactPlainText(turn.body, redactList) : turn.body
+    return [{ turnIndex, timestamp: turn.timestamp ?? null, label: labelOf(body) }]
+  })
+  const unusedPromptTurns = new Set(promptTurns.map((turn) => turn.turnIndex))
+  const phases: RoutePhase[] = []
+
+  if (route === null) {
+    for (const promptTurn of promptTurns) {
+      if (!visibleIndices.has(promptTurn.turnIndex)) continue
+      phases.push({
+        recordIndex: promptTurn.turnIndex,
+        turnIndex: promptTurn.turnIndex,
+        timestamp: promptTurn.timestamp,
+        isPrompt: true,
+        label: promptTurn.label,
+        tools: 0,
+        edits: 0,
+        commands: 0,
+        agents: 0,
+        errors: 0,
+        checkRuns: 0,
+        checkFails: 0,
+      })
+    }
+    if (phases.length === 0) return null
+    return {
+      goal: phases[0]?.label ?? null,
+      phases,
+      totalErrors: 0,
+      prUrl: null,
+      prLabel: null,
+    }
+  }
+
+  for (const phase of route.phases) {
+    if (!phase.isPrompt) continue
+
+    let promptTurn =
+      phase.timestamp === null
+        ? undefined
+        : promptTurns.find(
+            (turn) => unusedPromptTurns.has(turn.turnIndex) && turn.timestamp === phase.timestamp,
+          )
+    promptTurn ??= promptTurns.find((turn) => unusedPromptTurns.has(turn.turnIndex))
+    if (promptTurn === undefined) continue
+    unusedPromptTurns.delete(promptTurn.turnIndex)
+    if (!visibleIndices.has(promptTurn.turnIndex)) continue
+    phases.push({
+      ...phase,
+      label: promptTurn.label,
+      timestamp: promptTurn.timestamp,
+      turnIndex: promptTurn.turnIndex,
+    })
+  }
+
+  if (phases.length === 0) return null
+  const goal = phases.find((phase) => phase.isPrompt)?.label ?? null
+  return {
+    ...route,
+    goal,
+    phases,
+    totalErrors: phases.reduce((total, phase) => total + phase.errors + phase.checkFails, 0),
+    // A raw PR record is outside the authored .spool selection/redaction
+    // boundary. Only legacy raw readers may expose a validated PR outcome.
+    prUrl: null,
+    prLabel: null,
+  }
+}

--- a/apps/web/src/lib/site.ts
+++ b/apps/web/src/lib/site.ts
@@ -1,0 +1,5 @@
+/** Canonical public origin for metadata and links that must not depend on the
+ * request host. `spool.pro` remains reachable for legacy shares, but new
+ * public URLs and canonical tags always point at `spool.new`. */
+export const PUBLIC_SITE_ORIGIN = 'https://spool.new'
+export const PUBLIC_SITE_HOST = 'spool.new'

--- a/apps/web/src/pages/Explore.tsx
+++ b/apps/web/src/pages/Explore.tsx
@@ -126,7 +126,7 @@ function LeftNavigation() {
       </nav>
       <div className="explore-left-footer">
         <ExploreThemeButton />
-        <span>Warm Index</span>
+        <span>Void Index</span>
       </div>
     </aside>
   )

--- a/apps/web/src/pages/Me.tsx
+++ b/apps/web/src/pages/Me.tsx
@@ -633,7 +633,7 @@ export function Me() {
   }, [])
 
   useEffect(() => {
-    document.title = 'Your account · spool.pro'
+    document.title = 'Your account · spool.new'
     void load()
   }, [load])
 

--- a/apps/web/src/pages/Privacy.tsx
+++ b/apps/web/src/pages/Privacy.tsx
@@ -11,7 +11,7 @@ const LAST_UPDATED = 'July 20, 2026'
 
 export function Privacy() {
   useEffect(() => {
-    document.title = 'Privacy · spool.pro'
+    document.title = 'Privacy · spool.new'
   }, [])
 
   return (
@@ -19,7 +19,7 @@ export function Privacy() {
       <Header />
       <main className="sw-main">
         <article className="sw-card sw-legal w-600">
-          <p className="sw-eyebrow">spool.pro</p>
+          <p className="sw-eyebrow">spool.new</p>
           <h1 className="sw-title">Privacy policy</h1>
           <p className="sw-legal-date">Last updated: {LAST_UPDATED}</p>
 
@@ -29,19 +29,19 @@ export function Privacy() {
               <li>Local Session preparation does not publish anything.</li>
               <li>
                 Only the Session, range, Summary, and publication document you explicitly share are
-                sent to spool.pro.
+                sent to spool.new.
               </li>
               <li>
                 Supported Sessions are Public in Explore and search by default after you confirm
                 Share; providers not yet supported by Explore remain Link-only.
               </li>
-              <li>spool.pro runs no ads, behavioral analytics, or third-party tracking cookies.</li>
+              <li>spool.new runs no ads, behavioral analytics, or third-party tracking cookies.</li>
             </ul>
           </div>
 
           <h2>Who we are</h2>
           <p>
-            spool.pro is the publishing service for <a href="https://spool.pro">Spool</a>, an
+            spool.new is the publishing service for <a href="https://spool.new">Spool</a>, an
             open-source platform for sharing and continuing agent Sessions. Contact us at{' '}
             <a href="mailto:hello@spool.pro">hello@spool.pro</a>.
           </p>
@@ -132,7 +132,7 @@ export function Privacy() {
 
           <h2>Children</h2>
           <p>
-            spool.pro is not directed at children under 13, and we do not knowingly collect their
+            spool.new is not directed at children under 13, and we do not knowingly collect their
             data.
           </p>
 

--- a/apps/web/src/pages/Profile.tsx
+++ b/apps/web/src/pages/Profile.tsx
@@ -28,9 +28,9 @@ export function Profile({ handle }: { handle: string }) {
       setState(next)
       if (next.kind === 'ok') {
         const display = next.profile.name ?? `@${next.profile.handle}`
-        document.title = `${normalizeTabTitle(display)} · spool.pro`
+        document.title = `${normalizeTabTitle(display)} · spool.new`
       } else {
-        document.title = 'Profile not found · spool.pro'
+        document.title = 'Profile not found · spool.new'
       }
     })
     return () => {

--- a/apps/web/src/pages/Reader.tsx
+++ b/apps/web/src/pages/Reader.tsx
@@ -73,9 +73,9 @@ export function Reader({ id }: { id: string }) {
       const next = fromFetch(result)
       setState(next)
       if (next.kind === 'ok') {
-        document.title = `${normalizeTabTitle(next.snapshot.conversation.title)} · spool.pro`
+        document.title = `${normalizeTabTitle(next.snapshot.conversation.title)} · spool.new`
       } else if (next.kind === 'gone' || next.kind === 'not-found') {
-        document.title = 'Unavailable · spool.pro'
+        document.title = 'Unavailable · spool.new'
       }
     })
     return () => {

--- a/apps/web/src/pages/SignIn.tsx
+++ b/apps/web/src/pages/SignIn.tsx
@@ -110,7 +110,7 @@ export function SignIn({ next }: Props) {
           <div className="sw-signin-emblem">
             <SpoolMark size={30} />
           </div>
-          <div className="sw-eyebrow">spool.pro</div>
+          <div className="sw-eyebrow">spool.new</div>
           <h1 className="sw-signin-title">Sign in</h1>
           <p className="sw-signin-sub">Publish, manage, and unpublish your shares.</p>
           {PROVIDERS.map((p) => (

--- a/apps/web/src/pages/Terms.tsx
+++ b/apps/web/src/pages/Terms.tsx
@@ -1,6 +1,6 @@
 // Terms of service — static legal page. Keep every service and content
 // claim aligned with the publishing, visibility, withdrawal, and account
-// behavior implemented by spool.pro.
+// behavior implemented by spool.new.
 
 import { useEffect } from 'react'
 
@@ -10,7 +10,7 @@ const LAST_UPDATED = 'July 20, 2026'
 
 export function Terms() {
   useEffect(() => {
-    document.title = 'Terms · spool.pro'
+    document.title = 'Terms · spool.new'
   }, [])
 
   return (
@@ -18,12 +18,12 @@ export function Terms() {
       <Header />
       <main className="sw-main">
         <article className="sw-card sw-legal w-600">
-          <p className="sw-eyebrow">spool.pro</p>
+          <p className="sw-eyebrow">spool.new</p>
           <h1 className="sw-title">Terms of service</h1>
           <p className="sw-legal-date">Last updated: {LAST_UPDATED}</p>
 
           <p>
-            These terms cover spool.pro and its Session publishing, reading, Profile, Discovery, and
+            These terms cover spool.new and its Session publishing, reading, Profile, Discovery, and
             Resume services. By creating an account or sharing a Session, you agree to them. The
             short version: your content remains yours, you are responsible for what you disclose, do
             not use the service to harm people, and the service is provided as-is.
@@ -81,7 +81,7 @@ export function Terms() {
           </p>
 
           <h2>Use restrictions</h2>
-          <p>You may not use spool.pro to share, publish, or distribute:</p>
+          <p>You may not use spool.new to share, publish, or distribute:</p>
           <ul>
             <li>illegal content or material you do not have the right to disclose</li>
             <li>other people’s personal or confidential information without permission</li>
@@ -109,7 +109,7 @@ export function Terms() {
           <p>
             To the maximum extent permitted by law, we are not liable for indirect, incidental, or
             consequential damages arising from use of the service. Our total liability for a claim
-            is limited to the amount paid to use spool.pro during the previous twelve months—which
+            is limited to the amount paid to use spool.new during the previous twelve months—which
             is zero while the service is free.
           </p>
 

--- a/apps/web/src/pages/cli-auth.tsx
+++ b/apps/web/src/pages/cli-auth.tsx
@@ -235,7 +235,7 @@ function Card({
   return (
     <div className="sw-card tight sw-signin w-420">
       <div className="sw-signin-emblem">{icon ?? <SpoolMark size={30} />}</div>
-      <div className="sw-eyebrow">spool.pro</div>
+      <div className="sw-eyebrow">spool.new</div>
       <h1 className="sw-signin-title">{title}</h1>
       <p className="sw-signin-sub">{sub}</p>
       {children}

--- a/apps/web/src/pages/session-reader.load.test.ts
+++ b/apps/web/src/pages/session-reader.load.test.ts
@@ -5,7 +5,11 @@ import { describe, expect, it, vi } from 'vite-plus/test'
 vi.mock('../components/session/workbench', () => ({ SessionWorkbench: () => null }))
 
 import type { HubRecordLine, HubSessionMeta, RangeFetcher } from '../lib/hub-api'
-import { loadSessionContent } from './session-reader'
+import {
+  loadSessionContent,
+  loadSessionRouteRecords,
+  MAX_ROUTE_EVIDENCE_RECORDS,
+} from './session-reader'
 
 const meta: HubSessionMeta = {
   sid: 'claude_12345678',
@@ -128,5 +132,75 @@ describe('loadSessionContent', () => {
 
     expect(fetchSpoolFile).not.toHaveBeenCalled()
     expect(result).toEqual({ view, spoolDocument: null, records: [record(0), record(1)] })
+  })
+})
+
+describe('loadSessionRouteRecords', () => {
+  it('does not download unbounded evidence for large curated sessions', async () => {
+    const makeRangeFetcher = vi.fn((): RangeFetcher => vi.fn())
+
+    const records = await loadSessionRouteRecords(meta.sid, MAX_ROUTE_EVIDENCE_RECORDS + 1, {
+      makeRangeFetcher,
+    })
+
+    expect(records).toBeNull()
+    expect(makeRangeFetcher).not.toHaveBeenCalled()
+  })
+
+  it('loads route evidence independently after the curated document has rendered', async () => {
+    const fetchRange = vi.fn<RangeFetcher>(async (from, to) =>
+      Array.from({ length: to - from }, (_, offset) => record(from + offset)),
+    )
+
+    const records = await loadSessionRouteRecords(meta.sid, 501, {
+      makeRangeFetcher: vi.fn(() => fetchRange),
+    })
+
+    expect(records).toHaveLength(501)
+    expect(fetchRange).toHaveBeenNthCalledWith(1, 0, 500)
+    expect(fetchRange).toHaveBeenNthCalledWith(2, 500, 501)
+  })
+
+  it('isolates route evidence failures from the curated reader', async () => {
+    const records = await loadSessionRouteRecords(meta.sid, 2, {
+      makeRangeFetcher: vi.fn(() => vi.fn(async () => Promise.reject(new Error('offline')))),
+    })
+
+    expect(records).toBeNull()
+  })
+
+  it('stops a stale route load after cancellation', async () => {
+    let cancelled = false
+    const fetchRange = vi.fn<RangeFetcher>(async (from, to) => {
+      cancelled = true
+      return Array.from({ length: to - from }, (_, offset) => record(from + offset))
+    })
+
+    const records = await loadSessionRouteRecords(
+      meta.sid,
+      501,
+      { makeRangeFetcher: vi.fn(() => fetchRange) },
+      { isCancelled: () => cancelled },
+    )
+
+    expect(records).toBeNull()
+    expect(fetchRange).toHaveBeenCalledOnce()
+  })
+
+  it('forwards an abort signal to the active range request', async () => {
+    const abortController = new AbortController()
+    const fetchRange = vi.fn<RangeFetcher>(async (from, to) =>
+      Array.from({ length: to - from }, (_, offset) => record(from + offset)),
+    )
+    const makeRangeFetcher = vi.fn(() => fetchRange)
+
+    await loadSessionRouteRecords(
+      meta.sid,
+      2,
+      { makeRangeFetcher },
+      { signal: abortController.signal },
+    )
+
+    expect(makeRangeFetcher).toHaveBeenCalledWith(meta.sid, abortController.signal)
   })
 })

--- a/apps/web/src/pages/session-reader.tsx
+++ b/apps/web/src/pages/session-reader.tsx
@@ -22,9 +22,15 @@ import {
 import { useQualifiedRead } from '../lib/qualified-read'
 import { parseHubConversation } from '../lib/session-messages'
 import { deepLinkIndex, providerOf } from '../lib/session-page'
+import { deriveSessionRoute, projectSessionRouteToSpool } from '../lib/session-route'
 import { Tombstone } from './Tombstone'
 
 const FETCH_PAGE = 500
+/** Curated publications already contain their readable timeline. Raw records
+ * only enrich the optional Route with machine evidence, so keep that
+ * best-effort request bounded instead of re-downloading arbitrarily large
+ * Sessions in the background. */
+export const MAX_ROUTE_EVIDENCE_RECORDS = 2_000
 
 export interface LoadedSessionContent {
   view: SessionViewV1 | null
@@ -35,11 +41,12 @@ export interface LoadedSessionContent {
 interface SessionContentDeps {
   fetchView: (sid: string) => Promise<SessionViewV1 | null>
   fetchSpoolFile: (sid: string) => Promise<SpoolDocument | null>
-  makeRangeFetcher: (sid: string) => RangeFetcher
+  makeRangeFetcher: (sid: string, signal?: AbortSignal) => RangeFetcher
 }
 
 interface SessionContentLoadOptions {
   isCancelled?: () => boolean
+  signal?: AbortSignal
   onRecordProgress?: (loaded: number, total: number) => void
   /** Preserve record-addressed URLs by using the legacy MessageList, whose
    * record-to-message mapping is exact. Curated turns cannot be mapped back
@@ -51,6 +58,47 @@ const defaultSessionContentDeps: SessionContentDeps = {
   fetchView: fetchHubView,
   fetchSpoolFile: fetchHubSpoolFile,
   makeRangeFetcher,
+}
+
+async function loadRawRecords(
+  sid: string,
+  total: number,
+  makeFetcher: (sid: string, signal?: AbortSignal) => RangeFetcher,
+  options: Pick<SessionContentLoadOptions, 'isCancelled' | 'onRecordProgress' | 'signal'> = {},
+): Promise<HubRecordLine[] | null> {
+  const isCancelled = options.isCancelled ?? (() => false)
+  if (isCancelled()) return null
+  const fetchRange = makeFetcher(sid, options.signal)
+  const records: HubRecordLine[] = []
+  options.onRecordProgress?.(0, total)
+  while (records.length < total) {
+    const from = records.length
+    const page = await fetchRecordsExact(fetchRange, from, Math.min(from + FETCH_PAGE, total))
+    if (isCancelled()) return null
+    records.push(...page)
+    options.onRecordProgress?.(records.length, total)
+  }
+  return records
+}
+
+/**
+ * Best-effort evidence load for the route map on curated .spool pages.
+ * It is deliberately separate from loadSessionContent: the publication can
+ * render as soon as its compact document arrives, and a raw-record failure
+ * only suppresses the optional map instead of failing the reader.
+ */
+export async function loadSessionRouteRecords(
+  sid: string,
+  total: number,
+  deps: Pick<SessionContentDeps, 'makeRangeFetcher'> = defaultSessionContentDeps,
+  options: Pick<SessionContentLoadOptions, 'isCancelled' | 'signal'> = {},
+): Promise<HubRecordLine[] | null> {
+  if (total > MAX_ROUTE_EVIDENCE_RECORDS) return null
+  try {
+    return await loadRawRecords(sid, total, deps.makeRangeFetcher, options)
+  } catch {
+    return null
+  }
 }
 
 /**
@@ -80,17 +128,8 @@ export async function loadSessionContent(
     }
   }
 
-  const fetchRange = deps.makeRangeFetcher(sid)
-  const records: HubRecordLine[] = []
-  const total = meta.count
-  options.onRecordProgress?.(0, total)
-  while (records.length < total) {
-    const from = records.length
-    const page = await fetchRecordsExact(fetchRange, from, Math.min(from + FETCH_PAGE, total))
-    if (isCancelled()) return null
-    records.push(...page)
-    options.onRecordProgress?.(records.length, total)
-  }
+  const records = await loadRawRecords(sid, meta.count, deps.makeRangeFetcher, options)
+  if (records === null) return null
 
   const view = await viewPromise
   return isCancelled() ? null : { view, spoolDocument: null, records }
@@ -129,6 +168,10 @@ function useIsDark(): boolean {
 
 export function SessionReader({ sid }: { sid: string }) {
   const [state, setState] = useState<PageState>({ phase: 'loading', loaded: 0, total: null })
+  const [routeRecords, setRouteRecords] = useState<{
+    sid: string
+    records: HubRecordLine[]
+  } | null>(null)
   const isDark = useIsDark()
 
   const provider = providerOf(sid)
@@ -140,6 +183,8 @@ export function SessionReader({ sid }: { sid: string }) {
 
   useEffect(() => {
     let cancelled = false
+    const abortController = new AbortController()
+    setRouteRecords(null)
     setState({ phase: 'loading', loaded: 0, total: null })
     void (async () => {
       const meta = await fetchHubMeta(sid)
@@ -151,6 +196,7 @@ export function SessionReader({ sid }: { sid: string }) {
       try {
         const content = await loadSessionContent(sid, meta.meta, defaultSessionContentDeps, {
           isCancelled: () => cancelled,
+          signal: abortController.signal,
           onRecordProgress: (loaded, total) => {
             if (!cancelled) setState({ phase: 'loading', loaded, total })
           },
@@ -164,13 +210,54 @@ export function SessionReader({ sid }: { sid: string }) {
     })()
     return () => {
       cancelled = true
+      abortController.abort()
     }
   }, [initialRecordIndex, sid])
 
+  const routeRecordTotal =
+    state.phase === 'ready' &&
+    state.meta.sid === sid &&
+    state.spoolDocument !== null &&
+    state.records.length === 0 &&
+    state.meta.count <= MAX_ROUTE_EVIDENCE_RECORDS
+      ? state.meta.count
+      : null
+
+  useEffect(() => {
+    if (routeRecordTotal === null || routeRecordTotal === 0) return
+    let cancelled = false
+    const abortController = new AbortController()
+    void loadSessionRouteRecords(sid, routeRecordTotal, defaultSessionContentDeps, {
+      isCancelled: () => cancelled,
+      signal: abortController.signal,
+    }).then((records) => {
+      if (!cancelled && records !== null) setRouteRecords({ sid, records })
+    })
+    return () => {
+      cancelled = true
+      abortController.abort()
+    }
+  }, [routeRecordTotal, sid])
+
+  const effectiveRecords =
+    state.phase === 'ready' && state.records.length === 0 && routeRecords?.sid === sid
+      ? routeRecords.records
+      : state.phase === 'ready'
+        ? state.records
+        : []
+
   const conversation = useMemo(
-    () => (state.phase === 'ready' ? parseHubConversation(provider, state.records) : null),
-    [state, provider],
+    () => (state.phase === 'ready' ? parseHubConversation(provider, effectiveRecords) : null),
+    [effectiveRecords, state.phase, provider],
   )
+
+  const route = useMemo(() => {
+    if (state.phase !== 'ready') return null
+    const rawRoute = deriveSessionRoute(effectiveRecords)
+    return state.spoolDocument === null
+      ? rawRoute
+      : projectSessionRouteToSpool(rawRoute, state.spoolDocument)
+  }, [effectiveRecords, state])
 
   if (state.phase === 'not-found') return <Tombstone reason="not-found" />
 
@@ -231,6 +318,7 @@ export function SessionReader({ sid }: { sid: string }) {
           view={state.view}
           provider={provider}
           conversation={conversation}
+          route={route}
           spoolDocument={state.spoolDocument}
           isDark={isDark}
           initialRecordIndex={initialRecordIndex}

--- a/apps/web/src/routes/_site.blog.index.tsx
+++ b/apps/web/src/routes/_site.blog.index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 
 import { blogPosts } from '../lib/content'
+import { PUBLIC_SITE_ORIGIN } from '../lib/site'
 
 const TITLE = 'Blog — Spool'
 const DESC = 'Updates, technical deep-dives, and product announcements from the Spool team.'
@@ -11,18 +12,18 @@ export const Route = createFileRoute('/_site/blog/')({
       { title: TITLE },
       { name: 'description', content: DESC },
       { property: 'og:type', content: 'website' },
-      { property: 'og:url', content: 'https://spool.pro/blog/' },
+      { property: 'og:url', content: `${PUBLIC_SITE_ORIGIN}/blog/` },
       { property: 'og:title', content: TITLE },
       { property: 'og:description', content: DESC },
-      { property: 'og:image', content: 'https://spool.pro/og-image.png' },
+      { property: 'og:image', content: `${PUBLIC_SITE_ORIGIN}/og-image.png` },
       { property: 'og:site_name', content: 'Spool' },
       { name: 'twitter:card', content: 'summary_large_image' },
       { name: 'twitter:title', content: TITLE },
       { name: 'twitter:description', content: DESC },
-      { name: 'twitter:image', content: 'https://spool.pro/og-image.png' },
+      { name: 'twitter:image', content: `${PUBLIC_SITE_ORIGIN}/og-image.png` },
     ],
     links: [
-      { rel: 'canonical', href: 'https://spool.pro/blog/' },
+      { rel: 'canonical', href: `${PUBLIC_SITE_ORIGIN}/blog/` },
       { rel: 'alternate', type: 'application/rss+xml', title: 'Spool Blog', href: '/blog/rss.xml' },
     ],
   }),

--- a/apps/web/src/routes/_site.connectors.tsx
+++ b/apps/web/src/routes/_site.connectors.tsx
@@ -1,10 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useEffect } from 'react'
 
+import { PUBLIC_SITE_ORIGIN } from '../lib/site'
+
 export const Route = createFileRoute('/_site/connectors')({
   head: () => ({
     meta: [{ title: 'Redirecting to /daemon' }, { name: 'robots', content: 'noindex' }],
-    links: [{ rel: 'canonical', href: 'https://spool.pro/daemon' }],
+    links: [{ rel: 'canonical', href: `${PUBLIC_SITE_ORIGIN}/daemon` }],
   }),
   component: ConnectorsRedirect,
 })

--- a/apps/web/src/routes/_site.daemon.tsx
+++ b/apps/web/src/routes/_site.daemon.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import DaemonPage from '../components/site/daemon'
+import { PUBLIC_SITE_ORIGIN } from '../lib/site'
 
 const TITLE = 'Spool Daemon — Background sync for your captures'
 const DESC =
@@ -12,13 +13,13 @@ export const Route = createFileRoute('/_site/daemon')({
       { title: TITLE },
       { name: 'description', content: DESC },
       { property: 'og:type', content: 'website' },
-      { property: 'og:url', content: 'https://spool.pro/daemon' },
+      { property: 'og:url', content: `${PUBLIC_SITE_ORIGIN}/daemon` },
       { property: 'og:title', content: TITLE },
       { property: 'og:description', content: DESC },
-      { property: 'og:image', content: 'https://spool.pro/og-image.png' },
+      { property: 'og:image', content: `${PUBLIC_SITE_ORIGIN}/og-image.png` },
       { property: 'og:site_name', content: 'Spool' },
     ],
-    links: [{ rel: 'canonical', href: 'https://spool.pro/daemon' }],
+    links: [{ rel: 'canonical', href: `${PUBLIC_SITE_ORIGIN}/daemon` }],
   }),
   component: DaemonPage,
 })

--- a/apps/web/src/routes/_site.index.tsx
+++ b/apps/web/src/routes/_site.index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import HomePage from '../components/site/home'
+import { PUBLIC_SITE_ORIGIN } from '../lib/site'
 
 const TITLE = 'Spool — One shared space for agent sessions'
 const DESC =
@@ -12,8 +13,8 @@ const JSON_LD = JSON.stringify({
   name: 'Spool',
   description:
     'Spool publishes real coding-agent Sessions readable end to end — the reasoning, the dead ends, and the author decisions behind the diff — so others can learn from the work and resume it.',
-  url: 'https://spool.pro',
-  author: { '@type': 'Organization', name: 'Spool', url: 'https://spool.pro' },
+  url: PUBLIC_SITE_ORIGIN,
+  author: { '@type': 'Organization', name: 'Spool', url: PUBLIC_SITE_ORIGIN },
 })
 
 export const Route = createFileRoute('/_site/')({
@@ -22,20 +23,20 @@ export const Route = createFileRoute('/_site/')({
       { title: TITLE },
       { name: 'description', content: DESC },
       { property: 'og:type', content: 'website' },
-      { property: 'og:url', content: 'https://spool.pro/' },
+      { property: 'og:url', content: `${PUBLIC_SITE_ORIGIN}/` },
       { property: 'og:title', content: TITLE },
       { property: 'og:description', content: DESC },
-      { property: 'og:image', content: 'https://spool.pro/og-image.png' },
+      { property: 'og:image', content: `${PUBLIC_SITE_ORIGIN}/og-image.png` },
       { property: 'og:image:width', content: '1200' },
       { property: 'og:image:height', content: '630' },
       { property: 'og:site_name', content: 'Spool' },
       { name: 'twitter:card', content: 'summary_large_image' },
       { name: 'twitter:title', content: TITLE },
       { name: 'twitter:description', content: DESC },
-      { name: 'twitter:image', content: 'https://spool.pro/og-image.png' },
+      { name: 'twitter:image', content: `${PUBLIC_SITE_ORIGIN}/og-image.png` },
     ],
     links: [
-      { rel: 'canonical', href: 'https://spool.pro/' },
+      { rel: 'canonical', href: `${PUBLIC_SITE_ORIGIN}/` },
       { rel: 'alternate', type: 'application/rss+xml', title: 'Spool Blog', href: '/blog/rss.xml' },
     ],
     scripts: [{ type: 'application/ld+json', children: JSON_LD }],

--- a/apps/web/src/routes/_site.logo-lab.tsx
+++ b/apps/web/src/routes/_site.logo-lab.tsx
@@ -4,6 +4,6 @@ import { createFileRoute } from '@tanstack/react-router'
 import LogoLab from '../components/site/logo-lab'
 
 export const Route = createFileRoute('/_site/logo-lab')({
-  head: () => ({ meta: [{ title: 'Logo lab · spool.pro' }] }),
+  head: () => ({ meta: [{ title: 'Logo lab · spool.new' }] }),
   component: LogoLab,
 })

--- a/apps/web/src/routes/blog.rss[.]xml.ts
+++ b/apps/web/src/routes/blog.rss[.]xml.ts
@@ -5,8 +5,9 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { blogPosts } from '../lib/content'
+import { PUBLIC_SITE_ORIGIN } from '../lib/site'
 
-const SITE = 'https://spool.pro'
+const SITE = PUBLIC_SITE_ORIGIN
 const TITLE = 'Spool Blog'
 const DESC = 'Updates, technical deep-dives, and product announcements from the Spool team.'
 

--- a/apps/web/src/routes/explore.tsx
+++ b/apps/web/src/routes/explore.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { parseExploreSearch, type ExploreSearchState } from '../lib/discovery'
+import { PUBLIC_SITE_ORIGIN } from '../lib/site'
 import { ExplorePage } from '../pages/Explore'
 
 import '../styles/explore.css'
@@ -15,7 +16,7 @@ export const Route = createFileRoute('/explore')({
         content: 'Find public Claude Code and Codex CLI Sessions with summaries and evidence.',
       },
     ],
-    links: [{ rel: 'canonical', href: 'https://spool.pro/explore' }],
+    links: [{ rel: 'canonical', href: `${PUBLIC_SITE_ORIGIN}/explore` }],
   }),
   component: ExploreRoute,
 })

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -6,6 +6,6 @@ import { createFileRoute } from '@tanstack/react-router'
 import { Privacy } from '../pages/Privacy'
 
 export const Route = createFileRoute('/privacy')({
-  head: () => ({ meta: [{ title: 'Privacy · spool.pro' }] }),
+  head: () => ({ meta: [{ title: 'Privacy · spool.new' }] }),
   component: Privacy,
 })

--- a/apps/web/src/routes/s.$slug.tsx
+++ b/apps/web/src/routes/s.$slug.tsx
@@ -22,6 +22,7 @@ import { createFileRoute, notFound } from '@tanstack/react-router'
 import { snapshotOgHead } from '../lib/og-meta'
 import { SLUG_RE } from '../lib/route'
 import { serverApiOrigin } from '../lib/server-api-origin'
+import { PUBLIC_SITE_ORIGIN } from '../lib/site'
 import { Reader } from '../pages/Reader'
 
 interface MetaForOg {
@@ -33,23 +34,19 @@ interface MetaForOg {
 }
 
 export interface LoaderData {
-  og: { title: string; origin: string } | null
+  og: { title: string } | null
 }
 
 async function loadOgMeta(slug: string): Promise<LoaderData> {
   if (!SLUG_RE.test(slug)) throw notFound()
   if (!import.meta.env.SSR) return { og: null }
 
-  const server = await import('@tanstack/react-start/server')
-  const requestUrl = server.getRequest().url
-  const origin = new URL(requestUrl).origin
-
   try {
     const apiOrigin = serverApiOrigin()
     const res = await fetch(`${apiOrigin}/api/meta/${encodeURIComponent(slug)}`)
     if (res.status !== 200) return { og: null }
     const meta = (await res.json()) as MetaForOg
-    return { og: { title: meta.title ?? '', origin } }
+    return { og: { title: meta.title ?? '' } }
   } catch {
     return { og: null }
   }
@@ -63,8 +60,8 @@ export const Route = createFileRoute('/s/$slug')({
     if (!og) return {}
     return snapshotOgHead({
       title: og.title,
-      ogImageUrl: `${og.origin}/api/og/${params.slug}.png`,
-      canonicalUrl: `${og.origin}/s/${params.slug}`,
+      ogImageUrl: `${PUBLIC_SITE_ORIGIN}/api/og/${params.slug}.png`,
+      canonicalUrl: `${PUBLIC_SITE_ORIGIN}/s/${params.slug}`,
     })
   },
   component: SnapshotSharePage,

--- a/apps/web/src/routes/session.$sid.tsx
+++ b/apps/web/src/routes/session.$sid.tsx
@@ -12,6 +12,7 @@ import { createFileRoute, notFound } from '@tanstack/react-router'
 import { sessionOgHead, sessionOgTitle } from '../lib/og-meta'
 import { SID_RE } from '../lib/route'
 import { serverApiOrigin } from '../lib/server-api-origin'
+import { PUBLIC_SITE_ORIGIN } from '../lib/site'
 import { SessionReader } from '../pages/session-reader'
 
 interface HubMetaForOg {
@@ -22,16 +23,12 @@ interface HubMetaForOg {
 }
 
 export interface LoaderData {
-  og: { title: string; description: string; origin: string } | null
+  og: { title: string; description: string } | null
 }
 
 async function loadSessionOgMeta(sid: string): Promise<LoaderData> {
   if (!SID_RE.test(sid)) throw notFound()
   if (!import.meta.env.SSR) return { og: null }
-
-  const server = await import('@tanstack/react-start/server')
-  const requestUrl = server.getRequest().url
-  const origin = new URL(requestUrl).origin
 
   try {
     const apiOrigin = serverApiOrigin()
@@ -45,7 +42,6 @@ async function loadSessionOgMeta(sid: string): Promise<LoaderData> {
       og: {
         title: sessionOgTitle(meta.summaryMd ?? meta.noteMd),
         description: `A coding-agent session shared by ${author} — ${meta.count} records.`,
-        origin,
       },
     }
   } catch {
@@ -62,7 +58,7 @@ export const Route = createFileRoute('/session/$sid')({
     return sessionOgHead({
       title: og.title,
       description: og.description,
-      canonicalUrl: `${og.origin}/session/${params.sid}`,
+      canonicalUrl: `${PUBLIC_SITE_ORIGIN}/session/${params.sid}`,
     })
   },
   component: SessionSharePage,

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -8,6 +8,6 @@ import { createFileRoute } from '@tanstack/react-router'
 import { Terms } from '../pages/Terms'
 
 export const Route = createFileRoute('/terms')({
-  head: () => ({ meta: [{ title: 'Terms · spool.pro' }] }),
+  head: () => ({ meta: [{ title: 'Terms · spool.new' }] }),
   component: Terms,
 })

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -32,7 +32,7 @@
   --color-accent-dark: var(--sp-accent);
 }
 
-/* spool.pro share-web — unified design system.
+/* spool.new share-web — unified design system.
  * Tokens are scoped to .sw-root so the page can opt into a per-paper
  * surface (Reader) without leaking into 3rd-party DOM. data-theme
  * controls light/dark; default reads from the html[data-theme] root
@@ -123,7 +123,7 @@ html[data-theme='dark'] .sw-root {
 }
 
 /* ── Header chrome ──────────────────────────────────────────── */
-/* Matches spool.pro landing — solid --bg, hairline bottom border, no
+/* Matches spool.new landing — solid --bg, hairline bottom border, no
  * blur, no semi-transparent overlay. Solid color reads as "site chrome"
  * across light + dark; the frosted-glass look fought with the warm
  * parchment palette and confused the reader's paper card. */
@@ -1099,8 +1099,8 @@ html[data-theme='dark'] .sw-root {
   max-width: 100%;
   border-radius: var(--sp-radius-card);
   box-shadow:
-    0 1px 2px rgba(40, 34, 26, 0.05),
-    0 18px 50px rgba(40, 34, 26, 0.1);
+    0 1px 2px rgba(0, 0, 0, 0.05),
+    0 18px 50px rgba(0, 0, 0, 0.1);
 }
 html[data-theme='dark'] .reader-paper {
   box-shadow:
@@ -1112,7 +1112,7 @@ html[data-theme='dark'] .reader-paper {
 .sw-modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(20, 20, 16, 0.45);
+  background: rgba(0, 0, 0, 0.45);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -81,7 +81,7 @@ body {
   --paper: #faf7f0;
   --spool-scrollbar-thumb: rgba(0, 0, 0, 0.1);
   --spool-scrollbar-thumb-hover: rgba(0, 0, 0, 0.16);
-  --shadow-card: 0 1px 2px rgba(28, 28, 24, 0.04), 0 8px 24px rgba(28, 28, 24, 0.06);
+  --shadow-card: 0 1px 2px rgba(10, 10, 10, 0.04), 0 8px 24px rgba(10, 10, 10, 0.06);
   --radius: var(--sp-radius-card);
 
   color: var(--text);

--- a/apps/web/src/styles/daemon.css
+++ b/apps/web/src/styles/daemon.css
@@ -245,7 +245,7 @@
   overflow: hidden;
   box-shadow:
     0 1px 0 rgba(0, 0, 0, 0.02),
-    0 18px 40px -24px rgba(28, 28, 24, 0.18);
+    0 18px 40px -24px rgba(10, 10, 10, 0.18);
 }
 .code-head {
   display: flex;

--- a/apps/web/src/styles/home.css
+++ b/apps/web/src/styles/home.css
@@ -962,7 +962,7 @@ section.sect:last-of-type {
   height: 100%;
 }
 /* Narrow light beams sweeping slowly across the first screen. The base
-   stays the page's warm near-black — only thin shafts move, so there is
+   stays the page's void black — only thin shafts move, so there is
    no color jump when scrolling into the sections below. */
 .hs-band {
   position: absolute;

--- a/apps/web/src/styles/home.css
+++ b/apps/web/src/styles/home.css
@@ -1256,8 +1256,8 @@ html:not(.dark):not([data-theme='dark']) .hs-scrim {
 }
 .fs-lscreen {
   width: 100%;
-  background: #0c0c0a;
-  border: 2px solid #3a3a34;
+  background: #090909;
+  border: 2px solid #2e2e2e;
   border-bottom-width: 4px;
   border-radius: 12px 12px 3px 3px;
   padding: 10px;
@@ -1266,7 +1266,7 @@ html:not(.dark):not([data-theme='dark']) .hs-scrim {
   width: 112%;
   max-width: calc(100% + 36px);
   height: 9px;
-  background: linear-gradient(#454540, #24241f);
+  background: linear-gradient(#555555, #111111);
   border-radius: 1px 1px 9px 9px;
   position: relative;
 }
@@ -1278,7 +1278,7 @@ html:not(.dark):not([data-theme='dark']) .hs-scrim {
   transform: translateX(-50%);
   width: 56px;
   height: 3.5px;
-  background: #1a1a16;
+  background: #111111;
   border-radius: 0 0 5px 5px;
 }
 .fs-lwho {
@@ -1288,8 +1288,8 @@ html:not(.dark):not([data-theme='dark']) .hs-scrim {
   color: var(--muted);
 }
 .fs-win {
-  background: #161613;
-  border: 1px solid #2e2e28;
+  background: #090909;
+  border: 1px solid #2e2e2e;
   border-radius: 8px;
   overflow: hidden;
 }
@@ -1298,8 +1298,8 @@ html:not(.dark):not([data-theme='dark']) .hs-scrim {
   align-items: center;
   gap: 8px;
   padding: 6px 10px;
-  background: #1c1c18;
-  border-bottom: 1px solid #2e2e28;
+  background: #111111;
+  border-bottom: 1px solid #2e2e2e;
 }
 .fs-dots {
   display: inline-flex;
@@ -1309,7 +1309,7 @@ html:not(.dark):not([data-theme='dark']) .hs-scrim {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: #3a3a34;
+  background: #2e2e2e;
 }
 .gt-bar .fs-dots i {
   background: var(--border2);
@@ -1318,7 +1318,7 @@ html:not(.dark):not([data-theme='dark']) .hs-scrim {
   flex: 1;
   font-family: 'Geist Mono', monospace;
   font-size: 10px;
-  color: #8a8a80;
+  color: #a6a6a6;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1337,7 +1337,7 @@ html:not(.dark):not([data-theme='dark']) .hs-scrim {
   background: color-mix(in srgb, var(--accent) 72%, transparent);
 }
 .fs-line.fs-dim {
-  background: color-mix(in srgb, #8a8a80 45%, transparent);
+  background: color-mix(in srgb, #a6a6a6 45%, transparent);
 }
 .fs-line.fs-ok {
   background: color-mix(in srgb, var(--sp-success) 80%, transparent);
@@ -1346,9 +1346,9 @@ html:not(.dark):not([data-theme='dark']) .hs-scrim {
   margin-top: auto;
   font-family: 'Geist Mono', monospace;
   font-size: 11px;
-  color: #f2f2ec;
-  background: #101010;
-  border: 1px solid #2e2e28;
+  color: #ffffff;
+  background: #090909;
+  border: 1px solid #2e2e2e;
   border-radius: 6px;
   padding: 6px 10px;
   overflow: hidden;
@@ -1365,7 +1365,7 @@ html:not(.dark):not([data-theme='dark']) .hs-scrim {
 .fs-sel {
   font-family: 'Geist Mono', monospace;
   font-size: 10.5px;
-  color: #8a8a80;
+  color: #a6a6a6;
 }
 .fs-sel b {
   color: #7dc07d;

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -1,17 +1,20 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
-  // Keep the existing production service name so the first direct deploy can
-  // replace its script without trying to steal the already-bound route.
-  "name": "spool-pro-router",
+  // Post-acquisition home: the site runs on spool.new in the Paperboy
+  // Cloudflare account.
+  "name": "spool-new-router",
+  "account_id": "6898ecdad1e8341d3e09d4b46124d72e",
   "main": "src/server.ts",
   "compatibility_date": "2026-07-17",
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": false,
   "preview_urls": false,
+  // Keep a Worker route while the acquired apex still has legacy DNS.
+  // The route takes ownership of every request without disrupting spool.pro.
   "routes": [
     {
-      "pattern": "spool.pro/*",
-      "zone_name": "spool.pro",
+      "pattern": "spool.new/*",
+      "zone_name": "spool.new",
     },
   ],
   "vars": {
@@ -23,11 +26,11 @@
   },
   "env": {
     "staging": {
-      "name": "spool-pro-router-staging",
+      "name": "spool-new-router-staging",
       "routes": [
         {
-          "pattern": "staging.spool.pro/*",
-          "zone_name": "spool.pro",
+          "pattern": "staging.spool.new/*",
+          "zone_name": "spool.new",
         },
       ],
       "vars": {

--- a/packages/core/src/db/db.ts
+++ b/packages/core/src/db/db.ts
@@ -717,7 +717,7 @@ export function runMigrations(db: Database.Database): void {
     // The editor recomputes the same hash on the live draft and
     // compares; a mismatch surfaces the "Unpublished edits" badge in
     // the manage view so the user knows their next Republish click
-    // will actually change something on spool.pro.
+    // will actually change something on spool.new.
     db.exec(`
       CREATE TABLE IF NOT EXISTS published_shares_cache (
         id                 TEXT PRIMARY KEY,

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
       build: {
         command: 'pnpm run clean && tsc',
         input: [{ auto: true }, '!dist/**', '!node_modules/**'],
+        output: ['dist/**'],
       },
     },
   },

--- a/packages/redact/vite.config.ts
+++ b/packages/redact/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
       build: {
         command: 'pnpm run clean && tsc',
         input: [{ auto: true }, '!dist/**', '!node_modules/**'],
+        output: ['dist/**'],
       },
     },
   },

--- a/packages/session-kit/vite.config.ts
+++ b/packages/session-kit/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
       build: {
         command: 'pnpm run clean && tsc',
         input: [{ auto: true }, '!dist/**', '!node_modules/**'],
+        output: ['dist/**'],
       },
     },
   },

--- a/packages/session-view/src/tailwind.css
+++ b/packages/session-view/src/tailwind.css
@@ -16,28 +16,29 @@
 @source "./";
 
 @theme {
-  /* Warm palette — mirror of packages/app/src/renderer/styles.css @theme.
+  /* Legacy utility names mapped to the Void Index palette — mirror of
+   * packages/app/src/renderer/styles.css @theme.
    * Only the tokens these components reference. If the app palette
    * changes, change it here too (single-source extraction is a later
    * refactor). */
-  --color-warm-bg: #fafaf8;
-  --color-warm-surface: #f4f4f0;
-  --color-warm-surface2: #eeeee9;
-  --color-warm-border: #e8e8e2;
-  --color-warm-border2: #d8d8d0;
-  --color-warm-text: #1c1c18;
-  --color-warm-muted: #6b6b60;
-  --color-warm-faint: #adadaa;
-  --color-accent: #c85a00;
-  --color-dark-bg: #141410;
-  --color-dark-surface: #1c1c18;
-  --color-dark-surface2: #242420;
-  --color-dark-border: #2e2e28;
-  --color-dark-border2: #3a3a34;
-  --color-dark-text: #f2f2ec;
-  --color-dark-muted: #9a9a8e;
-  --color-dark-faint: #505048;
-  --color-accent-dark: #f07020;
+  --color-warm-bg: #ffffff;
+  --color-warm-surface: #f5f5f5;
+  --color-warm-surface2: #ececec;
+  --color-warm-border: #e5e5e5;
+  --color-warm-border2: #d4d4d4;
+  --color-warm-text: #0a0a0a;
+  --color-warm-muted: #666666;
+  --color-warm-faint: #a3a3a3;
+  --color-accent: #1387ff;
+  --color-dark-bg: #000000;
+  --color-dark-surface: #090909;
+  --color-dark-surface2: #111111;
+  --color-dark-border: #1f1f1f;
+  --color-dark-border2: #2e2e2e;
+  --color-dark-text: #ffffff;
+  --color-dark-muted: #a6a6a6;
+  --color-dark-faint: #555555;
+  --color-accent-dark: #5bb1f0;
 }
 
 /* Scrollbar plumbing the components rely on (mirrors the app's). */

--- a/packages/session-view/vite.config.ts
+++ b/packages/session-view/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       build: {
         command: 'pnpm run clean && vp build',
         input: [{ auto: true }, '!dist/**', '!node_modules/**'],
+        output: ['dist/**'],
       },
     },
   },

--- a/packages/share-kit/src/index.ts
+++ b/packages/share-kit/src/index.ts
@@ -1,5 +1,5 @@
 // @spool/share-kit — building blocks for the Spool Share editor surface.
-// Consumers (Spool app, spool.pro web) assemble these into their own
+// Consumers (Spool app, spool.new web) assemble these into their own
 // editor pages; the kit itself is host-agnostic (no routing, no global
 // state, no IPC).
 
@@ -53,7 +53,7 @@ export { Timeline, TimelineBody } from './templates/timeline'
 export type { TimelineBodyProps } from './templates/timeline'
 export { Chat } from './templates/chat'
 
-// ─── Snapshot reader (used by spool.pro web) ──────────────────
+// ─── Snapshot reader (used by spool.new web) ──────────────────
 export { SnapshotReader } from './reader/SnapshotReader'
 export type { SnapshotReaderProps } from './reader/SnapshotReader'
 export { decodeSnapshot } from './reader/snapshot-to-conversation'
@@ -115,7 +115,7 @@ export type { ParseErrorReason } from './lib/parsers'
 export { fetchContent, FetchError } from './lib/parsers/fetcher'
 export type { FetchedContent } from './lib/parsers/fetcher'
 
-// ─── Local draft storage (IndexedDB; for spool.pro web) ───────
+// ─── Local draft storage (IndexedDB; for spool.new web) ───────
 export {
   saveDraft,
   loadDraft,

--- a/packages/share-kit/src/lib/fixtures.ts
+++ b/packages/share-kit/src/lib/fixtures.ts
@@ -13,7 +13,7 @@ export const FIXTURE_PASTED: Conversation = {
   },
   title: 'Debugging a race condition in the cache layer',
   shareUrl: 'https://claude.ai/share/8f3a2e1b-d4c7-4a90-b3f2-1e9c7a0d5f8b',
-  shortUrl: 'spool.pro/s/3fm2',
+  shortUrl: 'spool.new/s/3fm2',
   createdAt: 'April 18, 2026',
   wordCount: 3412,
   readMin: 6,

--- a/packages/share-kit/src/lib/spool-to-snapshot.ts
+++ b/packages/share-kit/src/lib/spool-to-snapshot.ts
@@ -1,5 +1,5 @@
 // Pure display transform: a .spool document → the wire Snapshot the
-// reader renders. Used by the spool.pro session page to show the .spool
+// reader renders. Used by the spool.new session page to show the .spool
 // file attached to a hub share. No redaction here — attached documents
 // are sanitized at build time (buildSpoolDocument sanitize: true); this
 // mirrors the id-opaquing + hidden-turn blanking rules of the app's

--- a/packages/share-kit/src/lib/storage/spool-file.ts
+++ b/packages/share-kit/src/lib/storage/spool-file.ts
@@ -111,7 +111,7 @@ function escapeRx(s: string): string {
 /** FNV-1a 32-bit hash for deterministic legacy-turn id backfill. We
  *  intentionally use FNV (not the redact-detect content hash) — it's
  *  the cheapest stable function that's portable across the renderer
- *  and the future spool.pro web reader. */
+ *  and the spool.new web reader. */
 function fnv1a32(s: string): number {
   let h = 0x811c9dc5
   for (let i = 0; i < s.length; i++) {

--- a/packages/share-kit/src/lib/types.ts
+++ b/packages/share-kit/src/lib/types.ts
@@ -59,7 +59,7 @@ export interface Conversation {
   title: string
   /** Public share URL when applicable. Null for file origins. */
   shareUrl: string | null
-  /** Hosted spool.pro short URL. Only present after publish (Phase 2+). */
+  /** Hosted spool.new short URL. Only present after publish (Phase 2+). */
   shortUrl?: string
   createdAt: string
   wordCount: number
@@ -280,7 +280,7 @@ export interface SpoolDocument {
 
 /** Wire-format snapshot served by the share-backend reader endpoint.
  *  Mirrors `apps/app/src/shared/share-publish.ts` — kept here so the
- *  `spool.pro` web reader can depend on share-kit alone. The desktop
+ *  `spool.new` web reader can depend on share-kit alone. The desktop
  *  publish IPC owns the editor-side authoritative copy; if the two ever
  *  drift, the backend's zod validator in
  *  `packages/share-backend/src/publish/validators.ts` is canonical. */

--- a/packages/share-kit/src/reader/SnapshotReader.tsx
+++ b/packages/share-kit/src/reader/SnapshotReader.tsx
@@ -1,5 +1,5 @@
 // Renders an immutable Snapshot in read-only mode using the appropriate
-// template. This is the single entry point used by the spool.pro web
+// template. This is the single entry point used by the spool.new web
 // reader at `/s/<id>`.
 //
 // SAFETY: never uses dangerouslySetInnerHTML on user content. All turn

--- a/packages/share-kit/vite.config.ts
+++ b/packages/share-kit/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       build: {
         command: 'pnpm run clean && vp build',
         input: [{ auto: true }, '!dist/**', '!node_modules/**'],
+        output: ['dist/**'],
       },
     },
   },

--- a/packages/ui/src/build-output.test.ts
+++ b/packages/ui/src/build-output.test.ts
@@ -18,7 +18,7 @@ describe('package build output', () => {
       })
 
       expect(readFileSync(join(outDir, 'styles.css'), 'utf8')).toContain("@import './tokens.css'")
-      expect(readFileSync(join(outDir, 'tokens.css'), 'utf8')).toContain('--sp-accent: #c85a00')
+      expect(readFileSync(join(outDir, 'tokens.css'), 'utf8')).toContain('--sp-accent: #1387ff')
     } finally {
       rmSync(outDir, { recursive: true, force: true })
     }

--- a/packages/ui/src/css-contract.test.ts
+++ b/packages/ui/src/css-contract.test.ts
@@ -24,16 +24,18 @@ describe('shared UI CSS contract', () => {
     expect(tokens).toContain('--sp-motion-hover: 80ms')
   })
 
-  it('implements the DESIGN.md warm palette for both supported dark roots', () => {
-    expect(tokens).toContain('--sp-bg-light: #fafaf8')
-    expect(tokens).toContain('--sp-bg-dark: #141410')
-    expect(tokens).toContain('--sp-bg: #fafaf8')
-    expect(tokens).toContain('--sp-accent: #c85a00')
+  it('implements the DESIGN.md void palette for both supported dark roots', () => {
+    expect(tokens).toContain('--sp-bg-light: #ffffff')
+    expect(tokens).toContain('--sp-bg-dark: #000000')
+    expect(tokens).toContain('--sp-bg: #ffffff')
+    expect(tokens).toContain('--sp-accent: #1387ff')
+    expect(tokens).toContain('--sp-accent-dm: #5bb1f0')
     expect(tokens).toContain('html.dark,')
     expect(tokens).toContain("html[data-theme='dark']")
-    expect(tokens).toContain('--sp-bg: #141410')
-    expect(tokens).toContain('--sp-accent: #f07020')
-    expect(tokens).not.toMatch(/Inter|#000(?:000)?\b|#[0a]0[a0]0[a0]\b/i)
+    expect(tokens).toContain('--sp-bg: #000000')
+    expect(tokens).toContain('--sp-surface: #090909')
+    expect(tokens).toContain('--sp-accent: #5bb1f0')
+    expect(tokens).not.toMatch(/Inter|#c85a00|#f07020/i)
   })
 
   it('keeps primitive dimensions and row spacing tied to package tokens', () => {

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       build: {
         command: 'pnpm run clean && vp build',
         input: [{ auto: true }, '!dist/**', '!node_modules/**'],
+        output: ['dist/**'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- add a responsive, accessible Session Route map derived from Claude/Codex records, with curated `.spool` redaction/selection boundaries
- align AGENTS.md, DESIGN.md, desktop, web, reader, and OG surfaces with the Paperboy electric-blue/void UI
- move canonical/public defaults to `spool.new` while retaining `spool.pro` compatibility
- add reproducible Cloudflare Pages + Workers production deployment, including backend-first automation
- make Electron CSP policy tests runtime-independent and make Vite+ build cache restore package `dist` outputs reliably

## Validation
- `pnpm exec vp check`
- `pnpm typecheck`
- `pnpm build`
- web/backend/CLI/core/package unit suites (1,200+ passing; no local E2E)
- `pnpm --filter @spool/web run deploy:dry`
- live production: `spool.new/` 200 (`x-spool-route: web`)
- live production: `spool.new/api/health` 200 (`x-spool-route: backend`)
- live public Session canonical + OG URLs point to `spool.new`
- `spool.pro` remains available as a legacy entry point

Per AGENTS.md, local E2E was intentionally not run. Remote PR E2E remains authoritative.

## Operational follow-up
WorkOS currently rejects the new callback until `https://spool.new/api/auth/workos/callback` is added to the production application's redirect allowlist. The old `spool.pro` callback should remain during migration.