### PR TITLE
fix: gate automatic Cloudflare deploys

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -22,8 +22,75 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  release-gate:
+    name: Check deployment eligibility
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      deploy: ${{ steps.eligibility.outputs.deploy }}
+    env:
+      DEPLOY_TARGET: ${{ github.event_name == 'push' && 'production' || inputs.target }}
+    steps:
+      - uses: actions/checkout@v6
+
+      # Public pages and /install.sh must never advertise a CLI contract that
+      # npm does not serve yet. Main may advance before its matching release;
+      # that is an expected no-op for automatic production deployment, while
+      # an explicit production dispatch remains a hard release failure.
+      - name: Check matching CLI release
+        id: eligibility
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          stop_deployment() {
+            local reason="$1"
+            if [ "$GITHUB_EVENT_NAME" = 'push' ]; then
+              echo "::notice::${reason} Skipping automatic production deployment."
+              echo "deploy=false" >> "$GITHUB_OUTPUT"
+              {
+                echo '### Production deployment skipped'
+                echo
+                echo "$reason"
+                echo
+                echo 'Production can advance after the matching CLI release is published.'
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+
+            echo "::error::${reason}"
+            exit 1
+          }
+
+          if [ "$DEPLOY_TARGET" = 'staging' ]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          version="$(jq -r .version apps/cli/package.json)"
+          tag="v${version}"
+          if ! git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}" 2>/dev/null; then
+            stop_deployment "The matching CLI tag ${tag} does not exist."
+          fi
+          if ! git diff --quiet "$tag" -- \
+            apps/cli \
+            packages/core \
+            packages/redact \
+            packages/session-kit; then
+            stop_deployment "CLI sources differ from ${tag}."
+          fi
+          published="$(npm view "@spool-lab/cli@${version}" version 2>/dev/null || true)"
+          if [ "$published" != "$version" ]; then
+            stop_deployment "@spool-lab/cli@${version} is not available from npm yet."
+          fi
+
+          echo "deploy=true" >> "$GITHUB_OUTPUT"
+
   deploy:
     name: Deploy ${{ github.event_name == 'push' && 'production' || inputs.target }}
+    needs: release-gate
+    if: needs.release-gate.outputs.deploy == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
@@ -44,39 +111,32 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Public pages and /install.sh must never advertise a CLI contract that
-      # npm does not serve yet. A normal main push may race the release job, so
-      # production waits for a matching version tag and registry package.
-      - name: Verify production CLI release
-        if: env.DEPLOY_TARGET == 'production'
-        shell: bash
-        run: |
-          set -euo pipefail
-          version="$(jq -r .version apps/cli/package.json)"
-          tag="v${version}"
-          git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}"
-          if ! git diff --quiet "$tag" -- \
-            apps/cli \
-            packages/core \
-            packages/redact \
-            packages/session-kit; then
-            echo "::error::CLI sources differ from ${tag}. Publish the next CLI release before deploying production web."
-            exit 1
-          fi
-          published="$(npm view "@spool-lab/cli@${version}" version 2>/dev/null || true)"
-          if [ "$published" != "$version" ]; then
-            echo "::error::@spool-lab/cli@${version} is not available from npm yet."
-            exit 1
-          fi
-
       - name: Verify Cloudflare account target
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: test "$CLOUDFLARE_ACCOUNT_ID" = "$EXPECTED_CLOUDFLARE_ACCOUNT_ID"
 
-      # Keep the release self-gating. The separate E2E workflow may still be
-      # running when a main push arrives, so every non-E2E check required by
-      # this deployment runs before the first remote mutation.
+      # Fail before the expensive source checks if the CI token cannot reach
+      # the D1 database that this deployment will migrate.
+      - name: Verify Cloudflare D1 access
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$DEPLOY_TARGET" = 'production' ]; then
+            database='spool-share-db'
+            config='wrangler.prod.toml'
+          else
+            database='spool-share-db-staging'
+            config='wrangler.staging.toml'
+          fi
+          pnpm --filter @spool/backend exec wrangler d1 info "$database" --config "$config" >/dev/null
+
+      # Keep every eligible deployment self-gating. The separate E2E workflow
+      # may still be running, so every non-E2E check required by this release
+      # runs before the first remote mutation.
       - name: Check source
         run: pnpm exec vp check
 

--- a/scripts/lib/release-workflow.test.mjs
+++ b/scripts/lib/release-workflow.test.mjs
@@ -43,8 +43,22 @@ describe('npm release workflow', () => {
   })
 
   test('blocks production web until the matching CLI package is published', () => {
-    expect(deployWorkflow).toContain('Verify production CLI release')
+    expect(deployWorkflow).toContain('Check matching CLI release')
     expect(deployWorkflow).toContain('git diff --quiet "$tag"')
     expect(deployWorkflow).toContain('npm view "@spool-lab/cli@${version}" version')
+  })
+
+  test('skips only ineligible automatic production deployments', () => {
+    const gateJob = deployWorkflow.match(/  release-gate:[\s\S]*?(?=\n  deploy:)/)?.[0]
+    const deployJob = deployWorkflow.match(/^  deploy:[\s\S]*?steps:/m)?.[0]
+
+    expect(deployWorkflow).toContain('push:\n    branches: [main]')
+    expect(gateJob).toBeDefined()
+    expect(gateJob).toContain('if [ "$GITHUB_EVENT_NAME" = \'push\' ]')
+    expect(gateJob).toContain('echo "deploy=false" >> "$GITHUB_OUTPUT"')
+    expect(gateJob).toContain('echo "::error::${reason}"')
+    expect(deployJob).toContain('needs: release-gate')
+    expect(deployJob).toContain("if: needs.release-gate.outputs.deploy == 'true'")
+    expect(deployWorkflow).toContain('Verify Cloudflare D1 access')
   })
 })


### PR DESCRIPTION
## What changed

- split release eligibility into a fast `release-gate` job
- treat an unpublished CLI on automatic `main` pushes as an explicit skipped deployment instead of a failed workflow
- keep manual/release production dispatches fail-closed
- add an early D1 access check before expensive validation and remote mutations
- add regression coverage for the gate and deploy dependency

## Root cause

Every `main` push was treated as a production deploy, while production also requires a matching CLI tag and npm package. CLI-affecting merges and the release script's main-before-tag/npm ordering therefore turned an expected no-op into a red Actions run.

A separate production attempt also exposed Cloudflare error 7403 at D1 migration. The repository token still needs `D1 Edit` on account `6898ecdad1e8341d3e09d4b46124d72e`; this PR makes that credential failure happen early and clearly.

## Validation

- `pnpm exec vp check`
- `pnpm exec vp test run scripts/lib/release-workflow.test.mjs scripts/lib/cli-web-workspace.test.mjs` (11 passed)
- local OAuth read-only D1 lookup against `spool-share-db`
