### PR TITLE
fix: recover hosted WorkOS invitation callbacks

### DIFF
--- a/apps/backend/functions/_middleware.ts
+++ b/apps/backend/functions/_middleware.ts
@@ -7,7 +7,9 @@ export const onRequest: PagesFunction = async (ctx) => {
   const headers = new Headers(res.headers)
   headers.set('X-Robots-Tag', 'noindex')
   headers.set('X-Content-Type-Options', 'nosniff')
-  headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
+  if (!headers.has('referrer-policy')) {
+    headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
+  }
 
   const url = new URL(ctx.request.url)
   if (url.pathname.startsWith('/api/')) {

--- a/apps/backend/functions/api/auth/[provider]/callback.ts
+++ b/apps/backend/functions/api/auth/[provider]/callback.ts
@@ -17,7 +17,7 @@ import { safeNext } from '../../../../src/auth/next'
 import { getProvider } from '../../../../src/auth/providers/registry'
 import { MAX_TTL_SEC, createSession } from '../../../../src/auth/session'
 import { ApiError, jsonError } from '../../../../src/errors'
-import { oauthPublicBaseUrl } from '../../../../src/public-url'
+import { oauthPublicBaseUrl, publicBaseUrl } from '../../../../src/public-url'
 import { checkRate } from '../../../../src/rate-limit'
 import { clientIp } from '../../../../src/request'
 import { CC_NO_STORE } from '../../../../src/security/cache-control'
@@ -59,7 +59,50 @@ export const onRequestGet: PagesFunction<Env, 'provider'> = async (ctx) => {
     const url = new URL(ctx.request.url)
     const code = url.searchParams.get('code')
     const state = url.searchParams.get('state')
-    if (!code || !state) throw new ApiError('BAD_REQUEST')
+    if (!code) throw new ApiError('BAD_REQUEST')
+
+    // AuthKit's hosted invitation flow is allowed to return directly to the
+    // application's redirect URI with only an authorization code. Spool must
+    // not use that unbound result to create a browser session because the flow
+    // did not originate at /start and therefore has no state cookie to bind
+    // the browser to the authorization request. Doing so would make login CSRF
+    // / session swapping possible.
+    //
+    // Redeem the one-time code with the confidential-client secret so WorkOS
+    // can finish any hosted invitation bookkeeping, but deliberately discard
+    // the returned identity instead of creating a Spool session from an
+    // unbound browser request. If a stale/expired callback can no longer be
+    // redeemed, a fresh sign-in is still the safest recovery path.
+    //
+    // Then restart a normal Spool-owned authorization flow. The fresh /start
+    // request mints state, and the user's new AuthKit session normally makes
+    // the second round trip immediate. Canonicalizing through PUBLIC_BASE_URL
+    // also moves legacy spool.pro invitations onto spool.new.
+    if (!state) {
+      const redirectUri = `${publicBaseUrl(ctx.env)}/api/auth/${provider.id}/callback`
+      try {
+        await provider.exchangeCode({ code, codeVerifier: '', redirectUri }, ctx.env)
+      } catch (error) {
+        console.warn(
+          JSON.stringify({
+            message: 'hosted AuthKit callback completion failed before stateful restart',
+            provider: provider.id,
+            error: error instanceof ApiError ? error.code : 'INTERNAL',
+          }),
+        )
+      }
+
+      const restart = new URL(`/api/auth/${provider.id}/start`, publicBaseUrl(ctx.env))
+      restart.searchParams.set('next', '/me')
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: restart.toString(),
+          'Cache-Control': CC_NO_STORE,
+          'Referrer-Policy': 'no-referrer',
+        },
+      })
+    }
 
     const stateCookie = readCookie(ctx.request, OAUTH_STATE_COOKIE)
     const verifier = readCookie(ctx.request, OAUTH_VERIFIER_COOKIE)

