### PR TITLE
release: v0.8.5

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/cli",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": false,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool/web",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spool",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/core",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": false,
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/redact/package.json
+++ b/packages/redact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/redact",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Local, pure-TS sensitive-data detection for Spool sessions. Pattern + checksum + entropy pipeline today; pluggable provider boundary for future on-device ML (e.g. OpenAI Privacy Filter via transformers.js).",
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {

--- a/packages/session-kit/package.json
+++ b/packages/session-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spool-lab/session-kit",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Browser-safe content-addressed records, sequence hashing, edit extraction, views, and Session diffs for Spool.",
   "homepage": "https://github.com/paperboytm/spool#readme",
   "bugs": {


### PR DESCRIPTION
## Release train

Synchronize every release manifest at `0.8.5` after #509.

The `v0.8.5` tag will be created only after this PR lands through the required merge queue, so the Release workflow, npm packages, GitHub Release, production deployment, and D1 migrations all resolve to the final `main` SHA.

## Verification

- release checkpoint changes exactly six synchronized manifests
- parent commit is #509 merge SHA `8ff6463a6a8f88815de9ef985c23d09574f5ff66`
- `v0.8.5` is absent from origin and all four npm targets before publication
- feature CI, CodeQL, 1,969 tests, 40 Playwright E2E tests, build, and 16 migration smoke checks are green
