### PR TITLE
fix(web): point daemon links to archived repository

### DIFF
--- a/apps/web/src/components/site/daemon.tsx
+++ b/apps/web/src/components/site/daemon.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import registry from '../../../data/registry.json'
 
 const INSTALL_CMD = 'curl -fsSL https://spool.new/install-daemon.sh | bash'
-const REPO_URL = 'https://github.com/paperboytm/spool-daemon'
+const REPO_URL = 'https://github.com/spool-lab/spool-daemon'
 
 // ─── Tray cells (hero specimen, 8 cells × 2 cols) ──────────────────────
 const TRAY_CELLS = [


### PR DESCRIPTION
## What changed

- point every `/daemon` repository action at the real `spool-lab/spool-daemon` repository
- remove the stale `paperboytm/spool-daemon` target from the production bundle

## Why

Spool Daemon is being retained as an archived, unmaintained project. Its public entry should continue to resolve to the preserved source and existing releases.

## Impact

The `/daemon` page keeps working, but its GitHub, connector guide, connector source, and README links now resolve to the repository that is being archived.

## Checks

- `pnpm exec vp check apps/web/src/components/site/daemon.tsx`
- `pnpm --filter @spool/web run typecheck`
- `pnpm --filter @spool/web test` (282 passed)
- `pnpm --filter @spool/web run build`
- production HTML assertion for the new URL and absence of the stale URL
