### PR TITLE
release: v0.8.4

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/cli",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": false,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/web",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spool",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/core",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": false,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/redact",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Local, pure-TS sensitive-data detection for Spool sessions. Pattern + checksum + entropy pipeline today; pluggable provider boundary for future on-device ML (e.g. OpenAI Privacy Filter via transformers.js).",
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/session-kit/package.json
+++ b/packages/session-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/session-kit",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Browser-safe content-addressed records, sequence hashing, edit extraction, views, and Session diffs for Spool.",
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {


### PR DESCRIPTION
Bump all release-train manifests from 0.8.3 to 0.8.4 after Projects landed in #506.\n\nRelease train after merge:\n- tag the final merge-queue commit as v0.8.4\n- publish @spool-lab/redact, session-kit, core, and cli\n- create the GitHub release\n- deploy the matching production web and D1 migration