--- a/apps/backend/tests/endpoints.test.ts
+++ b/apps/backend/tests/endpoints.test.ts
@@ -52,11 +52,117 @@ afterEach(() => {
 })
 
 describe('GET /api/auth/workos/callback — plumbing edges', () => {
-  it('400 when code or state query params are missing', async () => {
+  it('400 when the authorization code is missing', async () => {
     const env = envFor()
-    const req = new Request('https://spool.new/api/auth/workos/callback?code=abc')
+    const req = new Request('https://spool.new/api/auth/workos/callback?state=abc')
     const res = await invoke(callbackGet, req, env, { provider: 'workos' })
     expect(res.status).toBe(400)
+  })
+
+  it('restarts a state-bound flow after a hosted invitation code-only callback', async () => {
+    const env = envFor()
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const res = workosOk(String(input))
+      if (!res) throw new Error(`unexpected fetch: ${String(input)}`)
+      return res
+    })
+    const req = new Request('https://spool.new/api/auth/workos/callback?code=invitation-code')
+    const res = await invoke(callbackGet, req, env, { provider: 'workos' })
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('https://spool.new/api/auth/workos/start?next=%2Fme')
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    expect(res.headers.get('referrer-policy')).toBe('no-referrer')
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toMatch(/\/user_management\/authenticate$/)
+    const exchangeBody = JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body)) as {
+      code: string
+      client_secret: string
+      code_verifier?: string
+    }
+    expect(exchangeBody).toMatchObject({
+      code: 'invitation-code',
+      client_secret: 'sk_test',
+    })
+    expect(exchangeBody).not.toHaveProperty('code_verifier')
+    expect(getSetCookies(res).join('\n')).not.toMatch(/spool_session=/)
+    expect(env.state.users).toHaveLength(0)
+  })
+
+  it('still restarts safely when a stale hosted invitation code cannot be redeemed', async () => {
+    const env = envFor()
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{"error":"invalid_grant"}', { status: 400 }),
+    )
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const req = new Request('https://spool.new/api/auth/workos/callback?code=expired-code')
+    const res = await invoke(callbackGet, req, env, { provider: 'workos' })
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('https://spool.new/api/auth/workos/start?next=%2Fme')
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('hosted AuthKit callback completion failed'),
+    )
+    expect(env.state.users).toHaveLength(0)
+  })
+
+  it('creates a browser session only after the restarted callback passes state checks', async () => {
+    const env = envFor()
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const res = workosOk(String(input))
+      if (!res) throw new Error(`unexpected fetch: ${String(input)}`)
+      return res
+    })
+
+    const recovery = await invoke(
+      callbackGet,
+      new Request('https://spool.new/api/auth/workos/callback?code=invitation-code'),
+      env,
+      { provider: 'workos' },
+    )
+    const start = await invoke(startGet, new Request(recovery.headers.get('location') ?? ''), env, {
+      provider: 'workos',
+    })
+    const authorize = new URL(start.headers.get('location') ?? '')
+    const state = authorize.searchParams.get('state')
+    expect(state).toBeTruthy()
+    const cookie = getSetCookies(start)
+      .map((value) => value.split(';', 1)[0])
+      .join('; ')
+
+    const callback = await invoke(
+      callbackGet,
+      new Request(
+        `https://spool.new/api/auth/workos/callback?code=stateful-code&state=${encodeURIComponent(state ?? '')}`,
+        { headers: { cookie } },
+      ),
+      env,
+      { provider: 'workos' },
+    )
+
+    expect(callback.status).toBe(302)
+    expect(callback.headers.get('location')).toBe('/me')
+    expect(getSetCookies(callback).join('\n')).toMatch(/spool_session=/)
+    expect(
+      fetchSpy.mock.calls.filter(([input]) => String(input).endsWith('/authenticate')),
+    ).toHaveLength(2)
+    expect(env.state.users).toHaveLength(1)
+  })
+
+  it('canonicalizes a legacy-host invitation recovery onto PUBLIC_BASE_URL', async () => {
+    const env = { ...envFor(), PUBLIC_BASE_URL: 'https://spool.new' }
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const res = workosOk(String(input))
+      if (!res) throw new Error(`unexpected fetch: ${String(input)}`)
+      return res
+    })
+    const req = new Request('https://spool.pro/api/auth/workos/callback?code=invitation-code', {
+      headers: { 'x-forwarded-host': 'spool.pro' },
+    })
+    const res = await invoke(callbackGet, req, env, { provider: 'workos' })
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('https://spool.new/api/auth/workos/start?next=%2Fme')
   })
 
   it('400 when state cookie is absent', async () => {

--- a/apps/backend/tests/security.test.ts
+++ b/apps/backend/tests/security.test.ts
@@ -176,6 +176,25 @@ describe('_middleware security headers', () => {
     expect(res.headers.get('cache-control')).toBe('no-store')
   })
 
+  it('does NOT override an explicit Referrer-Policy from a handler', async () => {
+    const { onRequest } = await import('../functions/_middleware')
+    const inner = new Response(null, {
+      status: 302,
+      headers: {
+        location: 'https://x/api/auth/workos/start',
+        'referrer-policy': 'no-referrer',
+      },
+    })
+    const req = new Request('https://x/api/auth/workos/callback?code=secret', { method: 'GET' })
+    const res = await (
+      onRequest as unknown as (c: {
+        request: Request
+        next: () => Promise<Response>
+      }) => Promise<Response>
+    )({ request: req, next: async () => inner })
+    expect(res.headers.get('referrer-policy')).toBe('no-referrer')
+  })
+
   it('does NOT override an explicit Cache-Control on a mutation', async () => {
     const { onRequest } = await import('../functions/_middleware')
     const inner = new Response('{"ok":true}', {

--- a/docs/team-operations.md
+++ b/docs/team-operations.md
@@ -21,7 +21,14 @@ Configure the application that owns `WORKOS_CLIENT_ID` under **Applications → 
 - App homepage: `https://spool.new/`
 - Sign-in endpoint: `https://spool.new/api/auth/workos/start`
 
-The sign-in endpoint deliberately starts a fresh state-protected AuthKit flow. It is needed when WorkOS initiates authentication outside Spool, such as from an email flow. Do not point WorkOS directly at the callback: a callback without Spool's state cookies is rejected. Leave custom sign-up, user-invitation, and password-reset URLs unset unless Spool implements matching routes; WorkOS-hosted flows remain the source of truth for those actions.
+The sign-in endpoint deliberately starts a fresh state-protected AuthKit flow. It is needed when WorkOS initiates authentication outside Spool, such as from an email flow. Do not point WorkOS directly at the callback: a callback without Spool's state cookies cannot establish a Spool session and enters only the controlled recovery described below. Leave custom sign-up, user-invitation, and password-reset URLs unset unless Spool implements matching routes; WorkOS-hosted flows remain the source of truth for those actions.
+
+AuthKit's hosted invitation flow may still return an authorization code without
+the application state created by Spool. The callback redeems that code only to
+finish WorkOS's hosted ceremony, discards its unbound identity result, and
+restarts through the sign-in endpoint. A code-only callback must never create a
+Spool browser session; the second callback must pass the normal state-cookie
+checks before membership reconciliation runs.
 
 ## Required production secrets
 


### PR DESCRIPTION
## Summary

- handle AuthKit hosted invitation callbacks that return an authorization code without Spool-owned state
- redeem the unbound code only to complete WorkOS bookkeeping, then restart a state-protected Spool login flow
- never create a Spool session from the unbound callback, preventing login CSRF/session swapping
- preserve callback-specific Referrer-Policy: no-referrer through middleware
- document the hosted-invitation recovery contract

## Production incident

WorkOS marked Alan and Edwin invitations accepted, but both callbacks returned BAD_REQUEST before Spool could upsert their users or synchronize organization membership. The production callback URL contained code only.

After deployment, each invitee can use the normal WorkOS start endpoint once; the authenticated callback will create the local user and synchronize the already-accepted WorkOS membership and intended role.

## Validation

- backend test suite: 31 files, 444 tests passed
- repository checks: pnpm exec vp check
- production build: pnpm run build
- backend typecheck passed
- no E2E run, per repository instructions