### PR TITLE
release: v0.8.2

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": false,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/web",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spool",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": false,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/redact",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Local, pure-TS sensitive-data detection for Spool sessions. Pattern + checksum + entropy pipeline today; pluggable provider boundary for future on-device ML (e.g. OpenAI Privacy Filter via transformers.js).",
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/session-kit/package.json
+++ b/packages/session-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/session-kit",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Browser-safe canonical records, sequence hashing, edit extraction, views, and Session diffs for Spool.",
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {


### PR DESCRIPTION
## Release checkpoint

Advances the synchronized Spool release train from `0.8.1` to `0.8.2` after #502.

The standard release script created this exact six-manifest version commit and annotated tag locally, but the repository now requires every `main` change to pass through a pull request and Merge Queue. No npm package, GitHub Release, migration, or production deployment has run yet.

After this PR lands, the existing local tag will be moved to the queue-produced `main` commit, pushed once, and the same `v0.8.2` Release workflow will continue. The release script will not be rerun and the version will not be bumped again.
