### PR TITLE
release: v0.8.3

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/cli",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": false,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/web",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spool",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/core",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": false,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/redact",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Local, pure-TS sensitive-data detection for Spool sessions. Pattern + checksum + entropy pipeline today; pluggable provider boundary for future on-device ML (e.g. OpenAI Privacy Filter via transformers.js).",
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/session-kit/package.json
+++ b/packages/session-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/session-kit",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Browser-safe canonical records, sequence hashing, edit extraction, views, and Session diffs for Spool.",
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {


### PR DESCRIPTION
Publishes the Session language switcher and synchronized v0.8.3 release train.

- bumps all six release manifests to 0.8.3
- publishes the four npm packages
- creates the matching GitHub release
- deploys the exact release commit to production