### PR TITLE
fix(web): align Team invitation controls

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1561,6 +1561,9 @@ html[data-theme='dark'] .sw-root {
 .sw-team-invite-controls label {
   min-width: 0;
 }
+.sw-team-invite-controls .sp-button {
+  height: 48px;
+}
 .sw-team-members-block,
 .sw-team-invitations-block {
   margin-top: var(--sp-space-6);

--- a/apps/web/tests/ui-system-contract.test.ts
+++ b/apps/web/tests/ui-system-contract.test.ts
@@ -56,6 +56,9 @@ describe('Web shared UI contract', () => {
     const desktopCss = css.split('@media (max-width: 768px)')[0] ?? ''
 
     expect(desktopCss).toMatch(
+      /\.sw-team-invite input,\s*\.sw-team-invite select,[^{]*\{[^}]*height:\s*48px;[^}]*\}/,
+    )
+    expect(desktopCss).toMatch(
       /\.sw-team-invite-controls \.sp-button\s*\{[^}]*height:\s*48px;[^}]*\}/,
     )
   })

--- a/apps/web/tests/ui-system-contract.test.ts
+++ b/apps/web/tests/ui-system-contract.test.ts
@@ -50,4 +50,13 @@ describe('Web shared UI contract', () => {
     expect(coarsePointerCss).toMatch(/min-width:\s*44px/)
     expect(coarsePointerCss).toMatch(/min-height:\s*44px/)
   })
+
+  it('keeps every control in the Team invitation row the same height on desktop', () => {
+    const css = source('src/styles/app.css')
+    const desktopCss = css.split('@media (max-width: 768px)')[0] ?? ''
+
+    expect(desktopCss).toMatch(
+      /\.sw-team-invite-controls \.sp-button\s*\{[^}]*height:\s*48px;[^}]*\}/,
+    )
+  })
 })


### PR DESCRIPTION
## Summary
- make the Team invite submit button match the 48px email and role controls on desktop
- add a CSS contract regression test for the invitation row

## Validation
- `pnpm --filter @spool/web test -- tests/ui-system-contract.test.ts` (38 files / 249 tests)
- `pnpm --filter @spool/web typecheck`
- `pnpm --filter @spool/web build`
- `git diff --check`

No E2E run per repository instructions.