### PR TITLE
fix(web): keep light hero background white

### DIFF
--- a/apps/web/src/components/site/hero-space.test.ts
+++ b/apps/web/src/components/site/hero-space.test.ts
@@ -1,8 +1,29 @@
 import { describe, expect, it } from 'vite-plus/test'
 
-import { getHeroRenderPolicy } from './hero-space'
+import { getHeroRenderPolicy, parseCssColor } from './hero-space'
 
 describe('HeroSpace theme rendering', () => {
+  it('recognizes minified short-hex light theme tokens', () => {
+    expect(parseCssColor('#fff', { r: 0, g: 0, b: 0 })).toEqual({
+      r: 255,
+      g: 255,
+      b: 255,
+    })
+  })
+
+  it('ignores alpha while parsing short and long alpha hex tokens', () => {
+    expect(parseCssColor('#1387', { r: 0, g: 0, b: 0 })).toEqual({
+      r: 17,
+      g: 51,
+      b: 136,
+    })
+    expect(parseCssColor('#1387ffff', { r: 0, g: 0, b: 0 })).toEqual({
+      r: 19,
+      g: 135,
+      b: 255,
+    })
+  })
+
   it('composites light mode onto the shared page background without bloom post-processing', () => {
     expect(getHeroRenderPolicy(false)).toEqual({
       transparentCanvas: true,

--- a/apps/web/src/components/site/hero-space.tsx
+++ b/apps/web/src/components/site/hero-space.tsx
@@ -27,11 +27,23 @@ interface Rgb {
   b: number
 }
 
-function parseCssColor(value: string, fallback: Rgb): Rgb {
+export function parseCssColor(value: string, fallback: Rgb): Rgb {
   const v = value.trim()
-  const hex = /^#([0-9a-f]{6})$/i.exec(v)
+  const hex = /^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.exec(v)
   if (hex) {
-    const n = parseInt(hex[1]!, 16)
+    /* Production CSS minification shortens values such as #ffffff to
+     * #fff. Alpha-bearing forms are valid computed token values too; the
+     * scene palette only needs their RGB channels. */
+    const raw = hex[1]!
+    const rgbHex =
+      raw.length <= 4
+        ? raw
+            .slice(0, 3)
+            .split('')
+            .map((channel) => channel + channel)
+            .join('')
+        : raw.slice(0, 6)
+    const n = parseInt(rgbHex, 16)
     return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 }
   }
   const rgb = /^rgba?\(\s*(\d+)[,\s]+(\d+)[,\s]+(\d+)/.exec(v)


### PR DESCRIPTION
## Summary

- parse minified 3/4-digit and alpha-bearing hex colors in the WebGL hero palette
- add regression coverage for production-shortened theme tokens
- preserve the existing dark-mode bloom path while keeping light mode transparent over white

## Root cause

The production CSS build shortens `#ffffff` to `#fff`. The Hero color parser only accepted six-digit hex values, so light mode fell back to void black and selected the dark WebGL pipeline. The light scrim then exposed that black canvas as a left-to-right gradient.

## Impact

The homepage Hero now renders on the intended white light-mode background in production, both on a direct light-mode load and after switching from dark mode.

## Validation

- `corepack pnpm --filter @spool/web exec vp test run src/components/site/hero-space.test.ts` (4 tests passed)
- `corepack pnpm --filter @spool/web typecheck`
- `corepack pnpm --filter @spool/web build`
- Playwright + Chrome against the local production build at 2048×1180: direct light load and dark → light transition both rendered a pure-white right-side background (`255,255,255`) with no browser console errors
- `git diff --check`
