### PR TITLE
feat(cli): spool teams — list your Teams by name

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -35,8 +35,11 @@ spool subscribe [dir] --link-only           # anyone with the URL
 spool subscribe [dir] --public              # explicit opt-in to Explore/search
 spool unsubscribe [dir]
 spool subscriptions
+spool teams                                 # list the Teams you belong to
 spool daemon start|stop|status|logs|run
 ```
+
+`--team` accepts a Team name (or id when two Teams share a name); `spool teams` shows exactly the names to use.
 
 Subscribing a directory is the one-time disclosure decision: from then on, the daemon publishes new and updated Sessions recorded in that directory — including its git worktrees and worktrees managed by tools like superset or orca — without prompting. The disclosure target is always an explicit choice among `Team · {name}`, Link-only, and Public; **there is no implicit default and Public is never preselected**. Interactive `spool subscribe` offers your Teams first.
 

--- a/apps/cli/src/cli.test.ts
+++ b/apps/cli/src/cli.test.ts
@@ -274,6 +274,7 @@ describe('cli entry point', () => {
     const out = run(['--help'])
     expect(out).toContain('Usage: spool')
     expect(out).toContain('subscribe')
+    expect(out).toContain('teams')
     expect(out).toContain('daemon')
     expect(out).toContain('sessions')
     expect(out).toContain('visibility')

--- a/apps/cli/src/commands/teams.test.ts
+++ b/apps/cli/src/commands/teams.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vite-plus/test'
+
+import type { HubTeam } from '../hub/client.js'
+import { createTextUi } from '../ui.js'
+import { handleTeamsCommand } from './teams.js'
+
+const dirs: string[] = []
+
+function tempHome(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'spool-teams-'))
+  dirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+function capturingUi() {
+  const output: string[] = []
+  const errors: string[] = []
+  return {
+    ui: createTextUi(
+      (message) => output.push(message),
+      (message) => errors.push(message),
+    ),
+    output,
+    errors,
+  }
+}
+
+const LOGGED_IN = { SPOOL_HUB_URL: 'https://hub.test', SPOOL_HUB_TOKEN: 'test-token' }
+const TEAMS: HubTeam[] = [
+  {
+    id: 'team_00000001',
+    name: 'Paperboy',
+    role: 'owner',
+    permissions: [],
+    member_count: 3,
+    archived_at: null,
+  },
+  {
+    id: 'team_00000002',
+    name: 'Weekend Hacks',
+    role: 'member',
+    permissions: [],
+    member_count: 1,
+    archived_at: null,
+  },
+]
+
+describe('teams command', () => {
+  it('requires login', async () => {
+    const { ui, errors } = capturingUi()
+    expect(await handleTeamsCommand({}, { ui, homeDir: tempHome(), env: {} })).toBe(1)
+    expect(errors.join('\n')).toContain('Not logged in')
+  })
+
+  it('lists teams with role and member count, and hints at name usage', async () => {
+    const { ui, output } = capturingUi()
+    expect(
+      await handleTeamsCommand(
+        {},
+        { ui, homeDir: tempHome(), env: LOGGED_IN, listTeams: async () => TEAMS },
+      ),
+    ).toBe(0)
+    const text = output.join('\n')
+    expect(text).toContain('Team · Paperboy  (owner, 3 members)')
+    expect(text).toContain('Team · Weekend Hacks  (member, 1 member)')
+    expect(text).toContain('subscribe --team <name>')
+  })
+
+  it('reports an empty membership', async () => {
+    const { ui, output } = capturingUi()
+    expect(
+      await handleTeamsCommand(
+        {},
+        { ui, homeDir: tempHome(), env: LOGGED_IN, listTeams: async () => [] },
+      ),
+    ).toBe(0)
+    expect(output.join('\n')).toContain('not a member of any Team')
+  })
+
+  it('outputs JSON', async () => {
+    const { ui } = capturingUi()
+    const lines: string[] = []
+    expect(
+      await handleTeamsCommand(
+        { json: true },
+        {
+          ui,
+          log: (message) => lines.push(message),
+          homeDir: tempHome(),
+          env: LOGGED_IN,
+          listTeams: async () => TEAMS,
+        },
+      ),
+    ).toBe(0)
+    const parsed = JSON.parse(lines.join('\n')) as HubTeam[]
+    expect(parsed).toHaveLength(2)
+    expect(parsed[0]?.name).toBe('Paperboy')
+  })
+})

--- a/apps/cli/src/commands/teams.ts
+++ b/apps/cli/src/commands/teams.ts
@@ -1,0 +1,84 @@
+import { formatCliCommand, formatCliInstallHint } from '@spool-lab/core'
+import { Command } from 'commander'
+
+import { HubClient, type HubFetch, type HubTeam } from '../hub/client.js'
+import { loadHubCredentials, type HubCredentialOptions } from '../hub/credentials.js'
+import { createClackUi, createTextUi, type CliUi } from '../ui.js'
+
+// Read-only: the Teams the signed-in user belongs to. Names printed here are
+// exactly what `spool subscribe --team <name>` and `spool visibility … --team
+// <name>` accept — the id is only needed when two Teams share a name.
+
+export interface TeamsCommandOptions {
+  json?: boolean
+}
+
+export interface TeamsCommandDependencies extends HubCredentialOptions {
+  fetch?: HubFetch
+  ui?: CliUi
+  log?: (message: string) => void
+  listTeams?: () => Promise<HubTeam[]>
+}
+
+export async function handleTeamsCommand(
+  options: TeamsCommandOptions,
+  dependencies: TeamsCommandDependencies = {},
+): Promise<0 | 1> {
+  const ui = dependencies.ui ?? createTextUi()
+  const log = dependencies.log ?? console.log
+  try {
+    const credentials = loadHubCredentials(pickCredentialOptions(dependencies))
+    if (!credentials.token) {
+      ui.error(`Not logged in. Run \`${formatCliCommand('login')}\` first.`)
+      ui.info(formatCliInstallHint())
+      return 1
+    }
+    const listTeams =
+      dependencies.listTeams ??
+      (() =>
+        new HubClient({
+          hubUrl: credentials.hubUrl,
+          token: credentials.token as string,
+          ...(dependencies.fetch === undefined ? {} : { fetch: dependencies.fetch }),
+        }).listTeams())
+    const teams = await listTeams()
+
+    if (options.json === true) {
+      log(JSON.stringify(teams, null, 2))
+      return 0
+    }
+    if (teams.length === 0) {
+      ui.info('You are not a member of any Team. Create one on spool.new.')
+      return 0
+    }
+    for (const team of teams) {
+      const members = `${team.member_count} member${team.member_count === 1 ? '' : 's'}`
+      ui.info(`Team · ${team.name}  (${team.role}, ${members})`)
+    }
+    ui.info(
+      `Use a name with \`${formatCliCommand('subscribe --team <name>')}\` or \`${formatCliCommand('visibility <sid> team --team <name>')}\`.`,
+    )
+    return 0
+  } catch (cause) {
+    ui.error(cause instanceof Error ? cause.message : String(cause))
+    return 1
+  }
+}
+
+export const teamsCommand = new Command('teams')
+  .description('List the Teams you belong to')
+  .option('--json', 'Machine-readable output')
+  .action(async (opts: { json?: boolean }) => {
+    const exitCode = await handleTeamsCommand(
+      { ...(opts.json === undefined ? {} : { json: opts.json }) },
+      { ui: createClackUi() },
+    )
+    if (exitCode !== 0) process.exitCode = exitCode
+  })
+
+function pickCredentialOptions(dependencies: HubCredentialOptions): HubCredentialOptions {
+  return {
+    ...(dependencies.homeDir === undefined ? {} : { homeDir: dependencies.homeDir }),
+    ...(dependencies.env === undefined ? {} : { env: dependencies.env }),
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -13,6 +13,7 @@ import { resumeCommand } from './commands/resume.js'
 import { sessionsCommand } from './commands/sessions.js'
 import { shareCommand } from './commands/share.js'
 import { subscribeCommand, subscriptionsCommand, unsubscribeCommand } from './commands/subscribe.js'
+import { teamsCommand } from './commands/teams.js'
 import { visibilityCommand } from './commands/visibility.js'
 import { withdrawCommand } from './commands/withdraw.js'
 
@@ -36,6 +37,7 @@ program
 program.addCommand(subscribeCommand)
 program.addCommand(unsubscribeCommand)
 program.addCommand(subscriptionsCommand)
+program.addCommand(teamsCommand)
 program.addCommand(daemonCommand)
 program.addCommand(shareCommand)
 program.addCommand(visibilityCommand)

--- a/apps/web/src/content/docs/reference/cli.md
+++ b/apps/web/src/content/docs/reference/cli.md
@@ -63,6 +63,17 @@ spool unsubscribe [dir]   # stop auto-publishing; published Sessions stay live
 spool subscriptions       # list subscribed directories and their disclosure
 ```
 
+## `spool teams`
+
+List the Teams you belong to, with your role and the member count:
+
+```bash
+spool teams
+spool teams --json
+```
+
+Every `--team` option (`spool subscribe`, `spool visibility`) accepts a Team name as printed here; the id is only needed when two Teams share a name.
+
 ## `spool daemon`
 
 The always-on half of continuous publishing — a watcher plus auto-publish loop supervised by the OS service manager (launchd on macOS, a systemd user unit on Linux):


### PR DESCRIPTION
## Summary

Adds the read-only `spool teams` command: the Teams the signed-in user belongs to, with role and member count. The names it prints are exactly what `--team` accepts in `spool subscribe` and `spool visibility` (name-first matching already existed; the id is only needed when two Teams share a name). Uses the hub-token `GET /api/hub/v1/teams` endpoint added in #494.

```
$ spool teams
Team · Paperboy  (owner, 3 members)
Use a name with `spool subscribe --team <name>` or `spool visibility <sid> team --team <name>`.
```

`--json` gives machine-readable output. Docs updated (CLI README + web CLI reference).

## Test plan
- New unit tests: login gate, listing format, empty membership, JSON output.
- `apps/cli` suite: 199 passed; `apps/web` (docs): 300 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)