### PR TITLE
release: v0.6.5

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/cli",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": false,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/web",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spool",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/core",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": false,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/redact",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Local, pure-TS sensitive-data detection for Spool sessions. Pattern + checksum + entropy pipeline today; pluggable provider boundary for future on-device ML (e.g. OpenAI Privacy Filter via transformers.js).",
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/session-kit/package.json
+++ b/packages/session-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/session-kit",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Browser-safe canonical records, sequence hashing, edit extraction, views, and Session diffs for Spool.",
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {


### PR DESCRIPTION
## Release checkpoint

Synchronize the root, Web, CLI, Core, Redact, and Session Kit manifests at `0.6.5`.

This is the verified checkpoint created by `scripts/release.sh --patch`. The script's direct push to protected `main` was rejected before any tag, npm package, GitHub release, or production deployment was published, so this PR advances the same version through the required merge queue.

After merge, the existing `v0.6.5` local checkpoint tag will be recreated at the merge commit, pushed once, and used to resume the Release workflow.

## Validation

- exactly the six manifests prescribed by `scripts/release.sh` changed
- all six versions agree on `0.6.5`
- `v0.6.5` is absent from the remote
- `@spool-lab/redact`, `@spool-lab/session-kit`, `@spool-lab/core`, and `@spool-lab/cli` remain at `0.6.4` before release
