### PR TITLE
release: v0.8.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": false,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/web",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spool",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": false,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/redact",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Local, pure-TS sensitive-data detection for Spool sessions. Pattern + checksum + entropy pipeline today; pluggable provider boundary for future on-device ML (e.g. OpenAI Privacy Filter via transformers.js).",
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/session-kit/package.json
+++ b/packages/session-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/session-kit",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Browser-safe canonical records, sequence hashing, edit extraction, views, and Session diffs for Spool.",
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {


### PR DESCRIPTION
## Release checkpoint

- Synchronize the root, web, CLI, core, redact, and session-kit manifests at `0.8.0`.
- Preserve the single release checkpoint created by `./scripts/release.sh --minor`.
- Recover from the protected-`main` direct-push rejection through the required merge queue.

After this PR merges, the resulting main commit will receive the unpublished `v0.8.0` tag and the same-version Release workflow will publish npm, create the GitHub Release, and dispatch the matching production deployment.

## Verification

- All six prescribed manifests are synchronized at `0.8.0`.
- The release checkpoint contains no changes beyond those six version edits.
- `v0.8.0` is absent from origin, npm, and GitHub Releases before this PR.
- Main CI and CodeQL for the feature merge are green.
