### PR TITLE
fix: preserve Cloudflare routes during CI deploys

### DIFF
--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -9,14 +9,10 @@
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": false,
   "preview_urls": false,
-  // Keep a Worker route while the acquired apex still has legacy DNS.
-  // The route takes ownership of every request without disrupting spool.pro.
-  "routes": [
-    {
-      "pattern": "spool.new/*",
-      "zone_name": "spool.new",
-    },
-  ],
+  // Routes are intentionally managed in Cloudflare rather than on every
+  // deploy. The production trigger is `spool.new/*`; omitting `routes` while
+  // `workers_dev` is false lets the least-privilege CI token update the Worker
+  // without needing DNS-zone permissions or disturbing that existing trigger.
   "vars": {
     "ORIGIN_BACKEND": "https://spool-share-backend.pages.dev",
   },
@@ -27,12 +23,8 @@
   "env": {
     "staging": {
       "name": "spool-new-router-staging",
-      "routes": [
-        {
-          "pattern": "staging.spool.new/*",
-          "zone_name": "spool.new",
-        },
-      ],
+      // Expected trigger once staging DNS is provisioned:
+      // `staging.spool.new/*` in the `spool.new` zone.
       "vars": {
         "ORIGIN_BACKEND": "https://spool-share-backend-staging.pages.dev",
       },


### PR DESCRIPTION
## What changed

- leave the existing `spool.new/*` Worker trigger managed in Cloudflare
- omit `routes` from generated deploy config so the least-privilege CI token can publish Worker versions without zone-route permission
- document the production and future staging triggers next to the config

## Why

The first main deployment after #475 successfully published the Pages backend and uploaded the Worker, then failed while trying to rewrite `/zones/.../workers/routes` with Cloudflare error 10000. Cloudflare documents that omitting `route`/`routes` while `workers_dev = false` preserves dashboard-managed routes.

Failed run: https://github.com/paperboytm/spool/actions/runs/29908603439

## Verification

- web production build passes (16 prerendered pages)
- generated `dist/server/wrangler.json` has no `routes`, keeps `workers_dev: false`, and retains the production backend binding
- `wrangler deploy --dry-run` passes
- no local E2E run (per repository instructions)